### PR TITLE
add record_to_memory before generate return reply_message

### DIFF
--- a/src/agentscope/agent/_react_agent.py
+++ b/src/agentscope/agent/_react_agent.py
@@ -393,7 +393,7 @@ class ReActAgent(ReActAgentBase):
         if reply_msg is None:
             reply_msg = await self._summarizing()
             reply_msg.metadata = structured_output
-            self.memory.add(reply_msg)
+            await self.memory.add(reply_msg)
 
         # Post-process the memory, long-term memory
         if self._static_control:


### PR DESCRIPTION
## AgentScope Version

[The version of AgentScope you are working on, e.g. `import agentscope; print(agentscope.__version__)`]

## Description

fix the bug in https://github.com/agentscope-ai/agentscope/issues/1037

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review