### PR TITLE
fix(docs): fix the typo of the incorrect port number in the tutorial

### DIFF
--- a/docs/tutorial/en/src/task_studio.py
+++ b/docs/tutorial/en/src/task_studio.py
@@ -43,7 +43,7 @@ To connect your application to the Studio, use the ``agentscope.init`` function 
 
     import agentscope
 
-    agentscope.init(studio_url="http://localhost:8000")
+    agentscope.init(studio_url="http://localhost:3000")
 
     # your application code
     ...

--- a/docs/tutorial/zh_CN/src/task_studio.py
+++ b/docs/tutorial/zh_CN/src/task_studio.py
@@ -43,7 +43,7 @@ AgentScope Studio 通过 ``npm`` 安装：
 
     import agentscope
 
-    agentscope.init(studio_url="http://localhost:8000")
+    agentscope.init(studio_url="http://localhost:3000")
 
     # 应用程序代码
     ...


### PR DESCRIPTION
## AgentScope Version
1.0.8

## Description
AgentScope Studio 实际运行在 3000 端口，tutorial 文档里面是 8000 端口，需要修改为 3000