### PR TITLE
fix(deps): resolve uv sync numpy dependency conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,8 +189,8 @@ build-backend = "setuptools.build_meta"
 version = {attr = "agentscope._version.__version__"}
 
 [tool.uv]
-# Override py-openjudge's numpy<2.0.0 constraint to resolve conflict
-# with qdrant-client's numpy>=2.1.0 requirement on Python>=3.13
+# Override py-openjudge's numpy<2.0.0 constraint to resolve conflicts
+# with dependencies requiring newer numpy (e.g., qdrant-client on Python>=3.13).
 override-dependencies = [
     "numpy>=1.22.0",
 ]


### PR DESCRIPTION
## Summary
- add `[tool.uv].override-dependencies` for `numpy>=1.22.0`
- remove the transitive `numpy<2.0.0` restriction coming from `py-openjudge`
- allow `uv sync` resolution to proceed with `qdrant-client` on Python >= 3.13

Closes #1267