### PR TITLE
fix(config):fix created_at timestamp format

### DIFF
--- a/src/agentscope/__init__.py
+++ b/src/agentscope/__init__.py
@@ -31,8 +31,7 @@ _config = _ConfigCls(
     ),
     created_at=ContextVar(
         "created_at",
-        default=datetime.now().strftime("%H%M%S_")
-        + _generate_random_suffix(4),
+        default=datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3],
     ),
     trace_enabled=ContextVar(
         "trace_enabled",


### PR DESCRIPTION
## AgentScope Version

[The version of AgentScope you are working on, e.g. `import agentscope; print(agentscope.__version__)`]
1.0.9dev
## Description

Fix the created_at timestamp format from "HHMMSS_XXXX" to "YYYY-MM-DD HH:MM:SS.fff" format
- Previous format: : hour-minute-second with random suffix (e.g., "131049_aRR5")
- New format: full datetime with milliseconds (e.g., "2025-11-11 11:11:11.705") 
## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review