### PR TITLE
fix(model): 修复DashScopeChatModel enable_thinking 不起作用

### DIFF
--- a/src/agentscope/model/_dashscope_model.py
+++ b/src/agentscope/model/_dashscope_model.py
@@ -176,7 +176,10 @@ class DashScopeChatModel(ChatModelBase):
             self._validate_tool_choice(tool_choice, tools)
             kwargs["tool_choice"] = self._format_tool_choice(tool_choice)
 
-        if self.enable_thinking is not None and "enable_thinking" not in kwargs:
+        if (
+            self.enable_thinking is not None
+            and "enable_thinking" not in kwargs
+        ):
             kwargs["enable_thinking"] = self.enable_thinking
 
         if structured_model:

--- a/src/agentscope/model/_dashscope_model.py
+++ b/src/agentscope/model/_dashscope_model.py
@@ -176,7 +176,7 @@ class DashScopeChatModel(ChatModelBase):
             self._validate_tool_choice(tool_choice, tools)
             kwargs["tool_choice"] = self._format_tool_choice(tool_choice)
 
-        if self.enable_thinking and "enable_thinking" not in kwargs:
+        if self.enable_thinking is not None and "enable_thinking" not in kwargs:
             kwargs["enable_thinking"] = self.enable_thinking
 
         if structured_model:


### PR DESCRIPTION
- 将 enable_thinking 判空条件由简单布尔判断改为非 None 判断
- 避免 enable_thinking 为 False 时跳过赋值的问题
- 确保当 kwargs 中无 enable_thinking 时正确添加对应参数

## AgentScope Version

[The version of AgentScope you are working on, e.g. `import agentscope; print(agentscope.__version__)`]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review