### PR TITLE
fix(examples): rename ReflectFailure.decompose_subtask.rephrased_plan to failed_subtask in deep research example

### DIFF
--- a/examples/agent/deep_research_agent/built_in_prompt/promptmodule.py
+++ b/examples/agent/deep_research_agent/built_in_prompt/promptmodule.py
@@ -127,7 +127,7 @@ class ReflectFailure(BaseModel):
                         "the failed subtask should "
                         "be further decomposed; otherwise, 'false'.",
                     },
-                    "rephrased_plan": {
+                    "failed_subtask": {
                         "type": "string",
                         "description": "Information about whether "
                         "the failed subtask requires "


### PR DESCRIPTION
## AgentScope Version

1.0.13

## Description
This PR fixes a formatting issue in the `reflect_failure` prompt template used in the deep research example.

Specifically, in
`examples/agent/deep_research_agent/built_in_prompt/promptmodule.py` (at line **130**),
the `decompose_subtask` schema used for LLM `format_template` contained a misnamed field.
The subfield `rephrased_plan` was semantically incorrect and has been renamed to `failed_subtask` to correctly represent the failed subtask that requires further decomposition.

This change improves the correctness and clarity of the structured prompt used in the deep research agent example, without affecting core framework behavior.

**How to test:**
* Run the deep research example and verify that the `reflect_failure` LLM output follows the updated schema.
* Run existing tests to ensure no regressions.

## Checklist
- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review