### PR TITLE
fix(react agent): filter None values when joining message text content

### DIFF
--- a/src/agentscope/agent/_react_agent.py
+++ b/src/agentscope/agent/_react_agent.py
@@ -775,7 +775,12 @@ class ReActAgent(ReActAgentBase):
             if isinstance(msg, Msg):
                 query = msg.get_text_content()
             elif isinstance(msg, list):
-                query = "\n".join(_.get_text_content() for _ in msg)
+                texts = []
+                for m in msg:
+                    text = m.get_text_content()
+                    if text:
+                        texts.append(text)
+                query = "\n".join(texts)
 
             # Skip if the query is empty
             if not query:


### PR DESCRIPTION
## AgentScope Version

1.0.10dev

## Description

Fix a bug in `query = "\n".join(_.get_text_content() for _ in msg)` when `None` occurs in `get_text_content()`

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review