### PR TITLE
fix: exclude compressed messages in reasoning method

### DIFF
--- a/src/agentscope/agent/_react_agent.py
+++ b/src/agentscope/agent/_react_agent.py
@@ -554,7 +554,7 @@ class ReActAgent(ReActAgentBase):
         prompt = await self.formatter.format(
             msgs=[
                 Msg("system", self.sys_prompt, "system"),
-                *await self.memory.get_memory(),
+                *await self.memory.get_memory(exclude_mark=_MemoryMark.COMPRESSED),
             ],
         )
         # Clear the hint messages after use


### PR DESCRIPTION
Fixed the _reasoning method to properly exclude compressed messages when retrieving memory for model prompts. Added exclude_mark=_MemoryMark.COMPRESSED parameter to the memory.get_memory() call on line 557, ensuring that compressed historical messages are filtered out from the reasoning context. This prevents redundant or compressed content from being sent to the model, improving prompt quality and context relevance.

## AgentScope Version

[The version of AgentScope you are working on, e.g. `import agentscope; print(agentscope.__version__)`]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review