### PR TITLE
fix(Ollama Formatter): resolve bug in _ollama_formatter.py

### DIFF
--- a/src/agentscope/formatter/_ollama_formatter.py
+++ b/src/agentscope/formatter/_ollama_formatter.py
@@ -15,6 +15,7 @@ from ..message import (
     ImageBlock,
     ToolUseBlock,
     ToolResultBlock,
+    ThinkingBlock,
     URLSource,
 )
 from ..token import TokenCounterBase
@@ -84,6 +85,7 @@ class OllamaChatFormatter(TruncatedFormatterBase):
     """Whether support vision data"""
 
     supported_blocks: list[type] = [
+        ThinkingBlock,
         TextBlock,
         # Multimodal
         ImageBlock,
@@ -231,6 +233,16 @@ class OllamaChatFormatter(TruncatedFormatterBase):
                         ),
                     )
 
+                elif typ == "thinking":
+                    thinking_content = block.get("thinking", "")
+                    if thinking_content:
+                        content_blocks.append(
+                            {
+                                "type": "text",
+                                "text": f"<think>{thinking_content}</think>",
+                            },
+                        )
+
                 else:
                     logger.warning(
                         "Unsupported block type %s in the message, skipped.",
@@ -279,6 +291,7 @@ class OllamaMultiAgentFormatter(TruncatedFormatterBase):
     """Whether support vision data"""
 
     supported_blocks: list[type] = [
+        ThinkingBlock,
         TextBlock,
         # Multimodal
         ImageBlock,


### PR DESCRIPTION
## AgentScope Version

[The version of AgentScope you are working on, e.g. `import agentscope; print(agentscope.__version__)`]

AgentScope Version: [1.0.10dev]
Python Version: [3.10.12]
OS: [windows]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

### Background
This PR addresses the issue reported in #1016: when interacting with Ollama-provided models that have think capabilities (models whose responses contain "thinking" blocks to expose reasoning processes), the existing `_ollama_formatter.py` module does not support the "thinking" block type. This leads to repeated warnings (`Unsupported block type thinking in the message, skipped`) in the terminal and skipped processing of "thinking" blocks, affecting the integrity of model response handling.

### Purpose
This PR aims to fix the warning and incorrect handling of "thinking" blocks when using Ollama think-capable models by adding support for the "thinking" block type in the Ollama formatter.

### Changes Made
- Modified the `_format` method in `_ollama_formatter.py` to recognize and process "thinking" block types.
- Added logic to properly handle "thinking" blocks (e.g., retain the block content, avoid skipping, and suppress unnecessary warnings).

### How to Test
1. Use an Ollama think-capable model (e.g., models that generate "thinking" blocks in responses).
2. Run a test script that sends multiple consecutive queries to the model.
3. Verify that:
   - No "Unsupported block type thinking" warnings appear in the terminal.
   - "Thinking" block content from the model is correctly processed (e.g., logged or included in the response flow without being skipped).


## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review