### PR TITLE
fix(agent): separate the logic of the arguments `enable_meta_tool` and `plan_notebook`

### DIFF
--- a/src/agentscope/agent/_react_agent.py
+++ b/src/agentscope/agent/_react_agent.py
@@ -225,20 +225,24 @@ class ReActAgent(ReActAgentBase):
         self.plan_notebook = None
         if plan_notebook:
             self.plan_notebook = plan_notebook
-            # When enable_meta_tool is True, the plan tool group activation is
-            # controlled by agent.
-            # Otherwise, the plan tool group is always active.
-            tool_group_active = not enable_meta_tool
-            self.toolkit.create_tool_group(
-                "plan_related",
-                description=self.plan_notebook.description,
-                active=tool_group_active,
-            )
-            for tool in plan_notebook.list_tools():
-                self.toolkit.register_tool_function(
-                    tool,
-                    group_name="plan_related",
+            # When enable_meta_tool is True, plan tools are in plan_related
+            # group and active by agent.
+            # Otherwise, plan tools in bassic group and always active.
+            if enable_meta_tool:
+                self.toolkit.create_tool_group(
+                    "plan_related",
+                    description=self.plan_notebook.description,
                 )
+                for tool in plan_notebook.list_tools():
+                    self.toolkit.register_tool_function(
+                        tool,
+                        group_name="plan_related",
+                    )
+            else:
+                for tool in plan_notebook.list_tools():
+                    self.toolkit.register_tool_function(
+                        tool,
+                    )
 
         # If print the reasoning hint messages
         self.print_hint_msg = print_hint_msg


### PR DESCRIPTION
## AgentScope Version

[The version of AgentScope you are working on, e.g. `import agentscope; print(agentscope.__version__)`]

## Description

When enable_meta_tool is True, the plan tool group activation is controlled by agent.
Otherwise, the plan tool group is always active.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review