### PR TITLE
fix(model): update DashScopeChatModel to use AioMultiModalConversatio…

### DIFF
--- a/src/agentscope/model/_dashscope_model.py
+++ b/src/agentscope/model/_dashscope_model.py
@@ -97,7 +97,7 @@ class DashScopeChatModel(ChatModelBase):
                 for more details.
             multimodality (`bool | None`, optional):
                 Whether to use multimodal conversation API. If `True`,
-                it will use `dashscope.MultiModalConversation.call`
+                it will use `dashscope.AioMultiModalConversation.call`
                 to process multimodal inputs such as images and text. If
                 `False`, it will use
                 `dashscope.aigc.generation.AioGeneration.call` to process
@@ -270,7 +270,7 @@ class DashScopeChatModel(ChatModelBase):
                 or "-vl" in self.model_name
             )
         ):
-            response = dashscope.MultiModalConversation.call(
+            response = await dashscope.AioMultiModalConversation.call(
                 api_key=self.api_key,
                 **kwargs,
             )
@@ -302,6 +302,7 @@ class DashScopeChatModel(ChatModelBase):
         start_datetime: datetime,
         response: Union[
             AsyncGenerator[GenerationResponse, None],
+            AsyncGenerator[MultiModalConversationResponse, None],
             Generator[MultiModalConversationResponse, None, None],
         ],
         structured_model: Type[BaseModel] | None = None,
@@ -313,11 +314,12 @@ class DashScopeChatModel(ChatModelBase):
             start_datetime (`datetime`):
                 The start datetime of the response generation.
             response (
-                `Union[AsyncGenerator[GenerationResponse, None], Generator[ \
-                MultiModalConversationResponse, None, None]]`
+                `Union[AsyncGenerator[GenerationResponse, None], \
+                AsyncGenerator[MultiModalConversationResponse, None], \
+                Generator[MultiModalConversationResponse, None, None]]`
             ):
-                DashScope streaming response generator (GenerationResponse or
-                MultiModalConversationResponse) to parse.
+                DashScope streaming response (async) generator
+                (GenerationResponse or MultiModalConversationResponse).
             structured_model (`Type[BaseModel] | None`, default `None`):
                 A Pydantic BaseModel class that defines the expected structure
                 for the model's output.

--- a/tests/model_dashscope_test.py
+++ b/tests/model_dashscope_test.py
@@ -2,7 +2,7 @@
 """Unit tests for DashScope API model class."""
 from typing import Any, AsyncGenerator
 from unittest.async_case import IsolatedAsyncioTestCase
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 from http import HTTPStatus
 from pydantic import BaseModel
 
@@ -381,6 +381,32 @@ class TestDashScopeChatModel(IsolatedAsyncioTestCase):
             except Exception as e:
                 if "schema must be a dict" in str(e):
                     self.fail("Valid tools schema was rejected")
+
+    async def test_call_with_multimodal_model(self) -> None:
+        """Test multimodal model uses AioMultiModalConversation (async)."""
+        model = DashScopeChatModel(
+            model_name="qwen-vl-plus",
+            api_key="test_key",
+            stream=False,
+            multimodality=True,
+        )
+        messages = [{"role": "user", "content": "Describe this image."}]
+        mock_response = self._create_mock_response("This is a test image.")
+        with patch(
+            "dashscope.AioMultiModalConversation.call",
+            new_callable=AsyncMock,
+        ) as mock_call:
+            mock_call.return_value = mock_response
+            result = await model(messages)
+            mock_call.assert_called_once()
+            call_kwargs = mock_call.call_args[1]
+            self.assertEqual(call_kwargs["messages"], messages)
+            self.assertEqual(call_kwargs["model"], "qwen-vl-plus")
+            self.assertIsInstance(result, ChatResponse)
+            self.assertEqual(
+                result.content,
+                [TextBlock(type="text", text="This is a test image.")],
+            )
 
     async def test_error_handling_scenarios(self) -> None:
         """Test various error handling scenarios."""


### PR DESCRIPTION
Fixes #1277

## AgentScope Version

1.0.16

## Description

**Background:** When `DashScopeChatModel` is used with multimodal models (e.g. `qwen-vl-plus` or with `multimodality=True`), it previously called the synchronous `dashscope.MultiModalConversation.call()`. That call blocks the asyncio event loop for the whole duration of the request, so in async frameworks (e.g. FastAPI) all other endpoints stay unresponsive until the call finishes.

**Purpose:** Use the async API provided by the DashScope SDK (`dashscope.AioMultiModalConversation.call()`) for the multimodal path so that the event loop is not blocked and behaviour is consistent with the non-multimodal path (`AioGeneration.call()`).

**Changes:**
- In `src/agentscope/model/_dashscope_model.py`, replace `dashscope.MultiModalConversation.call(...)` with `await dashscope.AioMultiModalConversation.call(...)` when the multimodal branch is taken.
- Update type hints for `_parse_dashscope_stream_response` to include `AsyncGenerator[MultiModalConversationResponse, None]` for the multimodal stream response.
- Update the docstring for the `multimodality` parameter to mention `AioMultiModalConversation.call`.
- Add a unit test `test_call_with_multimodal_model` in `tests/model_dashscope_test.py` that mocks `AioMultiModalConversation.call` and asserts the multimodal path is used and the response is parsed correctly.

**How to test:**
- Run: `pytest tests/model_dashscope_test.py -v` — all tests, including the new multimodal test, should pass.
- Optionally: use a FastAPI app that calls a multimodal `DashScopeChatModel` in an async endpoint; other routes should remain responsive during the model call.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x] Code has been formatted with `pre-commit run --all-files` command
- [x] All tests are passing
- [x] Docstrings are in Google style
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review