### PR TITLE
fix(pipeline): use Sequence for covariant type substitution in MsgHub

### DIFF
--- a/src/agentscope/pipeline/_msghub.py
+++ b/src/agentscope/pipeline/_msghub.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 """MsgHub is designed to share messages among a group of agents."""
+
+from collections.abc import Sequence
 from typing import Any
 
 import shortuuid
 
 from .._logging import logger
-
 from ..agent import AgentBase
 from ..message import Msg
 
@@ -40,7 +41,7 @@ class MsgHub:
 
     def __init__(
         self,
-        participants: list[AgentBase],
+        participants: Sequence[AgentBase],
         announcement: list[Msg] | Msg | None = None,
         enable_auto_broadcast: bool = True,
         name: str | None = None,
@@ -63,8 +64,9 @@ class MsgHub:
                 The name of this MsgHub. If not provided, a random ID
                 will be generated.
         """
+
         self.name = name or shortuuid.uuid()
-        self.participants = participants
+        self.participants = list(participants)
         self.announcement = announcement
         self.enable_auto_broadcast = enable_auto_broadcast
 


### PR DESCRIPTION
## AgentScope Version

1.0.7

## Description

Change `MsgHub.__init__` parameter from `list[AgentBase]` to `Sequence[AgentBase]` to support covariant type substitution, allowing subclass sequences like `list[ReActAgent]` to be passed directly without type errors.

**Problem Encountered:**
When passing a `list[ReActAgent]` to `MsgHub`, type checkers (Pyright) report:
```
"list[ReActAgent]" is not assignable to "list[AgentBase]"
Type parameter "_T@list" is invariant, but "ReActAgent" is not the same as "AgentBase"
Consider switching from "list" to "Sequence" which is covariant
```

**Example Code That Failed:**
```python
agents: list[ReActAgent] = [ReActAgent(...) for _ in range(9)]
async with MsgHub(participants=agents) as greeting_hub:  # ❌ Type Error!
    await greeting_hub.broadcast(msg)

### Changes
- Accept `Sequence[AgentBase]` parameter (covariant, read-only contract)
- Convert to list internally: `self.participants = list(participants)`
- Improves interface flexibility while maintaining type safety

### Why This Matters
`list` is invariant in its type parameter, so `list[ReActAgent]` cannot be assigned to `list[AgentBase]`. By using `Sequence` (which is covariant and read-only), we eliminate this type error while maintaining safety through lazy conversion to `list` internally.

## Checklist

- [x] Code has been formatted with `pre-commit run --all-files` command
- [x] All tests are passing
- [x] Docstrings are in Google style
- [x] Related documentation has been updated
- [x] Code is ready for review