### PR TITLE
fix bug of self._agent_control

### DIFF
--- a/src/agentscope/agent/_react_agent.py
+++ b/src/agentscope/agent/_react_agent.py
@@ -151,7 +151,10 @@ class ReActAgent(ReActAgentBase):
             "static_control",
             "both",
         ]
-        self._agent_control = long_term_memory and not self._static_control
+        self._agent_control = long_term_memory and long_term_memory_mode in [
+            "agent_control",
+            "both",
+        ]
 
         # If None, a default Toolkit will be created
         self.toolkit = toolkit or Toolkit()


### PR DESCRIPTION
## AgentScope Version

[The version of AgentScope you are working on, e.g. `import agentscope; print(agentscope.__version__)`]

## Description
Modify the ReActAgent's self._agent_control to avoid being assigned as False when the mode is "both".

self._agent_control = long_term_memory and long_term_memory_mode in [
            "agent_control",
            "both",
        ]

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review