### PR TITLE
feat: improve logging setup by validating level

### DIFF
--- a/src/agentscope/_logging.py
+++ b/src/agentscope/_logging.py
@@ -25,6 +25,11 @@ def setup_logger(
         filepath (`str | None`, optional):
             The filepath to save the logging output.
     """
+    if level not in ["INFO", "DEBUG", "WARNING", "ERROR", "CRITICAL"]:
+        raise ValueError(
+            f"Invalid logging level: {level}. Must be one of "
+            f"'INFO', 'DEBUG', 'WARNING', 'ERROR', 'CRITICAL'.",
+        )
     logger.handlers.clear()
     logger.setLevel(level)
     handler = logging.StreamHandler()


### PR DESCRIPTION
## AgentScope Version

[The version of AgentScope you are working on, e.g. `import agentscope; print(agentscope.__version__)`]


   - Added a check in the setup_logger function to validate that the provided level is one of "INFO", "DEBUG","WARNING", "ERROR", or "CRITICAL".
   - If an invalid level is provided, a ValueError is raised with a clear error message indicating the valid options.
[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review