### PR TITLE
fix: correct handling of non-existent file in insert_text_file

### DIFF
--- a/src/agentscope/tool/_text_file/_write_text_file.py
+++ b/src/agentscope/tool/_text_file/_write_text_file.py
@@ -42,8 +42,6 @@ async def insert_text_file(
         )
 
     if not os.path.exists(file_path):
-        with open(file_path, "w", encoding="utf-8") as file:
-            file.write(content + "\n")
         return ToolResponse(
             content=[
                 TextBlock(


### PR DESCRIPTION
## AgentScope Version

[v1.0.1]

## Description

[The insert_text_file function had a logical error: when the target file did not exist, it would create the file and then return an error message. This was inconsistent and likely a leftover from early implementation. I advised to adopt a scheme: return an error without creating the file. This maintains clear boundaries between functions - write_text_file is responsible for creating new files, while insert_text_file only works on existing files.]

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review