### PR TITLE
Fix Gemini formatter local file mime_type from image/* to proper medi…

### DIFF
--- a/tests/formatter_gemini_test.py
+++ b/tests/formatter_gemini_test.py
@@ -245,7 +245,7 @@ class TestGeminiFormatter(IsolatedAsyncioTestCase):
                     {
                         "inline_data": {
                             "data": "ZmFrZSBhdWRpbyBjb250ZW50",
-                            "mime_type": "image/mp3",
+                            "mime_type": "audio/mp3",
                         },
                     },
                 ],
@@ -338,7 +338,7 @@ class TestGeminiFormatter(IsolatedAsyncioTestCase):
                     {
                         "inline_data": {
                             "data": "ZmFrZSBhdWRpbyBjb250ZW50",
-                            "mime_type": "image/mp3",
+                            "mime_type": "audio/mp3",
                         },
                     },
                     {
@@ -476,7 +476,7 @@ class TestGeminiFormatter(IsolatedAsyncioTestCase):
                     {
                         "inline_data": {
                             "data": "ZmFrZSBhdWRpbyBjb250ZW50",
-                            "mime_type": "image/mp3",
+                            "mime_type": "audio/mp3",
                         },
                     },
                     {


### PR DESCRIPTION
…a category

## AgentScope Version

[v1.0.2]

## Description

[Fix local-file inline_data mime_type from hardcoded image/{ext} to {typ}/{extension} using extension-to-type lookup, aligned with the web URL branch.]

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review