### PR TITLE
[WIP] Separate the "plan" from the meta planner example and make it an independent module

### DIFF
--- a/examples/functionality/plan/main.py
+++ b/examples/functionality/plan/main.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""The main entry point of the plan example."""
+import asyncio
+import os
+
+from agentscope.agent import ReActAgent, UserAgent
+from agentscope.formatter import DashScopeChatFormatter
+from agentscope.model import DashScopeChatModel
+from agentscope.plan import PlanNotebook
+from agentscope.tool import (
+    Toolkit,
+    execute_shell_command,
+    execute_python_code,
+    write_text_file,
+    insert_text_file,
+    view_text_file,
+)
+
+
+async def main() -> None:
+    """The main entry point for the plan example."""
+    toolkit = Toolkit()
+    toolkit.register_tool_function(execute_shell_command)
+    toolkit.register_tool_function(execute_python_code)
+    toolkit.register_tool_function(write_text_file)
+    toolkit.register_tool_function(insert_text_file)
+    toolkit.register_tool_function(view_text_file)
+
+    agent = ReActAgent(
+        name="Friday",
+        sys_prompt="""You're a helpful assistant named Friday.
+
+# Target
+Your target is to finish the given task with careful planning.
+
+# Note
+- You can equip yourself with plan related tools to help you plan and execute the given task.
+- For simple tasks you can directly execute them without planning.
+- For complex tasks, e.g. programming a website, game, or app, you MUST create a plan first.
+- Once a plan is created, try your best to follow the plan and finish the task step by step.
+- If the task requires further clarification, ask the user for more information. Otherwise, don't stop until the task is completed.
+""",  # noqa
+        model=DashScopeChatModel(
+            model_name="qwen-max",
+            api_key=os.environ["DASHSCOPE_API_KEY"],
+        ),
+        formatter=DashScopeChatFormatter(),
+        toolkit=toolkit,
+        plan_notebook=PlanNotebook(),
+    )
+
+    user = UserAgent(name="User")
+
+    msg = None
+    while True:
+        msg = await user(msg)
+        if msg.get_text_content() == "exit":
+            break
+        msg = await agent(msg)
+
+
+asyncio.run(main())

--- a/examples/react_agent/main.py
+++ b/examples/react_agent/main.py
@@ -17,6 +17,9 @@ from agentscope.tool import (
 
 async def main() -> None:
     """The main entry point for the ReAct agent example."""
+    import agentscope
+
+    agentscope.init(tracing_url="")
     toolkit = Toolkit()
     toolkit.register_tool_function(execute_shell_command)
     toolkit.register_tool_function(execute_python_code)

--- a/src/agentscope/mcp/_stateful_client_base.py
+++ b/src/agentscope/mcp/_stateful_client_base.py
@@ -79,10 +79,10 @@ class StatefulClientBase(MCPClientBase, ABC):
             )
 
         try:
-            if self.stack:
-                await self.stack.aclose()
-
+            await self.stack.aclose()
             logger.info("MCP client closed.")
+        except Exception as e:
+            logger.warning("Error during MCP client cleanup: %s", e)
         finally:
             self.stack = None
             self.session = None

--- a/src/agentscope/plan/__init__.py
+++ b/src/agentscope/plan/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+"""The plan module in AgentScope."""
+from ._plan_model import (
+    SubTask,
+    Plan,
+)
+from ._plan_notebook import (
+    ReasoningHints,
+    PlanNotebook,
+)
+from ._storage_base import PlanStorageBase
+from ._in_memory_storage import InMemoryPlanStorage
+
+__all__ = [
+    "SubTask",
+    "Plan",
+    "ReasoningHints",
+    "PlanNotebook",
+    "PlanStorageBase",
+    "InMemoryPlanStorage",
+]

--- a/src/agentscope/plan/_in_memory_storage.py
+++ b/src/agentscope/plan/_in_memory_storage.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""The in-memory plan storage class."""
+from ._plan_model import Plan
+from .._logging import logger
+from ._storage_base import PlanStorageBase
+
+
+class InMemoryPlanStorage(PlanStorageBase):
+    """In-memory plan storage."""
+
+    def __init__(self) -> None:
+        """Initialize the in-memory plan storage."""
+        super().__init__()
+        self.plans = []
+
+    async def add_plan(self, plan: Plan) -> None:
+        """Add a plan to the storage.
+
+        Args:
+            plan (`Plan`):
+                The plan to be added.
+        """
+        self.plans.append(plan)
+
+    async def delete_plan(self, plan_name: str) -> None:
+        """Delete a plan from the storage.
+
+        Args:
+            plan_name (`str`):
+                The name of the plan to be deleted.
+        """
+        index = None
+        for i, plan in enumerate(self.plans):
+            if plan.name == plan_name:
+                index = i
+                break
+
+        if index is not None:
+            self.plans.pop(index)
+        else:
+            logger.warning("Plan with name '%s' not found", plan_name)
+
+    async def get_plans(self) -> list[Plan]:
+        """Get all plans from the storage.
+
+        Returns:
+            `list[Plan]`:
+                A list of all plans in the storage.
+        """
+        return self.plans

--- a/src/agentscope/plan/_plan_model.py
+++ b/src/agentscope/plan/_plan_model.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+"""The models used in the plan module."""
+from typing import Literal
+
+import shortuuid
+from pydantic import BaseModel, Field
+
+from .._utils._common import _get_timestamp
+
+
+class SubTask(BaseModel):
+    """The subtask model used in the plan module."""
+
+    name: str = Field(
+        description=(
+            "The subtask name, should be concise, descriptive and not"
+            "exceed 10 words."
+        ),
+    )
+    description: str = Field(
+        description=(
+            "The subtask description, including the constraints, target and "
+            "outcome to be achieved. The description should be clear, "
+            "specific and concise, and all the constraints, target and "
+            "outcome should be specific and measurable."
+        ),
+    )
+    expected_outcome: str = Field(
+        description=(
+            "The expected outcome of the subtask, which should be specific, "
+            "concrete and measurable."
+        ),
+    )
+    outcome: str | None = Field(
+        description="The actual outcome of the subtask.",
+        exclude=True,
+        default=None,
+    )
+    state: Literal["todo", "in_progress", "done", "deprecated"] = Field(
+        description="The state of the subtask.",
+        default="todo",
+        exclude=True,
+    )
+    created_at: str = Field(
+        description="The time the subtask was created.",
+        default_factory=_get_timestamp,
+    )
+    # Result related fields
+    finished_at: str | None = Field(
+        description="The time the subtask was finished.",
+        default=None,
+        exclude=True,
+    )
+
+    def finish(self, outcome: str) -> None:
+        """Finish the subtask with the actual outcome."""
+        self.state = "done"
+        self.outcome = outcome
+        self.finished_at = _get_timestamp()
+
+    def to_oneline_markdown(self) -> str:
+        """Convert the subtask to MarkDown format."""
+        status_map = {
+            "todo": "- []",
+            "in_progress": "- [][WIP]",
+            "done": "- [x]",
+            "deprecated": "- [][Deprecated]",
+        }
+        return f"{status_map[self.state]} {self.name}"
+
+    def to_markdown(self, detailed: bool = False) -> str:
+        """Convert the subtask to MarkDown format.
+
+        Args:
+            detailed (`bool`, defaults to `False`):
+                Whether to include detailed information about the subtask.
+        """
+        status_map = {
+            "todo": "- [ ] ",
+            "in_progress": "- [ ] [WIP]",
+            "done": "- [x] ",
+            "deprecated": "- [ ] [Deprecated]",
+        }
+
+        if detailed:
+            markdown_strs = [
+                f"{status_map[self.state]}{self.name}",
+                f"\t- Created At: {self.created_at}",
+                f"\t- Description: {self.description}",
+                f"\t- Expected Outcome: {self.expected_outcome}",
+                f"\t- State: {self.state}",
+            ]
+
+            if self.state == "done":
+                markdown_strs.extend(
+                    [
+                        f"\t- Finished At: {self.finished_at}",
+                        f"\t- Actual Outcome: {self.outcome}",
+                    ],
+                )
+
+            return "\n".join(markdown_strs)
+
+        return f"{status_map[self.state]}{self.name}"
+
+
+class Plan(BaseModel):
+    """The plan model used in the plan module, contains a list of subtasks."""
+
+    id: str = Field(exclude=True, default_factory=shortuuid.uuid)
+    name: str = Field(
+        description=(
+            "The plan name, should be concise, descriptive and not exceed 10 "
+            "words."
+        ),
+    )
+    description: str = Field(
+        description=(
+            "The plan description, including the constraints, target and "
+            "outcome to be achieved. The description should be clear, "
+            "specific and concise, and all the constraints, target and "
+            "outcome should be specific and measurable."
+        ),
+    )
+    expected_outcome: str = Field(
+        description=(
+            "The expected outcome of the plan, which should be specific, "
+            "concrete and measurable."
+        ),
+    )
+    subtasks: list[SubTask] = Field(
+        description=("A list of subtasks that make up the plan."),
+    )
+    created_at: str = Field(
+        description="The time the plan was created.",
+        default_factory=_get_timestamp,
+        exclude=True,
+    )
+    state: Literal["todo", "in_progress", "done", "deprecated"] = Field(
+        description="The state of the plan.",
+        default="todo",
+        exclude=True,
+    )
+    finished_at: str | None = Field(
+        description="The time the plan was finished.",
+        default=None,
+        exclude=True,
+    )
+    outcome: str | None = Field(
+        description="The actual outcome of the plan.",
+        default=None,
+        exclude=True,
+    )
+
+    def finish(self, outcome: str) -> None:
+        """Finish the plan."""
+        self.state = "done"
+        self.outcome = outcome
+        self.finished_at = _get_timestamp()
+
+    def to_markdown(self, detailed: bool = False) -> str:
+        """Convert the plan to MarkDown format."""
+        subtasks_markdown = "\n".join(
+            [
+                subtask.to_markdown(
+                    detailed=detailed,
+                )
+                for subtask in self.subtasks
+            ],
+        )
+
+        return "\n".join(
+            [
+                f"# {self.name}",
+                f"**Description**: {self.description}",
+                f"**Expected Outcome**: {self.expected_outcome}",
+                f"**State**: {self.state}",
+                f"**Created At**: {self.created_at}",
+                "## Subtasks",
+                subtasks_markdown,
+            ],
+        )

--- a/src/agentscope/plan/_plan_notebook.py
+++ b/src/agentscope/plan/_plan_notebook.py
@@ -1,0 +1,630 @@
+# -*- coding: utf-8 -*-
+"""The plan notebook class, used to manage the plan, providing hints and
+tool functions to the agent."""
+from collections import OrderedDict
+from typing import Callable, Literal, Coroutine, Any
+
+from pydantic import BaseModel
+
+from ._plan_model import SubTask, Plan
+from ._storage_base import PlanStorageBase
+from ..message import TextBlock, Msg
+from ..module import StateModule
+from ..tool import ToolResponse
+
+
+class ReasoningHints(BaseModel):
+    """The hints to be inserted before the agent's reasoning process to
+    guide the agent on next steps."""
+
+    hint_prefix: str = "<system-hint>"
+    hint_suffix: str = "</system-hint>"
+
+    at_the_beginning: str = (
+        "Currently, you have a plan as follows:\n"
+        "```\n"
+        "{plan}\n"
+        "```\n"
+        "Your options include\n"
+        "- mark the first subtask as 'in_progress' by calling "
+        "update_subtask_state with subtask_idx=0 and state='in_progress', "
+        "and start executing it.\n"
+        "- If the first subtask cannot be executed directly, you can ask the "
+        "user for more information or revise the plan by calling "
+        "'revise_current_plan'.\n"
+    )
+
+    when_a_subtask_in_progress: str = (
+        "Currently, you have a plan as follows:\n"
+        "```\n"
+        "{plan}\n"
+        "```\n"
+        "Now the subtask at index {subtask_idx}, named {subtask_name}, is "
+        "'in_progress'. Its details are as follows:\n"
+        "```\n"
+        "{subtask}\n"
+        "```\n"
+        "Your options include:\n"
+        "- execute the subtask and get the outcome.\n"
+        "- if you finish it, call 'finish_subtask' with the specific "
+        "outcome.\n"
+        "- ask the user for more information if you need.\n"
+        "- revise the plan by calling 'revise_current_plan' if necessary.\n"
+    )
+
+    when_no_subtask_in_progress: str = (
+        "Currently, you have a plan as follows:\n"
+        "```\n"
+        "{plan}\n"
+        "```\n"
+        "The first {index} subtasks are done, and there is no subtask "
+        "'in_progress'. Now Your options are:\n"
+        "- update the next subtask as 'in_progress' by calling "
+        "'update_subtask_state', and start executing it.\n"
+        "- ask the user for more information if you need.\n"
+        "- revise the plan by calling 'revise_current_plan' if necessary.\n"
+    )
+
+    at_the_end: str = (
+        "Currently, you have a plan as follows:\n"
+        "```\n"
+        "{plan}\n"
+        "```\n"
+        "All the subtasks are done. Now your options are:\n"
+        "- finish the plan by calling 'finish_plan' with the specific "
+        "outcome, and summarize the whole process and outcome to the user.\n"
+        "- revise the plan by calling 'revise_current_plan' if necessary.\n"
+    )
+
+
+class PlanNotebook(StateModule):
+    """The plan notebook to manage the plan, providing hints and plan related
+    tool functions to the agent."""
+
+    _plan_change_hooks: dict[str, Callable[["PlanNotebook", Plan], None]]
+    """The hooks that will be triggered when the plan is changed. For example,
+    used to display the plan on the frontend."""
+
+    description: str = (
+        "The plan-related tools. Activate this tool when you need to execute "
+        "complex task, e.g. building a website or a game. Once activated, "
+        "you'll enter the plan mode, where you will be guided to complete "
+        "the given query by creating and following a plan, and hint message "
+        "wrapped by <system-hint></system-hint> will guide you to complete "
+        "the task. If you think the user no longer wants to perform the "
+        "current task, you need to confirm with the user and call the "
+        "`finish_plan` function."
+    )
+
+    def __init__(
+        self,
+        max_tasks: int | None = None,
+        max_iters_per_task: int = 50,
+        hints: ReasoningHints | None = None,
+        storage: PlanStorageBase | None = None,
+    ) -> None:
+        """Initialize the plan notebook.
+
+        Args:
+            max_tasks (`int | None`, optional):
+                The maximum number of subtasks in a plan.
+            max_iters_per_task (`int`, defaults to 50):
+                The maximum number of iterations for each subtask. If
+                exceeded, the sub-task will be marked as failed.
+            hints (`ReasoningHints | None`, optional):
+                The hints to guide the agent before reasoning. If not provided,
+                a default hint will be used.
+            storage (`PlanStorageBase | None`, optional):
+                The plan storage. If not provided, an in-memory storage will
+                be used.
+        """
+        super().__init__()
+
+        self.max_tasks = max_tasks
+        self.max_iters_per_task = max_iters_per_task
+        self.hints = hints or ReasoningHints()
+        self.storage = storage or PlanStorageBase()
+
+        self.current_plan: Plan | None = None
+
+        self._plan_change_hooks = OrderedDict()
+
+    async def create_plan(
+        self,
+        name: str,
+        description: str,
+        expected_outcome: str,
+        subtasks: list[SubTask],
+    ) -> ToolResponse:
+        """Create a plan by given name and sub-tasks.
+
+        Args:
+            name (`str`):
+                The plan name, should be concise, descriptive and not exceed
+                10 words.
+            description (`str`):
+                The plan description, including the constraints, target and
+                outcome to be achieved. The description should be clear,
+                specific and concise, and all the constraints, target and
+                outcome should be specific and measurable.
+            expected_outcome (`str`):
+                The expected outcome of the plan, which should be specific,
+                concrete and measurable.
+            subtasks (`list[SubTask]`):
+                A list of sequential sub-tasks that make up the plan.
+
+        Returns:
+            `ToolResponse`:
+                The response of the tool call.
+        """
+        plan = Plan(
+            name=name,
+            description=description,
+            expected_outcome=expected_outcome,
+            subtasks=subtasks,
+        )
+        await self.storage.add_plan(plan)
+
+        if self.current_plan is None:
+            self.current_plan = plan
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=f"Plan '{name}' created successfully.",
+                    ),
+                ],
+            )
+        else:
+            self.current_plan = plan
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=(
+                            "The current plan named "
+                            f"'{self.current_plan.name}' is replaced by the "
+                            f"newly created plan named '{name}'."
+                        ),
+                    ),
+                ],
+            )
+
+    def _validate_current_plan(self) -> None:
+        """Validate the current plan."""
+        if self.current_plan is None:
+            raise ValueError(
+                "The current plan is None, you need to create a plan by "
+                "calling create_plan() first.",
+            )
+
+    async def revise_current_plan(
+        self,
+        subtask_idx: int,
+        action: Literal["add", "revise", "delete"],
+        subtask: SubTask | None = None,
+    ) -> ToolResponse:
+        """Revise the current plan by adding, revising or deleting a sub-task.
+
+        Args:
+            subtask_idx (`int`):
+                The index of the sub-task to be revised, starting from 0.
+            action (`Literal["add", "revise", "delete"]`):
+                The action to be performed on the sub-task. If "add", the
+                sub-task will be inserted before the given index. If "revise",
+                the sub-task at the given index will be revised. If "delete",
+                the sub-task at the given index will be deleted.
+            subtask (`SubTask | None`, optional):
+                The sub-task to be added or revised. Required if action is
+                "add" or "revise".
+
+        Raises:
+            `ValueError`:
+                If the current plan is `None`, `ValueError` will be raised.
+
+        Returns:
+            `ToolResponse`:
+                The response of the tool call.
+        """
+        if action not in ["add", "revise", "delete"]:
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=f"Invalid action '{action}'. Must be one of "
+                        "'add', 'revise', 'delete'.",
+                    ),
+                ],
+            )
+
+        if action in ["add", "revise"] and subtask is None:
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=f"The subtask must be provided when action is "
+                        f"'{action}', but got None.",
+                    ),
+                ],
+            )
+
+        self._validate_current_plan()
+
+        # validate subtask_idx
+        if subtask_idx >= len(self.current_plan.subtasks):
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=f"Invalid subtask_idx '{subtask_idx}'. Must "
+                        f"be between 0 and "
+                        f"{len(self.current_plan.subtasks) - 1}.",
+                    ),
+                ],
+            )
+
+        if action == "delete":
+            subtask = self.current_plan.subtasks.pop(subtask_idx)
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=f"Subtask (named {subtask.name}) at index "
+                        f"{subtask_idx} is deleted successfully.",
+                    ),
+                ],
+            )
+
+        if action == "add" and subtask:
+            self.current_plan.subtasks.insert(subtask_idx, subtask)
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=f"New subtask is added successfully at index "
+                        f"{subtask_idx}.",
+                    ),
+                ],
+            )
+
+        self.current_plan.subtasks[subtask_idx] = subtask
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text=f"Subtask at index {subtask_idx} is revised "
+                    f"successfully.",
+                ),
+            ],
+        )
+
+    async def update_subtask_state(
+        self,
+        subtask_idx: int,
+        state: Literal["todo", "in_progress", "deprecated"],
+    ) -> ToolResponse:
+        """Update the state of a subtask by given index and state. Note if you
+        want to mark a subtask as done, you SHOULD call `finish_subtask`
+        instead with the specific outcome.
+
+        Args:
+            subtask_idx (`int`):
+                The index of the subtask to be updated, starting from 0.
+            state (`Literal["todo", "in_progress", "deprecated"]`):
+                The new state of the subtask. If you want to mark a subtask
+                as done, you SHOULD call `finish_subtask` instead with the
+                specific outcome.
+        """
+        self._validate_current_plan()
+
+        if not 0 <= subtask_idx < len(self.current_plan.subtasks):
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=f"Invalid subtask_idx '{subtask_idx}'. Must "
+                        f"be between 0 and "
+                        f"{len(self.current_plan.subtasks) - 1}.",
+                    ),
+                ],
+            )
+
+        if state not in ["todo", "in_progress", "deprecated"]:
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=f"Invalid state '{state}'. Must be one of "
+                        "'todo', 'in_progress', 'deprecated'.",
+                    ),
+                ],
+            )
+
+        # Only one subtask can be in_progress at a time
+        if state == "in_progress":
+            # Check only one subtask is in_progress
+            for idx, subtask in enumerate(self.current_plan.subtasks):
+                # Check all previous subtasks are done or deprecated
+                if idx < subtask_idx and subtask.state not in [
+                    "done",
+                    "deprecated",
+                ]:
+                    return ToolResponse(
+                        content=[
+                            TextBlock(
+                                type="text",
+                                text=(
+                                    f"Subtask (at index {idx}) named "
+                                    f"{subtask.name} is not done yet. You "
+                                    "should finish the previous subtasks "
+                                    "first."
+                                ),
+                            ),
+                        ],
+                    )
+
+                # Check no other subtask is in_progress
+                if subtask.state == "in_progress":
+                    return ToolResponse(
+                        content=[
+                            TextBlock(
+                                type="text",
+                                text=(
+                                    f"Subtask (at index {idx}) named "
+                                    f"{subtask.name} is already "
+                                    "'in_progress'. You should finish it "
+                                    "first before starting another subtask."
+                                ),
+                            ),
+                        ],
+                    )
+
+        self.current_plan.subtasks[subtask_idx].state = state
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text=f"Subtask at index {subtask_idx}, named "
+                    f"'{self.current_plan.subtasks[subtask_idx].name}' "
+                    f"is marked as '{state}' successfully.",
+                ),
+            ],
+        )
+
+    async def finish_subtask(
+        self,
+        subtask_idx: int,
+        subtask_outcome: str,
+    ) -> ToolResponse:
+        """Label the subtask as done by given index and outcome.
+
+        Args:
+            subtask_idx (`int`):
+                The index of the sub-task to be marked as done, starting
+                from 0.
+            subtask_outcome (`str`):
+                The specific outcome of the sub-task, should exactly match the
+                expected outcome in the sub-task description.
+        """
+        self._validate_current_plan()
+
+        if not 0 <= subtask_idx < len(self.current_plan.subtasks):
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=f"Invalid subtask_idx '{subtask_idx}'. Must "
+                        f"be between 0 and "
+                        f"{len(self.current_plan.subtasks) - 1}.",
+                    ),
+                ],
+            )
+
+        for idx, subtask in enumerate(
+            self.current_plan.subtasks[0:subtask_idx],
+        ):
+            if subtask.state not in ["done", "deprecated"]:
+                return ToolResponse(
+                    content=[
+                        TextBlock(
+                            type="text",
+                            text=(
+                                "Cannot finish subtask at index "
+                                f"{subtask_idx} because the previous "
+                                f"subtask (at index {idx}) named "
+                                f"{subtask.name} is not done yet. You "
+                                "should finish the previous subtasks first."
+                            ),
+                        ),
+                    ],
+                )
+
+        # Label the subtask as done
+        self.current_plan.subtasks[subtask_idx].finish(subtask_outcome)
+        # Auto activate the next subtask if exists
+        if subtask_idx + 1 < len(self.current_plan.subtasks):
+            self.current_plan.subtasks[subtask_idx + 1].state = "in_progress"
+            next_subtask = self.current_plan.subtasks[subtask_idx + 1]
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=(
+                            f"Subtask (at index {subtask_idx}) named "
+                            f"'{self.current_plan.subtasks[subtask_idx].name}'"
+                            " is marked as done successfully. The next "
+                            f"subtask named {next_subtask.name} is activated."
+                        ),
+                    ),
+                ],
+            )
+
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text=(
+                        f"Subtask (at index {subtask_idx}) named "
+                        f"'{self.current_plan.subtasks[subtask_idx].name}'"
+                        " is marked as done successfully. "
+                    ),
+                ),
+            ],
+        )
+
+    async def view_subtasks(self, subtask_idx: list[int]) -> ToolResponse:
+        """View the details of the sub-tasks by given indexes.
+
+        Args:
+            subtask_idx (`list[int]`):
+                The indexes of the sub-tasks to be viewed, starting from 0.
+        """
+        self._validate_current_plan()
+
+        gathered_strs = []
+        invalid_subtask_idx = []
+        for idx in subtask_idx:
+            if not 0 <= idx < len(self.current_plan.subtasks):
+                invalid_subtask_idx.append(idx)
+                continue
+
+            subtask_markdown = self.current_plan.subtasks[idx].to_markdown(
+                detailed=True,
+            )
+            gathered_strs.append(
+                f"Subtask at index {idx}:\n"
+                "```\n"
+                f"{subtask_markdown}\n"
+                "```\n",
+            )
+
+        if invalid_subtask_idx:
+            gathered_strs.append(
+                f"Invalid subtask_idx '{invalid_subtask_idx}'. Must be "
+                f"between 0 and {len(self.current_plan.subtasks) - 1}.",
+            )
+
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text="\n".join(gathered_strs),
+                ),
+            ],
+        )
+
+    def list_tools(
+        self,
+    ) -> list[Callable[..., Coroutine[Any, Any, ToolResponse]]]:
+        """List all tool functions provided to agent
+
+        Returns:
+            `list[Callable[..., ToolResponse]]`:
+                A list of all tool functions provided by the plan notebook to
+                the agent.
+        """
+        return [
+            self.create_plan,
+            self.view_subtasks,
+            self.revise_current_plan,
+            self.update_subtask_state,
+            self.finish_subtask,
+        ]
+
+    def get_current_hint(self) -> Msg | None:
+        """Get the hint message based on the current plan and subtasks
+        states.
+
+        - If all subtasks are "todo", return the 'at_the_beginning' hint of
+        the ReasoningHints.
+        - If one subtask is "in_progress", return the
+        'when_a_subtask_in_progress' hint of the ReasoningHints.
+        - If no subtask is "in_progress", and some subtasks are "done",
+        return the 'when_no_subtask_in_progress' hint of the ReasoningHints.
+        - If all subtasks are "done", return the 'at_the_end' hint of the
+        ReasoningHints.
+        """
+        if self.current_plan is None:
+            return None
+
+        n_todo, n_in_progress, n_done, n_deprecated = 0, 0, 0, 0
+
+        in_progress_subtask_idx = None
+        for idx, subtask in enumerate(self.current_plan.subtasks):
+            match subtask.state:
+                case "todo":
+                    n_todo += 1
+                case "in_progress":
+                    n_in_progress += 1
+                    in_progress_subtask_idx = idx
+                case "done":
+                    n_done += 1
+                case "deprecated":
+                    n_deprecated += 1
+                case _:
+                    raise ValueError(
+                        f"Invalid subtask state '{subtask.state}'.",
+                    )
+
+        content = None
+        if n_todo == len(self.current_plan.subtasks):
+            content = self.hints.at_the_beginning.format(
+                plan=self.current_plan.to_markdown(),
+            )
+
+        elif in_progress_subtask_idx:
+            subtask = self.current_plan.subtasks[in_progress_subtask_idx]
+            content = self.hints.when_a_subtask_in_progress.format(
+                plan=self.current_plan.to_markdown(),
+                subtask_idx=in_progress_subtask_idx,
+                subtask_name=subtask.name,
+                subtask=subtask.to_markdown(detailed=True),
+            )
+
+        elif n_in_progress == 0:
+            content = self.hints.when_no_subtask_in_progress.format(
+                plan=self.current_plan.to_markdown(),
+                index=n_done,
+            )
+
+        elif n_done == len(self.current_plan.subtasks):
+            content = self.hints.at_the_end.format(
+                plan=self.current_plan.to_markdown(),
+            )
+
+        if content:
+            return Msg(
+                "user",
+                content,
+                "user",
+            )
+        return None
+
+    def register_plan_change_hook(
+        self,
+        hook_name: str,
+        hook: Callable[["PlanNotebook", Plan], None],
+    ) -> None:
+        """Register a plan hook that will be triggered when the plan is
+        changed.
+
+        Args:
+            hook_name (`str`):
+                The name of the hook, should be unique.
+            hook (`Callable[[Plan], None]`):
+                The hook function, which takes the current plan as input and
+                returns nothing.
+        """
+        self._plan_change_hooks[hook_name] = hook
+
+    def remove_plan_change_hook(self, hook_name: str) -> None:
+        """Remove a plan change hook by given name.
+
+        Args:
+            hook_name (`str`):
+                The name of the hook to be removed.
+        """
+        if hook_name in self._plan_change_hooks:
+            self._plan_change_hooks.pop(hook_name)
+        else:
+            raise ValueError(f"Hook '{hook_name}' not found.")

--- a/src/agentscope/plan/_storage_base.py
+++ b/src/agentscope/plan/_storage_base.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""The base class for plan storage."""
+from abc import abstractmethod
+
+from agentscope.module import StateModule
+from agentscope.plan._plan_model import Plan
+
+
+class PlanStorageBase(StateModule):
+    """The base class for plan storage."""
+
+    @abstractmethod
+    async def add_plan(self, plan: Plan) -> None:
+        """Add a plan to the storage."""
+
+    @abstractmethod
+    async def delete_plan(self, plan_name: str) -> None:
+        """Delete a plan from the storage."""
+
+    @abstractmethod
+    async def get_plans(self) -> list[Plan]:
+        """Get all plans from the storage."""

--- a/tests/plan_test.py
+++ b/tests/plan_test.py
@@ -1,0 +1,260 @@
+# -*- coding: utf-8 -*-
+"""The plan module related tests."""
+from unittest import IsolatedAsyncioTestCase
+
+from agentscope.plan import SubTask, Plan, PlanNotebook
+
+
+class PlanTest(IsolatedAsyncioTestCase):
+    """Test the plan module."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up the test case."""
+        self.subtask1 = SubTask(
+            name="Task 1",
+            description="Description 1",
+            expected_outcome="Expected outcome 1",
+            state="done",
+        )
+
+        self.subtask2 = SubTask(
+            name="Task 2",
+            description="Description 2",
+            expected_outcome="Expected outcome 2",
+            state="in_progress",
+        )
+
+        self.subtask3 = SubTask(
+            name="Task 3",
+            description="Description 3",
+            expected_outcome="Expected outcome 3",
+            state="todo",
+        )
+
+        self.plan = Plan(
+            name="Create website",
+            description="Create a personal portfolio website.",
+            expected_outcome="A new personal portfolio website is created on "
+            "GitHub.",
+            subtasks=[self.subtask1, self.subtask2, self.subtask3],
+        )
+
+    async def test_plan_model(self) -> None:
+        """Test the models used in plan module."""
+
+        self.assertEqual(
+            self.subtask1.to_markdown(detailed=True),
+            f"""- [x] Task 1
+\t- Created At: {self.subtask1.created_at}
+\t- Description: Description 1
+\t- Expected Outcome: Expected outcome 1
+\t- State: done
+\t- Finished At: None
+\t- Actual Outcome: None""",
+        )
+
+        self.assertEqual(
+            self.subtask1.to_markdown(detailed=False),
+            """- [x] Task 1""",
+        )
+
+        self.assertEqual(
+            self.plan.to_markdown(detailed=True),
+            f"""# Create website
+**Description**: Create a personal portfolio website.
+**Expected Outcome**: A new personal portfolio website is created on GitHub.
+**State**: todo
+**Created At**: {self.plan.created_at}
+## Subtasks
+- [x] Task 1
+\t- Created At: {self.subtask1.created_at}
+\t- Description: Description 1
+\t- Expected Outcome: Expected outcome 1
+\t- State: done
+\t- Finished At: None
+\t- Actual Outcome: None
+- [ ] [WIP]Task 2
+\t- Created At: {self.subtask2.created_at}
+\t- Description: Description 2
+\t- Expected Outcome: Expected outcome 2
+\t- State: in_progress
+- [ ] Task 3
+\t- Created At: {self.subtask3.created_at}
+\t- Description: Description 3
+\t- Expected Outcome: Expected outcome 3
+\t- State: todo""",
+        )
+
+        self.assertEqual(
+            self.plan.to_markdown(detailed=True),
+            f"""# Create website
+**Description**: Create a personal portfolio website.
+**Expected Outcome**: A new personal portfolio website is created on GitHub.
+**State**: todo
+**Created At**: {self.plan.created_at}
+## Subtasks
+- [x] Task 1
+\t- Created At: {self.subtask1.created_at}
+\t- Description: Description 1
+\t- Expected Outcome: Expected outcome 1
+\t- State: done
+\t- Finished At: None
+\t- Actual Outcome: None
+- [ ] [WIP]Task 2
+\t- Created At: {self.subtask2.created_at}
+\t- Description: Description 2
+\t- Expected Outcome: Expected outcome 2
+\t- State: in_progress
+- [ ] Task 3
+\t- Created At: {self.subtask3.created_at}
+\t- Description: Description 3
+\t- Expected Outcome: Expected outcome 3
+\t- State: todo""",
+        )
+
+    async def test_plan_subtasks(self) -> None:
+        """Test the plan and subtask models."""
+        plan_notebook = PlanNotebook()
+
+        self.assertListEqual(
+            [_.__name__ for _ in await plan_notebook.list_tools()],
+            [
+                "create_plan",
+                "view_subtasks",
+                "revise_current_plan",
+                "update_subtask_state",
+                "finish_subtask",
+            ],
+        )
+
+        plan_hint = await plan_notebook.get_current_hint()
+        self.assertIsNone(plan_hint)
+
+        res = await plan_notebook.create_plan(
+            name="Example Plan",
+            description="Example Description",
+            expected_outcome="Example Expected Outcome",
+            subtasks=[self.subtask1, self.subtask2, self.subtask3],
+        )
+        self.assertEqual(
+            res.content[0]["text"],
+            "Plan 'Example Plan' created successfully.",
+        )
+
+        res = await plan_notebook.view_subtasks([3])
+        self.assertEqual(
+            res.content[0]["text"],
+            "Invalid subtask_idx '[3]'. Must be between 0 and 2.",
+        )
+        res = await plan_notebook.view_subtasks([0, 2])
+        self.assertEqual(
+            res.content[0]["text"],
+            f"""Subtask at index 0:
+```
+- [x] Task 1
+\t- Created At: {self.subtask1.created_at}
+\t- Description: Description 1
+\t- Expected Outcome: Expected outcome 1
+\t- State: done
+\t- Finished At: None
+\t- Actual Outcome: None
+```
+
+Subtask at index 2:
+```
+- [ ] Task 3
+\t- Created At: {self.subtask3.created_at}
+\t- Description: Description 3
+\t- Expected Outcome: Expected outcome 3
+\t- State: todo
+```
+""",
+        )
+
+        await plan_notebook.revise_current_plan(
+            1,
+            action="add",
+            subtask=SubTask(
+                name="Task 11",
+                description="Description 11",
+                expected_outcome="Expected outcome 11",
+            ),
+        )
+        self.assertEqual(
+            plan_notebook.current_plan.subtasks[1].name,
+            "Task 11",
+        )
+        self.assertEqual(
+            len(plan_notebook.current_plan.subtasks),
+            4,
+        )
+
+        res = await plan_notebook.revise_current_plan(
+            1,
+            "delete",
+        )
+        self.assertEqual(
+            res.content[0]["text"],
+            "Subtask (named Task 11) at index 1 is deleted successfully.",
+        )
+        self.assertEqual(
+            len(plan_notebook.current_plan.subtasks),
+            3,
+        )
+
+        res = await plan_notebook.revise_current_plan(
+            1,
+            "revise",
+            subtask=SubTask(
+                name="Task 22",
+                description="Description 22",
+                expected_outcome="Expected outcome 22",
+            ),
+        )
+        self.assertEqual(
+            res.content[0]["text"],
+            "Subtask at index 1 is revised successfully.",
+        )
+        self.assertEqual(
+            plan_notebook.current_plan.subtasks[1].name,
+            "Task 22",
+        )
+        self.assertEqual(
+            len(plan_notebook.current_plan.subtasks),
+            3,
+        )
+
+        res = await plan_notebook.update_subtask_state(
+            2,
+            "in_progress",
+        )
+        self.assertEqual(
+            res.content[0]["text"],
+            "Subtask (at index 1) named Task 22 is not done yet. "
+            "You should finish the previous subtasks first.",
+        )
+
+        await plan_notebook.update_subtask_state(0, "in_progress")
+        res = await plan_notebook.update_subtask_state(
+            1,
+            "in_progress",
+        )
+        self.assertEqual(
+            res.content[0]["text"],
+            "Subtask (at index 0) named Task 1 is not done yet. You "
+            "should finish the previous subtasks first.",
+        )
+
+        res = await plan_notebook.finish_subtask(
+            0,
+            "Fake outcome for task 1",
+        )
+        self.assertEqual(
+            res.content[0]["text"],
+            "Subtask (at index 0) named 'Task 1' is marked as done "
+            "successfully. The next subtask named Task 22 is activated.",
+        )
+        self.assertEqual(
+            plan_notebook.current_plan.subtasks[1].state,
+            "in_progress",
+        )


### PR DESCRIPTION
## AgentScope Version

1.0.1

## Description

- We separate the plan from the meta planner example as an independent module that be compitable with the other features.
- The ReAct agent
  - A new `reasoning_hint_msg` attribute is added, as an instance of ``InMemoryMemory`` class to store the guiding messages, which will be cleared after reasoning
  - Add `plan_notebook` as input argument in its constructor

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review