### PR TITLE
fix mem0ai version <=0.1.116

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ full = [
     # Evaluator
     "ray",
     # Long-term memory
-    "mem0ai",
+    "mem0ai<=0.1.116",
     "packaging",
     "reme-ai>=0.2.0.3",
     # RAG


### PR DESCRIPTION
## AgentScope Version

[The version of AgentScope you are working on, e.g. `import agentscope; print(agentscope.__version__)`]

## Description

fix the mem0ai version <=0.1.116

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review