### PR TITLE
fix "tool":execute_shell_command 'utf-8' codec can't decode byte 0xd5

### DIFF
--- a/src/agentscope/tool/_coding/_shell.py
+++ b/src/agentscope/tool/_coding/_shell.py
@@ -49,8 +49,8 @@ async def execute_shell_command(
     try:
         await asyncio.wait_for(proc.wait(), timeout=timeout)
         stdout, stderr = await proc.communicate()
-        stdout_str = smart_decode(stdout)  
-        stderr_str = smart_decode(stderr) 
+        stdout_str = _smart_decode(stdout)
+        stderr_str = _smart_decode(stderr)
         returncode = proc.returncode
 
     except asyncio.TimeoutError:


### PR DESCRIPTION


## AgentScope Version
1.0.16.dev0

## Description

fix "tool":execute_shell_command 'utf-8' codec can't decode byte 0xd5
https://github.com/agentscope-ai/agentscope/issues/1237
