### PR TITLE
fix(DashScope formatter): convert local files to base64 data in dashscope formatter

### DIFF
--- a/examples/functionality/rag/multimodal_rag.py
+++ b/examples/functionality/rag/multimodal_rag.py
@@ -65,7 +65,7 @@ async def example_multimodal_rag() -> None:
 
     # Let's see if the agent has stored the retrieved document in its memory
     print("\nThe retrieved document stored in the agent's memory:")
-    content = (await agent.memory.get_memory())[-4].content
+    content = (await agent.memory.get_memory())[-2].content
     print(json.dumps(content, indent=2, ensure_ascii=False))
 
 

--- a/src/agentscope/formatter/_dashscope_formatter.py
+++ b/src/agentscope/formatter/_dashscope_formatter.py
@@ -6,7 +6,7 @@ import base64
 import json
 import mimetypes
 import os.path
-from typing import Any
+from typing import Any, cast
 
 from ._truncated_formatter_base import TruncatedFormatterBase
 from .._logging import logger
@@ -25,17 +25,17 @@ from ..token import TokenCounterBase
 
 
 def _format_dashscope_media_block(
-    block: ImageBlock | AudioBlock,
+    block: ImageBlock | AudioBlock | VideoBlock,
 ) -> dict[str, str]:
-    """Format an image or audio block for DashScope API.
+    """Format an image, audio, or video block for DashScope API.
 
     Args:
-        block (`ImageBlock` | `AudioBlock`):
-            The image or audio block to format.
+        block (`ImageBlock | AudioBlock | VideoBlock`):
+            The media block to format.
 
     Returns:
         `dict[str, str]`:
-            A dictionary with "image" or "audio" key and the formatted URL or
+            A dictionary with the media type key and the formatted URL or
             data URI as value.
 
     Raises:
@@ -278,7 +278,10 @@ class DashScopeChatFormatter(TruncatedFormatterBase):
                 elif typ in ["image", "audio", "video"]:
                     content_blocks.append(
                         _format_dashscope_media_block(
-                            block,  # type: ignore[arg-type]
+                            cast(
+                                ImageBlock | AudioBlock | VideoBlock,
+                                block,
+                            ),
                         ),
                     )
 
@@ -577,7 +580,12 @@ class DashScopeMultiAgentFormatter(TruncatedFormatterBase):
                         accumulated_text.clear()
 
                     conversation_blocks.append(
-                        _format_dashscope_media_block(block),
+                        _format_dashscope_media_block(
+                            cast(
+                                ImageBlock | AudioBlock | VideoBlock,
+                                block,
+                            ),
+                        ),
                     )
 
         if accumulated_text:

--- a/src/agentscope/formatter/_dashscope_formatter.py
+++ b/src/agentscope/formatter/_dashscope_formatter.py
@@ -45,7 +45,7 @@ def _format_dashscope_media_block(
     typ = block["type"]
     source = block["source"]
     if source["type"] == "url":
-        url = source["url"]
+        url = source["url"].removeprefix("file://")
         if _is_accessible_local_file(url):
             abs_path = os.path.abspath(url)
             media_type = mimetypes.guess_type(abs_path)[0]

--- a/tests/formatter_dashscope_test.py
+++ b/tests/formatter_dashscope_test.py
@@ -27,8 +27,14 @@ class TestDashScopeFormatter(IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:
         """Set up the test environment."""
         self.image_path = "./image.png"
+        self.image_content = b"fake image content"
         with open(self.image_path, "wb") as f:
-            f.write(b"fake image content")
+            f.write(self.image_content)
+
+        import base64
+
+        b64 = base64.b64encode(self.image_content).decode("utf-8")
+        self.image_data_uri = f"data:image/png;base64,{b64}"
 
         self.mock_audio_path = (
             "/var/folders/gf/krg8x_ws409cpw_46b2s6rjc0000gn/T/tmpfymnv2w9.wav"
@@ -228,7 +234,7 @@ class TestDashScopeFormatter(IsolatedAsyncioTestCase):
                         "text": "What is the capital of France?",
                     },
                     {
-                        "image": f"file://{os.path.abspath(self.image_path)}",
+                        "image": self.image_data_uri,
                     },
                 ],
             },
@@ -301,7 +307,7 @@ class TestDashScopeFormatter(IsolatedAsyncioTestCase):
                         " is the capital of France?",
                     },
                     {
-                        "image": f"file://{os.path.abspath(self.image_path)}",
+                        "image": self.image_data_uri,
                     },
                     {
                         "text": "assistant: The capital of France is Paris."
@@ -403,7 +409,7 @@ class TestDashScopeFormatter(IsolatedAsyncioTestCase):
                         "France?",
                     },
                     {
-                        "image": f"file://{os.path.abspath(self.image_path)}",
+                        "image": self.image_data_uri,
                     },
                     {
                         "text": "assistant: The capital of France is Paris."
@@ -583,7 +589,7 @@ class TestDashScopeFormatter(IsolatedAsyncioTestCase):
                         "text": "What is the capital of France?",
                     },
                     {
-                        "image": f"file://{os.path.abspath(self.image_path)}",
+                        "image": self.image_data_uri,
                     },
                 ],
             },
@@ -647,7 +653,7 @@ class TestDashScopeFormatter(IsolatedAsyncioTestCase):
                         "text": "\n- The image from './image.png': ",
                     },
                     {
-                        "image": f"file://{os.path.abspath(self.image_path)}",
+                        "image": self.image_data_uri,
                     },
                     {
                         "text": "\n- The audio from "
@@ -818,7 +824,7 @@ class TestDashScopeFormatter(IsolatedAsyncioTestCase):
                         " is the capital of France?",
                     },
                     {
-                        "image": f"file://{os.path.abspath(self.image_path)}",
+                        "image": self.image_data_uri,
                     },
                     {
                         "text": "assistant: The capital of France is Paris."
@@ -871,7 +877,7 @@ class TestDashScopeFormatter(IsolatedAsyncioTestCase):
                         "text": "\n- The image from './image.png': ",
                     },
                     {
-                        "image": f"file://{os.path.abspath(self.image_path)}",
+                        "image": self.image_data_uri,
                     },
                     {
                         "text": "\n- The audio from "


### PR DESCRIPTION
## AgentScope Version

1.0.16

## Description

- Fix the `FileAlreadyExists` error from DashScope SDK when the same local image appears in memory across multiple agent calls
- Local media files are now converted to base64 data URIs in `_format_dashscope_media_block` instead of `file:// URLs`, avoiding repeated OSS uploads
- Refactor DashScopeMultiAgentFormatter to reuse `_format_dashscope_media_block` for consistent media handling
## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review