### PR TITLE
[Lightweight Bugfix] Fix when init Msg class, error calling function logger.chat

### DIFF
--- a/src/agentscope/message/msg.py
+++ b/src/agentscope/message/msg.py
@@ -172,7 +172,7 @@ class Msg(BaseModel):
         )
 
         if echo:
-            logger.chat(self)
+            logger.info(self)
 
     def to_dict(self) -> dict:
         """Serialize the message into a dictionary, which can be

--- a/src/agentscope/message/msg.py
+++ b/src/agentscope/message/msg.py
@@ -172,7 +172,10 @@ class Msg(BaseModel):
         )
 
         if echo:
-            logger.info(self)
+            if hasattr(logger, "chat"):
+                logger.chat(self)
+            else:
+                logger.info(self)
 
     def to_dict(self) -> dict:
         """Serialize the message into a dictionary, which can be

--- a/tests/logger_test.py
+++ b/tests/logger_test.py
@@ -8,12 +8,13 @@ import unittest
 import datetime
 import uuid
 
+from unittest.mock import patch
 from loguru import logger
 
 from agentscope.logging import setup_logger
 from agentscope.manager import ASManager
 from agentscope.message import Msg
-from unittest.mock import patch
+
 
 
 class LoggerTest(unittest.TestCase):

--- a/tests/logger_test.py
+++ b/tests/logger_test.py
@@ -16,7 +16,6 @@ from agentscope.manager import ASManager
 from agentscope.message import Msg
 
 
-
 class LoggerTest(unittest.TestCase):
     """
     Unit test for logger.
@@ -60,17 +59,32 @@ class LoggerTest(unittest.TestCase):
         fix_uuid_obj = uuid.UUID(fix_uuid_str)
         fix_uuid_hex = fix_uuid_obj.hex
         fixed_time = datetime.datetime(2025, 9, 1)  # 固定时间
-        with patch('datetime.datetime') as mock_datetime, \
-             patch('uuid.uuid4') as mock_uuid:
+        with patch("datetime.datetime") as mock_datetime, patch(
+            "uuid.uuid4"
+        ) as mock_uuid:
             mock_datetime.now.return_value = fixed_time
             mock_uuid.return_value = fix_uuid_obj
-            msg5 = Msg("Villege", "test for msg init echo logger.chat", "system", echo=True)
-            msg6 = Msg("Villege", "test for msg init echo logger.chat", "system", echo=False)
+            msg5 = Msg(
+                "Villege",
+                "test for msg init echo logger.chat",
+                "system",
+                echo=True,
+            )
+            msg6 = Msg(
+                "Villege",
+                "test for msg init echo logger.chat",
+                "system",
+                echo=False,
+            )
 
         self.assertEqual(msg5.id, fix_uuid_hex)
-        self.assertEqual(msg5.timestamp, fixed_time.strftime("%Y-%m-%d %H:%M:%S"))
+        self.assertEqual(
+            msg5.timestamp, fixed_time.strftime("%Y-%m-%d %H:%M:%S")
+        )
         self.assertEqual(msg6.id, fix_uuid_hex)
-        self.assertEqual(msg6.timestamp, fixed_time.strftime("%Y-%m-%d %H:%M:%S"))
+        self.assertEqual(
+            msg6.timestamp, fixed_time.strftime("%Y-%m-%d %H:%M:%S")
+        )
 
         logger.chat(msg1)
         logger.chat(msg2)
@@ -129,7 +143,7 @@ class LoggerTest(unittest.TestCase):
                 '"__name__": "Msg", "id": "4ebf0fd267904f9998e45438bf9ca4ae", '
                 '"name": "Villege", "role": "system", '
                 '"content": "test for msg init echo logger.chat", '
-                '"metadata": null, "timestamp": "2025-09-01 00:00:00"}\n'
+                '"metadata": null, "timestamp": "2025-09-01 00:00:00"}\n',
             ],
         ):
             self.assertDictEqual(json.loads(line), json.loads(ground_truth))

--- a/tests/logger_test.py
+++ b/tests/logger_test.py
@@ -5,12 +5,15 @@ import os
 import shutil
 import time
 import unittest
+import datetime
+import uuid
 
 from loguru import logger
 
 from agentscope.logging import setup_logger
 from agentscope.manager import ASManager
 from agentscope.message import Msg
+from unittest.mock import patch
 
 
 class LoggerTest(unittest.TestCase):
@@ -51,10 +54,29 @@ class LoggerTest(unittest.TestCase):
         msg4.id = 4
         msg4.timestamp = 4
 
+        # cover test msg init print logger.info and logger.chat
+        fix_uuid_str = "4ebf0fd2-6790-4f99-98e4-5438bf9ca4ae"
+        fix_uuid_obj = uuid.UUID(fix_uuid_str)
+        fix_uuid_hex = fix_uuid_obj.hex
+        fixed_time = datetime.datetime(2025, 9, 1)  # 固定时间
+        with patch('datetime.datetime') as mock_datetime, \
+             patch('uuid.uuid4') as mock_uuid:
+            mock_datetime.now.return_value = fixed_time
+            mock_uuid.return_value = fix_uuid_obj
+            msg5 = Msg("Villege", "test for msg init echo logger.chat", "system", echo=True)
+            msg6 = Msg("Villege", "test for msg init echo logger.chat", "system", echo=False)
+
+        self.assertEqual(msg5.id, fix_uuid_hex)
+        self.assertEqual(msg5.timestamp, fixed_time.strftime("%Y-%m-%d %H:%M:%S"))
+        self.assertEqual(msg6.id, fix_uuid_hex)
+        self.assertEqual(msg6.timestamp, fixed_time.strftime("%Y-%m-%d %H:%M:%S"))
+
         logger.chat(msg1)
         logger.chat(msg2)
         logger.chat(msg3)
         logger.chat(msg4)
+        logger.chat(msg5)
+        logger.chat(msg6)
 
         # To avoid that logging is not finished before the file is read
         time.sleep(2)
@@ -69,6 +91,11 @@ class LoggerTest(unittest.TestCase):
         for line, ground_truth in zip(
             lines,
             [
+                '{"__module__": "agentscope.message.msg", '
+                '"__name__": "Msg", "id": "4ebf0fd267904f9998e45438bf9ca4ae", '
+                '"name": "Villege", "role": "system", '
+                '"content": "test for msg init echo logger.chat", '
+                '"metadata": null, "timestamp": "2025-09-01 00:00:00"}\n',
                 '{"__module__": "agentscope.message.msg", '
                 '"__name__": "Msg", "id": 1, "name": "abc", '
                 '"role": "assistant", '
@@ -92,6 +119,16 @@ class LoggerTest(unittest.TestCase):
                 '"role": "system", '
                 '"content": "<red>abc</div", "metadata": null, '
                 '"timestamp": 4}\n',
+                '{"__module__": "agentscope.message.msg", '
+                '"__name__": "Msg", "id": "4ebf0fd267904f9998e45438bf9ca4ae", '
+                '"name": "Villege", "role": "system", '
+                '"content": "test for msg init echo logger.chat", '
+                '"metadata": null, "timestamp": "2025-09-01 00:00:00"}\n',
+                '{"__module__": "agentscope.message.msg", '
+                '"__name__": "Msg", "id": "4ebf0fd267904f9998e45438bf9ca4ae", '
+                '"name": "Villege", "role": "system", '
+                '"content": "test for msg init echo logger.chat", '
+                '"metadata": null, "timestamp": "2025-09-01 00:00:00"}\n'
             ],
         ):
             self.assertDictEqual(json.loads(line), json.loads(ground_truth))

--- a/tests/logger_test.py
+++ b/tests/logger_test.py
@@ -60,7 +60,7 @@ class LoggerTest(unittest.TestCase):
         fix_uuid_hex = fix_uuid_obj.hex
         fixed_time = datetime.datetime(2025, 9, 1)  # 固定时间
         with patch("datetime.datetime") as mock_datetime, patch(
-            "uuid.uuid4"
+            "uuid.uuid4",
         ) as mock_uuid:
             mock_datetime.now.return_value = fixed_time
             mock_uuid.return_value = fix_uuid_obj
@@ -79,11 +79,13 @@ class LoggerTest(unittest.TestCase):
 
         self.assertEqual(msg5.id, fix_uuid_hex)
         self.assertEqual(
-            msg5.timestamp, fixed_time.strftime("%Y-%m-%d %H:%M:%S")
+            msg5.timestamp,
+            fixed_time.strftime("%Y-%m-%d %H:%M:%S"),
         )
         self.assertEqual(msg6.id, fix_uuid_hex)
         self.assertEqual(
-            msg6.timestamp, fixed_time.strftime("%Y-%m-%d %H:%M:%S")
+            msg6.timestamp,
+            fixed_time.strftime("%Y-%m-%d %H:%M:%S"),
         )
 
         logger.chat(msg1)


### PR DESCRIPTION
… logger.info

## AgentScope Version

AgentScope Version : v0

## Description

[Console Error Log]
  File "/Users/syrianazh/Desktop/pyWorkSpace/agentscope/src/agentscope/message/msg.py", line 175, in __init__
    logger.chat(self)
    ^^^^^^^^^^^
AttributeError: 'Logger' object has no attribute 'chat'

[Path]
https://github.com/agentscope-ai/agentscope/blob/v0/src/agentscope/message/msg.py#L175

[Cause]
I wanted to do some MCP test with logger print,  When I Init a ReActAgent with config parameter [verbose:true] and registry a [MCP service_toolkit], and then i calling agent(x) speak to agent. The calling step will execute to https://github.com/agentscope-ai/agentscope/blob/v0/src/agentscope/agents/_react_agent.py#L157 , in _reasoning(self) fuctions will new init a Msg use ReActAgent verbose param value assign to Msg echo param. And then when calling Msg init then logger.chat throw The Error. May be a careless coding.

[fix]
change logger.chat to logger.info


## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review