### PR TITLE
fix(hook): make set_console_output_enabled only affect console printing

### DIFF
--- a/src/agentscope/hooks/_studio_hooks.py
+++ b/src/agentscope/hooks/_studio_hooks.py
@@ -15,9 +15,6 @@ def as_studio_forward_message_pre_print_hook(
     run_id: str,
 ) -> None:
     """The pre-speak hook to forward messages to the studio."""
-    # Disable console output if needed
-    if self._disable_console_output:  # pylint: disable=protected-access
-        return
 
     msg = kwargs["msg"]
 


### PR DESCRIPTION
## AgentScope Version

[The version of AgentScope you are working on, e.g. `import agentscope; print(agentscope.__version__)`]
1.0.14
## Description

As title says.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review