### PR TITLE
fix(agent): remove duplicated message saved to long-term memory

### DIFF
--- a/src/agentscope/agent/_react_agent.py
+++ b/src/agentscope/agent/_react_agent.py
@@ -528,7 +528,7 @@ class ReActAgent(ReActAgentBase):
         if self._static_control:
             await self.long_term_memory.record(
                 [
-                    await self.memory.get_memory(
+                    *await self.memory.get_memory(
                         exclude_mark=_MemoryMark.COMPRESSED,
                     ),
                 ],


### PR DESCRIPTION
## AgentScope Version

## Description

Fix duplicate message entries in long-term memory when memory compression hasn’t been triggered (i.e., threshold not reached)—prevents both msg and reply_msg from being recorded twice in the final step of the reply function.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review