### PR TITLE
fix(plan): trigger hooks when recovering historical plans

### DIFF
--- a/src/agentscope/plan/_plan_notebook.py
+++ b/src/agentscope/plan/_plan_notebook.py
@@ -815,6 +815,7 @@ class PlanNotebook(StateModule):
                 ],
             )
         self.current_plan = historical_plan
+        await self._trigger_plan_change_hooks()
         return res
 
     def list_tools(

--- a/tests/plan_test.py
+++ b/tests/plan_test.py
@@ -782,3 +782,42 @@ Subtask at index 2:
         notebook.remove_plan_change_hook("test")
         with self.assertRaises(ValueError):
             notebook.remove_plan_change_hook("bad_hook")
+
+    async def test_recover_historical_plan_triggers_hook(self) -> None:
+        """Test recovering a historical plan triggers plan change hooks."""
+        notebook = PlanNotebook()
+        hook_calls: list[str | None] = []
+
+        def hook(_nb: PlanNotebook, plan: Plan | None) -> None:
+            hook_calls.append(plan.name if plan else None)
+
+        notebook.register_plan_change_hook("recover_hook", hook)
+
+        await notebook.create_plan(
+            "P1",
+            "desc",
+            "outcome",
+            [SubTask(name="t1", description="d", expected_outcome="e")],
+        )
+        await notebook.finish_plan("done", "final")
+
+        self.assertEqual(
+            len(hook_calls),
+            2,
+        )
+        self.assertEqual(
+            hook_calls,
+            ["P1", None],
+        )
+
+        historical_plan = (await notebook.storage.get_plans())[0]
+        await notebook.recover_historical_plan(historical_plan.id)
+
+        self.assertEqual(
+            len(hook_calls),
+            3,
+        )
+        self.assertEqual(
+            hook_calls[-1],
+            "P1",
+        )


### PR DESCRIPTION
## AgentScope Version

`1.0.16`

## Description

**Fixes #1280**

### Background
`PlanNotebook.recover_historical_plan()` updates `current_plan` but did not trigger plan change hooks. 
This causes hook-based observers (e.g., UI/state listeners) to miss the recover event and display stale plan state.

### Purpose
Ensure historical plan recovery emits the same plan-change signal as other plan state transitions.

### Changes
1. In `src/agentscope/plan/_plan_notebook.py`:
    - After `self.current_plan = historical_plan`, added: `await self._trigger_plan_change_hooks()`
2. In `tests/plan_test.py`:
    - Added regression test `test_recover_historical_plan_triggers_hook`
    - Verifies hook call count increases after `recover_historical_plan(...)`

### How to test
```bash
python3.10 -m pytest -q tests/plan_test.py
python3.10 -m pytest -q tests
python3.10 -m pre_commit run --all-files