### PR TITLE
Add meta tools examples

### DIFF
--- a/examples/Meta_tools/Meta_tool_config.json
+++ b/examples/Meta_tools/Meta_tool_config.json
@@ -1,0 +1,47 @@
+{
+    "Information Retrieval": {
+    "description": "The Information Retrieval category includes tools for retrieving web-based content or answering queries through external sources. These tools support tasks such as web search, open-domain fact lookup, and retrieval-augmented response generation. You can basically use this category to search and retrieve whatever you want to know.",
+    "tool_usage_notes": "When using online search tools, the max_results parameter MUST BE AT MOST 6 per query. For queries related to China-specific topics, consider translating the query into **Chinese** to better match the search engine styles.",
+    "tools": [
+      "bing_search",
+      "get-stations-code-in-city",
+      "get-station-code-of-citys",
+      "get-station-code-by-names",
+      "get-station-by-telecode",
+      "get-tickets",
+      "get-interline-tickets",
+      "get-train-route-stations",
+      "maps_weather"
+    ]
+  },
+    "Programming & Tech Support": {
+      "description": "The Programming & Tech Support category includes tools for executing code, executing shell command, running scripts, and interacting with system environments to support tasks such as debugging, automation, and developer operations.",
+      "tool_usage_notes": "",
+      "tools": [
+        "execute_python_code",
+        "execute_shell_command"
+      ]
+    },
+    "Location & Navigation": {
+      "description": "The Location & Navigation category includes tools for accessing and processing geospatial data, including walking, driving, cycling, and public transit navigation; distance estimation; geocoding and reverse geocoding; IP-based location detection; located weather retrieval; and various forms of location-based search such as keyword search, detailed POI lookup, and nearby place discovery. These tools support navigation and content generation tasks requiring spatial awareness, such as route descriptions, travel suggestions, and area-based comparisons.",
+      "tool_usage_notes": "",
+      "tools": [
+        "maps_direction_bicycling",
+        "maps_direction_driving",
+        "maps_direction_transit_integrated",
+        "maps_direction_walking",
+        "maps_distance",
+        "maps_geo",
+        "maps_regeocode",
+        "maps_ip_location",
+        "maps_schema_personal_map",
+        "maps_around_search",
+        "maps_search_detail",
+        "maps_text_search",
+        "maps_schema_navi",
+        "maps_schema_take_taxi",
+        "maps_weather"
+    ]
+  }
+  }
+  

--- a/examples/Meta_tools/Meta_toolkit.py
+++ b/examples/Meta_tools/Meta_toolkit.py
@@ -1,0 +1,601 @@
+"""
+This file is the core of the meta tool system.
+
+It contains the CategoryManager class, which manages the tools within a
+specific category. It also contains the MetaManager class, which is the
+top-level class that manages the category managers.
+"""
+
+import asyncio
+import json
+import os
+from functools import partial, wraps
+from typing import (
+    Any,
+    AsyncGenerator,
+    Callable,
+    Dict,
+    Generator,
+    Literal,
+    Type,
+)
+
+from agentscope.formatter import FormatterBase
+from agentscope.memory import InMemoryMemory
+from agentscope.message import Msg, TextBlock, ToolUseBlock
+from agentscope.tool import Toolkit, ToolResponse
+from agentscope.tool._registered_tool_function import RegisteredToolFunction
+from agentscope.tool._toolkit import ToolGroup
+
+
+# Constants
+MAX_ITERATIONS = 5
+
+
+class CategoryManager:
+    """Level 2 Category Manager - Manages tools within a specific category."""
+    
+    def __init__(
+        self, 
+        category_name: str, 
+        category_description: str, 
+        model, 
+        tool_usage_notes: str = "",
+        formatter: FormatterBase = None,
+    ):
+        self.category_name = category_name
+        self.category_description = category_description
+        self.model = model
+        self.tool_usage_notes = tool_usage_notes
+        self.memory = InMemoryMemory()
+        self.formatter = formatter
+        # internal level 1 tools
+        self.internal_toolkit = Toolkit()   
+
+    def _generate_category_json_schema(self) -> dict:
+        """Generate JSON schema for this category manager as a meta-tool."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.category_name,
+                "description": (
+                    f"{self.category_description} This category automatically "
+                    "selects and operates the most appropriate tool based on "
+                    "your objective and input."
+                ),
+                "parameters": {
+                    "type": "object", 
+                    "properties": {
+                        "objective": {
+                            "type": "string",
+                            "description": (
+                                "A clear and well-defined description of the goal "
+                                "you wish to accomplish using tools in this category. "
+                                "Be explicit about your intended outcome to ensure "
+                                "accurate tool selection and execution."
+                            )
+                        },
+                        "exact_input": {
+                            "type": "string",
+                            "description": (
+                                "The precise, detailed, and complete input or query "
+                                "to be processed by the selected tool. Ensure all "
+                                "relevant data, context, and execution details are "
+                                "fully provided to enable accurate tool operation."
+                            )
+                        }
+                    },
+                    "required": ["objective", "exact_input"]
+                }
+            }
+        }
+
+    @property
+    def json_schema(self) -> dict:
+        """Return the JSON schema for this category manager."""
+        return self._generate_category_json_schema()
+
+    def generate_internal_tool_json_schema(self) -> dict:
+        """Generate JSON schema for the internal tools of this category manager."""
+        return self.internal_toolkit.get_json_schemas()
+
+    def _get_prompt(
+        self,
+        prompt_type: Literal[
+            "tool_selection",
+            "tool_result_evaluation", 
+            "max_iteration_summary"
+        ]
+    ) -> str:
+        """Generate system prompt for tool selection by reading from file."""
+        # Get current directory
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        
+        # Read prompt template from file
+        prompt_file_path = os.path.join(
+            current_dir,
+            "meta_tool_prompts",
+            f"prompt_{prompt_type}.md"
+        )
+        
+        with open(prompt_file_path, "r", encoding="utf-8") as f:
+            prompt_template = f.read()
+       
+        formatted_prompt = prompt_template.format_map({
+            "category_name": self.category_name,
+        })
+        
+        # Add tool usage notes if they exist
+        if self.tool_usage_notes and self.tool_usage_notes.strip():
+            formatted_prompt += f"""
+
+## Special Tool Usage Considerations for {self.category_name}
+{self.tool_usage_notes.strip()}
+
+Please keep these considerations in mind when generating tool calls."""
+        return formatted_prompt
+
+
+    def add_internal_func_obj(
+        self,
+        func_obj:RegisteredToolFunction = None,
+        tool_group: ToolGroup = None,
+    ):
+        """
+        Add an internal func_obj to the category manager.
+        """
+        self.internal_toolkit.tools[func_obj.name] = func_obj
+
+        # Classify internal_toolkit according to the original groups of the
+        # toolkit if needed
+        if func_obj.group not in self.internal_toolkit.groups and tool_group:
+            self.internal_toolkit.groups[func_obj.group] = tool_group
+    
+    async def execute_category_task(
+        self, objective: str, exact_input: str
+    ) -> ToolResponse:
+        """
+        Core logic of category manager.
+        
+        Intelligent tool selection and execution based on objective and input.
+        """
+        try:
+            # 1. Check tool availability
+            if not self.internal_toolkit.tools:
+                return ToolResponse(
+                    content=[TextBlock(
+                        type="text",
+                        text=f"'{self.category_name}' has no available tools"
+                    )],
+                    metadata={
+                        "success": False
+                    }
+                )
+            
+            # 2. First round: tool selection (using tool_selection prompt)
+            response = await self._llm_select_tools(objective, exact_input)
+            
+            reasoning = response.get("reasoning", "")
+            tool_calls = response.get("tool_calls", [])
+            
+            # 3. Check if there are tool calls
+            if not tool_calls:
+                # No tool calls - did not select any tool due to constraint analysis
+                return ToolResponse(
+                    content=[TextBlock(
+                        type="text", 
+                        text=(
+                            f"Based on the constraint analysis, the "
+                            f"{self.category_name} category selects not to "
+                            f"perform any tool calls. \n\n Reason: {reasoning}"
+                        )
+                    )],
+                    metadata={
+                        "success": True
+                    }
+                )
+            
+            await self.memory.clear()
+            
+            # Add user request to memory
+            await self.memory.add(Msg(
+                name="user",
+                content=f"Task: {objective}\nInput: {exact_input}",
+                role="user"
+            ))
+            
+            # Add initial reasoning to memory
+            await self.memory.add(Msg(
+                name="assistant",
+                content=reasoning,
+                role="assistant"
+            ))
+            
+            all_execution_results = []
+            max_iterations = MAX_ITERATIONS
+            iteration = 0
+            
+            # 5. Execution loop
+            while iteration < max_iterations:
+                iteration += 1
+                
+                # Execute current round of tool calls
+                current_results = await self._execute_tool_calls(tool_calls)
+                all_execution_results.extend(current_results)
+                
+                # Evaluate whether to continue (using tool_result_evaluation prompt)
+                evaluation_response = await self._evaluate_tool_results(
+                    objective, exact_input
+                )
+                evaluation_text = evaluation_response.get("reasoning", "")
+                new_tool_calls = evaluation_response.get("tool_calls", [])
+                
+                # Add evaluation result to memory
+                if evaluation_text:
+                    await self.memory.add(Msg(
+                        name="assistant", 
+                        content=evaluation_text,
+                        role="assistant"
+                    ))
+                
+                # Key judgment: no new tool calls = task completed
+                if not new_tool_calls:
+                    final_output={
+                        "all_execution_results": all_execution_results,
+                        "summary": evaluation_text,
+                        "category": self.category_name,
+                    }
+                    final_output_str = json.dumps(
+                        final_output, indent=4, ensure_ascii=False
+                    )
+                    
+                    return ToolResponse(
+                        content=[TextBlock(
+                            type="text",
+                            text=final_output_str
+                        )],
+                        metadata={
+                            "success": True
+                        }
+                    )
+                
+                # Continue to next round
+                tool_calls = new_tool_calls
+            
+            # Reached maximum iterations
+            max_iter_summary = await self._generate_max_iteration_summary()
+            final_output={
+                "all_execution_results": all_execution_results,
+                "summary": max_iter_summary,
+                "category": self.category_name,
+            }
+            final_output_str = json.dumps(
+                final_output, indent=4, ensure_ascii=False
+            )
+
+            return ToolResponse(
+                content=[TextBlock(
+                    type="text",
+                    text=final_output_str
+                )],
+                metadata={
+                    "success": True
+                }
+            )
+            
+        except Exception as e:
+            return ToolResponse(
+                content=[TextBlock(
+                    type="text",
+                    text=f"{self.category_name} execution error: {str(e)}"
+                )],
+                metadata={
+                    "success": False
+                }
+            )
+        finally:
+            await self.memory.clear()
+            pass
+
+    async def _llm_select_tools(self, objective: str, exact_input: str) -> dict:
+        """
+        First round tool selection 
+        """
+        try:
+            # 1. Build prompt
+            system_prompt = self._get_prompt("tool_selection")
+            user_content = f"Task objective: {objective}\nInput data: {exact_input}"
+            
+            # 2. Format messages
+            messages = await self.formatter.format(
+                msgs=[
+                    Msg("system", system_prompt, "system"),
+                    Msg("user", user_content, "user")
+                ],
+            )
+            
+            # 3. Call model
+            tools = self.internal_toolkit.get_json_schemas()
+            res = await self.model(messages, tools=tools)
+            
+            # 4. Properly handle response (following ReActAgent)
+            msg = None
+            try:
+                if self.model.stream:
+                    # Streaming response: res is AsyncGenerator[ChatResponse]
+                    msg = Msg(self.category_name, [], "assistant")
+                    async for content_chunk in res:
+                        msg.content = content_chunk.content
+                    
+                else:
+                    # Non-streaming response: res is ChatResponse
+                    msg = Msg(self.category_name, list(res.content), "assistant")
+                
+                # 5. Parse response content
+                reasoning = ""
+                tool_calls = []
+                
+
+                if isinstance(msg.content, list):
+                    for block in msg.content:
+                        if isinstance(block, dict):
+                            if block.get("type") == "text":
+                                reasoning += block.get("text", "")
+                            elif block.get("type") == "tool_use":
+                                tool_calls.append(block)
+                
+
+                if hasattr(msg, 'get_content_blocks'):
+                    tool_calls = msg.get_content_blocks("tool_use")
+                
+                return {
+                    "reasoning": reasoning,
+                    "tool_calls": tool_calls
+                }
+                
+            except Exception as parse_error:
+                return {
+                    "reasoning": f"Response parsing failed: {str(parse_error)}",
+                    "tool_calls": []
+                }
+                
+        except Exception as e:
+            return {
+                "reasoning": f"Tool selection failed: {str(e)}",
+                "tool_calls": []
+            }
+
+    async def _evaluate_tool_results(self, objective: str, exact_input: str) -> dict:
+        """
+        Evaluate tool results
+        """
+        try:
+            # 1. Build evaluation prompt
+            system_prompt = self._get_prompt("tool_result_evaluation")
+            
+            # 2. Use complete memory history for evaluation
+            messages = await self.formatter.format(
+                msgs=[
+                    Msg("system", system_prompt, "system"),
+                    *await self.memory.get_memory()
+                ],
+            )
+            
+            # 3. Call model for evaluation
+            tools = self.internal_toolkit.get_json_schemas()
+            res = await self.model(messages, tools=tools)
+            
+            # 4. Properly handle response (following ReActAgent)
+            msg = None
+            try:
+                if self.model.stream:
+                    # Streaming response
+                    msg = Msg(self.category_name, [], "assistant")
+                    async for content_chunk in res:
+                        msg.content = content_chunk.content
+                else:
+                    # Non-streaming response
+                    msg = Msg(self.category_name, list(res.content), "assistant")
+                
+                # 5. Parse evaluation results
+                reasoning = ""
+                tool_calls = []
+                
+                # Extract content from msg.content
+                if isinstance(msg.content, list):
+                    for block in msg.content:
+                        if isinstance(block, dict):
+                            if block.get("type") == "text":
+                                reasoning += block.get("text", "")
+                            elif block.get("type") == "tool_use":
+                                tool_calls.append(block)
+                
+
+                if hasattr(msg, 'get_content_blocks'):
+                    tool_calls = msg.get_content_blocks("tool_use")
+                
+                return {
+                    "reasoning": reasoning,
+                    "tool_calls": tool_calls
+                }
+                
+            except Exception as parse_error:
+                return {
+                    "reasoning": f"Evaluation parsing failed: {str(parse_error)}",
+                    "tool_calls": []
+                }
+                
+        except Exception as e:
+            return {
+                "reasoning": f"Evaluation failed: {str(e)}",
+                "tool_calls": []
+            }
+
+    async def _generate_max_iteration_summary(self) -> str:
+        """
+        Generate intelligent summary when reaching max iterations.
+        
+        Uses LLM based on memory to generate the summary.
+        """
+        try:
+            system_prompt = self._get_prompt("max_iteration_summary")
+            
+            messages = await self.formatter.format(
+                msgs=[
+                    Msg("system", system_prompt, "system"),
+                    *await self.memory.get_memory()
+                ],
+            )
+            
+            res = await self.model(messages)  # No need for tools parameter
+            
+
+            msg = None
+            try:
+                if self.model.stream:
+                    # Streaming response
+                    msg = Msg(self.category_name, [], "assistant")
+                    async for content_chunk in res:
+                        msg.content = content_chunk.content
+                else:
+                    # Non-streaming response
+                    msg = Msg(self.category_name, list(res.content), "assistant")
+                
+                # Extract text content
+                summary_text = ""
+                if isinstance(msg.content, list):
+                    for block in msg.content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            summary_text += block.get("text", "")
+                
+                # Use get_text_content method (if available)
+                if hasattr(msg, 'get_text_content'):
+                    summary_text = msg.get_text_content()
+                
+                return summary_text or (
+                    f"Reached maximum iterations ({MAX_ITERATIONS} times). "
+                    "Summary generation succeeded but content is empty."
+                )
+                
+            except Exception as parse_error:
+                return f"Summary parsing failed: {str(parse_error)}"
+            
+        except Exception as e:
+            return (
+                f"Reached maximum iterations ({MAX_ITERATIONS} times). "
+                f"Summary generation failed: {str(e)}"
+            )
+
+    async def _execute_tool_calls(self, tool_calls: list) -> list:
+        """Execute tool calls and return results."""
+        results = []
+        
+        for tool_call in tool_calls:
+            try:
+                # Ensure tool_call is in correct ToolUseBlock format
+                if not isinstance(tool_call, dict) or "name" not in tool_call:
+                    results.append({
+                        'tool_name': 'unknown',
+                        'tool_args': {},
+                        'result': f"Invalid tool call format: {tool_call}",
+                        'status': 'ERROR'
+                    })
+                    continue
+                
+
+                tool_res = await self.internal_toolkit.call_tool_function(tool_call)
+                
+                result_chunks = []
+                async for chunk in tool_res:
+                    result_chunks.append(chunk)
+                
+                # Get final result
+                final_result = result_chunks[-1] if result_chunks else None
+                
+                # Extract content from ToolResponse
+                if final_result and hasattr(final_result, 'content'):
+                    result_text = ""
+                    for content_block in final_result.content:
+                        if (isinstance(content_block, dict) and 
+                            content_block.get("type") == "text"):
+                            result_text += content_block.get("text", "")
+                    
+                    result_content = (
+                        result_text or "Execution successful but no text output"
+                    )
+                else:
+                    result_content = "No result"
+                
+                # Record result
+                results.append({
+                    'tool_name': tool_call['name'],
+                    'tool_args': tool_call.get('input', {}),
+                    'result': result_content,
+                    'status': 'SUCCESS' if final_result else 'ERROR'
+                })
+                
+                # Add to memory (simplified format)
+                await self.memory.add(Msg(
+                    name="tool_result",
+                    content=f"Executed {tool_call['name']}: {result_content}",
+                    role="system"
+                ))
+                
+            except Exception as e:
+                error_msg = f"Error: {str(e)}"
+                results.append({
+                    'tool_name': tool_call.get('name', 'unknown'),
+                    'tool_args': tool_call.get('input', {}),
+                    'result': error_msg,
+                    'status': 'ERROR'
+                })
+                
+                await self.memory.add(Msg(
+                    name="tool_result",
+                    content=(
+                        f"Tool {tool_call.get('name', 'unknown')} failed: "
+                        f"{error_msg}"
+                    ),
+                    role="system"
+                ))
+        
+        return results
+
+class MetaManager(Toolkit):
+    """Level 3 Meta Manager - Manages Level 2 Category Managers."""
+
+    def __init__(self):
+        # self.toolkit manages the external interface of category manager.
+        # The internal routing is by self.category_managers
+        super().__init__()
+        self.category_managers: Dict[str, CategoryManager] = {}
+    
+    def add_category_manager(self, category_manager: CategoryManager):
+        """Add a complete category manager"""
+        category_name = category_manager.category_name
+        if category_name in self.category_managers:
+            raise ValueError(f"Category {category_name} already exists")
+
+        self.category_managers[category_name] = category_manager
+
+        # category_schema is the external schema exposed to the agent and does
+        # not contain any internal tools information
+        category_schema = category_manager.json_schema
+        
+        # Create a renamable function copy
+        async def named_executor(objective: str, exact_input: str) -> ToolResponse:
+            """
+            Wrapper function that forwards calls to the corresponding
+            category_manager.
+            """
+            return await category_manager.execute_category_task(objective, exact_input)
+            
+        # Set function name as category_name
+        named_executor.__name__ = category_name
+        named_executor.__doc__ = f"{category_manager.category_description}"
+        
+        # Key: Register the execution function of CategoryManager as a tool
+        self.register_tool_function(
+            named_executor,
+            json_schema=category_schema
+        )

--- a/examples/Meta_tools/example.py
+++ b/examples/Meta_tools/example.py
@@ -1,0 +1,175 @@
+import asyncio
+import contextlib
+import json
+import os
+
+from agentscope.agent import ReActAgent, UserAgent
+from agentscope.formatter import DashScopeChatFormatter
+from agentscope.mcp import StdIOStatefulClient, HttpStatefulClient
+from agentscope.memory import InMemoryMemory
+from agentscope.model import DashScopeChatModel
+from agentscope.tool import Toolkit, execute_python_code, execute_shell_command
+
+from Meta_toolkit import CategoryManager, MetaManager
+
+
+def init_meta_tool_from_intact_file(
+    model_config_name: str,
+    file_path: str = "Meta_tool_config.json",
+    global_toolkit: Toolkit = None,
+):
+    """
+    Initialize a meta manager from a complete tool configuration file.
+
+    All tools from the global toolkit are added to their respective category
+    managers, inheriting group information from the global toolkit. Within each
+    category manager, only tools whose groups are marked as active in the global
+    toolkit are visible, following the same visibility mechanism as in
+    AgentScope.
+    """
+
+    current_dir = os.path.dirname(os.path.realpath(__file__))
+    meta_tool_config_path = os.path.join(current_dir, file_path)
+    with open(meta_tool_config_path, "r") as f:
+        meta_tool_config = json.load(f)
+
+    meta_manager = MetaManager()
+
+    model = DashScopeChatModel(
+        model_name=model_config_name,
+        api_key=os.environ["DASHSCOPE_API_KEY"],
+        stream=True,
+    )
+
+    for category_name, category_config in meta_tool_config.items():
+        category_manager = CategoryManager(
+            category_name=category_name,
+            category_description=category_config["description"],
+            tool_usage_notes=category_config["tool_usage_notes"],
+            model=model,
+            formatter=DashScopeChatFormatter(),
+        )
+        for tool_name in category_config["tools"]:
+            if tool_name not in global_toolkit.tools:
+                print(f"Tool {tool_name} not found in global toolkit")
+                continue
+
+            tool_func_obj = global_toolkit.tools[tool_name]
+            if tool_func_obj.group == "basic":
+                category_manager.add_internal_func_obj(
+                    func_obj=tool_func_obj,
+                )
+            else:
+                category_manager.add_internal_func_obj(
+                    func_obj=tool_func_obj,
+                    tool_group=global_toolkit.groups[tool_func_obj.group],
+                )
+
+        if not category_manager.internal_toolkit.tools:
+            print(f"Category {category_name} has no tools, skip it")
+            continue
+
+        meta_manager.add_category_manager(category_manager=category_manager)
+
+    return meta_manager
+
+
+async def main():
+    # Create global toolkit with your tools
+    toolkit = Toolkit()
+    toolkit.register_tool_function(execute_python_code)
+    toolkit.register_tool_function(execute_shell_command)
+
+    toolkit.create_tool_group(
+        "map_tools", "Tools related to Gaode map", active=True
+    )
+    # If a group's 'active' flag is set to False, its tools will be registered
+    # to toolkit but remain hidden
+
+    gaode_client = HttpStatefulClient(
+        name="amap-sse",
+        transport="sse",
+        url="https://mcp.amap.com/sse?key={YOUR_AMAP_API_KEY}",
+        # get your own API keys from Gaode MCP servers
+    )
+    bing_client = HttpStatefulClient(
+        name="bing-cn-mcp-server",
+        transport="sse",
+        url="https://mcp.api-inference.modelscope.net/{YOUR_BING_API_KEY}/sse",
+        # get your own API keys from Modelscope's Bing MCP servers
+    )
+    train_client = HttpStatefulClient(
+        name="12306-mcp",
+        transport="sse",
+        url="https://mcp.api-inference.modelscope.net/{YOUR_12306_API_KEY}/sse",
+        # get your own API keys from Modelscope's train 12306 MCP servers
+    )
+    try:
+        try:
+            await gaode_client.connect()
+            await toolkit.register_mcp_client(
+                gaode_client, group_name="map_tools"
+            )
+            print("Gaode MCP client connected successfully")
+        except Exception as e:
+            print(f"Failed to connect Gaode MCP client: {e}")
+
+        try:
+            await bing_client.connect()
+            await toolkit.register_mcp_client(bing_client)
+            print("Bing MCP client connected successfully")
+        except Exception as e:
+            print(f"Failed to connect Bing MCP client: {e}")
+
+        try:
+            await train_client.connect()
+            await toolkit.register_mcp_client(train_client)
+            print("12306 MCP client connected successfully")
+        except Exception as e:
+            print(f"Failed to connect 12306 MCP client: {e}")
+
+        # Initialize meta manager from configuration
+        meta_manager = init_meta_tool_from_intact_file(
+            model_config_name="qwen-max",
+            global_toolkit=toolkit,
+        )
+
+        # Use meta_manager directly as toolkit for ReActAgent
+        agent = ReActAgent(
+            name="Friday",
+            sys_prompt="You're a helpful assistant named Friday.",
+            model=DashScopeChatModel(
+                model_name="qwen-max",
+                api_key=os.environ["DASHSCOPE_API_KEY"],
+                stream=True,
+            ),
+            memory=InMemoryMemory(),
+            formatter=DashScopeChatFormatter(),
+            toolkit=meta_manager,  # Direct replacement for traditional toolkit
+        )
+
+        user = UserAgent(name="user")
+
+        msg = None
+        try:
+            while True:
+                msg = await agent(msg)
+                msg = await user(msg)
+                if msg.get_text_content() == "exit":
+                    break
+        except Exception as e:
+            print(f"Error: {e}")
+
+        return
+
+    finally:
+        with contextlib.suppress(Exception):
+            await train_client.close()
+        with contextlib.suppress(Exception):
+            await bing_client.close()
+        with contextlib.suppress(Exception):
+            await gaode_client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/Meta_tools/meta_tool_prompts/prompt_max_iteration_summary.md
+++ b/examples/Meta_tools/meta_tool_prompts/prompt_max_iteration_summary.md
@@ -1,0 +1,11 @@
+You are an intelligent summarizer for the {category_name} category. You need to analyze and summarize the complete tool execution history and provide a comprehensive summary of what was accomplished and what remains incomplete.
+
+## Task
+Based on the conversation history, provide a concise but comprehensive summary that includes:
+1. **What was accomplished**: Summarize the successful tool executions and their key outputs
+2. **What remains incomplete**: Identify any unfinished aspects of the user's original objective
+
+## Important Notes
+- Be specific about what outputs/results are available for the user
+- Avoid technical details about iterations - focus on valuable information
+- Keep the summary concise but informative

--- a/examples/Meta_tools/meta_tool_prompts/prompt_tool_result_evaluation.md
+++ b/examples/Meta_tools/meta_tool_prompts/prompt_tool_result_evaluation.md
@@ -1,0 +1,40 @@
+## Instruction
+You are an intelligent agent responsible for evaluating the execution results of tool_calls within the {category_name} category. Your job is to carefully analyze the user's objective and input data, assess whether the current tool execution results have successfully fulfilled the task, and determine whether further tool_calls are necessary. If necessary, directly call the most appropriate tool to further accomplish the task.
+
+## Evaluation Guidelines
+
+Carefully Compare the execution results against the user's objective and input data.
+
+**If the user's task is not complete**: 
+
+If the previous tool results are incomplete or inadequate for user's task, directly call the most appropriate tool to accomplish the remaining task. 
+
+**If the user's task is complete**:
+
+- Synthesize a clear and informative summary that connects the core results of all executed tools with the user’s original objective and input. **Do not generate any new tool_calls.**
+
+## Important Notes
+
+1. If there are unresolved parts of the task **and** there are tools in this category capable of addressing them, you **must** directly call the most appropriate tool. Only generate **one** new tool_call at a time.
+
+- Always consider the results and context of previous tools when generating a new tool call — build on prior execution history to avoid redundancy and ensure progress.
+
+2. If a previous tool call returned an Error:
+
+- Carefully analyze the error message to determine its cause.
+
+- If caused by incorrect or incomplete parameters, fix the parameters accordingly and retry with the appropriate tool.
+
+- If caused by other unknown issues, consider **switching to another suitable tool** in this category and map its parameters correctly.
+
+3. If you determine that the user's objective has been fully satisfied, **Do not** generate any new tool calls . Only respond with a well-organized summary.
+
+4. If multiple similar tasks were required by user and part of them were successfully completed by current tool, consider reusing the same tool with different args to finish the remaining parts when generating tool calls.
+
+- If the result quality is poor or inadequate due to limitations of the current tool, consider switching to other more suitable tool when generating tool calls.
+
+5. Thoughtfully adapt and assign the user's remaining **objective** and **input data** to the correct parameters for the selected tool. - Consider both required and optional parameters when making the tool call.
+
+6. Do not hallucinate or assume the output of any tool that has not yet been executed. Only include tool call schema — do not provide analysis based on imaginary results!!!!
+
+7. **Do not attempt to engage in dialogue or ask the user for clarification** — your job is to independently plan and structure what tool should be called.

--- a/examples/Meta_tools/meta_tool_prompts/prompt_tool_selection.md
+++ b/examples/Meta_tools/meta_tool_prompts/prompt_tool_selection.md
@@ -1,0 +1,20 @@
+## Task
+You are an intelligent tool selector for the {category_name} category. Your job is to carefully analyze the user's objective and input data, then directly call the most appropriate tool(s) to accomplish the task. 
+
+## Selection Guidelines
+1. **Functional Relevance**: Select the tool(s) whose description best matches the user's stated objective
+2. **Input Compatibility**: Ensure the selected tool(s) can handle the provided input format
+3. **Parameter Mapping**: Map the user's objective and input to the corresponding parameters in the tool's schema. Interpret **both** required and optional parameters based on tool descriptions
+
+## Important Notes
+- You have access to detailed descriptions and parameter schemas for all tools in this category
+- Carefully compare the functionality and parameter requirements of each tool before making a decision
+- Thoughtfully adapt and assign the user's **objective** and **input data** to the correct parameters for the selected tool
+- Consider both required and optional parameters when making the tool call 
+
+## Strict Constraints
+- Only use tools from the provided list. **Do not invent, assume, or call any tools not explicitly defined in this category.**
+
+- If any required input content are missing or insufficient, do not generate tool calls. Instead, respond with detailed content of all missing or ambiguous elements needed to proceed.
+
+- If no tool in this category can accomplish the task due to functional limitations, do not generate tool calls. Instead, explain clearly why none of the tools in this category are suitable, and offer suggestions for other possible categories or actions to solve the objective.

--- a/examples/Meta_tools/readme.md
+++ b/examples/Meta_tools/readme.md
@@ -1,0 +1,131 @@
+# Meta Tools System for AgentScope
+
+Meta Tools is an innovative extension for AgentScope designed to manage and invoke large, diverse toolsets efficiently.
+By using a layered architecture, it drastically reduces context length, lowers cognitive load, and improves tool selection accuracy.
+
+## Background
+
+In the native AgentScope framework, the `Toolkit` exposes all active tools directly to a `ReActAgent`. While this approach works well for smaller tool sets, it faces significant challenges when dealing with numerous and diverse tools:
+
+1. **Excessive Context Length** – Long prompts reduce LLM reasoning efficiency
+2. **Cognitive Overload** – The agent must handle tasks *and* search through a large tool pool, which hurts performance
+
+## Our Solution: Three-Layer Meta Tools Architecture
+
+Meta Tools organizes tools into functional categories and applies intelligent selection within each category.
+From the main agent’s perspective, only high-level categories are visible — the actual tools are selected internally.
+
+```
+┌─────────────────────────┐
+│ Level 3: MetaManager    │ ← Exposed to main agent, shows categories only
+└──────────┬──────────────┘
+           │
+┌──────────▼──────────────┐
+│ Level 2: CategoryManager│ ← Manages category tools, multi-round reasoning
+└──────────┬──────────────┘
+           │
+┌──────────▼──────────────┐
+│ Level 1: Normal Tool    │ ← MCP tools, built-ins, custom functions
+└─────────────────────────┘
+```
+
+**Benefits**:
+
+- **Reduced Context Length**: Main agent only sees category-level abstractions, not individual tools
+- **Improved Selection Accuracy**: Specialized prompts and focused tool sets enhance selection precision
+- **Scalable Architecture**: System performance remains stable as tool count increases
+- **Agent-Level Decoupling**: Separates detailed tool selection from the agent, enabling focus on task decomposition and state monitoring  
+
+## How to Run This Example
+
+**Environment**
+
+* **LLM API Key**: Configure your environment variable:
+```bash
+export DASHSCOPE_API_KEY="your_dashscope_api_key"
+```
+**MCP Service Setup**
+
+* **Gaode Maps** (Navigation): [Gaode Open Platform](https://lbs.amap.com/)
+* **Bing Search** (Information Retrieval): [ModelScope MCP Service](https://www.modelscope.cn/mcp/servers/@yan5236/bing-cn-mcp-server)
+* **12306 Train Services** (Information Retrieval): [ModelScope MCP Service](https://www.modelscope.cn/mcp/servers/@Joooook/12306-mcp)
+
+Update your sse API keys in `example.py`.
+
+**Run Example**
+
+   ```bash
+   python example.py
+   ```
+
+The system automatically constructs the Meta Tool System based on the categories and tool descriptions defined in `Meta_tool_config.json`, and launches an interactive agent named Friday to assist you with various tasks across three main categories: Information Retrieval, Programming & Tech Support, and Location & Navigation. 
+For example, you can try a prompt like:  
+`I'm going to drive from West Lake in Hangzhou to Zhoushan. Please give me the driving route and a travel guide for Zhoushan.`  
+
+
+## Key Features
+
+### 1. Unified Interface Design
+From the external agent's perspective, each `CategoryManager` appears as a standard tool function with consistent schema:
+
+```json
+{
+    "type": "function",
+    "function": {
+        "name": "<category_name>",
+        "description": "<category_description> This category automatically selects and operates the most appropriate tool based on your objective and input.",
+        "parameters": {
+            "type": "object", 
+            "properties": {
+                "objective": {
+                    "type": "string",
+                    "description": "A clear and well-defined description of the goal you wish to accomplish using tools in this category."
+                },
+                "exact_input": {
+                    "type": "string",
+                    "description": "The precise, detailed, and complete input or query to be processed by the selected tool."
+                }
+            },
+            "required": ["objective", "exact_input"]
+        }
+    }
+}
+```
+
+From the main agent’s perspective, it only needs to call the corresponding high-level category tool and provide the `objective` and `exact_input` parameters to receive a complete and detailed execution flow along with a summary—without having to worry about which specific Level 1 tools were executed behind the scenes.
+
+### 2. Intelligent Multi-Round Execution
+
+* **Select → Execute → Evaluate → Continue/Summarize**: Each category starts by selecting the most suitable tool, executes it, evaluates the result, and decides whether to proceed with further actions or produce a final summary  
+* **Isolated in-category memory context**: Maintains a dedicated memory space for each category, preserving execution history and reasoning steps without polluting the main agent’s context  
+* **Automatic recovery on failure with fallback tools**: If a selected tool fails, the system automatically retries with alternative tools and adjusted parameters to ensure task completion  
+
+### 3. Configuration-Driven Setup
+Once tools are added to the global toolkit, they are grouped into meta categories via `Meta_tool_config.json`:
+```json
+{
+    "Information Retrieval": {
+        "description": "...",
+        "tool_usage_notes": "...",
+        "tools": [...]
+    }
+}
+```
+In the default configuration, `Meta_tool_config.json` defines a basic categorization for the MCP tools used in `example.py`.
+
+### 4. Execution Situations
+- **Normal Execution**: Complete execution history with results and comprehensive summaries
+
+The Meta Tool system includes robust countermeasures for all potential issues it may encounter:
+
+- **Insufficient Input**: Detailed explanation of missing required elements without tool execution
+- **No Suitable Tools**: Clear reasoning about functional limitations with alternative suggestions, without tool execution
+- **Execution Failures**: Automatic error recovery with alternative tool selection and parameter adjustment
+
+## Advanced Customization
+
+* **Custom Categories**: Edit `Meta_tool_config.json` to create new functional domains or reorganize existing tools into different categories  
+* **Custom Prompts**: Modify the selection, evaluation, and summary templates in `meta_tool_prompts/` to adapt reasoning behavior for specific domains or workflows  
+* **New Tools**: Integrate additional MCP services, built-in AgentScope tools, or custom local functions, and assign them to the most relevant categories for seamless integration  
+
+You can freely integrate multiple custom tools into the system, organize them into your own Meta Tool categories, and tailor the workflow to your needs—give it a try and explore the possibilities!  


### PR DESCRIPTION
## AgentScope Version
v.0.2.0

## Description
Meta Tools is an innovative extension for AgentScope designed to manage and invoke large, diverse toolsets efficiently. By using a layered architecture, it drastically reduces context length, lowers cognitive load, and improves tool selection accuracy.

Background
In the native AgentScope framework, the Toolkit exposes all active tools directly to a ReActAgent. While this approach works well for smaller tool sets, it faces significant challenges when dealing with numerous and diverse tools:

Excessive Context Length – Long prompts reduce LLM reasoning efficiency
Cognitive Overload – The agent must handle tasks and search through a large tool pool, which hurts performance
Our Solution: Three-Layer Meta Tools Architecture
Meta Tools organizes tools into functional categories and applies intelligent selection within each category. From the main agent’s perspective, only high-level categories are visible — the actual tools are selected internally.

The readme contains guidelines on how to complete the example.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review

ALL SET