### PR TITLE
fix(repair json): hotfix for _json_loads_with_repair

### DIFF
--- a/src/agentscope/_utils/_common.py
+++ b/src/agentscope/_utils/_common.py
@@ -37,6 +37,15 @@ def _json_loads_with_repair(
         This function is currently only used for parsing the streaming output
         of the argument field in `tool_use`, so the parsed result must be a
         dict.
+
+    Args:
+        json_str (`str`):
+            The JSON string to parse, which may be incomplete or malformed.
+
+    Returns:
+        `dict`:
+            A dictionary parsed from the JSON string after repair attempts.
+            Returns an empty dict if all repair attempts fail.
     """
     try:
         repaired = repair_json(json_str)
@@ -55,10 +64,13 @@ def _json_loads_with_repair(
         except Exception:
             continue
 
-    raise ValueError(
-        f"Failed to parse JSON string `{json_str}`. "
-        "All repair attempts (original + truncation) failed.",
+    logger.warning(
+        "Failed to parse JSON string `%s`. "
+        "All repair attempts (original + truncation) failed. "
+        "Returning empty dict.",
+        json_str,
     )
+    return {}
 
 
 def _is_accessible_local_file(url: str) -> bool:


### PR DESCRIPTION
## AgentScope Version

1.0.9dev

## Description

1. Force dictionary return type for the function.
2. In case of non-dictionary output, truncate the preceding content and initiate retry logic to ensure a valid dictionary response.


## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review