### PR TITLE
fix(tool):  execute_python_code utf8 encode for Chinese codes&comments issue#915

### DIFF
--- a/src/agentscope/tool/_coding/_python.py
+++ b/src/agentscope/tool/_coding/_python.py
@@ -40,12 +40,16 @@ async def execute_python_code(
         with open(temp_file, "w", encoding="utf-8") as f:
             f.write(code)
 
+        env = os.environ.copy()
+        env["PYTHONUTF8"] = "1"
+        env["PYTHONIOENCODING"] = "utf-8"
         proc = await asyncio.create_subprocess_exec(
             sys.executable,
             "-u",
             temp_file,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env=env,
         )
 
         try:


### PR DESCRIPTION
https://github.com/agentscope-ai/agentscope/issues/915

running on win10, the generated python code with Chinese strings or comments, will raise error `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc4 in position 0: invalid continuation byte`

In my commit, use only env variable `PYTHONUTF8` and `PYTHONIOENCODING`