### PR TITLE
fix(tool): expand user home in text file tools for paths with tilde

### DIFF
--- a/src/agentscope/tool/_text_file/_view_text_file.py
+++ b/src/agentscope/tool/_text_file/_view_text_file.py
@@ -26,6 +26,7 @@ async def view_text_file(
         `ToolResponse`:
             The tool response containing the file content or an error message.
     """
+    file_path = os.path.expanduser(file_path)
     if not os.path.exists(file_path):
         return ToolResponse(
             content=[

--- a/src/agentscope/tool/_text_file/_write_text_file.py
+++ b/src/agentscope/tool/_text_file/_write_text_file.py
@@ -41,6 +41,7 @@ async def insert_text_file(
             ],
         )
 
+    file_path = os.path.expanduser(file_path)
     if not os.path.exists(file_path):
         return ToolResponse(
             content=[
@@ -124,7 +125,7 @@ async def write_text_file(
         `ToolResponse`:
             The tool response containing the result of the writing operation.
     """
-
+    file_path = os.path.expanduser(file_path)
     if not os.path.exists(file_path):
         with open(file_path, "w", encoding="utf-8") as file:
             file.write(content)

--- a/tests/tool_test.py
+++ b/tests/tool_test.py
@@ -205,6 +205,21 @@ print("456")"""
                 res.content[0]["text"],
             )
 
+        # Test tilde expansion: path with ~ should resolve to user home
+        home = os.path.expanduser("~")
+        test_name = f".agentscope_tool_test_{shortuuid.uuid()}.txt"
+        tilde_path = f"~/{test_name}"
+        real_path = os.path.join(home, test_name)
+        try:
+            with open(real_path, "w", encoding="utf-8") as f:
+                f.write("tilde expansion works\n")
+            res = await view_text_file(file_path=tilde_path)
+            self.assertIn("tilde expansion works", res.content[0]["text"])
+            self.assertIn("1: tilde expansion works", res.content[0]["text"])
+        finally:
+            if os.path.exists(real_path):
+                os.remove(real_path)
+
     async def test_write_text_file(self) -> None:
         """Test writing to text file."""
         # create and write a new file


### PR DESCRIPTION
# fix(tool): expand user home in text file tools for paths with tilde

## Problem
`view_text_file`, `write_text_file`, and `insert_text_file` do not expand `~` in file paths. Passing a path like `~/.aiway/credentials.json` causes "The file ... does not exist" because `os.path.exists()` and `open()` receive the literal path without expanding the user home directory.

## Solution
Call `os.path.expanduser(file_path)` at the start of each of the three tool functions so that paths like `~/file.txt` resolve to the current user's home directory (cross-platform).

## Changes
- **src/agentscope/tool/_text_file/_view_text_file.py**: add `file_path = os.path.expanduser(file_path)` before existence check in `view_text_file`.
- **src/agentscope/tool/_text_file/_write_text_file.py**: add the same in `insert_text_file` and `write_text_file`.
- **tests/tool_test.py**: add a test that creates a file under `~`, calls `view_text_file("~/...")`, and asserts the content is returned correctly.

## Testing
- `pytest agentscope/tests/tool_test.py -v -k "test_view_text_file or test_write_text_file or test_insert_text_file"` (run from repo root with `PYTHONPATH=agentscope/src` if using a different venv).
