### PR TITLE
Add support for string input in memories

### DIFF
--- a/src/agentscope/memory/_in_memory_memory.py
+++ b/src/agentscope/memory/_in_memory_memory.py
@@ -92,6 +92,18 @@ class InMemoryMemory(MemoryBase):
         if memories is None:
             return
 
+        if isinstance(memories, str):
+            memories = Msg(
+                "system",
+                [
+                    TextBlock(
+                        type="text",
+                        text=memories,
+                    ),
+                ],
+                "user",
+            )
+
         if isinstance(memories, Msg):
             memories = [memories]
 


### PR DESCRIPTION
某些情况下，router 调用子agent时，传过去的 msg 是 str，导致子agent不能被正常调用，具体原因我没细看，只在 memory.add 处 hack 一下

## AgentScope Version

[The version of AgentScope you are working on, e.g. `import agentscope; print(agentscope.__version__)`]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review