### PR TITLE
fix rag example demo execute sphinx-build throw error

### DIFF
--- a/examples/conversation_with_RAG_agents/rag_example.py
+++ b/examples/conversation_with_RAG_agents/rag_example.py
@@ -36,7 +36,7 @@ def prepare_docstring_html() -> None:
     """Prepare docstring in html for API assistant"""
     if not os.path.exists("../../docs/docstring_html/"):
         os.system(
-            "sphinx-apidoc -f -o ../../docs/sphinx_doc/en/source "
+            "sphinx-apidoc -F -a -f -o ../../docs/sphinx_doc/en/source "
             "../../src/agentscope -t template",
         )
         os.system(


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request
---
## Description
fix rag_example demo when execute sphinx-apidoc did not generate conf.py, cause sphinx-build execute error throw

[represent]
when execute sphinx-build , throw error Configuration error: config directory doesn't contain a conf.py file

[fix reason]
1. sphinx-apidoc add parameter -F means use sphinx-quickstart generate full project contains conf.py.
2. sphinx-apidoc add parameter -a means append-syspath into conf.py define the moudle_path , prevent sphinx-build unfoud agentscore path.


## Checklist

Please check the following items before code is ready to be reviewed.

- [ ✅ ]  Code has passed all tests
- [ ✅ ]  Docstrings have been added/updated in Google Style
- [ ✅ ]  Documentation has been updated
- [ ✅ ]  Code is ready for review