### PR TITLE
bugfix: parse anthropic response content block type logic error.

### DIFF
--- a/src/agentscope/model/_anthropic_model.py
+++ b/src/agentscope/model/_anthropic_model.py
@@ -304,7 +304,10 @@ class AnthropicChatModel(ChatModelBase):
                     thinking_block["signature"] = content_block.signature
                     content_blocks.append(thinking_block)
 
-                elif hasattr(content_block, "text"):
+                elif (
+                    hasattr(content_block, "type")
+                    and content_block.type == "text"
+                ):
                     content_blocks.append(
                         TextBlock(
                             type="text",


### PR DESCRIPTION
## AgentScope Version

1.0.10 via `import agentscope; print(agentscope.__version__)`

## Description

This PR fixes type process error and inconsistent while parsing anthropic response which may return error result.

---

The buggy parser behave different for text block and may cause problem in many edge case,
ref to `agentscope.model._anthropic_model.AnthropicChatModel._parse_anthropic_stream_completion_response`

> Bad case example: anthropic return  blocks [text, tool_use], the parser return [text, text(empty)].

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review