### PR TITLE
fix(formatter): add ThinkingBlock support to DashScope formatter (#1067)

### DIFF
--- a/src/agentscope/formatter/_dashscope_formatter.py
+++ b/src/agentscope/formatter/_dashscope_formatter.py
@@ -12,6 +12,7 @@ from .._utils._common import _is_accessible_local_file
 from ..message import (
     Msg,
     TextBlock,
+    ThinkingBlock,
     ImageBlock,
     AudioBlock,
     VideoBlock,
@@ -179,6 +180,7 @@ class DashScopeChatFormatter(TruncatedFormatterBase):
 
     supported_blocks: list[type] = [
         TextBlock,
+        ThinkingBlock,
         ImageBlock,
         AudioBlock,
         VideoBlock,
@@ -260,6 +262,14 @@ class DashScopeChatFormatter(TruncatedFormatterBase):
                     content_blocks.append(
                         {
                             "text": block.get("text"),
+                        },
+                    )
+
+                elif typ == "thinking":
+                    content_blocks.append(
+                        {
+                            "type": "thinking",
+                            "thinking": block.get("thinking"),
                         },
                     )
 
@@ -440,6 +450,7 @@ class DashScopeMultiAgentFormatter(TruncatedFormatterBase):
 
     supported_blocks: list[type] = [
         TextBlock,
+        ThinkingBlock,
         # Multimodal
         ImageBlock,
         AudioBlock,
@@ -555,6 +566,22 @@ class DashScopeMultiAgentFormatter(TruncatedFormatterBase):
             for block in msg.get_content_blocks():
                 if block["type"] == "text":
                     accumulated_text.append(f"{msg.name}: {block['text']}")
+
+                elif block["type"] == "thinking":
+                    # Handle the accumulated text as a single block
+                    if accumulated_text:
+                        conversation_blocks.append(
+                            {"text": "\n".join(accumulated_text)},
+                        )
+                        accumulated_text.clear()
+
+                    # Add thinking block
+                    conversation_blocks.append(
+                        {
+                            "type": "thinking",
+                            "thinking": block.get("thinking"),
+                        },
+                    )
 
                 elif block["type"] in ["image", "audio", "video"]:
                     # Handle the accumulated text as a single block

--- a/tests/formatter_dashscope_test.py
+++ b/tests/formatter_dashscope_test.py
@@ -13,6 +13,7 @@ from agentscope.message import (
     ToolUseBlock,
     ToolResultBlock,
     TextBlock,
+    ThinkingBlock,
     ImageBlock,
     AudioBlock,
     VideoBlock,
@@ -901,6 +902,47 @@ class TestDashScopeFormatter(IsolatedAsyncioTestCase):
 
         self.maxDiff = None
         self.assertListEqual(expected_result, res)
+
+    async def test_thinking_block_support(self) -> None:
+        """Test that DashScope formatter supports ThinkingBlock (issue #1067)."""
+        formatter = DashScopeChatFormatter()
+
+        # Test with ThinkingBlock in assistant message
+        msg_with_thinking = Msg(
+            name="assistant",
+            role="assistant",
+            content=[
+                ThinkingBlock(
+                    type="thinking",
+                    thinking="Let me analyze this problem step by step...",
+                ),
+                TextBlock(
+                    type="text",
+                    text="Based on my analysis, the answer is 42.",
+                ),
+            ],
+        )
+
+        res = await formatter.format([msg_with_thinking])
+
+        # Verify thinking block is preserved in the output
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0]["role"], "assistant")
+        self.assertIsInstance(res[0]["content"], list)
+        self.assertEqual(len(res[0]["content"]), 2)
+
+        # Check thinking block
+        self.assertEqual(res[0]["content"][0]["type"], "thinking")
+        self.assertEqual(
+            res[0]["content"][0]["thinking"],
+            "Let me analyze this problem step by step...",
+        )
+
+        # Check text block
+        self.assertEqual(
+            res[0]["content"][1]["text"],
+            "Based on my analysis, the answer is 42.",
+        )
 
     async def asyncTearDown(self) -> None:
         """Clean up the test environment."""


### PR DESCRIPTION
## Summary

- **Bug**: DashScope formatter skips ThinkingBlock with warning "Unsupported block type thinking"
- **Root cause**: `src/agentscope/formatter/_dashscope_formatter.py` doesn't include ThinkingBlock in supported_blocks list and has no handling logic
- **Fix**: Add ThinkingBlock to supported_blocks and implement handling logic (similar to Anthropic formatter)

Fixes #1067

## Problem

When using DashScope models (qwen-plus, qwen3-max, etc.) with thinking mode enabled, the formatter skips ThinkingBlock content and logs a warning:

```
WARNING | _dashscope_formatter:_format:391 - Unsupported block type thinking in the message, skipped.
```

This causes:
1. Thinking process is not preserved in the conversation
2. Stream printing is interrupted (last=true triggered prematurely)
3. Users reported this affects multiple models: qwen-plus, qwen3-max, Kimi-k2.5, MiniMax-M2.5, glm-5, etc.

**Before fix:**
```python
formatter = DashScopeChatFormatter()
msg = Msg(
    name="assistant",
    role="assistant",
    content=[
        ThinkingBlock(type="thinking", thinking="Let me think..."),
        TextBlock(type="text", text="Here is my answer."),
    ],
)
formatted = await formatter.format([msg])
# Output: [{'role': 'assistant', 'content': 'Here is my answer.'}]
# ThinkingBlock is skipped\!
```

## Changes

- `src/agentscope/formatter/_dashscope_formatter.py`:
  - Import ThinkingBlock
  - Add ThinkingBlock to supported_blocks in both DashScopeChatFormatter and DashScopeMultiAgentFormatter
  - Add handling logic for thinking blocks in _format methods (preserves thinking content)
- `tests/formatter_dashscope_test.py`:
  - Import ThinkingBlock
  - Add test_thinking_block_support test case

**After fix:**
```python
formatted = await formatter.format([msg])
# Output: [{'role': 'assistant', 'content': [
#   {'type': 'thinking', 'thinking': 'Let me think...'},
#   {'text': 'Here is my answer.'}
# ]}]
# ThinkingBlock is preserved\!
```

## Test plan

- [x] **Reproduced bug on main**: Created reproduction script, confirmed ThinkingBlock is skipped with warning
- [x] **Verified fix**: Reproduction script passes after fix, no warning, ThinkingBlock preserved
- [x] New test: test_thinking_block_support verifies ThinkingBlock handling
- [x] All 5 existing DashScope formatter tests pass
- [x] No breaking changes to existing functionality

## Effect on User Experience

**Before:** Thinking process is lost when using DashScope models with thinking mode. Stream printing is interrupted. Multiple users affected across different models.

**After:** Thinking blocks are correctly preserved and passed to DashScope API. Stream printing works smoothly. Users can see the full reasoning process.