### PR TITLE
[hotfix] fix the response error in deep research agent

### DIFF
--- a/examples/agent/deep_research_agent/main.py
+++ b/examples/agent/deep_research_agent/main.py
@@ -41,7 +41,7 @@ async def main(user_query: str) -> None:
             sys_prompt="You are a helpful assistant named Friday.",
             model=DashScopeChatModel(
                 api_key=os.environ.get("DASHSCOPE_API_KEY"),
-                model_name="qwen-max",
+                model_name="qwen3-max",
                 enable_thinking=False,
                 stream=True,
             ),
@@ -49,6 +49,7 @@ async def main(user_query: str) -> None:
             memory=InMemoryMemory(),
             search_mcp_client=tavily_search_client,
             tmp_file_storage_dir=agent_working_dir,
+            max_tool_results_words=10000,
         )
         user_name = "Bob"
         msg = Msg(

--- a/examples/agent/deep_research_agent/utils.py
+++ b/examples/agent/deep_research_agent/utils.py
@@ -9,9 +9,6 @@ from pydantic import BaseModel
 from agentscope.tool import Toolkit, ToolResponse
 
 
-TOOL_RESULTS_MAX_WORDS = 5000
-
-
 def get_prompt_from_file(
     file_path: str,
     return_json: bool,
@@ -25,7 +22,10 @@ def get_prompt_from_file(
     return prompt
 
 
-def truncate_by_words(sentence: str) -> str:
+def truncate_by_words(
+    sentence: str,
+    max_tool_results_words: int = 10000,
+) -> str:
     """Truncate too long sentences by words number"""
     words = re.findall(
         r"\w+|[^\w\s]",
@@ -38,7 +38,7 @@ def truncate_by_words(sentence: str) -> str:
     for word in words:
         if re.match(r"\w+", word):
             word_count += 1
-        if word_count > TOOL_RESULTS_MAX_WORDS:
+        if word_count > max_tool_results_words:
             break
         result.append(word)
 
@@ -55,6 +55,7 @@ def truncate_by_words(sentence: str) -> str:
 
 def truncate_search_result(
     res: list,
+    max_tool_results_words: int = 10000,
     search_func: str = "tavily-search",
     extract_function: str = "tavily-extract",
 ) -> list:
@@ -65,7 +66,10 @@ def truncate_search_result(
         )
 
     for i, val in enumerate(res):
-        res[i]["text"] = truncate_by_words(val["text"])
+        res[i]["text"] = truncate_by_words(
+            val["text"],
+            max_tool_results_words,
+        )
 
     return res
 


### PR DESCRIPTION
1. Fix the "NoneType" error that occurs when calling the `generate_response` tool in the deep research agent.
2. Add a `max_tool_results_word parameter` that allows users to truncate tool results by the number of words.