### PR TITLE
fix(utils): resolve double dot in file extension when saving base64 data

### DIFF
--- a/src/agentscope/_utils/_common.py
+++ b/src/agentscope/_utils/_common.py
@@ -176,7 +176,7 @@ def _save_base64_data(
     extension = "." + media_type.split("/")[-1]
 
     with tempfile.NamedTemporaryFile(
-        suffix=f".{extension}",
+        suffix=extension,
         delete=False,
     ) as temp_file:
         decoded_data = base64.b64decode(base64_data)


### PR DESCRIPTION
## AgentScope Version

1.0.16 (e.g. `import agentscope; print(agentscope.__version__)`)

## Description

**Background:** In `_save_base64_data` (`src/agentscope/_utils/_common.py`), the temporary file suffix was built by adding a dot to `extension`, but `extension` already includes the leading dot (e.g. `.png`), which produced a double dot (e.g. `..png`).

**Purpose:** Ensure saved base64 files get a correct single-dot extension (e.g. `.png`, `.mpeg`) so downstream tools and paths behave as expected.

**Changes:** Use `suffix=extension` instead of `suffix=f".{extension}"` when creating the `NamedTemporaryFile`, since `extension` is already in the form `.png`.

**How to test:**
```python
from agentscope._utils._common import _save_base64_data

base64_data = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
path = _save_base64_data("image/png", base64_data)
assert path.endswith(".png") and "..png" not in path  # should pass
print(path)  # e.g. /tmp/tmpXXXXXX.png
```

Fixes #1288