### PR TITLE
Add optional compression for session state in JSONSession

### DIFF
--- a/docs/tutorial/en/src/task_state.py
+++ b/docs/tutorial/en/src/task_state.py
@@ -213,3 +213,22 @@ asyncio.run(example_load_session())
 # %%
 # Now we can see the agent state is restored to the saved state.
 #
+
+# %%
+# Using JSONSession with compression
+# -----------------------------------------
+# The `JSONSession` class also supports optional compression for session data to save storage space.
+session = JSONSession(
+    session_id="session_2025-08-08",
+    save_dir="./user-bob/",
+    compress=True  # Enable compression for session data
+)
+
+async def example_compressed_session() -> None:
+    """Example of saving and loading session state with compression."""
+    await session.save_session_state(agent=agent)
+    print("Compressed session state saved.")
+    await session.load_session_state(agent=agent)
+    print("Compressed session state loaded.")
+
+asyncio.run(example_compressed_session())

--- a/src/agentscope/session/_json_session.py
+++ b/src/agentscope/session/_json_session.py
@@ -2,6 +2,7 @@
 """The JSON session class."""
 import json
 import os
+import zlib
 
 from ._session_base import SessionBase
 from ..module import StateModule
@@ -10,17 +11,20 @@ from ..module import StateModule
 class JSONSession(SessionBase):
     """The JSON session class."""
 
-    def __init__(self, session_id: str, save_dir: str) -> None:
-        """Initialize the JSON session class.
+    def __init__(self, session_id: str, save_dir: str, compress: bool = False) -> None:
+        """Initialize the JSON session class with optional compression.
 
         Args:
             session_id (`str`):
                 The session id.
             save_dir (`str`):
                 The directory to save the session state.
+            compress (`bool`):
+                Whether to enable compression for session data.
         """
         super().__init__(session_id=session_id)
         self.save_dir = save_dir
+        self.compress = compress
 
     @property
     def save_path(self) -> str:
@@ -32,7 +36,7 @@ class JSONSession(SessionBase):
         self,
         **state_modules_mapping: StateModule,
     ) -> None:
-        """Load the state dictionary from a JSON file.
+        """Save the state dictionary to a JSON file with optional compression.
 
         Args:
             **state_modules_mapping (`dict[str, StateModule]`):
@@ -42,22 +46,36 @@ class JSONSession(SessionBase):
             name: state_module.state_dict()
             for name, state_module in state_modules_mapping.items()
         }
-        with open(self.save_path, "w", encoding="utf-8") as file:
-            json.dump(state_dicts, file, ensure_ascii=False)
+        data = json.dumps(state_dicts, ensure_ascii=False).encode("utf-8")
+        if self.compress:
+            data = zlib.compress(data)
+        with open(
+            self.save_path,
+            "wb" if self.compress else "w",
+            encoding=None if self.compress else "utf-8",
+        ) as file:
+            file.write(data)
 
     async def load_session_state(
         self,
         **state_modules_mapping: StateModule,
     ) -> None:
-        """Get the state dictionary to be saved to a JSON file.
+        """Load the state dictionary from a JSON file with optional decompression.
 
         Args:
             state_modules_mapping (`list[StateModule]`):
                 The list of state modules to be loaded.
         """
         if os.path.exists(self.save_path):
-            with open(self.save_path, "r", encoding="utf-8") as file:
-                states = json.load(file)
+            with open(
+                self.save_path,
+                "rb" if self.compress else "r",
+                encoding=None if self.compress else "utf-8",
+            ) as file:
+                data = file.read()
+                if self.compress:
+                    data = zlib.decompress(data).decode("utf-8")
+                states = json.loads(data)
 
             for name, state_module in state_modules_mapping.items():
                 if name in states:

--- a/src/agentscope/session/_json_session.py
+++ b/src/agentscope/session/_json_session.py
@@ -11,7 +11,9 @@ from ..module import StateModule
 class JSONSession(SessionBase):
     """The JSON session class."""
 
-    def __init__(self, session_id: str, save_dir: str, compress: bool = False) -> None:
+    def __init__(
+        self, session_id: str, save_dir: str, compress: bool = False
+    ) -> None:
         """Initialize the JSON session class with optional compression.
 
         Args:
@@ -54,7 +56,10 @@ class JSONSession(SessionBase):
             "wb" if self.compress else "w",
             encoding=None if self.compress else "utf-8",
         ) as file:
-            file.write(data)
+            if self.compress:
+                file.write(data)  # Write bytes directly for compressed data
+            else:
+                file.write(data.decode("utf-8"))  # Decode bytes to string for uncompressed data
 
     async def load_session_state(
         self,

--- a/tests/session_test.py
+++ b/tests/session_test.py
@@ -76,6 +76,42 @@ class SessionTest(IsolatedAsyncioTestCase):
 
         await session.save_session_state(agent1=agent1, agent2=agent2)
 
+    async def test_session_with_compression(self) -> None:
+        """Test the JSONSession class with compression enabled."""
+        session = JSONSession(
+            "user_1_compressed",
+            save_dir="./",
+            compress=True,  # Enable compression
+        )
+
+        agent1 = ReActAgent(
+            name="Friday",
+            sys_prompt="A helpful assistant.",
+            model=DashScopeChatModel(api_key="xxx", model_name="qwen_max"),
+            formatter=DashScopeChatFormatter(),
+            toolkit=Toolkit(),
+            memory=InMemoryMemory(),
+        )
+        agent2 = MyAgent()
+
+        await agent2.memory.add(
+            Msg(
+                "Alice",
+                "Hi!",
+                "user",
+            ),
+        )
+
+        # Save session state with compression
+        await session.save_session_state(agent1=agent1, agent2=agent2)
+
+        # Load session state with compression
+        await session.load_session_state(agent1=agent1, agent2=agent2)
+
+        # Verify that the state was loaded correctly
+        memory_content = await agent2.memory.get_memory()
+        self.assertEqual(memory_content[0].content, "Hi!")
+
     async def asyncTearDown(self) -> None:
         """Clean up after the test."""
         # Remove the session file if it exists


### PR DESCRIPTION
## AgentScope Version

1.0.1

## Description

This pull request introduces support for session data compression in the [JSONSession](vscode-file://vscode-app/c:/Users/aashi/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) class within the [session](vscode-file://vscode-app/c:/Users/aashi/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) module. The changes include:

Adding an optional `compress` parameter to the `JSONSession` class to enable or disable compression.
Using the `zlib` library for compressing and decompressing session data.
Updating the `save_session_state` and `load_session_state` methods to handle compressed data appropriately.
Adding test cases to validate the functionality of session data compression.
Additionally, related documentation has been updated to reflect the new feature, including examples and changelog entries.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review