### PR TITLE
fix(DeepSeekChatFormatter): Add reasoning_content in messages for deepseek-reasoner

### DIFF
--- a/src/agentscope/formatter/_deepseek_formatter.py
+++ b/src/agentscope/formatter/_deepseek_formatter.py
@@ -52,12 +52,15 @@ class DeepSeekChatFormatter(TruncatedFormatterBase):
         messages: list[dict] = []
         for msg in msgs:
             content_blocks: list = []
+            reasoning_content_blocks: list = []
             tool_calls = []
 
             for block in msg.get_content_blocks():
                 typ = block.get("type")
                 if typ == "text":
                     content_blocks.append({**block})
+                elif typ == "thinking":
+                    reasoning_content_blocks.append({**block})
 
                 elif typ == "tool_use":
                     tool_calls.append(
@@ -95,10 +98,18 @@ class DeepSeekChatFormatter(TruncatedFormatterBase):
             content_msg = "\n".join(
                 content.get("text", "") for content in content_blocks
             )
+            reasoning_msg = "\n".join(
+                reasoning.get("thinking", "")
+                for reasoning in reasoning_content_blocks
+            )
+
             msg_deepseek = {
                 "role": msg.role,
                 "content": content_msg or None,
             }
+
+            if reasoning_msg:
+                msg_deepseek["reasoning_content"] = reasoning_msg
 
             if tool_calls:
                 msg_deepseek["tool_calls"] = tool_calls


### PR DESCRIPTION
## AgentScope Version

1.0.9dev

## Description

DeepSeek model's thinking mode now supports tool calls.  
<img width="2016" height="414" alt="image" src="https://github.com/user-attachments/assets/83a1be64-dec6-47a4-8f01-f4aa08f196e7" />

For more details, please refer to the [official document](https://api-docs.deepseek.com/guides/thinking_mode).


## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review