### PR TITLE
Add a comment when pre-commit is finished

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,6 +1,9 @@
 name: Pre-commit
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  pull_request_target:
 
 jobs:
   run:


### PR DESCRIPTION
## What's new?
I support auto PR comments when pre-commit is finished in this PR.
The current UT coverage results are messy and very long, which is not suitable for display. So, the PR comment with UT results should be done in later PR.


## Why this PR failed?
`${{ secrets.GITHUB_TOKEN }}` is unable to access other Repo.
The explanation offtered by the author:

Note: In public repositories this action does not work in pull_request workflows when triggered by forks. Any attempt will be met with the error, Resource not accessible by integration. This is due to token restrictions put in place by GitHub Actions. Private repositories can be configured to [enable workflows](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#enabling-workflows-for-forks-of-private-repositories) from forks to run without restriction. See [here](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#restrictions-on-repository-forks) for further explanation. Alternatively, use the [pull_request_target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) event to comment on pull requests.


## You can see how the comment looks like in:
https://github.com/rayrayraykk/AgentScope/pull/10


## Checklist

Please check the following items before code is ready to be reviewed.

- [X]  Code has passed all tests
- [X]  Docstrings have been added/updated in Google Style
- [X]  Documentation has been updated
- [X]  Code is ready for review