### PR TITLE
fix(openai formatter): Correctly extract image extension from URLs with query parameters

### DIFF
--- a/src/agentscope/formatter/_openai_formatter.py
+++ b/src/agentscope/formatter/_openai_formatter.py
@@ -86,7 +86,7 @@ def _to_openai_image_url(url: str) -> str:
 
     # Web url
     if not os.path.exists(url) and parsed_url.scheme != "":
-        path_lower = parsed_url.path.lower()
+        path_lower = parsed_url.path if parsed_url.path else parsed_url.netloc
         if any(path_lower.endswith(_) for _ in support_image_extensions):
             return url
 


### PR DESCRIPTION
## AgentScope Version

1.0.10

## Description

This PR fixes an issue where image URLs with query parameters (e.g., OSS URLs with authentication tokens) were incorrectly rejected due to extension validation failure.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review