### PR TITLE
fix deep research agent example condition

### DIFF
--- a/examples/agent_deep_research/deep_research_agent.py
+++ b/examples/agent_deep_research/deep_research_agent.py
@@ -599,7 +599,7 @@ class DeepResearchAgent(ReActAgent):
                 follow_up_subtask = {}
 
             #  Step #2: extract the url
-            if follow_up_subtask.get("need_more_information", False):
+            if follow_up_subtask.get("need_more_information", True):
                 expansion_response_msg = Msg(
                     "assistant",
                     follow_up_subtask.get(


### PR DESCRIPTION
## AgentScope Version

1.0.4

## Description

from the deeper expansion's prompt I found instruction that:
1. **Find information with valuable, but insufficient or shallow content**: Carefully review the web search results to assess whether there is any snippet or web content that
    - could potentially help address checklist items or fulfill knowledge gaps of the task as the content increases
    - **but whose content is limited or only briefly mentioned**!
2. **Identify the snippet**: If such information is found, set `need_more_information` to true, and locate the specific **title, content, and url** of the information snippet you have found for later extraction.

While in the _follow_up method after calling llm with expansion prompt ,it only extracts more when the "need_more_information" is false, in opposite return a "sufficient_hint" response. 

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review