### PR TITLE
fix plan note book status，uniform deprecated to abandoned.

### DIFF
--- a/src/agentscope/plan/_plan_notebook.py
+++ b/src/agentscope/plan/_plan_notebook.py
@@ -91,7 +91,10 @@ class DefaultPlanToHint:
         "```\n"
         "All the subtasks are done. Now your options are:\n"
         "- Finish the plan by calling 'finish_plan' with the specific "
-        "outcome, and summarize the whole process and outcome to the user.\n"
+        "outcome,you need to provide a summary of the overall task. "
+        "If the user requires a clear response—for example, "
+        "outputting a report—you must deliver the completed "
+        "report upon finishing the plan. and summarize the whole process and outcome to the user.\n"
         "- Revise the plan by calling 'revise_current_plan' if necessary.\n"
         "- If the user asks you to do something unrelated to the plan, "
         "prioritize the completion of user's query first, and then return to "
@@ -424,7 +427,7 @@ class PlanNotebook(StateModule):
     async def update_subtask_state(
         self,
         subtask_idx: int,
-        state: Literal["todo", "in_progress", "deprecated"],
+        state: Literal["todo", "in_progress", "abandoned"],
     ) -> ToolResponse:
         """Update the state of a subtask by given index and state. Note if you
         want to mark a subtask as done, you SHOULD call `finish_subtask`
@@ -487,7 +490,7 @@ class PlanNotebook(StateModule):
                 # Check all previous subtasks are done or deprecated
                 if idx < subtask_idx and subtask.state not in [
                     "done",
-                    "deprecated",
+                    "abandoned",
                 ]:
                     return ToolResponse(
                         content=[


### PR DESCRIPTION
## AgentScope Version

1.0.6

## Description

1.one sub task updated to 'abandoned' , state machine wants to push on next sub task to 'in_progress' , but it checks previous sub task status must be in (""done", "deprecated",") ,it result in state machine push on fail
2. onece  a plan finished ,it dose not give a full response to user, so change prompt to fix it.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review