### PR TITLE
Add support for the mcp.types.EmbeddedResource with text resource

### DIFF
--- a/src/agentscope/mcp/_client_base.py
+++ b/src/agentscope/mcp/_client_base.py
@@ -75,7 +75,7 @@ class MCPClientBase:
                     as_content.append(
                         TextBlock(
                             type="text",
-                            text=content.resource.model_dump_json(),
+                            text=content.resource.model_dump_json(indent=2),
                         ),
                     )
                 else:

--- a/tests/mcp_streamable_http_client_test.py
+++ b/tests/mcp_streamable_http_client_test.py
@@ -173,10 +173,12 @@ class StreamableHttpMCPClientTest(IsolatedAsyncioTestCase):
                 content=[
                     TextBlock(
                         type="text",
-                        text=(
-                            "Source: file://tmp.txt/\n\n"
-                            "Content:\ntest content"
-                        ),
+                        text="""{
+  "uri": "file://tmp.txt/",
+  "mimeType": "text/plain",
+  "meta": null,
+  "text": "test content"
+}""",
                     ),
                 ],
             ),


### PR DESCRIPTION
## AgentScope Version

1.0.5

## Description

Enable support for the mcp.types.EmbeddedResource

* About mcp.types.EmbeddedResource: https://modelcontextprotocol.io/specification/draft/schema#embeddedresource
* Why we need this? Some MCP returns contain such data structure and has critical information, such as the `get_file_contents` function in the GitHub MCP


## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review