### PR TITLE
[HOTFIX]: Add default value None for memory_type in _mem0_record

### DIFF
--- a/src/agentscope/memory/_mem0_long_term_memory.py
+++ b/src/agentscope/memory/_mem0_long_term_memory.py
@@ -403,7 +403,7 @@ class Mem0LongTermMemory(LongTermMemoryBase):
     async def _mem0_record(
         self,
         messages: str | list[dict],
-        memory_type: str | None,
+        memory_type: str | None = None,
         infer: bool = True,
         **kwargs: Any,
     ) -> dict:


### PR DESCRIPTION
## AgentScope Version
1.0.5dev
[The version of AgentScope you are working on, e.g. `import agentscope; print(agentscope.__version__)`]

## Description

Error recording memory: Mem0LongTermMemory._mem0_record() missing 1 required positional argument: 'memory_type'


## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review