### PR TITLE
feat(evaluate): add AgentLoop integration for CMS dataset loading

### DIFF
--- a/examples/evaluation/agentloop_demo/README.md
+++ b/examples/evaluation/agentloop_demo/README.md
@@ -11,7 +11,7 @@ This example demonstrates how to use the AgentLoop integration:
 1. **Install dependencies**
 
 ```bash
-pip install agentscope[agentloop]
+pip install agentscope aliyun-log-python-sdk alibabacloud-cms20240330-inner
 ```
 
 2. **Prepare your credentials**

--- a/examples/evaluation/agentloop_demo/README.md
+++ b/examples/evaluation/agentloop_demo/README.md
@@ -1,0 +1,74 @@
+# AgentLoop Integration Example
+
+This example demonstrates how to use the AgentLoop integration:
+1. Load evaluation datasets from Alibaba Cloud AgentLoop 
+2. Write Experiment results to SLS (Log Service)
+
+## Quick Start
+
+### Prerequisites
+
+1. **Install dependencies**
+
+```bash
+pip install agentscope
+```
+
+2. **Prepare your credentials**
+
+You need Alibaba Cloud Access Key ID and Secret with permissions to access CMS and SLS.
+
+### Running the Example
+
+1. **Edit `main.py`** and replace the placeholder values:
+
+```python
+await run_agentloop_experiment(
+    ak="replace with your ak",
+    sk="replace with your sk",
+    workspace="replace with your workspace",
+    dataset="replace with your dataset name",
+    region_id="replace with your region_id",
+    result_dir="./results",
+)
+```
+
+2. **Run the evaluation**
+
+```bash
+cd examples/evaluation/agentloop_demo
+python main.py
+```
+
+## Configuration
+
+The `AgentLoopConfig` class is used to configure both dataset loading and result storage:
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `workspace` | Yes | CMS workspace name |
+| `dataset` | Yes | CMS dataset name |
+| `region_id` | Yes | Alibaba Cloud region ID (e.g., `cn-hangzhou`) |
+| `access_key_id` | Yes | Alibaba Cloud Access Key ID |
+| `access_key_secret` | Yes | Alibaba Cloud Access Key Secret |
+
+## Code Structure
+
+### Solution Function
+
+Implement your agent logic in the solution function:
+
+```python
+async def http_agent_solution(
+    task: Task,
+    pre_hook: Callable,
+) -> SolutionOutput:
+    output = ""  # Call your agent and get the output
+    
+    return SolutionOutput(
+        success=True,
+        output=output,
+        trajectory=[],
+        meta={"task": task},
+    )
+```

--- a/examples/evaluation/agentloop_demo/README.md
+++ b/examples/evaluation/agentloop_demo/README.md
@@ -11,16 +11,7 @@ This example demonstrates how to use the AgentLoop integration:
 1. **Install dependencies**
 
 ```bash
-pip install agentscope
-
-# For writing results to SLS (Log Service)
-pip install aliyun-log-python-sdk
-
-# For loading datasets from AgentLoop CMS (requires Alibaba internal PyPI)
-pip install -i http://yum.tbsite.net/aliyun-pypi/simple/ \
-    --extra-index-url http://yum.tbsite.net/pypi/simple/ \
-    --trusted-host=yum.tbsite.net \
-    alibabacloud-cms20240330-inner==6.0.8
+pip install agentscope[agentloop]
 ```
 
 2. **Prepare your credentials**
@@ -42,7 +33,24 @@ await run_agentloop_experiment(
 )
 ```
 
-2. **Run the evaluation**
+2. **Implement your agent logic in the solution function**:
+
+```python
+async def http_agent_solution(
+    task: Task,
+    pre_hook: Callable,
+) -> SolutionOutput:
+    output = ""  # Call your agent and get the output
+
+    return SolutionOutput(
+        success=True,
+        output=output,
+        trajectory=[],
+        meta={"task": task},
+    )
+```
+
+3. **Run the evaluation**
 
 ```bash
 cd examples/evaluation/agentloop_demo
@@ -60,24 +68,3 @@ The `AgentLoopConfig` class is used to configure both dataset loading and result
 | `region_id` | Yes | Alibaba Cloud region ID (e.g., `cn-hangzhou`) |
 | `access_key_id` | Yes | Alibaba Cloud Access Key ID |
 | `access_key_secret` | Yes | Alibaba Cloud Access Key Secret |
-
-## Code Structure
-
-### Solution Function
-
-Implement your agent logic in the solution function:
-
-```python
-async def http_agent_solution(
-    task: Task,
-    pre_hook: Callable,
-) -> SolutionOutput:
-    output = ""  # Call your agent and get the output
-
-    return SolutionOutput(
-        success=True,
-        output=output,
-        trajectory=[],
-        meta={"task": task},
-    )
-```

--- a/examples/evaluation/agentloop_demo/README.md
+++ b/examples/evaluation/agentloop_demo/README.md
@@ -1,7 +1,7 @@
 # AgentLoop Integration Example
 
 This example demonstrates how to use the AgentLoop integration:
-1. Load evaluation datasets from Alibaba Cloud AgentLoop 
+1. Load evaluation datasets from Alibaba Cloud AgentLoop
 2. Write Experiment results to SLS (Log Service)
 
 ## Quick Start
@@ -12,6 +12,15 @@ This example demonstrates how to use the AgentLoop integration:
 
 ```bash
 pip install agentscope
+
+# For writing results to SLS (Log Service)
+pip install aliyun-log-python-sdk
+
+# For loading datasets from AgentLoop CMS (requires Alibaba internal PyPI)
+pip install -i http://yum.tbsite.net/aliyun-pypi/simple/ \
+    --extra-index-url http://yum.tbsite.net/pypi/simple/ \
+    --trusted-host=yum.tbsite.net \
+    alibabacloud-cms20240330-inner==6.0.8
 ```
 
 2. **Prepare your credentials**
@@ -64,7 +73,7 @@ async def http_agent_solution(
     pre_hook: Callable,
 ) -> SolutionOutput:
     output = ""  # Call your agent and get the output
-    
+
     return SolutionOutput(
         success=True,
         output=output,

--- a/examples/evaluation/agentloop_demo/main.py
+++ b/examples/evaluation/agentloop_demo/main.py
@@ -24,16 +24,20 @@ PYTHONPATH=/Users/wu.cc/Code/python/agentscope/src python main.py
 If you don't have a real SLS environment, use --mock parameter for mock mode:
     python main.py --mock
 """
+
 import asyncio
-import uuid
+import logging
 from typing import Callable
 
 from agentscope.evaluate import (
-    Task,
-    SolutionOutput,
-    RayEvaluator,
     AgentLoopConfig,
+    RayEvaluator,
+    SolutionOutput,
+    Task,
 )
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 # ============ HTTP Agent Solution ============
@@ -43,7 +47,7 @@ async def http_agent_solution(
 ) -> SolutionOutput:
     pre_hook(task)
 
-    output = "" # call your agent and get the output
+    output = ""  # call your agent and get the output
 
     return SolutionOutput(
         success=True,
@@ -53,7 +57,6 @@ async def http_agent_solution(
             "task": task,
         },
     )
-
 
 
 async def run_agentloop_experiment(
@@ -66,19 +69,19 @@ async def run_agentloop_experiment(
     # Local storage
     result_dir: str,
 ) -> None:
-    """Run evaluation using AgentLoop
+    """Run evaluation using AgentLoop.
 
     Args:
-        workspace: CMS workspace name where the dataset is located
-        dataset: CMS dataset name
-        region_id: Region ID for dataset (used to construct CMS endpoint)
-        result_workspace: CMS workspace name for result upload
-        result_region_id: Region ID for result upload (used to construct CMS/SLS endpoint)
-        result_dir: Local result storage directory
+        ak: Alibaba Cloud access key ID.
+        sk: Alibaba Cloud access key secret.
+        workspace: CMS workspace name where the dataset is located.
+        dataset: CMS dataset name.
+        region_id: Region ID for dataset (constructs CMS endpoint).
+        result_dir: Local result storage directory.
     """
-    print("=" * 60)
-    print("Running AgentLoop Evaluation")
-    print("=" * 60)
+    logger.info("=" * 60)
+    logger.info("Running AgentLoop Evaluation")
+    logger.info("=" * 60)
 
     try:
         from agentscope.evaluate import (
@@ -86,11 +89,16 @@ async def run_agentloop_experiment(
             AgentLoopEvaluatorStorage,
         )
     except ImportError as e:
-        print(f"Import error: {e}")
-        print("Please install aliyun-log-python-sdk: pip install aliyun-log-python-sdk")
+        logger.error("Import error: %s", e)
+        logger.error(
+            "Please install the required Alibaba Cloud SDKs:\n"
+            "  pip install aliyun-log-python-sdk\n"
+            "  pip install -i http://yum.tbsite.net/aliyun-pypi/simple/ "
+            "--extra-index-url http://yum.tbsite.net/pypi/simple/ "
+            "--trusted-host=yum.tbsite.net "
+            "alibabacloud-cms20240330-inner==6.0.8",
+        )
         return
-    exp_id = str(uuid.uuid4())
-
     # Create AgentLoopConfig for Benchmark
     agentloop_config = AgentLoopConfig(
         workspace=workspace,
@@ -103,22 +111,22 @@ async def run_agentloop_experiment(
     experiment_config = {"agent_name": "MockAgent"}
 
     # Load dataset from CMS Dataset
-    print(f"\nLoading dataset from CMS:")
-    print(f"  Workspace: {agentloop_config.workspace}")
-    print(f"  Dataset:   {agentloop_config.dataset}")
-    print(f"  Region ID: {agentloop_config.region_id}")
+    logger.info("Loading dataset from CMS:")
+    logger.info("  Workspace: %s", agentloop_config.workspace)
+    logger.info("  Dataset:   %s", agentloop_config.dataset)
+    logger.info("  Region ID: %s", agentloop_config.region_id)
     benchmark = AgentLoopBenchmark(
         config=agentloop_config,
         name="AgentLoop Benchmark",
         description=f"Benchmark from CMS: {workspace}/{dataset}",
     )
-    print(f"Loaded {len(benchmark)} tasks")
+    logger.info("Loaded %d tasks", len(benchmark))
 
     # Configure storage
-    print(f"\nUsing SLS to store results:")
-    print(f"  Result Workspace: {agentloop_config.workspace}")
-    print(f"  Result Region ID: {agentloop_config.region_id}")
-    print(f"Also saving locally to: {result_dir}")
+    logger.info("Using SLS to store results:")
+    logger.info("  Result Workspace: %s", agentloop_config.workspace)
+    logger.info("  Result Region ID: %s", agentloop_config.region_id)
+    logger.info("Also saving locally to: %s", result_dir)
     storage = AgentLoopEvaluatorStorage(
         save_dir=result_dir,
         config=agentloop_config,
@@ -127,10 +135,10 @@ async def run_agentloop_experiment(
         experiment_metadata={"run_env": "local_run"},
         experiment_config=experiment_config,
     )
-    print(f"  Project:  {storage.config.project}")
-    print(f"  SLS Endpoint: {storage.config.sls_endpoint}")
-    print(f"  Logstore: {storage.logstore}")
-    print(f"Experiment ID: {storage.experiment_id}")
+    logger.info("  Project:      %s", storage.config.project)
+    logger.info("  SLS Endpoint: %s", storage.config.sls_endpoint)
+    logger.info("  Logstore:     %s", storage.logstore)
+    logger.info("Experiment ID: %s", storage.experiment_id)
 
     # Run experiment
     evaluator = RayEvaluator(
@@ -141,9 +149,9 @@ async def run_agentloop_experiment(
         n_workers=4,
     )
 
-    print("\nStarting experiment...")
+    logger.info("Starting experiment...")
     await evaluator.run(http_agent_solution)
-    print("\nExperiment completed!")
+    logger.info("Experiment completed!")
 
 
 async def main() -> None:

--- a/examples/evaluation/agentloop_demo/main.py
+++ b/examples/evaluation/agentloop_demo/main.py
@@ -9,7 +9,7 @@ from typing import Callable
 
 from agentscope.evaluate import (
     AgentLoopConfig,
-    RayEvaluator,
+    GeneralEvaluator,
     SolutionOutput,
     Task,
 )
@@ -23,8 +23,6 @@ async def http_agent_solution(
     task: Task,
     pre_hook: Callable,
 ) -> SolutionOutput:
-    pre_hook(task)
-
     output = ""  # call your agent and get the output
 
     return SolutionOutput(
@@ -32,7 +30,7 @@ async def http_agent_solution(
         output=output,
         trajectory=[],
         meta={
-            "task": task,
+            "task": task.input,
         },
     )
 
@@ -114,7 +112,7 @@ async def run_agentloop_experiment(
     logger.info("Experiment ID: %s", storage.experiment_id)
 
     # Run experiment
-    evaluator = RayEvaluator(
+    evaluator = GeneralEvaluator(
         name="AgentLoop Evaluation",
         benchmark=benchmark,
         n_repeat=1,

--- a/examples/evaluation/agentloop_demo/main.py
+++ b/examples/evaluation/agentloop_demo/main.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+"""
+AgentLoop Integration Example - Load dataset from SLS and write results to SLS
+
+Before running, set the following environment variables:
+    # Dataset SLS configuration
+    export SLS_DATASET_ENDPOINT="cn-hangzhou.log.aliyuncs.com"
+    export SLS_DATASET_PROJECT="your-dataset-project"
+    export SLS_DATASET_LOGSTORE="your-dataset-logstore"
+
+    # Result upload SLS configuration (can be different from dataset)
+    export SLS_RESULT_ENDPOINT="cn-shanghai.log.aliyuncs.com"
+    export SLS_RESULT_PROJECT="your-result-project"
+    export SLS_RESULT_LOGSTORE="experiment_detail"
+
+    # Alibaba Cloud credentials
+    export ALIBABA_CLOUD_ACCESS_KEY_ID="your-access-key-id"
+    export ALIBABA_CLOUD_ACCESS_KEY_SECRET="your-access-key-secret"
+
+How to run:
+cd  /Users/wu.cc/Code/python/agentscope/examples/evaluation/agentloop_demo
+PYTHONPATH=/Users/wu.cc/Code/python/agentscope/src python main.py
+
+If you don't have a real SLS environment, use --mock parameter for mock mode:
+    python main.py --mock
+"""
+import asyncio
+import uuid
+from typing import Callable
+
+from agentscope.evaluate import (
+    Task,
+    SolutionOutput,
+    RayEvaluator,
+    AgentLoopConfig,
+)
+
+
+# ============ HTTP Agent Solution ============
+async def http_agent_solution(
+    task: Task,
+    pre_hook: Callable,
+) -> SolutionOutput:
+    pre_hook(task)
+
+    output = "" # call your agent and get the output
+
+    return SolutionOutput(
+        success=True,
+        output=output,
+        trajectory=[],
+        meta={
+            "task": task,
+        },
+    )
+
+
+
+async def run_agentloop_experiment(
+    # Dataset CMS configuration
+    ak: str,
+    sk: str,
+    workspace: str,
+    dataset: str,
+    region_id: str,
+    # Local storage
+    result_dir: str,
+) -> None:
+    """Run evaluation using AgentLoop
+
+    Args:
+        workspace: CMS workspace name where the dataset is located
+        dataset: CMS dataset name
+        region_id: Region ID for dataset (used to construct CMS endpoint)
+        result_workspace: CMS workspace name for result upload
+        result_region_id: Region ID for result upload (used to construct CMS/SLS endpoint)
+        result_dir: Local result storage directory
+    """
+    print("=" * 60)
+    print("Running AgentLoop Evaluation")
+    print("=" * 60)
+
+    try:
+        from agentscope.evaluate import (
+            AgentLoopBenchmark,
+            AgentLoopEvaluatorStorage,
+        )
+    except ImportError as e:
+        print(f"Import error: {e}")
+        print("Please install aliyun-log-python-sdk: pip install aliyun-log-python-sdk")
+        return
+    exp_id = str(uuid.uuid4())
+
+    # Create AgentLoopConfig for Benchmark
+    agentloop_config = AgentLoopConfig(
+        workspace=workspace,
+        dataset=dataset,
+        region_id=region_id,
+        access_key_id=ak,
+        access_key_secret=sk,
+    )
+
+    experiment_config = {"agent_name": "MockAgent"}
+
+    # Load dataset from CMS Dataset
+    print(f"\nLoading dataset from CMS:")
+    print(f"  Workspace: {agentloop_config.workspace}")
+    print(f"  Dataset:   {agentloop_config.dataset}")
+    print(f"  Region ID: {agentloop_config.region_id}")
+    benchmark = AgentLoopBenchmark(
+        config=agentloop_config,
+        name="AgentLoop Benchmark",
+        description=f"Benchmark from CMS: {workspace}/{dataset}",
+    )
+    print(f"Loaded {len(benchmark)} tasks")
+
+    # Configure storage
+    print(f"\nUsing SLS to store results:")
+    print(f"  Result Workspace: {agentloop_config.workspace}")
+    print(f"  Result Region ID: {agentloop_config.region_id}")
+    print(f"Also saving locally to: {result_dir}")
+    storage = AgentLoopEvaluatorStorage(
+        save_dir=result_dir,
+        config=agentloop_config,
+        experiment_name="AgentLoop Demo",
+        experiment_type="agent",
+        experiment_metadata={"run_env": "local_run"},
+        experiment_config=experiment_config,
+    )
+    print(f"  Project:  {storage.config.project}")
+    print(f"  SLS Endpoint: {storage.config.sls_endpoint}")
+    print(f"  Logstore: {storage.logstore}")
+    print(f"Experiment ID: {storage.experiment_id}")
+
+    # Run experiment
+    evaluator = RayEvaluator(
+        name="AgentLoop Evaluation",
+        benchmark=benchmark,
+        n_repeat=1,
+        storage=storage,
+        n_workers=4,
+    )
+
+    print("\nStarting experiment...")
+    await evaluator.run(http_agent_solution)
+    print("\nExperiment completed!")
+
+
+async def main() -> None:
+    """Main function"""
+    await run_agentloop_experiment(
+        ak="replace with your ak",
+        sk="replace with your sk",
+        # CMS dataset configuration
+        workspace="replace with your workspace",
+        dataset="replace with your dataset name",
+        region_id="replace with your region_id",
+        result_dir="./results",
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/evaluation/agentloop_demo/main.py
+++ b/examples/evaluation/agentloop_demo/main.py
@@ -1,28 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-AgentLoop Integration Example - Load dataset from SLS and write results to SLS
-
-Before running, set the following environment variables:
-    # Dataset SLS configuration
-    export SLS_DATASET_ENDPOINT="cn-hangzhou.log.aliyuncs.com"
-    export SLS_DATASET_PROJECT="your-dataset-project"
-    export SLS_DATASET_LOGSTORE="your-dataset-logstore"
-
-    # Result upload SLS configuration (can be different from dataset)
-    export SLS_RESULT_ENDPOINT="cn-shanghai.log.aliyuncs.com"
-    export SLS_RESULT_PROJECT="your-result-project"
-    export SLS_RESULT_LOGSTORE="experiment_detail"
-
-    # Alibaba Cloud credentials
-    export ALIBABA_CLOUD_ACCESS_KEY_ID="your-access-key-id"
-    export ALIBABA_CLOUD_ACCESS_KEY_SECRET="your-access-key-secret"
-
-How to run:
-cd  /Users/wu.cc/Code/python/agentscope/examples/evaluation/agentloop_demo
-PYTHONPATH=/Users/wu.cc/Code/python/agentscope/src python main.py
-
-If you don't have a real SLS environment, use --mock parameter for mock mode:
-    python main.py --mock
+AgentLoop Integration Example - Load dataset from Agentloop dataset and write results to SLS
 """
 
 import asyncio
@@ -91,13 +69,8 @@ async def run_agentloop_experiment(
     except ImportError as e:
         logger.error("Import error: %s", e)
         logger.error(
-            "Please install the required Alibaba Cloud SDKs:\n"
-            "  pip install aliyun-log-python-sdk\n"
-            "  pip install -i http://yum.tbsite.net/aliyun-pypi/simple/ "
-            "--extra-index-url http://yum.tbsite.net/pypi/simple/ "
-            "--trusted-host=yum.tbsite.net "
-            "alibabacloud-cms20240330-inner==6.0.8",
-        )
+            "Please install the required Agentloop SDKs:\n"
+            "  pip install aliyun-log-python-sdk alibabacloud-cms20240330-inner")
         return
     # Create AgentLoopConfig for Benchmark
     agentloop_config = AgentLoopConfig(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,12 +137,6 @@ rag = [
 # ------------ Evaluation ------------
 evaluate = ["ray"]
 
-# ------------ AgentLoop (SLS) ------------
-agentloop = [
-    "aliyun-log-python-sdk",
-    "alibabacloud-cms20240330-inner"
-    ]
-
 # ------------ Full ------------
 full = [
     "agentscope[a2a]",
@@ -152,7 +146,6 @@ full = [
     "agentscope[rag]",
     "agentscope[evaluate]",
     "agentscope[realtime]",
-    "agentscope[agentloop]",
 ]
 
 # ------------ Development ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,9 @@ rag = [
 # ------------ Evaluation ------------
 evaluate = ["ray"]
 
+# ------------ AgentLoop (SLS) ------------
+agentloop = ["aliyun-log-python-sdk"]
+
 # ------------ Full ------------
 full = [
     "agentscope[a2a]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,10 @@ rag = [
 evaluate = ["ray"]
 
 # ------------ AgentLoop (SLS) ------------
-agentloop = ["aliyun-log-python-sdk"]
+agentloop = [
+    "aliyun-log-python-sdk",
+    "alibabacloud-cms20240330-inner"
+    ]
 
 # ------------ Full ------------
 full = [
@@ -149,6 +152,7 @@ full = [
     "agentscope[rag]",
     "agentscope[evaluate]",
     "agentscope[realtime]",
+    "agentscope[agentloop]",
 ]
 
 # ------------ Development ------------

--- a/src/agentscope/evaluate/__init__.py
+++ b/src/agentscope/evaluate/__init__.py
@@ -17,6 +17,7 @@ from ._benchmark_base import BenchmarkBase
 from ._evaluator_storage import (
     EvaluatorStorageBase,
     FileEvaluatorStorage,
+    AgentLoopEvaluatorStorage,
 )
 from ._ace_benchmark import (
     ACEBenchmark,
@@ -24,6 +25,10 @@ from ._ace_benchmark import (
     ACEProcessAccuracy,
     ACEPhone,
 )
+from ._agentloop_benchmark import (
+    AgentLoopBenchmark,
+)
+from ._agentloop_config import AgentLoopConfig
 
 __all__ = [
     "BenchmarkBase",
@@ -35,10 +40,13 @@ __all__ = [
     "MetricType",
     "EvaluatorStorageBase",
     "FileEvaluatorStorage",
+    "AgentLoopEvaluatorStorage",
     "Task",
     "SolutionOutput",
     "ACEBenchmark",
     "ACEAccuracy",
     "ACEProcessAccuracy",
     "ACEPhone",
+    "AgentLoopBenchmark",
+    "AgentLoopConfig",
 ]

--- a/src/agentscope/evaluate/_agentloop_benchmark/__init__.py
+++ b/src/agentscope/evaluate/_agentloop_benchmark/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""The AgentLoop benchmark module in AgentScope for loading datasets from SLS."""
+
+from ._agentloop_benchmark import AgentLoopBenchmark
+
+__all__ = [
+    "AgentLoopBenchmark",
+]

--- a/src/agentscope/evaluate/_agentloop_benchmark/__init__.py
+++ b/src/agentscope/evaluate/_agentloop_benchmark/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""The AgentLoop benchmark module in AgentScope for loading datasets from SLS."""
+"""The AgentLoop benchmark module in AgentScope for loading datasets from CMS."""
 
 from ._agentloop_benchmark import AgentLoopBenchmark
 

--- a/src/agentscope/evaluate/_agentloop_benchmark/_agentloop_benchmark.py
+++ b/src/agentscope/evaluate/_agentloop_benchmark/_agentloop_benchmark.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 """The AgentLoop benchmark class for loading evaluation datasets from CMS."""
-import json
-from typing import Generator, Callable, Any
 
+import json
+import uuid
+from typing import Any, Generator
+
+from ..._logging import logger
 from .._benchmark_base import BenchmarkBase
 from .._task import Task
 from .._agentloop_config import AgentLoopConfig
@@ -49,10 +52,10 @@ class AgentLoopBenchmark(BenchmarkBase):
 
         # Define task_converter
         def task_converter(log_record: dict) -> Task:
-            import uuid
             # Generate a random ID for each task
             task_id = str(uuid.uuid4())
-            # Get ground_truth from configured field, empty string if not configured
+            # Get ground_truth from configured field,
+            # empty string if not configured
             ground_truth = ""
             if config.ground_truth_field:
                 ground_truth = log_record.get(config.ground_truth_field, "")
@@ -64,6 +67,7 @@ class AgentLoopBenchmark(BenchmarkBase):
                 metrics=[],
                 metadata={},
             )
+
         # Load dataset from CMS and convert to Task objects
         # Convert once and cache to ensure stable task IDs
         raw_dataset = self._load_data_from_cms()
@@ -125,8 +129,8 @@ class AgentLoopBenchmark(BenchmarkBase):
             query=self.config.query,
         )
 
-        print(f"CMS query: {self.config.query}")
-        print(
+        logger.info(f"CMS query: {self.config.query}")
+        logger.info(
             f"CMS workspace: {self.config.workspace}, "
             f"dataset: {self.config.dataset}",
         )
@@ -136,7 +140,7 @@ class AgentLoopBenchmark(BenchmarkBase):
             self.config.dataset,
             req,
         )
-        print(json.dumps(resp.to_map(), default=str, indent=2))
+        logger.debug(json.dumps(resp.to_map(), default=str, indent=2))
 
         # Parse response data
         dataset = []

--- a/src/agentscope/evaluate/_agentloop_benchmark/_agentloop_benchmark.py
+++ b/src/agentscope/evaluate/_agentloop_benchmark/_agentloop_benchmark.py
@@ -93,7 +93,7 @@ class AgentLoopBenchmark(BenchmarkBase):
             raise ImportError(
                 "The alibabacloud-cms20240330-inner package is required for "
                 "AgentLoopBenchmark. Install it with: "
-                "pip install alibabacloud-cms20240330-inner==6.0.8",
+                "pip install alibabacloud-cms20240330-inner",
             ) from e
 
         client_config = open_api_models.Config(
@@ -119,7 +119,7 @@ class AgentLoopBenchmark(BenchmarkBase):
             raise ImportError(
                 "The alibabacloud-cms20240330-inner package is required for "
                 "AgentLoopBenchmark. Install it with: "
-                "pip install alibabacloud-cms20240330-inner==6.0.8",
+                "pip install alibabacloud-cms20240330-inner",
             ) from e
 
         client = self._get_client()

--- a/src/agentscope/evaluate/_agentloop_benchmark/_agentloop_benchmark.py
+++ b/src/agentscope/evaluate/_agentloop_benchmark/_agentloop_benchmark.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+"""The AgentLoop benchmark class for loading evaluation datasets from CMS."""
+import json
+from typing import Generator, Callable, Any
+
+from .._benchmark_base import BenchmarkBase
+from .._task import Task
+from .._agentloop_config import AgentLoopConfig
+
+
+class AgentLoopBenchmark(BenchmarkBase):
+    """The AgentLoop benchmark for loading evaluation datasets from
+    Alibaba Cloud CMS (Cloud Monitor Service).
+
+    This benchmark allows users to load evaluation datasets directly from
+    CMS by specifying the workspace and dataset names. The data is queried
+    using the CMS SDK and converted to Task objects using a user-provided
+    converter function.
+
+    Install the required SDK:
+        pip install -i http://yum.tbsite.net/aliyun-pypi/simple/ \\
+            --extra-index-url http://yum.tbsite.net/pypi/simple/ \\
+            --trusted-host=yum.tbsite.net \\
+            alibabacloud-cms20240330-inner==6.0.8
+    """
+
+    def __init__(
+        self,
+        config: AgentLoopConfig,
+        name: str = "AgentLoopBenchmark",
+        description: str = "Benchmark loaded from AgentLoop.",
+    ) -> None:
+        """Initialize the AgentLoopBenchmark.
+
+        Args:
+            config (`AgentLoopConfig`):
+                The AgentLoop configuration containing workspace, dataset,
+                region_id, query, and credentials.
+            name (`str`):
+                The name of this benchmark. Defaults to "AgentLoopBenchmark".
+            description (`str`):
+                A brief description of this benchmark.
+                Defaults to "Benchmark loaded from CMS.".
+        """
+        super().__init__(name=name, description=description)
+
+        self.config = config
+        self.config.validate_credentials()
+
+        # Define task_converter
+        def task_converter(log_record: dict) -> Task:
+            import uuid
+            # Generate a random ID for each task
+            task_id = str(uuid.uuid4())
+            # Get ground_truth from configured field, empty string if not configured
+            ground_truth = ""
+            if config.ground_truth_field:
+                ground_truth = log_record.get(config.ground_truth_field, "")
+
+            return Task(
+                id=task_id,
+                input=log_record,
+                ground_truth=ground_truth,
+                metrics=[],
+                metadata={},
+            )
+        # Load dataset from CMS and convert to Task objects
+        # Convert once and cache to ensure stable task IDs
+        raw_dataset = self._load_data_from_cms()
+        self._tasks: list[Task] = [
+            task_converter(item) for item in raw_dataset
+        ]
+
+    def _get_client(self) -> Any:
+        """Get the CMS client instance.
+
+        Returns:
+            `Cms20240330Client`:
+                The CMS client instance.
+
+        Raises:
+            `ImportError`:
+                If the alibabacloud-cms20240330-inner package is not installed.
+        """
+        try:
+            from alibabacloud_cms20240330.client import Client
+            from alibabacloud_tea_openapi import models as open_api_models
+        except ImportError as e:
+            raise ImportError(
+                "The alibabacloud-cms20240330-inner package is required for "
+                "AgentLoopBenchmark. Install it with: "
+                "pip install alibabacloud-cms20240330-inner==6.0.8",
+            ) from e
+
+        client_config = open_api_models.Config(
+            access_key_id=self.config.access_key_id,
+            access_key_secret=self.config.access_key_secret,
+        )
+        client_config.endpoint = self.config.cms_endpoint
+
+        return Client(client_config)
+
+    def _load_data_from_cms(self) -> list[dict]:
+        """Load the dataset from CMS using ExecuteQuery API.
+
+        Returns:
+            `list[dict]`:
+                A list of data records loaded from CMS.
+        """
+        try:
+            from alibabacloud_cms20240330 import (
+                models as cms_20240330_models,
+            )
+        except ImportError as e:
+            raise ImportError(
+                "The alibabacloud-cms20240330-inner package is required for "
+                "AgentLoopBenchmark. Install it with: "
+                "pip install alibabacloud-cms20240330-inner==6.0.8",
+            ) from e
+
+        client = self._get_client()
+
+        req = cms_20240330_models.ExecuteQueryRequest(
+            type="SQL",
+            query=self.config.query,
+        )
+
+        print(f"CMS query: {self.config.query}")
+        print(
+            f"CMS workspace: {self.config.workspace}, "
+            f"dataset: {self.config.dataset}",
+        )
+
+        resp = client.execute_query(
+            self.config.workspace,
+            self.config.dataset,
+            req,
+        )
+        print(json.dumps(resp.to_map(), default=str, indent=2))
+
+        # Parse response data
+        dataset = []
+        if resp.body and resp.body.data:
+            # The response data structure may vary, handle accordingly
+            data = resp.body.data
+            if isinstance(data, list):
+                dataset = data
+            elif isinstance(data, dict):
+                # If data is a dict with rows/records
+                if "rows" in data:
+                    dataset = data["rows"]
+                elif "records" in data:
+                    dataset = data["records"]
+                else:
+                    dataset = [data]
+
+        return dataset
+
+    def __iter__(self) -> Generator[Task, None, None]:
+        """Iterate over the benchmark, yielding Task objects.
+
+        Yields:
+            `Task`:
+                Task objects converted from data records.
+        """
+        for task in self._tasks:
+            yield task
+
+    def __getitem__(self, index: int) -> Task:
+        """Get a task by index.
+
+        Args:
+            index (`int`):
+                The index of the task.
+
+        Returns:
+            `Task`:
+                The Task object at the given index.
+        """
+        return self._tasks[index]
+
+    def __len__(self) -> int:
+        """Get the number of tasks in the benchmark.
+
+        Returns:
+            `int`:
+                The number of tasks.
+        """
+        return len(self._tasks)

--- a/src/agentscope/evaluate/_agentloop_benchmark/_agentloop_benchmark.py
+++ b/src/agentscope/evaluate/_agentloop_benchmark/_agentloop_benchmark.py
@@ -21,10 +21,7 @@ class AgentLoopBenchmark(BenchmarkBase):
     converter function.
 
     Install the required SDK:
-        pip install -i http://yum.tbsite.net/aliyun-pypi/simple/ \\
-            --extra-index-url http://yum.tbsite.net/pypi/simple/ \\
-            --trusted-host=yum.tbsite.net \\
-            alibabacloud-cms20240330-inner==6.0.8
+        pip install alibabacloud-cms20240330-inner
     """
 
     def __init__(
@@ -104,12 +101,103 @@ class AgentLoopBenchmark(BenchmarkBase):
 
         return Client(client_config)
 
+    def _parse_response_data(self, data: Any) -> list[dict]:
+        """Parse the data field from a CMS ExecuteQuery response.
+
+        Args:
+            data:
+                The ``resp.body.data`` value returned by the CMS API.
+
+        Returns:
+            `list[dict]`:
+                A list of parsed data records.
+        """
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            if "rows" in data:
+                return data["rows"]
+            if "records" in data:
+                return data["records"]
+            logger.warning(
+                "CMS response data is a dict but contains neither 'rows' nor "
+                "'records' key. Treating the entire dict as a single record. "
+                f"Keys present: {list(data.keys())}",
+            )
+            return [data]
+        logger.warning(
+            "Unexpected CMS response data type: %s. Returning empty dataset.",
+            type(data).__name__,
+        )
+        return []
+
+    # Number of records fetched per paginated request
+    _PAGE_SIZE: int = 100
+
+    def _execute_query_request(
+        self,
+        client: Any,
+        cms_20240330_models: Any,
+        query: str,
+    ) -> list[dict]:
+        """Execute a single CMS ExecuteQuery request and return parsed records.
+
+        Args:
+            client:
+                The CMS client instance.
+            cms_20240330_models:
+                The CMS models module.
+            query (`str`):
+                The SQL query string to execute.
+
+        Returns:
+            `list[dict]`:
+                Parsed records from the response, or an empty list if the
+                response contains no data.
+
+        Raises:
+            `RuntimeError`:
+                If the CMS API call fails.
+        """
+        req = cms_20240330_models.ExecuteQueryRequest(
+            type="SQL",
+            query=query,
+        )
+        try:
+            resp = client.execute_query(
+                self.config.workspace,
+                self.config.dataset,
+                req,
+            )
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to query CMS dataset '{self.config.dataset}' "
+                f"in workspace '{self.config.workspace}': {e}",
+            ) from e
+
+        logger.debug(json.dumps(resp.to_map(), default=str, indent=2))
+
+        if resp.body and resp.body.data:
+            return self._parse_response_data(resp.body.data)
+        return []
+
     def _load_data_from_cms(self) -> list[dict]:
-        """Load the dataset from CMS using ExecuteQuery API.
+        """Load the dataset from CMS.
+
+        - If ``config.query`` is set, executes it as-is in a single call.
+        - Otherwise, uses LIMIT/OFFSET pagination to load up to
+          ``config.max_rows`` records, stopping early when a page returns
+          no data or the API raises an error.
 
         Returns:
             `list[dict]`:
                 A list of data records loaded from CMS.
+
+        Raises:
+            `ImportError`:
+                If the alibabacloud-cms20240330-inner package is not installed.
+            `RuntimeError`:
+                If the CMS API call fails (single-query mode only).
         """
         try:
             from alibabacloud_cms20240330 import (
@@ -124,40 +212,61 @@ class AgentLoopBenchmark(BenchmarkBase):
 
         client = self._get_client()
 
-        req = cms_20240330_models.ExecuteQueryRequest(
-            type="SQL",
-            query=self.config.query,
-        )
-
-        logger.info(f"CMS query: {self.config.query}")
         logger.info(
             f"CMS workspace: {self.config.workspace}, "
             f"dataset: {self.config.dataset}",
         )
 
-        resp = client.execute_query(
-            self.config.workspace,
-            self.config.dataset,
-            req,
-        )
-        logger.debug(json.dumps(resp.to_map(), default=str, indent=2))
+        if self.config.query:
+            # User-provided custom query: execute as-is in a single call
+            logger.info(f"CMS custom query: {self.config.query}")
+            return self._execute_query_request(
+                client,
+                cms_20240330_models,
+                self.config.query,
+            )
 
-        # Parse response data
-        dataset = []
-        if resp.body and resp.body.data:
-            # The response data structure may vary, handle accordingly
-            data = resp.body.data
-            if isinstance(data, list):
-                dataset = data
-            elif isinstance(data, dict):
-                # If data is a dict with rows/records
-                if "rows" in data:
-                    dataset = data["rows"]
-                elif "records" in data:
-                    dataset = data["records"]
-                else:
-                    dataset = [data]
+        # No custom query: paginate with LIMIT/OFFSET up to max_rows
+        escaped_dataset = self.config.dataset.replace("`", "``")
+        dataset: list[dict] = []
 
+        while len(dataset) < self.config.max_rows:
+            remaining = self.config.max_rows - len(dataset)
+            page_size = min(self._PAGE_SIZE, remaining)
+            offset = len(dataset)
+            page_query = (
+                f"* | select * from `{escaped_dataset}` "
+                f"LIMIT {offset}, {page_size}"
+            )
+            logger.info(
+                f"CMS paginated query "
+                f"(offset={offset}, limit={page_size}): {page_query}",
+            )
+            try:
+                page = self._execute_query_request(
+                    client,
+                    cms_20240330_models,
+                    page_query,
+                )
+            except RuntimeError as e:
+                logger.warning(
+                    f"Paginated query failed at offset {offset}, "
+                    f"stopping early: {e}",
+                )
+                break
+
+            if not page:
+                logger.info(
+                    f"Empty response at offset {offset}, stopping pagination.",
+                )
+                break
+
+            dataset.extend(page)
+            if len(dataset) >= self.config.max_rows:
+                dataset = dataset[: self.config.max_rows]
+                break
+
+        logger.info(f"Loaded {len(dataset)} records from CMS.")
         return dataset
 
     def __iter__(self) -> Generator[Task, None, None]:

--- a/src/agentscope/evaluate/_agentloop_config.py
+++ b/src/agentscope/evaluate/_agentloop_config.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+"""Configuration class for AgentLoop components."""
+import os
+from dataclasses import dataclass, field
+
+
+@dataclass
+class AgentLoopConfig:
+    """Configuration for AgentLoop benchmark and evaluator storage.
+
+    This class encapsulates all the configuration needed to connect to
+    Alibaba Cloud CMS (Cloud Monitor Service) and SLS (Simple Log Service)
+    for the AgentLoop evaluation framework.
+
+    Attributes:
+        workspace (`str`):
+            The CMS workspace name.
+        dataset (`str`):
+            The CMS dataset name.
+        region_id (`str`):
+            The Alibaba Cloud region ID (e.g., "cn-hangzhou", "cn-shanghai").
+            Used to construct endpoints.
+        project (`str`):
+            The SLS project name. If not provided, will be queried from
+            the workspace at runtime.
+        query (`str`):
+            Custom SQL query for loading data. If not provided, defaults to
+            "* | select * from {dataset}".
+        ground_truth_field (`str`):
+            The field name in the dataset that contains the ground truth.
+            If not provided, ground_truth will be empty string.
+        access_key_id (`str`):
+            The Alibaba Cloud AccessKey ID. If not provided, will try to
+            get from environment variable `ALIBABA_CLOUD_ACCESS_KEY_ID`.
+        access_key_secret (`str`):
+            The Alibaba Cloud AccessKey Secret. If not provided, will try
+            to get from environment variable `ALIBABA_CLOUD_ACCESS_KEY_SECRET`.
+    """
+
+    workspace: str
+    dataset: str
+    region_id: str
+    project: str = ""
+    query: str = ""
+    ground_truth_field: str = ""
+    access_key_id: str = field(default="", repr=False)
+    access_key_secret: str = field(default="", repr=False)
+
+    def __post_init__(self) -> None:
+        """Post-initialization to load credentials and set defaults."""
+        if not self.access_key_id:
+            self.access_key_id = os.environ.get(
+                "ALIBABA_CLOUD_ACCESS_KEY_ID",
+                "",
+            )
+        if not self.access_key_secret:
+            self.access_key_secret = os.environ.get(
+                "ALIBABA_CLOUD_ACCESS_KEY_SECRET",
+                "",
+            )
+        if not self.query:
+            self.query = f"* | select * from {self.dataset}"
+
+    def validate_credentials(self) -> None:
+        """Validate that required credentials are present.
+
+        Raises:
+            ValueError: If AccessKey credentials are missing.
+        """
+        if not self.access_key_id or not self.access_key_secret:
+            raise ValueError(
+                "AccessKey credentials are required. Provide them via "
+                "`access_key_id` and `access_key_secret` parameters or set "
+                "`ALIBABA_CLOUD_ACCESS_KEY_ID` and "
+                "`ALIBABA_CLOUD_ACCESS_KEY_SECRET` environment variables.",
+            )
+
+    @property
+    def cms_endpoint(self) -> str:
+        """Get the CMS endpoint URL.
+
+        Returns:
+            `str`: The CMS endpoint URL.
+        """
+        return f"cms.{self.region_id}.aliyuncs.com"
+
+    @property
+    def sls_endpoint(self) -> str:
+        """Get the SLS endpoint URL.
+
+        Returns:
+            `str`: The SLS endpoint URL.
+        """
+        return f"{self.region_id}.log.aliyuncs.com"

--- a/src/agentscope/evaluate/_agentloop_config.py
+++ b/src/agentscope/evaluate/_agentloop_config.py
@@ -24,8 +24,14 @@ class AgentLoopConfig:
             The SLS project name. If not provided, will be queried from
             the workspace at runtime.
         query (`str`):
-            Custom SQL query for loading data. If not provided, defaults to
-            "* | select * from {dataset}".
+            Custom SQL query for loading data. When provided, the query is
+            executed as-is in a single call. When empty (the default),
+            automatic LIMIT/OFFSET pagination is used to load up to
+            ``max_rows`` records.
+        max_rows (`int`):
+            Maximum number of records to load when using automatic pagination
+            (i.e., when ``query`` is empty). Defaults to 1000. Ignored when
+            a custom ``query`` is provided.
         ground_truth_field (`str`):
             The field name in the dataset that contains the ground truth.
             If not provided, ground_truth will be empty string.
@@ -42,6 +48,7 @@ class AgentLoopConfig:
     region_id: str
     project: str = ""
     query: str = ""
+    max_rows: int = 1000
     ground_truth_field: str = ""
     access_key_id: str = field(default="", repr=False)
     access_key_secret: str = field(default="", repr=False)
@@ -58,8 +65,10 @@ class AgentLoopConfig:
                 "ALIBABA_CLOUD_ACCESS_KEY_SECRET",
                 "",
             )
-        if not self.query:
-            self.query = f"* | select * from {self.dataset}"
+        if self.max_rows <= 0:
+            raise ValueError(
+                f"`max_rows` must be a positive integer, got {self.max_rows}.",
+            )
 
     def validate_credentials(self) -> None:
         """Validate that required credentials are present.

--- a/src/agentscope/evaluate/_evaluator_storage/__init__.py
+++ b/src/agentscope/evaluate/_evaluator_storage/__init__.py
@@ -3,8 +3,10 @@
 
 from ._evaluator_storage_base import EvaluatorStorageBase
 from ._file_evaluator_storage import FileEvaluatorStorage
+from ._agentloop_evaluator_storage import AgentLoopEvaluatorStorage
 
 __all__ = [
     "EvaluatorStorageBase",
     "FileEvaluatorStorage",
+    "AgentLoopEvaluatorStorage",
 ]

--- a/src/agentscope/evaluate/_evaluator_storage/_agentloop_evaluator_storage.py
+++ b/src/agentscope/evaluate/_evaluator_storage/_agentloop_evaluator_storage.py
@@ -77,6 +77,10 @@ class AgentLoopEvaluatorStorage(FileEvaluatorStorage):
 
         self.logstore = EXPERIMENT_LOGSTORE
 
+        # Lazily-initialized cached clients (created on first use)
+        self._cms_client: Any = None
+        self._sls_client: Any = None
+
         # Query project from workspace if not provided in config
         if not self.config.project:
             self.config.project = self._get_workspace_project()
@@ -85,7 +89,7 @@ class AgentLoopEvaluatorStorage(FileEvaluatorStorage):
         self.experiment_id = experiment_id or str(uuid.uuid4())
         self.experiment_name = experiment_name or (
             f"experiment_{self.experiment_id[:8]}_"
-            f"{time.strftime('%Y-%m-%d %H:%M:%S')}"
+            f"{time.strftime('%Y%m%d_%H%M%S')}"
         )
         self.experiment_type = experiment_type
         self.experiment_start_time = int(time.time() * 1000)
@@ -98,12 +102,15 @@ class AgentLoopEvaluatorStorage(FileEvaluatorStorage):
         self._task_meta_cache: dict[str, dict] = {}
 
     def _get_cms_client(self) -> Any:
-        """Get the CMS client instance.
+        """Get the CMS client instance, creating and caching it on first call.
 
         Returns:
             `Cms20240330Client`:
                 The CMS client instance.
         """
+        if self._cms_client is not None:
+            return self._cms_client
+
         try:
             from alibabacloud_cms20240330.client import Client
             from alibabacloud_tea_openapi import models as open_api_models
@@ -120,7 +127,8 @@ class AgentLoopEvaluatorStorage(FileEvaluatorStorage):
         )
         client_config.endpoint = self.config.cms_endpoint
 
-        return Client(client_config)
+        self._cms_client = Client(client_config)
+        return self._cms_client
 
     def _get_workspace_project(self) -> str:
         """Get the SLS project from workspace.
@@ -164,12 +172,16 @@ class AgentLoopEvaluatorStorage(FileEvaluatorStorage):
         )
 
     def _get_sls_client(self) -> Any:
-        """Get the SLS LogClient instance.
+        """Get the SLS LogClient instance, creating and caching it on first
+        call.
 
         Returns:
             `LogClient`:
                 The SLS LogClient instance.
         """
+        if self._sls_client is not None:
+            return self._sls_client
+
         try:
             from aliyun.log import LogClient
         except ImportError as e:
@@ -179,11 +191,12 @@ class AgentLoopEvaluatorStorage(FileEvaluatorStorage):
                 "pip install aliyun-log-python-sdk",
             ) from e
 
-        return LogClient(
+        self._sls_client = LogClient(
             self.config.sls_endpoint,
             self.config.access_key_id,
             self.config.access_key_secret,
         )
+        return self._sls_client
 
     def _put_log(self, contents: list[tuple[str, str]]) -> None:
         """Write a log entry to SLS.
@@ -277,7 +290,8 @@ class AgentLoopEvaluatorStorage(FileEvaluatorStorage):
             output (`SolutionOutput`):
                 The solution output to be saved.
         """
-        # First, save to local file using parent class
+        # First, save to local file using parent class.
+        # This must succeed before attempting the SLS write.
         super().save_solution_result(
             task_id=task_id,
             repeat_id=repeat_id,
@@ -285,57 +299,67 @@ class AgentLoopEvaluatorStorage(FileEvaluatorStorage):
             **kwargs,
         )
 
-        # Then, write to SLS
-        contents = self._build_base_log_contents(
-            task_id=task_id,
-            repeat_id=repeat_id,
-        )
-        # Get cached experiment_data
-        experiment_data = self._task_meta_cache.get(task_id, {})
+        # Then, write to SLS. Failures are logged as warnings so that a
+        # transient network / permission issue does not abort the evaluation.
+        try:
+            contents = self._build_base_log_contents(
+                task_id=task_id,
+                repeat_id=repeat_id,
+            )
+            # Get cached experiment_data
+            experiment_data = self._task_meta_cache.get(task_id, {})
 
-        # Add data_config field
-        data_config = {
-            "data_type": "dataset",
-            "project": self.config.project,
-            "dataset_id": self.config.dataset,
-            "dataset_item_id": experiment_data.get("input", {}).get(
-                "id",
-                task_id,
-            ),
-        }
-        contents.append(
-            (
-                "data_config",
-                json.dumps(data_config, ensure_ascii=False),
-            ),
-        )
-
-        # Add experiment_data field
-        contents.append(
-            (
-                "experiment_data",
-                json.dumps(
-                    experiment_data.get("input", {}),
-                    ensure_ascii=False,
-                    default=str,
+            # Add data_config field
+            data_config = {
+                "data_type": "dataset",
+                "project": self.config.project,
+                "dataset_id": self.config.dataset,
+                "dataset_item_id": experiment_data.get("input", {}).get(
+                    "id",
+                    task_id,
                 ),
-            ),
-        )
+            }
+            contents.append(
+                (
+                    "data_config",
+                    json.dumps(data_config, ensure_ascii=False),
+                ),
+            )
 
-        # Add experiment_result field with output data
-        result_data = {
-            "success": output.success,
-            "output": output.output,
-            "trajectory": output.trajectory,
-            "meta": output.meta,
-        }
-        contents.append(
-            (
-                "experiment_output",
-                json.dumps(result_data, ensure_ascii=False, default=str),
-            ),
-        )
-        self._put_log(contents)
+            # Add experiment_data field
+            contents.append(
+                (
+                    "experiment_data",
+                    json.dumps(
+                        experiment_data.get("input", {}),
+                        ensure_ascii=False,
+                        default=str,
+                    ),
+                ),
+            )
+
+            # Add experiment_result field with output data
+            result_data = {
+                "success": output.success,
+                "output": output.output,
+                "trajectory": output.trajectory,
+                "meta": output.meta,
+            }
+            contents.append(
+                (
+                    "experiment_output",
+                    json.dumps(result_data, ensure_ascii=False, default=str),
+                ),
+            )
+            self._put_log(contents)
+        except Exception as e:
+            logger.warning(
+                f"Failed to write task '{task_id}' result to SLS "
+                f"(local file already saved): {e}",
+            )
+        finally:
+            # Release cached task meta to avoid unbounded memory growth
+            self._task_meta_cache.pop(task_id, None)
 
     def save_task_meta(
         self,

--- a/src/agentscope/evaluate/_evaluator_storage/_agentloop_evaluator_storage.py
+++ b/src/agentscope/evaluate/_evaluator_storage/_agentloop_evaluator_storage.py
@@ -5,11 +5,13 @@ to additionally write evaluation results to Alibaba Cloud SLS.
 Refer to:
 https://help.aliyun.com/zh/sls/developer-reference/write-log
 """
+
 import json
 import time
 import uuid
 from typing import Any
 
+from ..._logging import logger
 from ._file_evaluator_storage import FileEvaluatorStorage
 from .._solution import SolutionOutput
 from .._agentloop_config import AgentLoopConfig
@@ -20,7 +22,8 @@ EXPERIMENT_LOGSTORE = "experiment_detail"
 
 
 class AgentLoopEvaluatorStorage(FileEvaluatorStorage):
-    """AgentLoop (SLS) based evaluator storage that extends FileEvaluatorStorage.
+    """AgentLoop (SLS) based evaluator storage that extends
+    FileEvaluatorStorage.
 
     This storage implementation inherits all functionality from
     FileEvaluatorStorage for local file operations, and additionally writes
@@ -144,7 +147,7 @@ class AgentLoopEvaluatorStorage(FileEvaluatorStorage):
             headers,
             runtime,
         )
-        print(
+        logger.debug(
             f"CMS workspace response: "
             f"{json.dumps(resp.to_map(), default=str, indent=2)}",
         )
@@ -339,7 +342,8 @@ class AgentLoopEvaluatorStorage(FileEvaluatorStorage):
         task_id: str,
         meta_info: dict[str, JSONSerializableObject],
     ) -> None:
-        """Save the task meta information to local file and cache for later use.
+        """Save the task meta information to local file and cache for
+        later use.
 
         The task meta (experiment_data) is cached and will be written to SLS
         together with the solution result in save_solution_result().

--- a/src/agentscope/evaluate/_evaluator_storage/_agentloop_evaluator_storage.py
+++ b/src/agentscope/evaluate/_evaluator_storage/_agentloop_evaluator_storage.py
@@ -111,7 +111,7 @@ class AgentLoopEvaluatorStorage(FileEvaluatorStorage):
             raise ImportError(
                 "The alibabacloud-cms20240330-inner package is required for "
                 "AgentLoopEvaluatorStorage. Install it with: "
-                "pip install alibabacloud-cms20240330-inner==6.0.8",
+                "pip install alibabacloud-cms20240330-inner",
             ) from e
 
         client_config = open_api_models.Config(
@@ -135,7 +135,7 @@ class AgentLoopEvaluatorStorage(FileEvaluatorStorage):
             raise ImportError(
                 "The alibabacloud-cms20240330-inner package is required for "
                 "AgentLoopEvaluatorStorage. Install it with: "
-                "pip install alibabacloud-cms20240330-inner==6.0.8",
+                "pip install alibabacloud-cms20240330-inner",
             ) from e
 
         client = self._get_cms_client()

--- a/src/agentscope/evaluate/_evaluator_storage/_agentloop_evaluator_storage.py
+++ b/src/agentscope/evaluate/_evaluator_storage/_agentloop_evaluator_storage.py
@@ -1,0 +1,360 @@
+# -*- coding: utf-8 -*-
+"""An AgentLoop (SLS) based evaluator storage that extends FileEvaluatorStorage
+to additionally write evaluation results to Alibaba Cloud SLS.
+
+Refer to:
+https://help.aliyun.com/zh/sls/developer-reference/write-log
+"""
+import json
+import time
+import uuid
+from typing import Any
+
+from ._file_evaluator_storage import FileEvaluatorStorage
+from .._solution import SolutionOutput
+from .._agentloop_config import AgentLoopConfig
+from ...types import JSONSerializableObject
+
+# Fixed logstore name for experiment results
+EXPERIMENT_LOGSTORE = "experiment_detail"
+
+
+class AgentLoopEvaluatorStorage(FileEvaluatorStorage):
+    """AgentLoop (SLS) based evaluator storage that extends FileEvaluatorStorage.
+
+    This storage implementation inherits all functionality from
+    FileEvaluatorStorage for local file operations, and additionally writes
+    evaluation results to SLS using the PutLogs API.
+
+    The logs written to SLS follow the AgentLoop experiment schema with fields
+    like experiment_id, experiment_type, experiment_data, experiment_result,
+    experiment_metrics, etc.
+    """
+
+    def __init__(
+        self,
+        save_dir: str,
+        config: AgentLoopConfig,
+        experiment_id: str | None = None,
+        experiment_name: str | None = None,
+        experiment_type: str = "agent",
+        experiment_metadata: dict | None = None,
+        experiment_config: dict | None = None,
+    ) -> None:
+        """Initialize the AgentLoop evaluator storage.
+
+        Args:
+            save_dir (`str`):
+                The directory to save evaluation results locally.
+            config (`AgentLoopConfig`):
+                The AgentLoop configuration containing workspace, dataset,
+                region_id, project, and credentials.
+            experiment_id (`str | None`):
+                The unique experiment ID. If not provided, a UUID will be
+                generated automatically.
+            experiment_name (`str | None`):
+                A human-readable name for the experiment. If not provided,
+                will be generated based on experiment_id and timestamp.
+            experiment_type (`str`):
+                The experiment type. Either "model" or "agent".
+                Defaults to "agent".
+            experiment_metadata (`dict | None`):
+                Additional experiment metadata, e.g. {"run_env": "local_run"}.
+                Defaults to None.
+            experiment_config (`dict | None`):
+                The experiment configuration, e.g. model settings or agent
+                configuration. Defaults to None.
+        """
+        # Initialize parent class
+        super().__init__(save_dir=save_dir)
+
+        # Store config reference
+        self.config = config
+        self.config.validate_credentials()
+
+        self.logstore = EXPERIMENT_LOGSTORE
+
+        # Query project from workspace if not provided in config
+        if not self.config.project:
+            self.config.project = self._get_workspace_project()
+
+        # Experiment identification
+        self.experiment_id = experiment_id or str(uuid.uuid4())
+        self.experiment_name = experiment_name or (
+            f"experiment_{self.experiment_id[:8]}_"
+            f"{time.strftime('%Y-%m-%d %H:%M:%S')}"
+        )
+        self.experiment_type = experiment_type
+        self.experiment_start_time = int(time.time() * 1000)
+        self.experiment_metadata = experiment_metadata or {
+            "run_env": "local_run",
+        }
+        self.experiment_config = experiment_config or {}
+
+        # Cache for task meta (experiment_data), keyed by task_id
+        self._task_meta_cache: dict[str, dict] = {}
+
+    def _get_cms_client(self) -> Any:
+        """Get the CMS client instance.
+
+        Returns:
+            `Cms20240330Client`:
+                The CMS client instance.
+        """
+        try:
+            from alibabacloud_cms20240330.client import Client
+            from alibabacloud_tea_openapi import models as open_api_models
+        except ImportError as e:
+            raise ImportError(
+                "The alibabacloud-cms20240330-inner package is required for "
+                "AgentLoopEvaluatorStorage. Install it with: "
+                "pip install alibabacloud-cms20240330-inner==6.0.8",
+            ) from e
+
+        client_config = open_api_models.Config(
+            access_key_id=self.config.access_key_id,
+            access_key_secret=self.config.access_key_secret,
+        )
+        client_config.endpoint = self.config.cms_endpoint
+
+        return Client(client_config)
+
+    def _get_workspace_project(self) -> str:
+        """Get the SLS project from workspace.
+
+        Returns:
+            `str`:
+                The SLS project name.
+        """
+        try:
+            from alibabacloud_tea_util import models as util_models
+        except ImportError as e:
+            raise ImportError(
+                "The alibabacloud-cms20240330-inner package is required for "
+                "AgentLoopEvaluatorStorage. Install it with: "
+                "pip install alibabacloud-cms20240330-inner==6.0.8",
+            ) from e
+
+        client = self._get_cms_client()
+        runtime = util_models.RuntimeOptions()
+        headers: dict = {}
+
+        resp = client.get_workspace_with_options(
+            self.config.workspace,
+            headers,
+            runtime,
+        )
+        print(
+            f"CMS workspace response: "
+            f"{json.dumps(resp.to_map(), default=str, indent=2)}",
+        )
+
+        # Extract project from response
+        body = resp.body
+        if body and body.sls_project:
+            return body.sls_project
+
+        raise ValueError(
+            f"Failed to get SLS project for workspace "
+            f"'{self.config.workspace}'. "
+            "Please ensure the workspace exists and has SLS configured.",
+        )
+
+    def _get_sls_client(self) -> Any:
+        """Get the SLS LogClient instance.
+
+        Returns:
+            `LogClient`:
+                The SLS LogClient instance.
+        """
+        try:
+            from aliyun.log import LogClient
+        except ImportError as e:
+            raise ImportError(
+                "The aliyun-log-python-sdk package is required for "
+                "AgentLoopEvaluatorStorage. Install it with: "
+                "pip install aliyun-log-python-sdk",
+            ) from e
+
+        return LogClient(
+            self.config.sls_endpoint,
+            self.config.access_key_id,
+            self.config.access_key_secret,
+        )
+
+    def _put_log(self, contents: list[tuple[str, str]]) -> None:
+        """Write a log entry to SLS.
+
+        Args:
+            contents (`list[tuple[str, str]]`):
+                The log contents as key-value pairs.
+        """
+        try:
+            from aliyun.log import LogItem, PutLogsRequest
+        except ImportError as e:
+            raise ImportError(
+                "The aliyun-log-python-sdk package is required for "
+                "AgentLoopEvaluatorStorage. Install it with: "
+                "pip install aliyun-log-python-sdk",
+            ) from e
+
+        client = self._get_sls_client()
+
+        log_item = LogItem()
+        log_item.set_time(int(time.time()))
+        log_item.set_contents(contents)
+
+        request = PutLogsRequest(
+            self.config.project,
+            self.logstore,
+            "",  # topic
+            "",  # source
+            [log_item],
+        )
+        client.put_logs(request)
+
+    def _build_base_log_contents(
+        self,
+        task_id: str | None = None,
+        repeat_id: str | None = None,
+    ) -> list[tuple[str, str]]:
+        """Build the base log contents with common fields.
+
+        Args:
+            task_id (`str | None`):
+                The task ID if applicable.
+            repeat_id (`str | None`):
+                The repeat ID if applicable.
+
+        Returns:
+            `list[tuple[str, str]]`:
+                A list of key-value tuples for log contents.
+        """
+        contents = [
+            ("experiment_id", self.experiment_id),
+            ("experiment_name", self.experiment_name),
+            ("experiment_start_time", str(self.experiment_start_time)),
+            ("experiment_type", self.experiment_type),
+            (
+                "experiment_metadata",
+                json.dumps(self.experiment_metadata, ensure_ascii=False),
+            ),
+            (
+                "experiment_config",
+                json.dumps(self.experiment_config, ensure_ascii=False),
+            ),
+        ]
+
+        if task_id is not None:
+            contents.append(("task_id", task_id))
+        if repeat_id is not None:
+            contents.append(("repeat_id", repeat_id))
+
+        return contents
+
+    def save_solution_result(
+        self,
+        task_id: str,
+        repeat_id: str,
+        output: SolutionOutput,
+        **kwargs: Any,
+    ) -> None:
+        """Save the solution result to both local file and SLS.
+
+        This method writes the complete experiment record to SLS, including:
+        - experiment_data: from cached task meta
+        - data_config: dataset configuration
+        - experiment_result: the solution output
+
+        Args:
+            task_id (`str`):
+                The task ID.
+            repeat_id (`str`):
+                The repeat ID for the task.
+            output (`SolutionOutput`):
+                The solution output to be saved.
+        """
+        # First, save to local file using parent class
+        super().save_solution_result(
+            task_id=task_id,
+            repeat_id=repeat_id,
+            output=output,
+            **kwargs,
+        )
+
+        # Then, write to SLS
+        contents = self._build_base_log_contents(
+            task_id=task_id,
+            repeat_id=repeat_id,
+        )
+        # Get cached experiment_data
+        experiment_data = self._task_meta_cache.get(task_id, {})
+
+        # Add data_config field
+        data_config = {
+            "data_type": "dataset",
+            "project": self.config.project,
+            "dataset_id": self.config.dataset,
+            "dataset_item_id": experiment_data.get("input", {}).get(
+                "id",
+                task_id,
+            ),
+        }
+        contents.append(
+            (
+                "data_config",
+                json.dumps(data_config, ensure_ascii=False),
+            ),
+        )
+
+        # Add experiment_data field
+        contents.append(
+            (
+                "experiment_data",
+                json.dumps(
+                    experiment_data.get("input", {}),
+                    ensure_ascii=False,
+                    default=str,
+                ),
+            ),
+        )
+
+        # Add experiment_result field with output data
+        result_data = {
+            "success": output.success,
+            "output": output.output,
+            "trajectory": output.trajectory,
+            "meta": output.meta,
+        }
+        contents.append(
+            (
+                "experiment_output",
+                json.dumps(result_data, ensure_ascii=False, default=str),
+            ),
+        )
+        self._put_log(contents)
+
+    def save_task_meta(
+        self,
+        task_id: str,
+        meta_info: dict[str, JSONSerializableObject],
+    ) -> None:
+        """Save the task meta information to local file and cache for later use.
+
+        The task meta (experiment_data) is cached and will be written to SLS
+        together with the solution result in save_solution_result().
+
+        Args:
+            task_id (`str`):
+                The task ID.
+            meta_info (`dict[str, JSONSerializableObject]`):
+                The task meta information to be saved.
+        """
+        # Save to local file using parent class
+        super().save_task_meta(
+            task_id=task_id,
+            meta_info=meta_info,
+        )
+
+        # Cache the meta_info for later use in save_solution_result
+        self._task_meta_cache[task_id] = meta_info

--- a/tests/agentloop_test.py
+++ b/tests/agentloop_test.py
@@ -64,9 +64,46 @@ class TestAgentLoopConfig(unittest.TestCase):
         self.assertEqual(config.access_key_id, "test_key_id")
         self.assertEqual(config.access_key_secret, "test_key_secret")
 
-    def test_default_query_generated_from_dataset(self) -> None:
+    def test_default_query_is_empty(self) -> None:
         config = _make_config(query="")
-        self.assertEqual(config.query, "* | select * from test_dataset")
+        self.assertEqual(config.query, "")
+
+    def test_default_max_rows(self) -> None:
+        config = _make_config()
+        self.assertEqual(config.max_rows, 1000)
+
+    def test_custom_max_rows(self) -> None:
+        config = AgentLoopConfig(
+            workspace="ws",
+            dataset="ds",
+            region_id="cn-hangzhou",
+            max_rows=500,
+            access_key_id="k",
+            access_key_secret="s",
+        )
+        self.assertEqual(config.max_rows, 500)
+
+    def test_invalid_max_rows_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            AgentLoopConfig(
+                workspace="ws",
+                dataset="ds",
+                region_id="cn-hangzhou",
+                max_rows=0,
+                access_key_id="k",
+                access_key_secret="s",
+            )
+
+    def test_negative_max_rows_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            AgentLoopConfig(
+                workspace="ws",
+                dataset="ds",
+                region_id="cn-hangzhou",
+                max_rows=-1,
+                access_key_id="k",
+                access_key_secret="s",
+            )
 
     def test_custom_query_preserved(self) -> None:
         custom_query = "* | select col1 from test_dataset limit 10"
@@ -317,7 +354,11 @@ class TestAgentLoopBenchmark(unittest.TestCase):
         return mock_client
 
     def _call_load_data(self, data: object) -> list[dict]:
-        """Call _load_data_from_cms with a mocked client and SDK module."""
+        """Call _load_data_from_cms in single-query mode with a mocked client.
+
+        A custom query is set on the config so that _load_data_from_cms takes
+        the single-call path, which exercises _parse_response_data directly.
+        """
         mock_client = self._make_mock_execute_query(data)
         mock_cms_models = MagicMock()
         mock_cms_models.ExecuteQueryRequest.return_value = MagicMock()
@@ -330,19 +371,20 @@ class TestAgentLoopBenchmark(unittest.TestCase):
         ):
             with patch.object(
                 AgentLoopBenchmark,
-                "_get_client",
-                return_value=mock_client,
+                "_load_data_from_cms",
+                return_value=[],
             ):
-                with patch.object(
-                    AgentLoopBenchmark,
-                    "_load_data_from_cms",
-                    return_value=[],
-                ):
-                    benchmark = AgentLoopBenchmark(config=_make_config())
+                benchmark = AgentLoopBenchmark(config=_make_config())
 
-                # Now call the real _load_data_from_cms
-                benchmark._get_client = MagicMock(return_value=mock_client)  # type: ignore[method-assign]
-                return AgentLoopBenchmark._load_data_from_cms(benchmark)  # type: ignore[arg-type]
+            # Force single-call mode by providing a custom query
+            benchmark.config.query = "* | select * from test_dataset"
+            benchmark._get_client = MagicMock(return_value=mock_client)  # type: ignore[method-assign]
+            return AgentLoopBenchmark._load_data_from_cms(benchmark)  # type: ignore[arg-type]
+
+    def _make_paginated_benchmark(self) -> AgentLoopBenchmark:
+        """Create a benchmark with no custom query (paginated mode)."""
+        with patch.object(AgentLoopBenchmark, "_load_data_from_cms", return_value=[]):
+            return AgentLoopBenchmark(config=_make_config())
 
     def test_load_data_list_response(self) -> None:
         records = [{"a": 1}, {"a": 2}]
@@ -386,6 +428,169 @@ class TestAgentLoopBenchmark(unittest.TestCase):
     def test_load_data_none_data(self) -> None:
         result = self._call_load_data(None)
         self.assertEqual(result, [])
+
+    # ------------------------------------------------------------------
+    # Paginated loading (_load_data_from_cms with no custom query)
+    # ------------------------------------------------------------------
+
+    def test_paginated_stops_on_empty_response(self) -> None:
+        """When a page returns [], pagination terminates immediately."""
+        benchmark = self._make_paginated_benchmark()
+        with patch.object(
+            benchmark,
+            "_execute_query_request",
+            return_value=[],
+        ):
+            result = AgentLoopBenchmark._load_data_from_cms(benchmark)  # type: ignore[arg-type]
+        # Benchmark needs SDK import mocked
+        mock_cms_pkg = MagicMock()
+        with patch.dict("sys.modules", {"alibabacloud_cms20240330": mock_cms_pkg}):
+            with patch.object(benchmark, "_get_client", return_value=MagicMock()):
+                with patch.object(benchmark, "_execute_query_request", return_value=[]):
+                    result = AgentLoopBenchmark._load_data_from_cms(benchmark)  # type: ignore[arg-type]
+        self.assertEqual(result, [])
+
+    def test_paginated_stops_on_error(self) -> None:
+        """When a page raises RuntimeError, pagination stops and returns
+        whatever was collected so far."""
+        benchmark = self._make_paginated_benchmark()
+        first_page = [{"q": "1"}, {"q": "2"}]
+        call_count = 0
+
+        def side_effect(*_args: object, **_kwargs: object) -> list[dict]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return first_page
+            raise RuntimeError("simulated API error")
+
+        mock_cms_pkg = MagicMock()
+        with patch.dict("sys.modules", {"alibabacloud_cms20240330": mock_cms_pkg}):
+            with patch.object(benchmark, "_get_client", return_value=MagicMock()):
+                with patch.object(
+                    benchmark,
+                    "_execute_query_request",
+                    side_effect=side_effect,
+                ):
+                    result = AgentLoopBenchmark._load_data_from_cms(benchmark)  # type: ignore[arg-type]
+
+        self.assertEqual(result, first_page)
+        self.assertEqual(call_count, 2)
+
+    def test_paginated_respects_max_rows(self) -> None:
+        """Pagination stops once max_rows records have been collected."""
+        benchmark = self._make_paginated_benchmark()
+        benchmark.config.max_rows = 5
+        page = [{"i": i} for i in range(3)]  # 3 records per page
+
+        call_count = 0
+
+        def side_effect(*_args: object, **_kwargs: object) -> list[dict]:
+            nonlocal call_count
+            call_count += 1
+            return page
+
+        mock_cms_pkg = MagicMock()
+        with patch.dict("sys.modules", {"alibabacloud_cms20240330": mock_cms_pkg}):
+            with patch.object(benchmark, "_get_client", return_value=MagicMock()):
+                with patch.object(
+                    benchmark,
+                    "_execute_query_request",
+                    side_effect=side_effect,
+                ):
+                    result = AgentLoopBenchmark._load_data_from_cms(benchmark)  # type: ignore[arg-type]
+
+        # Page 1: LIMIT 5 OFFSET 0 → mock returns 3; page 2: LIMIT 2 OFFSET 3
+        # → mock returns 3 but result is truncated to max_rows=5
+        self.assertEqual(len(result), 5)
+        self.assertEqual(call_count, 2)
+
+    def test_paginated_multiple_pages_collected(self) -> None:
+        """All records from multiple pages are concatenated."""
+        benchmark = self._make_paginated_benchmark()
+        benchmark.config.max_rows = 10
+        pages = [
+            [{"n": 0}, {"n": 1}, {"n": 2}],
+            [{"n": 3}, {"n": 4}, {"n": 5}],
+            [],  # empty → stop
+        ]
+        call_count = 0
+
+        def side_effect(*_args: object, **_kwargs: object) -> list[dict]:
+            nonlocal call_count
+            result_page = pages[call_count]
+            call_count += 1
+            return result_page
+
+        mock_cms_pkg = MagicMock()
+        with patch.dict("sys.modules", {"alibabacloud_cms20240330": mock_cms_pkg}):
+            with patch.object(benchmark, "_get_client", return_value=MagicMock()):
+                with patch.object(
+                    benchmark,
+                    "_execute_query_request",
+                    side_effect=side_effect,
+                ):
+                    result = AgentLoopBenchmark._load_data_from_cms(benchmark)  # type: ignore[arg-type]
+
+        self.assertEqual(len(result), 6)
+        self.assertEqual(result, pages[0] + pages[1])
+        self.assertEqual(call_count, 3)
+
+    def test_paginated_uses_correct_limit_offset_in_query(self) -> None:
+        """Verify the page_query contains correct LIMIT and OFFSET values."""
+        benchmark = self._make_paginated_benchmark()
+        benchmark.config.max_rows = 3
+
+        captured_queries: list[str] = []
+        pages = [[{"n": 0}, {"n": 1}], [{"n": 2}], []]
+
+        call_count = 0
+
+        def side_effect(
+            _client: object,
+            _models: object,
+            query: str,
+        ) -> list[dict]:
+            nonlocal call_count
+            captured_queries.append(query)
+            page = pages[call_count]
+            call_count += 1
+            return page
+
+        mock_cms_pkg = MagicMock()
+        with patch.dict("sys.modules", {"alibabacloud_cms20240330": mock_cms_pkg}):
+            with patch.object(benchmark, "_get_client", return_value=MagicMock()):
+                with patch.object(
+                    benchmark,
+                    "_execute_query_request",
+                    side_effect=side_effect,
+                ):
+                    AgentLoopBenchmark._load_data_from_cms(benchmark)  # type: ignore[arg-type]
+
+        # First page: LIMIT 3 OFFSET 0; second: LIMIT 1 OFFSET 2
+        self.assertIn("LIMIT 3", captured_queries[0])
+        self.assertIn("OFFSET 0", captured_queries[0])
+        self.assertIn("LIMIT 1", captured_queries[1])
+        self.assertIn("OFFSET 2", captured_queries[1])
+
+    def test_custom_query_uses_single_call(self) -> None:
+        """When config.query is set, _execute_query_request is called exactly once."""
+        benchmark = self._make_paginated_benchmark()
+        benchmark.config.query = "* | select * from test_dataset"
+        records = [{"a": 1}]
+
+        mock_cms_pkg = MagicMock()
+        with patch.dict("sys.modules", {"alibabacloud_cms20240330": mock_cms_pkg}):
+            with patch.object(benchmark, "_get_client", return_value=MagicMock()):
+                with patch.object(
+                    benchmark,
+                    "_execute_query_request",
+                    return_value=records,
+                ) as mock_exec:
+                    result = AgentLoopBenchmark._load_data_from_cms(benchmark)  # type: ignore[arg-type]
+
+        mock_exec.assert_called_once()
+        self.assertEqual(result, records)
 
     # ------------------------------------------------------------------
     # ImportError handling

--- a/tests/agentloop_test.py
+++ b/tests/agentloop_test.py
@@ -1,0 +1,929 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for AgentLoop benchmark and evaluator storage."""
+import json
+import os
+import sys
+import shutil
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+# Ensure local source is preferred over any installed version so that
+# newly added modules (not yet published) are importable.
+_SRC_DIR = os.path.join(os.path.dirname(__file__), "..", "src")
+if _SRC_DIR not in sys.path:
+    sys.path.insert(0, os.path.abspath(_SRC_DIR))
+
+from agentscope.evaluate._agentloop_config import AgentLoopConfig
+from agentscope.evaluate._agentloop_benchmark._agentloop_benchmark import (
+    AgentLoopBenchmark,
+)
+from agentscope.evaluate._evaluator_storage._agentloop_evaluator_storage import (
+    AgentLoopEvaluatorStorage,
+    EXPERIMENT_LOGSTORE,
+)
+from agentscope.evaluate._task import Task
+from agentscope.evaluate._solution import SolutionOutput
+
+
+# ============================================================
+# Helper factories
+# ============================================================
+
+def _make_config(
+    region_id: str = "cn-hangzhou",
+    project: str = "test_project",
+    ground_truth_field: str = "",
+    query: str = "",
+) -> AgentLoopConfig:
+    return AgentLoopConfig(
+        workspace="test_workspace",
+        dataset="test_dataset",
+        region_id=region_id,
+        project=project,
+        query=query,
+        ground_truth_field=ground_truth_field,
+        access_key_id="test_key_id",
+        access_key_secret="test_key_secret",
+    )
+
+
+# ============================================================
+# AgentLoopConfig tests
+# ============================================================
+
+class TestAgentLoopConfig(unittest.TestCase):
+    """Tests for AgentLoopConfig dataclass."""
+
+    def test_basic_initialization(self) -> None:
+        config = _make_config()
+        self.assertEqual(config.workspace, "test_workspace")
+        self.assertEqual(config.dataset, "test_dataset")
+        self.assertEqual(config.region_id, "cn-hangzhou")
+        self.assertEqual(config.project, "test_project")
+        self.assertEqual(config.access_key_id, "test_key_id")
+        self.assertEqual(config.access_key_secret, "test_key_secret")
+
+    def test_default_query_generated_from_dataset(self) -> None:
+        config = _make_config(query="")
+        self.assertEqual(config.query, "* | select * from test_dataset")
+
+    def test_custom_query_preserved(self) -> None:
+        custom_query = "* | select col1 from test_dataset limit 10"
+        config = _make_config(query=custom_query)
+        self.assertEqual(config.query, custom_query)
+
+    def test_credentials_loaded_from_env(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "ALIBABA_CLOUD_ACCESS_KEY_ID": "env_key",
+                "ALIBABA_CLOUD_ACCESS_KEY_SECRET": "env_secret",
+            },
+        ):
+            config = AgentLoopConfig(
+                workspace="ws",
+                dataset="ds",
+                region_id="cn-hangzhou",
+            )
+        self.assertEqual(config.access_key_id, "env_key")
+        self.assertEqual(config.access_key_secret, "env_secret")
+
+    def test_explicit_credentials_override_env(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "ALIBABA_CLOUD_ACCESS_KEY_ID": "env_key",
+                "ALIBABA_CLOUD_ACCESS_KEY_SECRET": "env_secret",
+            },
+        ):
+            config = AgentLoopConfig(
+                workspace="ws",
+                dataset="ds",
+                region_id="cn-hangzhou",
+                access_key_id="explicit_key",
+                access_key_secret="explicit_secret",
+            )
+        self.assertEqual(config.access_key_id, "explicit_key")
+        self.assertEqual(config.access_key_secret, "explicit_secret")
+
+    def test_validate_credentials_success(self) -> None:
+        config = _make_config()
+        config.validate_credentials()  # should not raise
+
+    def test_validate_credentials_missing_key_id(self) -> None:
+        config = _make_config()
+        config.access_key_id = ""
+        with self.assertRaises(ValueError) as ctx:
+            config.validate_credentials()
+        self.assertIn("AccessKey", str(ctx.exception))
+
+    def test_validate_credentials_missing_key_secret(self) -> None:
+        config = _make_config()
+        config.access_key_secret = ""
+        with self.assertRaises(ValueError):
+            config.validate_credentials()
+
+    def test_validate_credentials_both_missing(self) -> None:
+        config = AgentLoopConfig(
+            workspace="ws",
+            dataset="ds",
+            region_id="cn-hangzhou",
+        )
+        # Ensure env vars are absent
+        with patch.dict(os.environ, {}, clear=True):
+            config.access_key_id = ""
+            config.access_key_secret = ""
+            with self.assertRaises(ValueError):
+                config.validate_credentials()
+
+    def test_cms_endpoint(self) -> None:
+        config = _make_config(region_id="cn-hangzhou")
+        self.assertEqual(config.cms_endpoint, "cms.cn-hangzhou.aliyuncs.com")
+
+    def test_sls_endpoint(self) -> None:
+        config = _make_config(region_id="cn-hangzhou")
+        self.assertEqual(config.sls_endpoint, "cn-hangzhou.log.aliyuncs.com")
+
+    def test_endpoints_with_different_region(self) -> None:
+        config = _make_config(region_id="cn-shanghai")
+        self.assertEqual(config.cms_endpoint, "cms.cn-shanghai.aliyuncs.com")
+        self.assertEqual(config.sls_endpoint, "cn-shanghai.log.aliyuncs.com")
+
+    def test_default_project_is_empty_string(self) -> None:
+        config = AgentLoopConfig(
+            workspace="ws",
+            dataset="ds",
+            region_id="cn-hangzhou",
+            access_key_id="k",
+            access_key_secret="s",
+        )
+        self.assertEqual(config.project, "")
+
+    def test_default_ground_truth_field_is_empty(self) -> None:
+        config = _make_config()
+        self.assertEqual(config.ground_truth_field, "")
+
+
+# ============================================================
+# AgentLoopBenchmark tests
+# ============================================================
+
+class TestAgentLoopBenchmark(unittest.TestCase):
+    """Tests for AgentLoopBenchmark class."""
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_benchmark(
+        self,
+        raw_data: list[dict],
+        ground_truth_field: str = "",
+        name: str = "AgentLoopBenchmark",
+        description: str = "Benchmark loaded from AgentLoop.",
+    ) -> AgentLoopBenchmark:
+        """Create a benchmark with _load_data_from_cms patched."""
+        with patch.object(
+            AgentLoopBenchmark,
+            "_load_data_from_cms",
+            return_value=raw_data,
+        ):
+            return AgentLoopBenchmark(
+                config=_make_config(ground_truth_field=ground_truth_field),
+                name=name,
+                description=description,
+            )
+
+    # ------------------------------------------------------------------
+    # Initialization
+    # ------------------------------------------------------------------
+
+    def test_default_name_and_description(self) -> None:
+        benchmark = self._make_benchmark([])
+        self.assertEqual(benchmark.name, "AgentLoopBenchmark")
+        self.assertEqual(benchmark.description, "Benchmark loaded from AgentLoop.")
+
+    def test_custom_name_and_description(self) -> None:
+        benchmark = self._make_benchmark(
+            [],
+            name="MyBench",
+            description="Custom desc",
+        )
+        self.assertEqual(benchmark.name, "MyBench")
+        self.assertEqual(benchmark.description, "Custom desc")
+
+    def test_config_stored(self) -> None:
+        config = _make_config()
+        with patch.object(AgentLoopBenchmark, "_load_data_from_cms", return_value=[]):
+            benchmark = AgentLoopBenchmark(config=config)
+        self.assertIs(benchmark.config, config)
+
+    # ------------------------------------------------------------------
+    # Task conversion
+    # ------------------------------------------------------------------
+
+    def test_task_input_equals_log_record(self) -> None:
+        record = {"question": "What is 1+1?", "category": "math"}
+        benchmark = self._make_benchmark([record])
+        self.assertEqual(benchmark[0].input, record)
+
+    def test_task_ground_truth_empty_when_no_field_configured(self) -> None:
+        record = {"question": "Q", "answer": "A"}
+        benchmark = self._make_benchmark([record], ground_truth_field="")
+        self.assertEqual(benchmark[0].ground_truth, "")
+
+    def test_task_ground_truth_from_configured_field(self) -> None:
+        record = {"question": "Q", "answer": "42"}
+        benchmark = self._make_benchmark([record], ground_truth_field="answer")
+        self.assertEqual(benchmark[0].ground_truth, "42")
+
+    def test_task_ground_truth_missing_field_falls_back_to_empty(self) -> None:
+        record = {"question": "Q"}
+        benchmark = self._make_benchmark([record], ground_truth_field="answer")
+        self.assertEqual(benchmark[0].ground_truth, "")
+
+    def test_task_ids_are_unique(self) -> None:
+        records = [{"q": str(i)} for i in range(10)]
+        benchmark = self._make_benchmark(records)
+        ids = [task.id for task in benchmark]
+        self.assertEqual(len(ids), len(set(ids)), "Task IDs are not unique")
+
+    def test_task_ids_are_stable_across_iterations(self) -> None:
+        records = [{"q": "1"}, {"q": "2"}]
+        benchmark = self._make_benchmark(records)
+        first_pass = [task.id for task in benchmark]
+        second_pass = [task.id for task in benchmark]
+        self.assertEqual(first_pass, second_pass)
+
+    def test_task_has_empty_metrics(self) -> None:
+        benchmark = self._make_benchmark([{"q": "Q"}])
+        self.assertEqual(benchmark[0].metrics, [])
+
+    def test_task_has_empty_metadata(self) -> None:
+        benchmark = self._make_benchmark([{"q": "Q"}])
+        self.assertEqual(benchmark[0].metadata, {})
+
+    # ------------------------------------------------------------------
+    # __len__ / __iter__ / __getitem__
+    # ------------------------------------------------------------------
+
+    def test_len_empty(self) -> None:
+        benchmark = self._make_benchmark([])
+        self.assertEqual(len(benchmark), 0)
+
+    def test_len_non_empty(self) -> None:
+        benchmark = self._make_benchmark([{"q": str(i)} for i in range(5)])
+        self.assertEqual(len(benchmark), 5)
+
+    def test_iter_yields_task_objects(self) -> None:
+        benchmark = self._make_benchmark([{"q": "1"}, {"q": "2"}])
+        for task in benchmark:
+            self.assertIsInstance(task, Task)
+
+    def test_iter_yields_all_tasks(self) -> None:
+        records = [{"q": str(i)} for i in range(3)]
+        benchmark = self._make_benchmark(records)
+        tasks = list(benchmark)
+        self.assertEqual(len(tasks), 3)
+        for task, record in zip(tasks, records):
+            self.assertEqual(task.input, record)
+
+    def test_getitem_first(self) -> None:
+        records = [{"q": "first"}, {"q": "second"}]
+        benchmark = self._make_benchmark(records)
+        self.assertEqual(benchmark[0].input, {"q": "first"})
+
+    def test_getitem_last(self) -> None:
+        records = [{"q": "a"}, {"q": "b"}, {"q": "c"}]
+        benchmark = self._make_benchmark(records)
+        self.assertEqual(benchmark[2].input, {"q": "c"})
+
+    def test_getitem_out_of_range(self) -> None:
+        benchmark = self._make_benchmark([{"q": "only"}])
+        with self.assertRaises(IndexError):
+            _ = benchmark[5]
+
+    # ------------------------------------------------------------------
+    # _load_data_from_cms response parsing
+    # ------------------------------------------------------------------
+
+    def _make_mock_execute_query(self, data: object) -> MagicMock:
+        """Build a fake execute_query callable returning the given data."""
+        mock_resp = MagicMock()
+        mock_resp.body.data = data
+        mock_client = MagicMock()
+        mock_client.execute_query.return_value = mock_resp
+        return mock_client
+
+    def _call_load_data(self, data: object) -> list[dict]:
+        """Call _load_data_from_cms with a mocked client and SDK module."""
+        mock_client = self._make_mock_execute_query(data)
+        mock_cms_models = MagicMock()
+        mock_cms_models.ExecuteQueryRequest.return_value = MagicMock()
+        mock_cms_pkg = MagicMock()
+        mock_cms_pkg.models = mock_cms_models
+
+        with patch.dict(
+            "sys.modules",
+            {"alibabacloud_cms20240330": mock_cms_pkg},
+        ):
+            with patch.object(
+                AgentLoopBenchmark,
+                "_get_client",
+                return_value=mock_client,
+            ):
+                with patch.object(
+                    AgentLoopBenchmark,
+                    "_load_data_from_cms",
+                    return_value=[],
+                ):
+                    benchmark = AgentLoopBenchmark(config=_make_config())
+
+                # Now call the real _load_data_from_cms
+                benchmark._get_client = MagicMock(return_value=mock_client)  # type: ignore[method-assign]
+                return AgentLoopBenchmark._load_data_from_cms(benchmark)  # type: ignore[arg-type]
+
+    def test_load_data_list_response(self) -> None:
+        records = [{"a": 1}, {"a": 2}]
+        result = self._call_load_data(records)
+        self.assertEqual(result, records)
+
+    def test_load_data_dict_with_rows(self) -> None:
+        rows = [{"r": 1}, {"r": 2}]
+        result = self._call_load_data({"rows": rows})
+        self.assertEqual(result, rows)
+
+    def test_load_data_dict_with_records(self) -> None:
+        records = [{"rec": 1}]
+        result = self._call_load_data({"records": records})
+        self.assertEqual(result, records)
+
+    def test_load_data_dict_without_known_keys(self) -> None:
+        data = {"unknown_key": "value"}
+        result = self._call_load_data(data)
+        self.assertEqual(result, [data])
+
+    def test_load_data_none_body(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.body = None
+        mock_client = MagicMock()
+        mock_client.execute_query.return_value = mock_resp
+
+        mock_cms_pkg = MagicMock()
+        with patch.dict("sys.modules", {"alibabacloud_cms20240330": mock_cms_pkg}):
+            with patch.object(
+                AgentLoopBenchmark,
+                "_load_data_from_cms",
+                return_value=[],
+            ):
+                benchmark = AgentLoopBenchmark(config=_make_config())
+
+            benchmark._get_client = MagicMock(return_value=mock_client)  # type: ignore[method-assign]
+            result = AgentLoopBenchmark._load_data_from_cms(benchmark)  # type: ignore[arg-type]
+        self.assertEqual(result, [])
+
+    def test_load_data_none_data(self) -> None:
+        result = self._call_load_data(None)
+        self.assertEqual(result, [])
+
+    # ------------------------------------------------------------------
+    # ImportError handling
+    # ------------------------------------------------------------------
+
+    def test_get_client_import_error(self) -> None:
+        with patch.object(AgentLoopBenchmark, "_load_data_from_cms", return_value=[]):
+            benchmark = AgentLoopBenchmark(config=_make_config())
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "alibabacloud_cms20240330": None,
+                "alibabacloud_cms20240330.client": None,
+                "alibabacloud_tea_openapi": None,
+                "alibabacloud_tea_openapi.models": None,
+            },
+        ):
+            with self.assertRaises((ImportError, AttributeError)):
+                benchmark._get_client()
+
+    def test_load_data_from_cms_import_error(self) -> None:
+        with patch.object(AgentLoopBenchmark, "_load_data_from_cms", return_value=[]):
+            benchmark = AgentLoopBenchmark(config=_make_config())
+
+        with patch.dict(
+            "sys.modules",
+            {"alibabacloud_cms20240330": None},
+        ):
+            with self.assertRaises((ImportError, AttributeError)):
+                AgentLoopBenchmark._load_data_from_cms(benchmark)  # type: ignore[arg-type]
+
+    # ------------------------------------------------------------------
+    # validate_credentials propagation
+    # ------------------------------------------------------------------
+
+    def test_invalid_credentials_raise_on_init(self) -> None:
+        bad_config = AgentLoopConfig(
+            workspace="ws",
+            dataset="ds",
+            region_id="cn-hangzhou",
+        )
+        bad_config.access_key_id = ""
+        bad_config.access_key_secret = ""
+
+        with patch.object(AgentLoopBenchmark, "_load_data_from_cms", return_value=[]):
+            with self.assertRaises(ValueError):
+                AgentLoopBenchmark(config=bad_config)
+
+
+# ============================================================
+# AgentLoopEvaluatorStorage tests
+# ============================================================
+
+class TestAgentLoopEvaluatorStorage(unittest.TestCase):
+    """Tests for AgentLoopEvaluatorStorage class."""
+
+    def setUp(self) -> None:
+        self.save_dir = tempfile.mkdtemp()
+        self.config = _make_config(project="my_sls_project")
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.save_dir, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_storage(
+        self,
+        experiment_id: str = "exp-001",
+        experiment_name: str = "test_exp",
+        experiment_type: str = "agent",
+        experiment_metadata: dict | None = None,
+        experiment_config: dict | None = None,
+    ) -> AgentLoopEvaluatorStorage:
+        return AgentLoopEvaluatorStorage(
+            save_dir=self.save_dir,
+            config=self.config,
+            experiment_id=experiment_id,
+            experiment_name=experiment_name,
+            experiment_type=experiment_type,
+            experiment_metadata=experiment_metadata,
+            experiment_config=experiment_config,
+        )
+
+    def _make_solution_output(
+        self,
+        success: bool = True,
+        output: object = "42",
+    ) -> SolutionOutput:
+        return SolutionOutput(
+            success=success,
+            output=output,
+            trajectory=[],
+            meta={"note": "test"},
+        )
+
+    # ------------------------------------------------------------------
+    # Initialization
+    # ------------------------------------------------------------------
+
+    def test_experiment_id_stored(self) -> None:
+        storage = self._make_storage(experiment_id="my-exp-id")
+        self.assertEqual(storage.experiment_id, "my-exp-id")
+
+    def test_experiment_name_stored(self) -> None:
+        storage = self._make_storage(experiment_name="MyExperiment")
+        self.assertEqual(storage.experiment_name, "MyExperiment")
+
+    def test_experiment_type_stored(self) -> None:
+        storage = self._make_storage(experiment_type="model")
+        self.assertEqual(storage.experiment_type, "model")
+
+    def test_logstore_is_experiment_detail(self) -> None:
+        storage = self._make_storage()
+        self.assertEqual(storage.logstore, EXPERIMENT_LOGSTORE)
+
+    def test_default_experiment_id_generated_when_none(self) -> None:
+        storage = AgentLoopEvaluatorStorage(
+            save_dir=self.save_dir,
+            config=self.config,
+        )
+        self.assertIsNotNone(storage.experiment_id)
+        self.assertGreater(len(storage.experiment_id), 0)
+
+    def test_default_experiment_name_generated_when_none(self) -> None:
+        storage = AgentLoopEvaluatorStorage(
+            save_dir=self.save_dir,
+            config=self.config,
+            experiment_id="abc12345",
+        )
+        self.assertIn("experiment_", storage.experiment_name)
+
+    def test_default_metadata_is_local_run(self) -> None:
+        storage = AgentLoopEvaluatorStorage(
+            save_dir=self.save_dir,
+            config=self.config,
+        )
+        self.assertEqual(storage.experiment_metadata, {"run_env": "local_run"})
+
+    def test_custom_metadata_stored(self) -> None:
+        storage = self._make_storage(experiment_metadata={"run_env": "ci"})
+        self.assertEqual(storage.experiment_metadata, {"run_env": "ci"})
+
+    def test_default_experiment_config_is_empty_dict(self) -> None:
+        storage = AgentLoopEvaluatorStorage(
+            save_dir=self.save_dir,
+            config=self.config,
+        )
+        self.assertEqual(storage.experiment_config, {})
+
+    def test_custom_experiment_config_stored(self) -> None:
+        cfg = {"model": "gpt-4", "temperature": 0.7}
+        storage = self._make_storage(experiment_config=cfg)
+        self.assertEqual(storage.experiment_config, cfg)
+
+    def test_task_meta_cache_initialized_empty(self) -> None:
+        storage = self._make_storage()
+        self.assertEqual(storage._task_meta_cache, {})
+
+    def test_project_from_config(self) -> None:
+        storage = self._make_storage()
+        self.assertEqual(storage.config.project, "my_sls_project")
+
+    def test_project_queried_when_not_provided(self) -> None:
+        config = AgentLoopConfig(
+            workspace="ws",
+            dataset="ds",
+            region_id="cn-hangzhou",
+            project="",
+            access_key_id="k",
+            access_key_secret="s",
+        )
+        with patch.object(
+            AgentLoopEvaluatorStorage,
+            "_get_workspace_project",
+            return_value="queried_project",
+        ) as mock_get:
+            storage = AgentLoopEvaluatorStorage(
+                save_dir=self.save_dir,
+                config=config,
+            )
+            mock_get.assert_called_once()
+        self.assertEqual(storage.config.project, "queried_project")
+
+    def test_invalid_credentials_raise_on_init(self) -> None:
+        bad_config = AgentLoopConfig(
+            workspace="ws",
+            dataset="ds",
+            region_id="cn-hangzhou",
+        )
+        bad_config.access_key_id = ""
+        bad_config.access_key_secret = ""
+        with self.assertRaises(ValueError):
+            AgentLoopEvaluatorStorage(save_dir=self.save_dir, config=bad_config)
+
+    # ------------------------------------------------------------------
+    # _build_base_log_contents
+    # ------------------------------------------------------------------
+
+    def test_build_base_log_contents_core_fields(self) -> None:
+        storage = self._make_storage(
+            experiment_id="eid",
+            experiment_name="ename",
+            experiment_type="agent",
+        )
+        contents = storage._build_base_log_contents()
+        content_dict = dict(contents)
+
+        self.assertEqual(content_dict["experiment_id"], "eid")
+        self.assertEqual(content_dict["experiment_name"], "ename")
+        self.assertEqual(content_dict["experiment_type"], "agent")
+        self.assertIn("experiment_start_time", content_dict)
+        self.assertIn("experiment_metadata", content_dict)
+        self.assertIn("experiment_config", content_dict)
+
+    def test_build_base_log_contents_without_task_and_repeat(self) -> None:
+        storage = self._make_storage()
+        contents = storage._build_base_log_contents()
+        keys = [k for k, _ in contents]
+        self.assertNotIn("task_id", keys)
+        self.assertNotIn("repeat_id", keys)
+
+    def test_build_base_log_contents_with_task_id(self) -> None:
+        storage = self._make_storage()
+        contents = storage._build_base_log_contents(task_id="task-123")
+        content_dict = dict(contents)
+        self.assertEqual(content_dict["task_id"], "task-123")
+        self.assertNotIn("repeat_id", content_dict)
+
+    def test_build_base_log_contents_with_both_ids(self) -> None:
+        storage = self._make_storage()
+        contents = storage._build_base_log_contents(
+            task_id="task-123",
+            repeat_id="repeat-0",
+        )
+        content_dict = dict(contents)
+        self.assertEqual(content_dict["task_id"], "task-123")
+        self.assertEqual(content_dict["repeat_id"], "repeat-0")
+
+    def test_build_base_log_contents_metadata_is_json_string(self) -> None:
+        metadata = {"run_env": "test", "version": "1.0"}
+        storage = self._make_storage(experiment_metadata=metadata)
+        contents = storage._build_base_log_contents()
+        content_dict = dict(contents)
+        self.assertEqual(
+            json.loads(content_dict["experiment_metadata"]),
+            metadata,
+        )
+
+    def test_build_base_log_contents_config_is_json_string(self) -> None:
+        exp_config = {"model": "claude", "temp": 0.5}
+        storage = self._make_storage(experiment_config=exp_config)
+        contents = storage._build_base_log_contents()
+        content_dict = dict(contents)
+        self.assertEqual(
+            json.loads(content_dict["experiment_config"]),
+            exp_config,
+        )
+
+    def test_build_base_log_contents_start_time_is_string(self) -> None:
+        storage = self._make_storage()
+        contents = storage._build_base_log_contents()
+        content_dict = dict(contents)
+        # All SLS values must be strings
+        self.assertIsInstance(content_dict["experiment_start_time"], str)
+
+    # ------------------------------------------------------------------
+    # save_task_meta
+    # ------------------------------------------------------------------
+
+    def test_save_task_meta_writes_file(self) -> None:
+        storage = self._make_storage()
+        task_id = "task-001"
+        meta = {"input": {"question": "Q1"}, "label": "label1"}
+        storage.save_task_meta(task_id=task_id, meta_info=meta)
+
+        expected_file = os.path.join(
+            self.save_dir,
+            task_id,
+            "task_meta.json",
+        )
+        self.assertTrue(os.path.exists(expected_file))
+        with open(expected_file, encoding="utf-8") as f:
+            loaded = json.load(f)
+        self.assertEqual(loaded, meta)
+
+    def test_save_task_meta_caches_in_memory(self) -> None:
+        storage = self._make_storage()
+        task_id = "task-002"
+        meta = {"input": {"question": "Q2"}}
+        storage.save_task_meta(task_id=task_id, meta_info=meta)
+
+        self.assertIn(task_id, storage._task_meta_cache)
+        self.assertEqual(storage._task_meta_cache[task_id], meta)
+
+    def test_save_task_meta_cache_isolated_per_task(self) -> None:
+        storage = self._make_storage()
+        storage.save_task_meta("task-a", {"x": 1})
+        storage.save_task_meta("task-b", {"x": 2})
+        self.assertEqual(storage._task_meta_cache["task-a"], {"x": 1})
+        self.assertEqual(storage._task_meta_cache["task-b"], {"x": 2})
+
+    # ------------------------------------------------------------------
+    # save_solution_result
+    # ------------------------------------------------------------------
+
+    def test_save_solution_result_writes_local_file(self) -> None:
+        storage = self._make_storage()
+        task_id = "task-sol-001"
+        repeat_id = "0"
+        output = self._make_solution_output()
+
+        with patch.object(storage, "_put_log"):
+            storage.save_solution_result(
+                task_id=task_id,
+                repeat_id=repeat_id,
+                output=output,
+            )
+
+        solution_file = os.path.join(
+            self.save_dir,
+            task_id,
+            repeat_id,
+            "solution.json",
+        )
+        self.assertTrue(os.path.exists(solution_file))
+
+    def test_save_solution_result_calls_put_log(self) -> None:
+        storage = self._make_storage()
+        task_id = "task-sol-002"
+        repeat_id = "0"
+        output = self._make_solution_output()
+
+        with patch.object(storage, "_put_log") as mock_put:
+            storage.save_solution_result(
+                task_id=task_id,
+                repeat_id=repeat_id,
+                output=output,
+            )
+            mock_put.assert_called_once()
+
+    def test_save_solution_result_put_log_contains_correct_fields(self) -> None:
+        storage = self._make_storage(experiment_id="exp-xyz")
+        task_id = "task-sol-003"
+        repeat_id = "1"
+        output = self._make_solution_output(success=True, output="hello")
+
+        captured: list[list[tuple[str, str]]] = []
+
+        def capture_put_log(contents: list[tuple[str, str]]) -> None:
+            captured.append(contents)
+
+        with patch.object(storage, "_put_log", side_effect=capture_put_log):
+            storage.save_solution_result(
+                task_id=task_id,
+                repeat_id=repeat_id,
+                output=output,
+            )
+
+        self.assertEqual(len(captured), 1)
+        content_dict = dict(captured[0])
+
+        self.assertEqual(content_dict["experiment_id"], "exp-xyz")
+        self.assertEqual(content_dict["task_id"], task_id)
+        self.assertEqual(content_dict["repeat_id"], repeat_id)
+        self.assertIn("experiment_output", content_dict)
+        self.assertIn("data_config", content_dict)
+        self.assertIn("experiment_data", content_dict)
+
+    def test_save_solution_result_experiment_output_content(self) -> None:
+        storage = self._make_storage()
+        task_id = "task-sol-004"
+        repeat_id = "0"
+        output = self._make_solution_output(success=False, output="error_output")
+
+        captured: list[list[tuple[str, str]]] = []
+        with patch.object(storage, "_put_log", side_effect=captured.append):
+            storage.save_solution_result(
+                task_id=task_id,
+                repeat_id=repeat_id,
+                output=output,
+            )
+
+        content_dict = dict(captured[0])
+        experiment_output = json.loads(content_dict["experiment_output"])
+        self.assertFalse(experiment_output["success"])
+        self.assertEqual(experiment_output["output"], "error_output")
+
+    def test_save_solution_result_uses_cached_task_meta(self) -> None:
+        storage = self._make_storage()
+        task_id = "task-sol-005"
+        repeat_id = "0"
+        meta = {"input": {"question": "What is AI?", "id": "q-999"}}
+        output = self._make_solution_output()
+
+        storage.save_task_meta(task_id=task_id, meta_info=meta)
+
+        captured: list[list[tuple[str, str]]] = []
+        with patch.object(storage, "_put_log", side_effect=captured.append):
+            storage.save_solution_result(
+                task_id=task_id,
+                repeat_id=repeat_id,
+                output=output,
+            )
+
+        content_dict = dict(captured[0])
+        experiment_data = json.loads(content_dict["experiment_data"])
+        self.assertEqual(experiment_data, meta["input"])
+
+        data_config = json.loads(content_dict["data_config"])
+        self.assertEqual(data_config["dataset_item_id"], "q-999")
+
+    def test_save_solution_result_data_config_structure(self) -> None:
+        storage = self._make_storage()
+        task_id = "task-sol-006"
+        repeat_id = "0"
+        output = self._make_solution_output()
+
+        captured: list[list[tuple[str, str]]] = []
+        with patch.object(storage, "_put_log", side_effect=captured.append):
+            storage.save_solution_result(
+                task_id=task_id,
+                repeat_id=repeat_id,
+                output=output,
+            )
+
+        content_dict = dict(captured[0])
+        data_config = json.loads(content_dict["data_config"])
+        self.assertEqual(data_config["data_type"], "dataset")
+        self.assertEqual(data_config["project"], self.config.project)
+        self.assertEqual(data_config["dataset_id"], self.config.dataset)
+
+    def test_save_solution_result_dataset_item_id_falls_back_to_task_id(self) -> None:
+        storage = self._make_storage()
+        task_id = "task-fallback"
+        repeat_id = "0"
+        output = self._make_solution_output()
+        # no task meta cached → dataset_item_id should fall back to task_id
+
+        captured: list[list[tuple[str, str]]] = []
+        with patch.object(storage, "_put_log", side_effect=captured.append):
+            storage.save_solution_result(
+                task_id=task_id,
+                repeat_id=repeat_id,
+                output=output,
+            )
+
+        content_dict = dict(captured[0])
+        data_config = json.loads(content_dict["data_config"])
+        self.assertEqual(data_config["dataset_item_id"], task_id)
+
+    # ------------------------------------------------------------------
+    # _put_log ImportError
+    # ------------------------------------------------------------------
+
+    def test_put_log_raises_import_error_when_sdk_missing(self) -> None:
+        storage = self._make_storage()
+        with patch.dict("sys.modules", {"aliyun": None, "aliyun.log": None}):
+            with self.assertRaises((ImportError, AttributeError)):
+                storage._put_log([("key", "value")])
+
+    # ------------------------------------------------------------------
+    # _get_sls_client ImportError
+    # ------------------------------------------------------------------
+
+    def test_get_sls_client_raises_import_error_when_sdk_missing(self) -> None:
+        storage = self._make_storage()
+        with patch.dict("sys.modules", {"aliyun": None, "aliyun.log": None}):
+            with self.assertRaises((ImportError, AttributeError)):
+                storage._get_sls_client()
+
+    # ------------------------------------------------------------------
+    # _get_cms_client ImportError
+    # ------------------------------------------------------------------
+
+    def test_get_cms_client_raises_import_error_when_sdk_missing(self) -> None:
+        storage = self._make_storage()
+        with patch.dict(
+            "sys.modules",
+            {
+                "alibabacloud_cms20240330": None,
+                "alibabacloud_cms20240330.client": None,
+                "alibabacloud_tea_openapi": None,
+                "alibabacloud_tea_openapi.models": None,
+            },
+        ):
+            with self.assertRaises((ImportError, AttributeError)):
+                storage._get_cms_client()
+
+    # ------------------------------------------------------------------
+    # _get_workspace_project
+    # ------------------------------------------------------------------
+
+    def test_get_workspace_project_success(self) -> None:
+        storage = self._make_storage()
+
+        mock_resp = MagicMock()
+        mock_resp.body.sls_project = "found_project"
+
+        mock_client = MagicMock()
+        mock_client.get_workspace_with_options.return_value = mock_resp
+
+        mock_util_pkg = MagicMock()
+
+        with patch.dict("sys.modules", {"alibabacloud_tea_util": mock_util_pkg}):
+            with patch.object(storage, "_get_cms_client", return_value=mock_client):
+                result = storage._get_workspace_project()
+
+        self.assertEqual(result, "found_project")
+
+    def test_get_workspace_project_no_sls_project_raises(self) -> None:
+        storage = self._make_storage()
+
+        mock_resp = MagicMock()
+        mock_resp.body.sls_project = None
+
+        mock_client = MagicMock()
+        mock_client.get_workspace_with_options.return_value = mock_resp
+
+        mock_util_pkg = MagicMock()
+
+        with patch.dict("sys.modules", {"alibabacloud_tea_util": mock_util_pkg}):
+            with patch.object(storage, "_get_cms_client", return_value=mock_client):
+                with self.assertRaises(ValueError) as ctx:
+                    storage._get_workspace_project()
+        self.assertIn("SLS project", str(ctx.exception))
+
+    def test_get_workspace_project_import_error(self) -> None:
+        storage = self._make_storage()
+        with patch.dict(
+            "sys.modules",
+            {"alibabacloud_tea_util": None, "alibabacloud_tea_util.models": None},
+        ):
+            with self.assertRaises((ImportError, AttributeError)):
+                storage._get_workspace_project()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add AgentLoop benchmark and storage components to support:
- Loading evaluation datasets from Alibaba Cloud CMS 
- Writing evaluation results to SLS (Log Service)
- AgentLoopConfig for unified configuration
- Example demo with documentation

Change-Id: Ic7ba6d8b79784b6d4b8474aa11b34584e9332b36
Co-developed-by: Cursor <noreply@cursor.com>
Made-with: Cursor

## PR Title Format

Please ensure your PR title follows the Conventional Commits format:
- Format: `<type>(<scope>): <description>`
- Example: `feat(memory): add redis cache support`
- Allowed types: `feat`, `fix`, `docs`, `ci`, `refactor`, `test`, `chore`, `perf`, `style`, `build`, `revert`
- Description should start with a lowercase letter