### PR TITLE
feat(agent): support to disable console output from environment variable

### DIFF
--- a/src/agentscope/agent/_agent_base.py
+++ b/src/agentscope/agent/_agent_base.py
@@ -3,6 +3,7 @@
 import asyncio
 import io
 import json
+import os
 from asyncio import Task, Queue
 from collections import OrderedDict
 from copy import deepcopy
@@ -168,7 +169,13 @@ class AgentBase(StateModule, metaclass=_AgentMeta):
 
         # We add this variable in case developers want to disable the console
         # output of the agent, e.g., in a production environment.
-        self._disable_console_output: bool = False
+        self._disable_console_output: bool = (
+            os.getenv(
+                "AGENTSCOPE_DISABLE_CONSOLE_OUTPUT",
+                "false",
+            ).lower()
+            == "true"
+        )
 
         # The streaming message queue used to export the messages as a
         # generator


### PR DESCRIPTION
## AgentScope Version

1.0.9dev

## Description

Support to use the environment variable `"AGENTSCOPE_DISABLE_CONSOLE_OUTPUT"` to disable the console output

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review