### PR TITLE
[HotFix] Fix missing await in browser agent's format

### DIFF
--- a/examples/agent_browser/browser_agent.py
+++ b/examples/agent_browser/browser_agent.py
@@ -322,7 +322,7 @@ class BrowserAgent(ReActAgent):
         )
 
         # Format the prompt for the model
-        prompt = self.formatter.format(
+        prompt = await self.formatter.format(
             msgs=[
                 Msg("system", self.sys_prompt, "system"),
                 *memory_msgs,


### PR DESCRIPTION
## AgentScope Version

[The version of AgentScope you are working on, e.g. `import agentscope; print(agentscope.__version__)`]

## Description

As the titles says.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review