### PR TITLE
Add Model Class for Trinity-RFT RL Training

### DIFF
--- a/src/agentscope/model/__init__.py
+++ b/src/agentscope/model/__init__.py
@@ -8,6 +8,7 @@ from ._openai_model import OpenAIChatModel
 from ._anthropic_model import AnthropicChatModel
 from ._ollama_model import OllamaChatModel
 from ._gemini_model import GeminiChatModel
+from ._trinity_model import TrinityModel
 
 __all__ = [
     "ChatModelBase",
@@ -17,4 +18,5 @@ __all__ = [
     "AnthropicChatModel",
     "OllamaChatModel",
     "GeminiChatModel",
+    "TrinityModel",
 ]

--- a/src/agentscope/model/_trinity_model.py
+++ b/src/agentscope/model/_trinity_model.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=too-many-branches
+"""A model class for RL Training with Trinity-RFT."""
+from typing import (
+    TYPE_CHECKING,
+)
+from ._openai_model import OpenAIChatModel
+from ..types import JSONSerializableObject
+
+
+if TYPE_CHECKING:
+    from openai import AsyncOpenAI
+else:
+    AsyncOpenAI = "openai.AsyncOpenAI"
+
+
+class TrinityModel(OpenAIChatModel):
+    """A model class for RL Training with Trinity-RFT."""
+
+    def __init__(
+        self,
+        openai_async_client: AsyncOpenAI,
+        generate_kwargs: dict[str, JSONSerializableObject] | None = None,
+    ):
+        """Initialize the Trinity model class.
+
+        Args:
+            openai_async_client (`AsyncOpenAI`):
+                The OpenAI async client instance provided by Trinity-RFT.
+        """
+        model_name = getattr(openai_async_client, "model_name", None)
+        if model_name is None:
+            raise ValueError(
+                "The provided openai_async_client does not have a "
+                "`model_name` attribute. Please ensure you are using "
+                "the instance provided by Trinity-RFT.",
+            )
+        super().__init__(
+            model_name=getattr(openai_async_client, "model_name"),
+            api_key="EMPTY",
+            generate_kwargs=generate_kwargs,
+            stream=False,  # RL training does not support streaming
+        )
+        # change the client instance to the provided one
+        self.client = openai_async_client

--- a/tests/model_trinity_test.py
+++ b/tests/model_trinity_test.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for Trinity-RFT model class."""
+from unittest.async_case import IsolatedAsyncioTestCase
+from unittest.mock import Mock, AsyncMock
+
+from agentscope.model import TrinityModel, ChatResponse
+from agentscope.message import TextBlock
+
+
+class TestTrinityModel(IsolatedAsyncioTestCase):
+    """Test cases for TrinityModel."""
+
+    async def test_init_with_trinity_client(self) -> None:
+        """Test initialization with a valid OpenAI async client."""
+        MODEL_NAME = "Qwen/Qwen3-8B"
+        mock_client = Mock()
+        mock_client.model_name = MODEL_NAME
+
+        # test init
+        model = TrinityModel(openai_async_client=mock_client)
+        self.assertEqual(model.model_name, MODEL_NAME)
+        self.assertFalse(model.stream)
+        self.assertIs(model.client, mock_client)
+
+        # create mock response
+        messages = [{"role": "user", "content": "Hello"}]
+        mock_message = Mock()
+        mock_message.content = "Hi there!"
+        mock_message.role = "assistant"
+        mock_message.tool_calls = []
+        mock_message.audio = None
+        mock_message.parsed = None
+        mock_choice = Mock()
+        mock_choice.messaage = mock_message
+        mock_response = Mock()
+        mock_response.choices = [mock_choice]
+        mock_usage = Mock()
+        mock_usage.prompt_tokens = 10
+        mock_usage.completion_tokens = 20
+        mock_response.usage = mock_usage
+
+        mock_client.chat.completions.create = AsyncMock(
+            return_value=mock_response,
+        )
+
+        result = await model(messages)
+        call_args = mock_client.chat.completions.create.call_args[1]
+        self.assertEqual(call_args["model"], MODEL_NAME)
+        self.assertEqual(call_args["messages"], messages)
+        self.assertFalse(call_args["stream"])
+        self.assertIsInstance(result, ChatResponse)
+        expected_content = [
+            TextBlock(type="text", text="Hi there!"),
+        ]
+        self.assertEqual(result.content, expected_content)

--- a/tests/model_trinity_test.py
+++ b/tests/model_trinity_test.py
@@ -26,12 +26,12 @@ class TestTrinityModel(IsolatedAsyncioTestCase):
         messages = [{"role": "user", "content": "Hello"}]
         mock_message = Mock()
         mock_message.content = "Hi there!"
-        mock_message.role = "assistant"
+        mock_message.reasoning_content = None
         mock_message.tool_calls = []
         mock_message.audio = None
         mock_message.parsed = None
         mock_choice = Mock()
-        mock_choice.messaage = mock_message
+        mock_choice.message = mock_message
         mock_response = Mock()
         mock_response.choices = [mock_choice]
         mock_usage = Mock()


### PR DESCRIPTION
## AgentScope Version

`1.0.4`

## Description

This PR add a new model class named `TrinityModel`, which can be used to support RL training with [Trinity-RFT](https://github.com/modelscope/Trinity-RFT)

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review