### PR TITLE
feat(tool): add original name in RegisteredToolFunction

### DIFF
--- a/src/agentscope/tool/_toolkit.py
+++ b/src/agentscope/tool/_toolkit.py
@@ -370,7 +370,6 @@ Check "{dir}/SKILL.md" for how to use this skill"""
 
         func_obj = RegisteredToolFunction(
             name=func_name,
-            original_name=func_name,
             group=group_name,
             source="function",
             original_func=original_func,
@@ -426,6 +425,7 @@ Check "{dir}/SKILL.md" for how to use this skill"""
                 )
 
                 # Replace the function name with the new one
+                func_obj.original_name = func_name
                 func_obj.name = new_func_name
                 func_obj.json_schema["function"]["name"] = new_func_name
 

--- a/src/agentscope/tool/_types.py
+++ b/src/agentscope/tool/_types.py
@@ -18,9 +18,6 @@ class RegisteredToolFunction:
 
     name: str
     """The name of the tool function."""
-    original_name: str
-    """The original name of the tool function, preserved when the tool is
-    renamed."""
     group: str | Literal["basic"]
     """The belonging group of the tool function"""
     source: Literal["function", "mcp_server", "function_group"]
@@ -34,6 +31,8 @@ class RegisteredToolFunction:
     )
     """The preset keyword arguments, which won't be presented in the JSON
     schema and exposed to the user."""
+    original_name: str | None = None
+    """The original name of the tool function when it has been renamed."""
     extended_model: Type[BaseModel] | None = None
     """The base model used to extend the JSON schema of the original tool
     function, so that we can dynamically adjust the tool function."""


### PR DESCRIPTION
## AgentScope Version

1.0.10dev

## Description

Add the original name in RegisteredToolFunction, preserved when the tool is renamed.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review