### PR TITLE
feat(toolkit): support built-in SKILL.md reader for registered skills

### DIFF
--- a/src/agentscope/tool/_toolkit.py
+++ b/src/agentscope/tool/_toolkit.py
@@ -1060,6 +1060,8 @@ Check "{dir}/SKILL.md" for how to use this skill"""
         """
         import frontmatter
 
+        skill_dir = os.path.abspath(os.path.expanduser(skill_dir))
+
         # Check the skill directory
         if not os.path.isdir(skill_dir):
             raise ValueError(

--- a/src/agentscope/tool/_toolkit.py
+++ b/src/agentscope/tool/_toolkit.py
@@ -1065,6 +1065,11 @@ Check "{dir}/SKILL.md" for how to use this skill"""
             ranges (`list[int] | None`, optional):
                 The inclusive line range to read, e.g. `[1, 100]`. If omitted,
                 the whole file is returned.
+
+        Returns:
+            `ToolResponse`:
+                The tool response containing either the `SKILL.md` content or
+                an error message when the skill is not registered.
         """
         skill = self.skills.get(skill_name)
         if skill is None:

--- a/src/agentscope/tool/_toolkit.py
+++ b/src/agentscope/tool/_toolkit.py
@@ -1041,14 +1041,13 @@ Check "{dir}/SKILL.md" for how to use this skill"""
             )
 
     def _ensure_builtin_skill_md_reader_registered(self) -> None:
-        """Register the built-in SKILL.md reader tool when skills exist."""
-        if len(self.skills) == 0:
+        """Register the built-in SKILL.md reader tool once."""
+        if "read_skill_md" in self.tools:
             return
 
         self.register_tool_function(
             self.read_skill_md,
             func_name="read_skill_md",
-            namesake_strategy="skip",
         )
 
     async def read_skill_md(

--- a/tests/toolkit_basic_test.py
+++ b/tests/toolkit_basic_test.py
@@ -3,6 +3,8 @@
 # mypy: disable-error-code="index"
 """Test toolkit module in agentscope."""
 import asyncio
+import os
+import tempfile
 import time
 from copy import deepcopy
 from functools import partial
@@ -601,6 +603,28 @@ class ToolkitBasicTest(IsolatedAsyncioTestCase):
             ],
             self.toolkit.get_json_schemas(),
         )
+
+    async def test_register_agent_skill_stores_absolute_path(self) -> None:
+        """Verify agent skill directory is stored as absolute path."""
+        with tempfile.TemporaryDirectory(dir=".") as tmp_dir:
+            with open(
+                os.path.join(tmp_dir, "SKILL.md"),
+                "w",
+                encoding="utf-8",
+            ) as file:
+                file.write(
+                    "---\n"
+                    "name: test-skill\n"
+                    "description: test description\n"
+                    "---\n",
+                )
+
+            relative_skill_dir = os.path.relpath(tmp_dir)
+            self.toolkit.register_agent_skill(relative_skill_dir)
+            self.assertEqual(
+                self.toolkit.skills["test-skill"]["dir"],
+                os.path.abspath(relative_skill_dir),
+            )
 
     async def _verify_async_generator_wo_interruption(
         self,

--- a/tests/toolkit_basic_test.py
+++ b/tests/toolkit_basic_test.py
@@ -625,6 +625,73 @@ class ToolkitBasicTest(IsolatedAsyncioTestCase):
                 self.toolkit.skills["test-skill"]["dir"],
                 os.path.abspath(relative_skill_dir),
             )
+            self.assertIn("read_skill_md", self.toolkit.tools)
+
+    async def test_builtin_read_skill_md_tool(self) -> None:
+        """Verify built-in SKILL.md reader can read a registered skill."""
+        with tempfile.TemporaryDirectory(dir=".") as tmp_dir:
+            with open(
+                os.path.join(tmp_dir, "SKILL.md"),
+                "w",
+                encoding="utf-8",
+            ) as file:
+                file.write(
+                    "---\n"
+                    "name: test-skill\n"
+                    "description: test description\n"
+                    "---\n"
+                    "This is the detailed skill instruction.\n",
+                )
+
+            self.toolkit.register_agent_skill(tmp_dir)
+            response = await self.toolkit.call_tool_function(
+                ToolUseBlock(
+                    type="tool_use",
+                    id="123",
+                    name="read_skill_md",
+                    input={"skill_name": "test-skill"},
+                ),
+            )
+
+            chunks = [chunk async for chunk in response]
+            self.assertEqual(len(chunks), 1)
+            self.assertEqual(len(chunks[0].content), 1)
+            self.assertIn(
+                "This is the detailed skill instruction.",
+                chunks[0].content[0]["text"],
+            )
+
+    async def test_builtin_read_skill_md_tool_unknown_skill(self) -> None:
+        """Verify built-in SKILL.md reader handles unknown skill names."""
+        with tempfile.TemporaryDirectory(dir=".") as tmp_dir:
+            with open(
+                os.path.join(tmp_dir, "SKILL.md"),
+                "w",
+                encoding="utf-8",
+            ) as file:
+                file.write(
+                    "---\n"
+                    "name: known-skill\n"
+                    "description: test description\n"
+                    "---\n",
+                )
+
+            self.toolkit.register_agent_skill(tmp_dir)
+            response = await self.toolkit.call_tool_function(
+                ToolUseBlock(
+                    type="tool_use",
+                    id="123",
+                    name="read_skill_md",
+                    input={"skill_name": "unknown-skill"},
+                ),
+            )
+
+            chunks = [chunk async for chunk in response]
+            self.assertEqual(len(chunks), 1)
+            self.assertEqual(
+                chunks[0].content[0]["text"],
+                "Error: Skill 'unknown-skill' is not registered.",
+            )
 
     async def _verify_async_generator_wo_interruption(
         self,


### PR DESCRIPTION
## Summary
- store agent skill directories as absolute paths in `register_agent_skill`
- add built-in `read_skill_md` tool and auto-register it when at least one skill is registered
- add tests for absolute path behavior and built-in skill reader behavior

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
