### PR TITLE
Add `base_http_api_url` in DashScopeChatModel's constructor

### DIFF
--- a/src/agentscope/model/_dashscope_model.py
+++ b/src/agentscope/model/_dashscope_model.py
@@ -50,6 +50,7 @@ class DashScopeChatModel(ChatModelBase):
         stream: bool = True,
         enable_thinking: bool | None = None,
         generate_kwargs: dict[str, JSONSerializableObject] | None = None,
+        base_http_api_url: str | None = None,
     ) -> None:
         """Initialize the DashScope chat model.
 
@@ -69,6 +70,9 @@ class DashScopeChatModel(ChatModelBase):
             optional):
                The extra keyword arguments used in DashScope API generation,
                e.g. `temperature`, `seed`.
+            base_http_api_url (`str | None`, optional):
+                The base URL for DashScope API requests. If not provided,
+                the default base URL from the DashScope SDK will be used.
         """
         if enable_thinking and not stream:
             logger.info(
@@ -83,6 +87,11 @@ class DashScopeChatModel(ChatModelBase):
         self.enable_thinking = enable_thinking
         self.incremental_output = self.stream
         self.generate_kwargs = generate_kwargs or {}
+
+        if base_http_api_url is not None:
+            import dashscope
+
+            dashscope.base_http_api_url = base_http_api_url
 
     @trace_llm
     async def __call__(


### PR DESCRIPTION
## AgentScope Version

v1.0.0

## Description

Add `base_http_api_url` in DashScopeChatModel's constructor

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review