### PR TITLE
feat: Use only current turn history for LTM addition

### DIFF
--- a/src/agentscope/memory/_mem0_long_term_memory.py
+++ b/src/agentscope/memory/_mem0_long_term_memory.py
@@ -462,6 +462,14 @@ class Mem0LongTermMemory(LongTermMemoryBase):
 
         # Filter out None
         msg_list = [_ for _ in msgs if _]
+
+        start_index = 0
+        for i in range(len(msg_list) - 1, -1, -1):
+            if msg_list[i].name == "User":
+                start_index = i
+                break
+        msg_list = msg_list[start_index:]
+
         if not all(isinstance(_, Msg) for _ in msg_list):
             raise TypeError(
                 "The input messages must be a list of Msg objects.",


### PR DESCRIPTION
## AgentScope Version

1.0.6

## Description

Great project!

I've noticed that before storing long-term memory after each turn, the process uses the entire conversation history as context.
This can lead to a few issues as a conversation continues:
1. Increased Token Consumption: The context for `mem0` expands indefinitely.
2. Distracted Attention: The model's attention is drawn to potentially irrelevant information from much earlier in the conversation.
3. Poor Extraction Quality: If the model's capabilities are limited, this could result in low-quality information extraction for the current turn. (e.g., as shown in the image below).
<img width="1595" height="572" alt="image" src="https://github.com/user-attachments/assets/b1f41805-3647-470a-a59d-caa5afa0f970" />

I also observed that the recalled long-term memory for the current request is already appended immediately after the user's prompt. This recalled information already contains the key historical context.

Given this, it seems unnecessary to include the entire conversation history when extracting features for the new long-term memory.It seems like a better approach would be to use only the most recent turn (from the last user request to the end of the current response) as the context for this extraction.

What do you all think?

Looking forward to your reply!


## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review