### PR TITLE
fix(evaluator_storage): correct docstring on directory organization

### DIFF
--- a/src/agentscope/evaluate/_evaluator_storage/_file_evaluator_storage.py
+++ b/src/agentscope/evaluate/_evaluator_storage/_file_evaluator_storage.py
@@ -21,8 +21,8 @@ class FileEvaluatorStorage(EvaluatorStorageBase):
     - save_dir/
         - evaluation_result.json
         - evaluation_meta.json
-        - {task_id}/
-            - {repeat_id}/
+        - {repeat_id}/
+            - {task_id}/
                 - solution.json
                 - evaluation/
                     - {metric_name}.json
@@ -40,7 +40,7 @@ class FileEvaluatorStorage(EvaluatorStorageBase):
 
     def _get_save_path(self, task_id: str, repeat_id: str, *args: str) -> str:
         """Get the save path for a given task and repeat ID."""
-        return os.path.join(self.save_dir, task_id, repeat_id, *args)
+        return os.path.join(self.save_dir, repeat_id, task_id, *args)
 
     def save_solution_result(
         self,


### PR DESCRIPTION


## AgentScope Version

commit: 5c3a7705c3a922e8a41c88f91666c870737f9075

I am updating the latest code in main branch.

## Description

fix(evaluator_storage): correct save path ordering in FileEvaluatorStorage

In docstring, the directory structure is:
```markdown
The files are organized in a directory structure:
    - save_dir/
        - evaluation_result.json
        - evaluation_meta.json
        - {task_id}/
            - {repeat_id}/
                - solution.json
                - evaluation/
                    - {metric_name}.json
```

But the implementation doesn't follow this structure.

<img width="946" height="148" alt="image" src="https://github.com/user-attachments/assets/efd6ebda-60af-42d8-883e-878a76d4b66b" />


## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing 
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review