### PR TITLE
fix(formattter): assigns content as an empty list [] for messages without valid content blocks

### DIFF
--- a/src/agentscope/model/_dashscope_model.py
+++ b/src/agentscope/model/_dashscope_model.py
@@ -152,15 +152,6 @@ class DashScopeChatModel(ChatModelBase):
         """
         import dashscope
 
-        # For qvq and qwen-vl models, the content field cannot be `None` or
-        # `[{"text": None}]`, so we need to convert it to an empty list.
-        if self.model_name.startswith("qvq") or "-vl" in self.model_name:
-            for msg in messages:
-                if msg["content"] is None or msg["content"] == [
-                    {"text": None},
-                ]:
-                    msg["content"] = []
-
         kwargs = {
             "messages": messages,
             "model": self.model_name,

--- a/tests/formatter_dashscope_test.py
+++ b/tests/formatter_dashscope_test.py
@@ -257,7 +257,7 @@ class TestDashScopeFormatter(IsolatedAsyncioTestCase):
             },
             {
                 "role": "assistant",
-                "content": [{"text": None}],
+                "content": [],
                 "tool_calls": [
                     {
                         "id": "1",
@@ -319,11 +319,7 @@ class TestDashScopeFormatter(IsolatedAsyncioTestCase):
             },
             {
                 "role": "assistant",
-                "content": [
-                    {
-                        "text": None,
-                    },
-                ],
+                "content": [],
                 "tool_calls": [
                     {
                         "id": "1",
@@ -360,11 +356,7 @@ class TestDashScopeFormatter(IsolatedAsyncioTestCase):
             },
             {
                 "role": "assistant",
-                "content": [
-                    {
-                        "text": None,
-                    },
-                ],
+                "content": [],
                 "tool_calls": [
                     {
                         "id": "1",
@@ -429,11 +421,7 @@ class TestDashScopeFormatter(IsolatedAsyncioTestCase):
             },
             {
                 "role": "assistant",
-                "content": [
-                    {
-                        "text": None,
-                    },
-                ],
+                "content": [],
                 "tool_calls": [
                     {
                         "id": "1",
@@ -463,11 +451,7 @@ class TestDashScopeFormatter(IsolatedAsyncioTestCase):
             },
             {
                 "role": "assistant",
-                "content": [
-                    {
-                        "text": None,
-                    },
-                ],
+                "content": [],
                 "tool_calls": [
                     {
                         "id": "1",
@@ -628,7 +612,7 @@ class TestDashScopeFormatter(IsolatedAsyncioTestCase):
             },
             {
                 "role": "assistant",
-                "content": [{"text": None}],
+                "content": [],
                 "tool_calls": [
                     {
                         "id": "1",
@@ -852,11 +836,7 @@ class TestDashScopeFormatter(IsolatedAsyncioTestCase):
             },
             {
                 "role": "assistant",
-                "content": [
-                    {
-                        "text": None,
-                    },
-                ],
+                "content": [],
                 "tool_calls": [
                     {
                         "id": "1",


### PR DESCRIPTION
## AgentScope Version

1.0.13dev

## Description

As the title says, and see #1136 

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review