### PR TITLE
[HOTFIX] Fix the bug of missing metadata field when finish function fail to execute in the toolkit

### DIFF
--- a/src/agentscope/agent/_react_agent.py
+++ b/src/agentscope/agent/_react_agent.py
@@ -411,7 +411,7 @@ class ReActAgent(ReActAgentBase):
 
         Returns:
             `Union[Msg, None]`:
-                Return a message to the user if the `_finish_function` is
+                Return a message to the user if the `finish_function` is
                 called, otherwise return `None`.
         """
 
@@ -443,7 +443,10 @@ class ReActAgent(ReActAgentBase):
                 if (
                     tool_call["name"] != self.finish_function_name
                     or tool_call["name"] == self.finish_function_name
-                    and not chunk.metadata.get("success")
+                    and (
+                        chunk.metadata is None
+                        or not chunk.metadata.get("success")
+                    )
                 ):
                     await self.print(tool_res_msg, chunk.is_last)
 


### PR DESCRIPTION
## AgentScope Version

1.0.3

## Description

Fix the bug of missing metadata field when finish function fail to execute in the toolkit

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review