### PR TITLE
fix(model): Empty string output on GPT-5 truncation. Update: Ensure all OpenAI model responses return finish_reason consistently.

### DIFF
--- a/src/agentscope/message/_message_block.py
+++ b/src/agentscope/message/_message_block.py
@@ -14,6 +14,9 @@ class TextBlock(TypedDict, total=False):
     text: str
     """The text content"""
 
+    finish_reason: str
+    """The finish reason """
+
 
 class ThinkingBlock(TypedDict, total=False):
     """The thinking block."""

--- a/src/agentscope/model/_openai_model.py
+++ b/src/agentscope/model/_openai_model.py
@@ -479,11 +479,12 @@ class OpenAIChatModel(ChatModelBase):
                     ),
                 )
 
-            if choice.message.content:
+            if choice.message.content is not None:
                 content_blocks.append(
                     TextBlock(
                         type="text",
                         text=response.choices[0].message.content,
+                        finish_reason=response.choices[0].finish_reason,
                     ),
                 )
             if choice.message.audio:


### PR DESCRIPTION
## AgentScope Version
"1.0.10"


## Description
As the title says.

The result in AgentStudio after the fix.
<img width="906" height="375" alt="as" src="https://github.com/user-attachments/assets/4fda903f-7932-44ec-8ea7-57aa63d7fb61" />


## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review