### PR TITLE
feat: support execution timeout for MCP tools in toolkit

### DIFF
--- a/src/agentscope/mcp/_http_stateful_client.py
+++ b/src/agentscope/mcp/_http_stateful_client.py
@@ -2,8 +2,9 @@
 """The MCP stateful HTTP client module in AgentScope."""
 from typing import Any, Literal
 
+import httpx
+from mcp.client.streamable_http import streamable_http_client
 from mcp.client.sse import sse_client
-from mcp.client.streamable_http import streamablehttp_client
 
 from ._stateful_client_base import StatefulClientBase
 
@@ -67,12 +68,14 @@ class HttpStatefulClient(StatefulClientBase):
         self.transport = transport
 
         if self.transport == "streamable_http":
-            self.client = streamablehttp_client(
-                url=url,
+            http_client = httpx.AsyncClient(
                 headers=headers,
-                timeout=timeout,
-                sse_read_timeout=sse_read_timeout,
+                timeout=httpx.Timeout(timeout, read=sse_read_timeout),
                 **client_kwargs,
+            )
+            self.client = streamable_http_client(
+                url=url,
+                http_client=http_client,
             )
         else:
             self.client = sse_client(

--- a/src/agentscope/tool/_toolkit.py
+++ b/src/agentscope/tool/_toolkit.py
@@ -875,7 +875,7 @@ Check "{dir}/SKILL.md" for how to use this skill"""
                 - 'skip': skip the registration of the new tool function.
                 - 'rename': rename the new tool function by appending a random
                   suffix to make it unique.
-            execution_timeout (`float | None`, defaults to `None`):
+            execution_timeout (`float | None`, optional):
                 The timeout in seconds for executing tool functions. If `None`,
                 no timeout is applied.
         """

--- a/src/agentscope/tool/_toolkit.py
+++ b/src/agentscope/tool/_toolkit.py
@@ -838,6 +838,7 @@ Check "{dir}/SKILL.md" for how to use this skill"""
             "raise",
             "rename",
         ] = "raise",
+        execution_timeout: float | None = None,
     ) -> None:
         """Register tool functions from an MCP client.
 
@@ -874,6 +875,9 @@ Check "{dir}/SKILL.md" for how to use this skill"""
                 - 'skip': skip the registration of the new tool function.
                 - 'rename': rename the new tool function by appending a random
                   suffix to make it unique.
+            execution_timeout (`float | None`, defaults to `None`):
+                The timeout in seconds for executing tool functions. If `None`,
+                no timeout is applied.
         """
         if (
             isinstance(mcp_client, StatefulClientBase)
@@ -933,6 +937,7 @@ Check "{dir}/SKILL.md" for how to use this skill"""
             func_obj = await mcp_client.get_callable_function(
                 func_name=mcp_tool.name,
                 wrap_tool_result=True,
+                execution_timeout=execution_timeout,
             )
 
             # Prepare preset kwargs

--- a/tests/mcp_streamable_http_client_test.py
+++ b/tests/mcp_streamable_http_client_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """The MCP client test module in agentscope."""
 import asyncio
+import time
 from multiprocessing import Process
 from unittest.async_case import IsolatedAsyncioTestCase
 
@@ -9,8 +10,8 @@ from mcp.server import FastMCP
 from mcp.types import EmbeddedResource, TextResourceContents
 
 from agentscope.mcp import HttpStatelessClient, HttpStatefulClient
-from agentscope.message import TextBlock
-from agentscope.tool import ToolResponse
+from agentscope.message import TextBlock, ToolUseBlock
+from agentscope.tool import ToolResponse, Toolkit
 
 
 async def tool_1(arg1: str, arg2: list[int]) -> str:
@@ -41,6 +42,17 @@ async def tool_2() -> list:
     ]
 
 
+async def slow_tool(delay: float = 3.0) -> str:
+    """A slow tool that simulates timeout.
+
+    Args:
+        delay (`float`):
+            Sleep duration in seconds.
+    """
+    await asyncio.sleep(delay)
+    return f"Completed after {delay} seconds"
+
+
 def setup_server() -> None:
     """Set up the streamable HTTP MCP server."""
     sse_server = FastMCP("StreamableHTTP", port=8002)
@@ -48,6 +60,7 @@ def setup_server() -> None:
     sse_server.tool(
         description="A test tool function with embedded resource.",
     )(tool_2)
+    sse_server.tool(description="A slow tool for timeout testing.")(slow_tool)
     sse_server.run(transport="streamable-http")
 
 
@@ -66,6 +79,7 @@ class StreamableHttpMCPClientTest(IsolatedAsyncioTestCase):
         self.process = Process(target=setup_server)
         self.process.start()
         await asyncio.sleep(10)
+        self.toolkit = Toolkit()
 
     async def test_streamable_http_stateless_client(self) -> None:
         """Test the MCP server connection functionality."""
@@ -183,3 +197,75 @@ class StreamableHttpMCPClientTest(IsolatedAsyncioTestCase):
                 ],
             ),
         )
+
+    async def test_execution_timeout_with_register_mcp_client(self) -> None:
+        """Test execution_timeout parameter in register_mcp_client."""
+        stateless_client = HttpStatelessClient(
+            name="test_timeout_stateless",
+            transport="streamable_http",
+            url=f"http://127.0.0.1:{self.port}/mcp",
+        )
+
+        # Register with execution_timeout=1.0 second
+        await self.toolkit.register_mcp_client(
+            stateless_client,
+            execution_timeout=1.0,
+        )
+
+        # Call slow_tool should timeout in ~1 second
+        start_time = time.time()
+        res_gen = await self.toolkit.call_tool_function(
+            ToolUseBlock(
+                id="timeout_test",
+                type="tool_use",
+                name="slow_tool",
+                input={"delay": 3.0},
+            ),
+        )
+
+        response_received = False
+        async for chunk in res_gen:
+            response_received = True
+            self.assertIsInstance(chunk, ToolResponse)
+
+        elapsed = time.time() - start_time
+        self.assertTrue(response_received, "Should receive error response")
+        # Should timeout around 1 second, allow 0.5s tolerance
+        self.assertLess(elapsed, 2.0, f"Should timeout in ~1s, got {elapsed:.2f}s")
+        self.assertGreater(elapsed, 0.5, f"Should take at least 0.5s, got {elapsed:.2f}s")
+
+        # Test stateful client
+        self.toolkit.clear()
+        stateful_client = HttpStatefulClient(
+            name="test_timeout_stateful",
+            transport="streamable_http",
+            url=f"http://127.0.0.1:{self.port}/mcp",
+        )
+        await stateful_client.connect()
+
+        await self.toolkit.register_mcp_client(
+            stateful_client,
+            execution_timeout=1.0,
+        )
+
+        start_time = time.time()
+        res_gen = await self.toolkit.call_tool_function(
+            ToolUseBlock(
+                id="timeout_test_stateful",
+                type="tool_use",
+                name="slow_tool",
+                input={"delay": 3.0},
+            ),
+        )
+
+        response_received = False
+        async for chunk in res_gen:
+            response_received = True
+            self.assertIsInstance(chunk, ToolResponse)
+
+        elapsed = time.time() - start_time
+        self.assertTrue(response_received, "Should receive error response")
+        self.assertLess(elapsed, 2.0, f"Should timeout in ~1s, got {elapsed:.2f}s")
+        self.assertGreater(elapsed, 0.5, f"Should take at least 0.5s, got {elapsed:.2f}s")
+
+        await stateful_client.close()


### PR DESCRIPTION

## PR Title

```
feat(toolkit): add execution_timeout parameter to register_mcp_tools()
```

## AgentScope Version

```
0.1.5
```

## Description

**Background:** MCP tool function execution may block indefinitely due to network or server issues, requiring timeout control.

**Purpose:** Add `execution_timeout` parameter to `register_mcp_tools()` method to allow users to set execution timeout for MCP tool functions.

**Changes:**
- `_toolkit.py` line 841: Add `execution_timeout: float | None = None` parameter to method signature
- `_toolkit.py` lines 875-877: Add parameter documentation
- `_toolkit.py` line 940: Pass `execution_timeout` to `get_callable_function()`

**How to test:**
```python
from agentscope.tool import Toolkit
from agentscope.mcp import MCPClient

toolkit = Toolkit()
# Set 30 seconds timeout
toolkit.register_mcp_tools(mcp_client, execution_timeout=30.0)
```

## Checklist

- [ ] Code has been formatted with `pre-commit run --all-files` command
- [ ] All tests are passing
- [ ] Docstrings are in Google style
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [ ] Code is ready for review