### PR TITLE
feat(tracing): add support for configurable tracing protocol in setup_tracing function

### DIFF
--- a/src/agentscope/__init__.py
+++ b/src/agentscope/__init__.py
@@ -77,6 +77,7 @@ def init(
     logging_level: str = "INFO",
     studio_url: str | None = None,
     tracing_url: str | None = None,
+    tracing_protocol: str = "http/protobuf",
 ) -> None:
     """Initialize the agentscope library.
 
@@ -101,6 +102,11 @@ def init(
             OpenTelemetry tracing platforms like Arize-Phoenix and Langfuse.
             If not provided and `studio_url` is provided, it will send traces
             to the AgentScope Studio's tracing endpoint.
+        tracing_protocol (`str`, optional):
+            The protocol to use for the trace exporter. Supported values are:
+            - "grpc": Use gRPC protocol
+            - "http/protobuf": Use HTTP protocol with protobuf encoding
+            Defaults to "http/protobuf".
     """
 
     if project:
@@ -152,7 +158,7 @@ def init(
     if endpoint:
         from .tracing import setup_tracing
 
-        setup_tracing(endpoint=endpoint)
+        setup_tracing(endpoint=endpoint, protocol=tracing_protocol)
         _config.trace_enabled = True
 
 

--- a/src/agentscope/tracing/_setup.py
+++ b/src/agentscope/tracing/_setup.py
@@ -8,20 +8,34 @@ else:
     Tracer = "Tracer"
 
 
-def setup_tracing(endpoint: str) -> None:
+def setup_tracing(
+    endpoint: str,
+    protocol: str = "http/protobuf",
+) -> None:
     """Set up the AgentScope tracing by configuring the endpoint URL.
 
     Args:
         endpoint (`str`):
             The endpoint URL for the tracing exporter.
+        protocol (`str`, optional):
+            The protocol to use for the trace exporter. Supported values are:
+            - "grpc": Use gRPC protocol
+            - "http/protobuf": Use HTTP protocol with protobuf encoding
+            Defaults to "http/protobuf".
     """
     # Lazy import
     from opentelemetry import trace
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
-    from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
-        OTLPSpanExporter,
-    )
+
+    if protocol == "grpc":
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+            OTLPSpanExporter,
+        )
+    else:
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter,
+        )
 
     # Prepare a span_processor
     exporter = OTLPSpanExporter(endpoint=endpoint)


### PR DESCRIPTION
## AgentScope Version

1.0.7

## Description

Opentelemetry tracing support both `grpc` and `http/protobuf` protocol.
Defaults to `http/protobuf`.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review