### PR TITLE
fix(openai-model): support newer vllm reasoning field parsing

### DIFF
--- a/src/agentscope/model/_openai_model.py
+++ b/src/agentscope/model/_openai_model.py
@@ -375,7 +375,9 @@ class OpenAIChatModel(ChatModelBase):
                 choice = chunk.choices[0]
 
                 delta_reasoning = getattr(
-                    choice.delta, "reasoning_content", None
+                    choice.delta,
+                    "reasoning_content",
+                    None,
                 )
                 if not isinstance(delta_reasoning, str):
                     delta_reasoning = getattr(choice.delta, "reasoning", None)

--- a/src/agentscope/model/_openai_model.py
+++ b/src/agentscope/model/_openai_model.py
@@ -374,11 +374,13 @@ class OpenAIChatModel(ChatModelBase):
 
                 choice = chunk.choices[0]
 
-                thinking += (
-                    getattr(choice.delta, "reasoning_content", None) 
-                    or getattr(choice.delta, "reasoning", None)
-                    or ""
-                )
+                delta_reasoning = getattr(choice.delta, "reasoning_content", None)
+                if not isinstance(delta_reasoning, str):
+                    delta_reasoning = getattr(choice.delta, "reasoning", None)
+                if not isinstance(delta_reasoning, str):
+                    delta_reasoning = ""
+
+                thinking += delta_reasoning
                 text += getattr(choice.delta, "content", None) or ""
 
                 if (
@@ -540,10 +542,11 @@ class OpenAIChatModel(ChatModelBase):
 
         if response.choices:
             choice = response.choices[0]
-            reasoning = (
-                getattr(choice.message, "reasoning_content", None)
-                or getattr(choice.message, "reasoning", None)
-            )
+            reasoning = getattr(choice.message, "reasoning_content", None)
+            if not isinstance(reasoning, str):
+                reasoning = getattr(choice.message, "reasoning", None)
+            if not isinstance(reasoning, str):
+                reasoning = None
 
             if reasoning is not None:
                 content_blocks.append(

--- a/src/agentscope/model/_openai_model.py
+++ b/src/agentscope/model/_openai_model.py
@@ -374,7 +374,9 @@ class OpenAIChatModel(ChatModelBase):
 
                 choice = chunk.choices[0]
 
-                delta_reasoning = getattr(choice.delta, "reasoning_content", None)
+                delta_reasoning = getattr(
+                    choice.delta, "reasoning_content", None
+                )
                 if not isinstance(delta_reasoning, str):
                     delta_reasoning = getattr(choice.delta, "reasoning", None)
                 if not isinstance(delta_reasoning, str):

--- a/src/agentscope/model/_openai_model.py
+++ b/src/agentscope/model/_openai_model.py
@@ -375,7 +375,9 @@ class OpenAIChatModel(ChatModelBase):
                 choice = chunk.choices[0]
 
                 thinking += (
-                    getattr(choice.delta, "reasoning_content", None) or ""
+                    getattr(choice.delta, "reasoning_content", None) 
+                    or getattr(choice.delta, "reasoning", None)
+                    or ""
                 )
                 text += getattr(choice.delta, "content", None) or ""
 
@@ -538,14 +540,16 @@ class OpenAIChatModel(ChatModelBase):
 
         if response.choices:
             choice = response.choices[0]
-            if (
-                hasattr(choice.message, "reasoning_content")
-                and choice.message.reasoning_content is not None
-            ):
+            reasoning = (
+                getattr(choice.message, "reasoning_content", None)
+                or getattr(choice.message, "reasoning", None)
+            )
+
+            if reasoning is not None:
                 content_blocks.append(
                     ThinkingBlock(
                         type="thinking",
-                        thinking=response.choices[0].message.reasoning_content,
+                        thinking=reasoning,
                     ),
                 )
 


### PR DESCRIPTION
## Summary

This PR adds compatibility for newer vLLM (v0.16.0+) OpenAI-compatible responses that return
`reasoning` instead of `reasoning_content`.

AgentScope currently reads `reasoning_content` when constructing thinking blocks.
With newer vLLM versions, thinking output may be missed.

## Changes

- keep backward compatibility with `reasoning_content`
- add fallback to `reasoning` for streaming responses
- add fallback to `reasoning` for non-streaming responses

## Motivation

Upstream vLLM has migrated reasoning output from `reasoning_content` to `reasoning`.
In v0.16.0, vLLM explicitly removed the deprecated `reasoning_content` message field.
This patch allows AgentScope to support both old and new vLLM versions without
breaking existing integrations.

## References

- [vLLM latest docs: Reasoning Outputs](https://docs.vllm.ai/en/latest/features/reasoning_outputs/)
- [vLLM RFC: `reasoning_content` -> `reasoning`](https://github.com/vllm-project/vllm/issues/27755)
- [vLLM release v0.16.0: deprecated `reasoning_content` field removed](https://github.com/vllm-project/vllm/releases/tag/v0.16.0)
- [Older vLLM docs: `reasoning_content` (for comparison)](https://docs.vllm.ai/en/v0.9.1/features/reasoning_outputs.html)

This change is backward compatible and only extends the existing parsing logic.