### PR TITLE
feat(models): add MiniMax model support

### DIFF
--- a/src/agentscope/formatter/__init__.py
+++ b/src/agentscope/formatter/__init__.py
@@ -27,6 +27,10 @@ from ._deepseek_formatter import (
     DeepSeekChatFormatter,
     DeepSeekMultiAgentFormatter,
 )
+from ._minimax_formatter import (
+    MiniMaxChatFormatter,
+    MiniMaxMultiAgentFormatter,
+)
 from ._a2a_formatter import A2AChatFormatter
 
 __all__ = [
@@ -44,5 +48,7 @@ __all__ = [
     "OllamaMultiAgentFormatter",
     "DeepSeekChatFormatter",
     "DeepSeekMultiAgentFormatter",
+    "MiniMaxChatFormatter",
+    "MiniMaxMultiAgentFormatter",
     "A2AChatFormatter",
 ]

--- a/src/agentscope/formatter/_minimax_formatter.py
+++ b/src/agentscope/formatter/_minimax_formatter.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=too-many-branches
+"""The MiniMax formatter module."""
+import json
+from typing import Any
+
+from ._truncated_formatter_base import TruncatedFormatterBase
+from .._logging import logger
+from ..message import Msg, TextBlock, ThinkingBlock, ToolUseBlock, ToolResultBlock
+from ..token import TokenCounterBase
+
+
+class MiniMaxChatFormatter(TruncatedFormatterBase):
+    """The MiniMax formatter class for chatbot scenario, where only a user
+    and an agent are involved. MiniMax M2.5 uses <think></think> tags for
+    reasoning content in the message content field.
+    """
+
+    support_tools_api: bool = True
+
+    support_multiagent: bool = False
+
+    support_vision: bool = False
+
+    supported_blocks: list[type] = [
+        TextBlock,
+        ToolUseBlock,
+        ToolResultBlock,
+    ]
+
+    async def _format(
+        self,
+        msgs: list[Msg],
+    ) -> list[dict[str, Any]]:
+        self.assert_list_of_msgs(msgs)
+
+        messages: list[dict] = []
+        for msg in msgs:
+            content_blocks: list = []
+            thinking_blocks: list = []
+            tool_calls = []
+
+            for block in msg.get_content_blocks():
+                typ = block.get("type")
+                if typ == "text":
+                    content_blocks.append({**block})
+                elif typ == "thinking":
+                    thinking_blocks.append({**block})
+
+                elif typ == "tool_use":
+                    tool_calls.append(
+                        {
+                            "id": block.get("id"),
+                            "type": "function",
+                            "function": {
+                                "name": block.get("name"),
+                                "arguments": json.dumps(
+                                    block.get("input", {}),
+                                    ensure_ascii=False,
+                                ),
+                            },
+                        },
+                    )
+
+                elif typ == "tool_result":
+                    textual_output, _ = self.convert_tool_result_to_string(
+                        block.get("output"),
+                    )
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": block.get("id"),
+                            "content": textual_output,
+                            "name": block.get("name"),
+                        },
+                    )
+
+                else:
+                    logger.warning(
+                        "Unsupported block type %s in the message, skipped.",
+                        typ,
+                    )
+
+            text_content = "\n".join(
+                content.get("text", "") for content in content_blocks
+            )
+            thinking_content = "\n".join(
+                t.get("thinking", "") for t in thinking_blocks
+            )
+
+            full_content = ""
+            if thinking_content:
+                full_content += f"<think>{thinking_content}</think>"
+            if text_content:
+                if full_content:
+                    full_content += "\n"
+                full_content += text_content
+
+            msg_minimax = {
+                "role": msg.role,
+                "content": full_content or None,
+            }
+
+            if tool_calls:
+                msg_minimax["tool_calls"] = tool_calls
+
+            if msg_minimax["content"] or msg_minimax.get("tool_calls"):
+                messages.append(msg_minimax)
+
+        return messages
+
+
+class MiniMaxMultiAgentFormatter(TruncatedFormatterBase):
+    """MiniMax formatter for multi-agent conversations, where more than
+    a user and an agent are involved.
+    """
+
+    support_tools_api: bool = True
+
+    support_multiagent: bool = True
+
+    support_vision: bool = False
+
+    supported_blocks: list[type] = [
+        TextBlock,
+        ToolUseBlock,
+        ToolResultBlock,
+    ]
+
+    def __init__(
+        self,
+        conversation_history_prompt: str = (
+            "# Conversation History\n"
+            "The content between <history></history> tags contains "
+            "your conversation history\n"
+        ),
+        token_counter: TokenCounterBase | None = None,
+        max_tokens: int | None = None,
+    ) -> None:
+        super().__init__(token_counter=token_counter, max_tokens=max_tokens)
+        self.conversation_history_prompt = conversation_history_prompt
+
+    async def _format_tool_sequence(
+        self,
+        msgs: list[Msg],
+    ) -> list[dict[str, Any]]:
+        return await MiniMaxChatFormatter().format(msgs)
+
+    async def _format_agent_message(
+        self,
+        msgs: list[Msg],
+        is_first: bool = True,
+    ) -> list[dict[str, Any]]:
+        if is_first:
+            conversation_history_prompt = self.conversation_history_prompt
+        else:
+            conversation_history_prompt = ""
+
+        formatted_msgs: list[dict] = []
+
+        conversation_blocks: list = []
+        accumulated_text = []
+        for msg in msgs:
+            for block in msg.get_content_blocks():
+                if block["type"] == "text":
+                    accumulated_text.append(f"{msg.name}: {block['text']}")
+
+        if accumulated_text:
+            conversation_blocks.append(
+                {"text": "\n".join(accumulated_text)},
+            )
+
+        if conversation_blocks:
+            if conversation_blocks[0].get("text"):
+                conversation_blocks[0]["text"] = (
+                    conversation_history_prompt
+                    + "<history>\n"
+                    + conversation_blocks[0]["text"]
+                )
+            else:
+                conversation_blocks.insert(
+                    0,
+                    {
+                        "text": conversation_history_prompt + "<history>\n",
+                    },
+                )
+
+            if conversation_blocks[-1].get("text"):
+                conversation_blocks[-1]["text"] += "\n</history>"
+            else:
+                conversation_blocks.append({"text": "</history>"})
+
+        conversation_blocks_text = "\n".join(
+            conversation_block.get("text", "")
+            for conversation_block in conversation_blocks
+        )
+
+        user_message = {
+            "role": "user",
+            "content": conversation_blocks_text,
+        }
+
+        if conversation_blocks:
+            formatted_msgs.append(user_message)
+
+        return formatted_msgs

--- a/src/agentscope/model/__init__.py
+++ b/src/agentscope/model/__init__.py
@@ -9,6 +9,7 @@ from ._anthropic_model import AnthropicChatModel
 from ._ollama_model import OllamaChatModel
 from ._gemini_model import GeminiChatModel
 from ._trinity_model import TrinityChatModel
+from ._minimax_model import MiniMaxChatModel
 
 __all__ = [
     "ChatModelBase",
@@ -19,4 +20,5 @@ __all__ = [
     "OllamaChatModel",
     "GeminiChatModel",
     "TrinityChatModel",
+    "MiniMaxChatModel",
 ]

--- a/src/agentscope/model/_minimax_model.py
+++ b/src/agentscope/model/_minimax_model.py
@@ -1,0 +1,389 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=too-many-branches
+"""MiniMax Chat model class."""
+import copy
+import json
+import re
+from datetime import datetime
+from typing import (
+    Any,
+    TYPE_CHECKING,
+    List,
+    AsyncGenerator,
+    Literal,
+    Type,
+)
+from collections import OrderedDict
+
+from pydantic import BaseModel
+
+from . import ChatResponse
+from ._model_base import ChatModelBase
+from ._model_usage import ChatUsage
+from .._logging import logger
+from .._utils._common import _json_loads_with_repair
+from ..message import (
+    ToolUseBlock,
+    TextBlock,
+    ThinkingBlock,
+)
+from ..tracing import trace_llm
+from ..types import JSONSerializableObject
+
+if TYPE_CHECKING:
+    from openai.types.chat import ChatCompletion
+    from openai import AsyncStream
+else:
+    ChatCompletion = "openai.types.chat.ChatCompletion"
+    AsyncStream = "openai.types.chat.AsyncStream"
+
+_THINK_PATTERN = re.compile(
+    r"<think>(.*?)</think>",
+    re.DOTALL,
+)
+
+_DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+
+
+def _parse_think_tags(content: str) -> tuple[str, str]:
+    thinking = ""
+    text = content
+    matches = _THINK_PATTERN.findall(content)
+    if matches:
+        thinking = "\n".join(m.strip() for m in matches)
+        text = _THINK_PATTERN.sub("", content).strip()
+    return thinking, text
+
+
+class MiniMaxChatModel(ChatModelBase):
+    """The MiniMax chat model class, compatible with MiniMax-M2.5 series."""
+
+    def __init__(
+        self,
+        model_name: str,
+        api_key: str | None = None,
+        stream: bool = True,
+        stream_tool_parsing: bool = True,
+        client_kwargs: dict[str, JSONSerializableObject] | None = None,
+        generate_kwargs: dict[str, JSONSerializableObject] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if kwargs:
+            logger.warning(
+                "Unknown keyword arguments: %s. These will be ignored.",
+                list(kwargs.keys()),
+            )
+
+        super().__init__(model_name, stream)
+
+        import openai
+
+        client_kwargs = client_kwargs or {}
+        if "base_url" not in client_kwargs:
+            client_kwargs["base_url"] = _DEFAULT_MINIMAX_BASE_URL
+
+        self.client = openai.AsyncClient(
+            api_key=api_key,
+            **(client_kwargs),
+        )
+
+        self.stream_tool_parsing = stream_tool_parsing
+        self.generate_kwargs = generate_kwargs or {}
+
+    @trace_llm
+    async def __call__(
+        self,
+        messages: list[dict],
+        tools: list[dict] | None = None,
+        tool_choice: Literal["auto", "none", "required"] | str | None = None,
+        structured_model: Type[BaseModel] | None = None,
+        **kwargs: Any,
+    ) -> ChatResponse | AsyncGenerator[ChatResponse, None]:
+        if not isinstance(messages, list):
+            raise ValueError(
+                "MiniMax `messages` field expected type `list`, "
+                f"got `{type(messages)}` instead.",
+            )
+        if not all("role" in msg and "content" in msg for msg in messages):
+            raise ValueError(
+                "Each message in the 'messages' list must contain a 'role' "
+                "and 'content' key for MiniMax API.",
+            )
+
+        kwargs = {
+            "model": self.model_name,
+            "messages": messages,
+            "stream": self.stream,
+            **self.generate_kwargs,
+            **kwargs,
+        }
+
+        if tools:
+            kwargs["tools"] = self._format_tools_json_schemas(tools)
+
+        if tool_choice:
+            self._validate_tool_choice(tool_choice, tools)
+            kwargs["tool_choice"] = self._format_tool_choice(tool_choice)
+
+        if self.stream:
+            kwargs["stream_options"] = {"include_usage": True}
+
+        start_datetime = datetime.now()
+
+        if structured_model:
+            if tools or tool_choice:
+                logger.warning(
+                    "structured_model is provided. Both 'tools' and "
+                    "'tool_choice' parameters will be overridden and "
+                    "ignored. The model will only perform structured output "
+                    "generation without calling any other tools.",
+                )
+            kwargs.pop("stream", None)
+            kwargs.pop("tools", None)
+            kwargs.pop("tool_choice", None)
+            kwargs["response_format"] = structured_model
+            if not self.stream:
+                response = await self.client.chat.completions.parse(**kwargs)
+            else:
+                response = self.client.chat.completions.stream(**kwargs)
+                return self._parse_stream_response(
+                    start_datetime,
+                    response,
+                    structured_model,
+                )
+        else:
+            response = await self.client.chat.completions.create(**kwargs)
+
+        if self.stream:
+            return self._parse_stream_response(
+                start_datetime,
+                response,
+                structured_model,
+            )
+
+        parsed_response = self._parse_completion_response(
+            start_datetime,
+            response,
+            structured_model,
+        )
+
+        return parsed_response
+
+    # pylint: disable=too-many-statements
+    async def _parse_stream_response(
+        self,
+        start_datetime: datetime,
+        response: AsyncStream,
+        structured_model: Type[BaseModel] | None = None,
+    ) -> AsyncGenerator[ChatResponse, None]:
+        usage, res = None, None
+        raw_text = ""
+        tool_calls = OrderedDict()
+        last_input_objs = {}
+        metadata: dict | None = None
+        contents: List[TextBlock | ToolUseBlock | ThinkingBlock] = []
+        last_contents = None
+
+        async with response as stream:
+            async for item in stream:
+                if structured_model:
+                    if item.type != "chunk":
+                        continue
+                    chunk = item.chunk
+                else:
+                    chunk = item
+
+                if chunk.usage:
+                    usage = ChatUsage(
+                        input_tokens=chunk.usage.prompt_tokens,
+                        output_tokens=chunk.usage.completion_tokens,
+                        time=(datetime.now() - start_datetime).total_seconds(),
+                        metadata=chunk.usage,
+                    )
+
+                if not chunk.choices:
+                    if usage and contents:
+                        res = ChatResponse(
+                            content=contents,
+                            usage=usage,
+                            metadata=metadata,
+                        )
+                        yield res
+                    continue
+
+                choice = chunk.choices[0]
+
+                raw_text += getattr(choice.delta, "content", None) or ""
+
+                for tool_call in (
+                    getattr(choice.delta, "tool_calls", None) or []
+                ):
+                    if tool_call.index in tool_calls:
+                        if tool_call.function.arguments is not None:
+                            tool_calls[tool_call.index][
+                                "input"
+                            ] += tool_call.function.arguments
+                    else:
+                        tool_calls[tool_call.index] = {
+                            "type": "tool_use",
+                            "id": tool_call.id,
+                            "name": tool_call.function.name,
+                            "input": tool_call.function.arguments or "",
+                        }
+
+                contents = []
+                thinking, text = _parse_think_tags(raw_text)
+
+                if thinking:
+                    contents.append(
+                        ThinkingBlock(
+                            type="thinking",
+                            thinking=thinking,
+                        ),
+                    )
+
+                if text:
+                    contents.append(
+                        TextBlock(
+                            type="text",
+                            text=text,
+                        ),
+                    )
+
+                    if structured_model:
+                        metadata = _json_loads_with_repair(text)
+
+                for tool_call in tool_calls.values():
+                    input_str = tool_call["input"]
+                    tool_id = tool_call["id"]
+
+                    if self.stream_tool_parsing:
+                        repaired_input = _json_loads_with_repair(
+                            input_str or "{}",
+                        )
+                        last_input = last_input_objs.get(tool_id, {})
+                        if len(json.dumps(last_input)) > len(
+                            json.dumps(repaired_input),
+                        ):
+                            repaired_input = last_input
+                        last_input_objs[tool_id] = repaired_input
+                    else:
+                        repaired_input = {}
+
+                    contents.append(
+                        ToolUseBlock(
+                            type=tool_call["type"],
+                            id=tool_id,
+                            name=tool_call["name"],
+                            input=repaired_input,
+                            raw_input=input_str,
+                        ),
+                    )
+
+                if contents:
+                    res = ChatResponse(
+                        content=contents,
+                        usage=usage,
+                        metadata=metadata,
+                    )
+                    yield res
+                    last_contents = copy.deepcopy(contents)
+
+        if not self.stream_tool_parsing and tool_calls and last_contents:
+            metadata = None
+            for block in last_contents:
+                if block.get("type") == "tool_use":
+                    block["input"] = input_obj = _json_loads_with_repair(
+                        str(block.get("raw_input") or "{}"),
+                    )
+                    if structured_model:
+                        metadata = input_obj
+
+            yield ChatResponse(
+                content=last_contents,
+                usage=usage,
+                metadata=metadata,
+            )
+
+    def _parse_completion_response(
+        self,
+        start_datetime: datetime,
+        response: ChatCompletion,
+        structured_model: Type[BaseModel] | None = None,
+    ) -> ChatResponse:
+        content_blocks: List[TextBlock | ToolUseBlock | ThinkingBlock] = []
+        metadata: dict | None = None
+
+        if response.choices:
+            choice = response.choices[0]
+
+            raw_content = choice.message.content or ""
+            thinking, text = _parse_think_tags(raw_content)
+
+            if thinking:
+                content_blocks.append(
+                    ThinkingBlock(
+                        type="thinking",
+                        thinking=thinking,
+                    ),
+                )
+
+            if text:
+                content_blocks.append(
+                    TextBlock(
+                        type="text",
+                        text=text,
+                    ),
+                )
+
+            for tool_call in choice.message.tool_calls or []:
+                content_blocks.append(
+                    ToolUseBlock(
+                        type="tool_use",
+                        id=tool_call.id,
+                        name=tool_call.function.name,
+                        input=_json_loads_with_repair(
+                            tool_call.function.arguments,
+                        ),
+                    ),
+                )
+
+            if structured_model:
+                metadata = choice.message.parsed.model_dump()
+
+        usage = None
+        if response.usage:
+            usage = ChatUsage(
+                input_tokens=response.usage.prompt_tokens,
+                output_tokens=response.usage.completion_tokens,
+                time=(datetime.now() - start_datetime).total_seconds(),
+                metadata=response.usage,
+            )
+
+        return ChatResponse(
+            content=content_blocks,
+            usage=usage,
+            metadata=metadata,
+        )
+
+    def _format_tools_json_schemas(
+        self,
+        schemas: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        return schemas
+
+    def _format_tool_choice(
+        self,
+        tool_choice: Literal["auto", "none", "required"] | str | None,
+    ) -> str | dict | None:
+        if tool_choice is None:
+            return None
+
+        mode_mapping = {
+            "auto": "auto",
+            "none": "none",
+            "required": "required",
+        }
+        if tool_choice in mode_mapping:
+            return mode_mapping[tool_choice]
+        return {"type": "function", "function": {"name": tool_choice}}

--- a/src/agentscope/tts/__init__.py
+++ b/src/agentscope/tts/__init__.py
@@ -11,6 +11,7 @@ from ._dashscope_cosyvoice_tts_model import DashScopeCosyVoiceTTSModel
 from ._dashscope_cosyvoice_realtime_tts_model import (
     DashScopeCosyVoiceRealtimeTTSModel,
 )
+from ._minimax_tts_model import MiniMaxTTSModel
 
 __all__ = [
     "TTSModelBase",
@@ -22,4 +23,5 @@ __all__ = [
     "OpenAITTSModel",
     "DashScopeCosyVoiceTTSModel",
     "DashScopeCosyVoiceRealtimeTTSModel",
+    "MiniMaxTTSModel",
 ]

--- a/src/agentscope/tts/_minimax_tts_model.py
+++ b/src/agentscope/tts/_minimax_tts_model.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+"""MiniMax TTS model implementation."""
+import base64
+import json
+from typing import Any, AsyncGenerator
+
+from ._tts_base import TTSModelBase
+from ._tts_response import TTSResponse
+from ..message import Msg, AudioBlock, Base64Source
+from ..types import JSONSerializableObject
+
+_DEFAULT_MINIMAX_TTS_URL = "https://api.minimax.io/v1/t2a_v2"
+
+
+class MiniMaxTTSModel(TTSModelBase):
+    """MiniMax TTS model implementation using the T2A v2 HTTP API.
+    For more details, please see the `official document
+    <https://platform.minimax.io/docs/api-reference/speech-t2a-http>`_.
+    """
+
+    supports_streaming_input: bool = False
+
+    def __init__(
+        self,
+        api_key: str,
+        model_name: str = "speech-2.8-hd",
+        voice_id: str = "English_Graceful_Lady",
+        stream: bool = True,
+        api_url: str | None = None,
+        voice_setting: dict[str, Any] | None = None,
+        audio_setting: dict[str, Any] | None = None,
+        generate_kwargs: dict[str, JSONSerializableObject] | None = None,
+    ) -> None:
+        super().__init__(model_name=model_name, stream=stream)
+
+        self.api_key = api_key
+        self.voice_id = voice_id
+        self.api_url = api_url or _DEFAULT_MINIMAX_TTS_URL
+        self.voice_setting = voice_setting or {}
+        self.audio_setting = audio_setting or {}
+        self.generate_kwargs = generate_kwargs or {}
+
+        import httpx
+
+        self._client = httpx.AsyncClient(
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            },
+            timeout=httpx.Timeout(60.0, connect=10.0),
+        )
+
+    async def synthesize(
+        self,
+        msg: Msg | None = None,
+        **kwargs: Any,
+    ) -> TTSResponse | AsyncGenerator[TTSResponse, None]:
+        if msg is None:
+            return TTSResponse(content=None)
+
+        text = msg.get_text_content()
+
+        if not text:
+            return TTSResponse(content=None)
+
+        voice_setting = {"voice_id": self.voice_id, **self.voice_setting}
+        audio_setting = self.audio_setting.copy()
+        if "format" not in audio_setting:
+            audio_setting["format"] = "mp3"
+
+        payload: dict[str, Any] = {
+            "model": self.model_name,
+            "text": text,
+            "stream": self.stream,
+            "voice_setting": voice_setting,
+            "audio_setting": audio_setting,
+            **self.generate_kwargs,
+            **kwargs,
+        }
+
+        media_type = f"audio/{audio_setting['format']}"
+
+        if self.stream:
+            return self._stream_synthesize(payload, media_type)
+
+        response = await self._client.post(
+            self.api_url,
+            json=payload,
+        )
+        response.raise_for_status()
+        result = response.json()
+
+        if result.get("base_resp", {}).get("status_code", 0) != 0:
+            raise RuntimeError(
+                f"MiniMax TTS API error: "
+                f"{result.get('base_resp', {}).get('status_msg', 'unknown')}",
+            )
+
+        hex_audio = result.get("data", {}).get("audio", "")
+        if not hex_audio:
+            return TTSResponse(content=None)
+
+        audio_bytes = bytes.fromhex(hex_audio)
+        audio_base64 = base64.b64encode(audio_bytes).decode("utf-8")
+
+        return TTSResponse(
+            content=AudioBlock(
+                type="audio",
+                source=Base64Source(
+                    type="base64",
+                    data=audio_base64,
+                    media_type=media_type,
+                ),
+            ),
+        )
+
+    async def _stream_synthesize(
+        self,
+        payload: dict[str, Any],
+        media_type: str,
+    ) -> AsyncGenerator[TTSResponse, None]:
+        async with self._client.stream(
+            "POST",
+            self.api_url,
+            json=payload,
+        ) as response:
+            response.raise_for_status()
+            buffer = ""
+            async for chunk_text in response.aiter_text():
+                buffer += chunk_text
+                while "\n" in buffer:
+                    line, buffer = buffer.split("\n", 1)
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        chunk_data = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    base_resp = chunk_data.get("base_resp", {})
+                    if base_resp.get("status_code", 0) != 0:
+                        raise RuntimeError(
+                            f"MiniMax TTS API error: "
+                            f"{base_resp.get('status_msg', 'unknown')}",
+                        )
+
+                    hex_audio = (
+                        chunk_data.get("data", {}).get("audio", "")
+                    )
+                    if not hex_audio:
+                        continue
+
+                    audio_bytes = bytes.fromhex(hex_audio)
+                    audio_base64 = base64.b64encode(audio_bytes).decode(
+                        "utf-8",
+                    )
+
+                    status = chunk_data.get("data", {}).get("status", 1)
+                    is_last = status == 2
+
+                    yield TTSResponse(
+                        content=AudioBlock(
+                            type="audio",
+                            source=Base64Source(
+                                type="base64",
+                                data=audio_base64,
+                                media_type=media_type,
+                            ),
+                        ),
+                        is_last=is_last,
+                    )

--- a/tests/model_minimax_test.py
+++ b/tests/model_minimax_test.py
@@ -1,0 +1,406 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for MiniMax API model class."""
+from typing import AsyncGenerator, Any
+from unittest.async_case import IsolatedAsyncioTestCase
+from unittest.mock import Mock, patch, AsyncMock
+from pydantic import BaseModel
+
+from agentscope.model import MiniMaxChatModel, ChatResponse
+from agentscope.message import TextBlock, ToolUseBlock, ThinkingBlock
+
+
+class SampleModel(BaseModel):
+    name: str
+    age: int
+
+
+class TestMiniMaxChatModel(IsolatedAsyncioTestCase):
+
+    def test_init_default_params(self) -> None:
+        with patch("openai.AsyncClient") as mock_client:
+            model = MiniMaxChatModel(
+                model_name="MiniMax-M2.5",
+                api_key="test_key",
+            )
+            self.assertEqual(model.model_name, "MiniMax-M2.5")
+            self.assertTrue(model.stream)
+            self.assertEqual(model.generate_kwargs, {})
+            mock_client.assert_called_once_with(
+                api_key="test_key",
+                base_url="https://api.minimax.io/v1",
+            )
+
+    def test_init_with_custom_params(self) -> None:
+        generate_kwargs = {"temperature": 1.0, "top_p": 0.95}
+        client_kwargs = {"timeout": 30, "base_url": "https://api.minimaxi.com/v1"}
+        with patch("openai.AsyncClient") as mock_client:
+            model = MiniMaxChatModel(
+                model_name="MiniMax-M2.5-highspeed",
+                api_key="test_key",
+                stream=False,
+                client_kwargs=client_kwargs,
+                generate_kwargs=generate_kwargs,
+            )
+            self.assertEqual(model.model_name, "MiniMax-M2.5-highspeed")
+            self.assertFalse(model.stream)
+            self.assertEqual(model.generate_kwargs, generate_kwargs)
+            mock_client.assert_called_once_with(
+                api_key="test_key",
+                timeout=30,
+                base_url="https://api.minimaxi.com/v1",
+            )
+
+    async def test_call_with_regular_model(self) -> None:
+        with patch("openai.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value = mock_client
+
+            model = MiniMaxChatModel(
+                model_name="MiniMax-M2.5",
+                api_key="test_key",
+                stream=False,
+            )
+            model.client = mock_client
+
+            messages = [{"role": "user", "content": "Hello"}]
+            mock_response = self._create_mock_response(
+                "Hello! How can I help you?",
+            )
+            mock_client.chat.completions.create = AsyncMock(
+                return_value=mock_response,
+            )
+
+            result = await model(messages)
+            call_args = mock_client.chat.completions.create.call_args[1]
+            self.assertEqual(call_args["model"], "MiniMax-M2.5")
+            self.assertEqual(call_args["messages"], messages)
+            self.assertFalse(call_args["stream"])
+            self.assertIsInstance(result, ChatResponse)
+            expected_content = [
+                TextBlock(type="text", text="Hello! How can I help you?"),
+            ]
+            self.assertEqual(result.content, expected_content)
+
+    async def test_call_with_thinking_content(self) -> None:
+        with patch("openai.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value = mock_client
+
+            model = MiniMaxChatModel(
+                model_name="MiniMax-M2.5",
+                api_key="test_key",
+                stream=False,
+            )
+            model.client = mock_client
+
+            messages = [
+                {"role": "user", "content": "What is 2+2?"},
+            ]
+            mock_response = self._create_mock_response(
+                "<think>Let me calculate 2+2 = 4</think>\nThe answer is 4.",
+            )
+            mock_client.chat.completions.create = AsyncMock(
+                return_value=mock_response,
+            )
+            result = await model(messages)
+
+            expected_content = [
+                ThinkingBlock(
+                    type="thinking",
+                    thinking="Let me calculate 2+2 = 4",
+                ),
+                TextBlock(type="text", text="The answer is 4."),
+            ]
+            self.assertEqual(result.content, expected_content)
+
+    async def test_call_with_tools_integration(self) -> None:
+        with patch("openai.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value = mock_client
+
+            model = MiniMaxChatModel(
+                model_name="MiniMax-M2.5",
+                api_key="test_key",
+                stream=False,
+            )
+            model.client = mock_client
+
+            messages = [{"role": "user", "content": "What's the weather?"}]
+            tools = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get weather info",
+                        "parameters": {"type": "object"},
+                    },
+                },
+            ]
+
+            mock_response = self._create_mock_response_with_tools(
+                "I'll check the weather for you.",
+                [
+                    {
+                        "id": "call_123",
+                        "name": "get_weather",
+                        "arguments": '{"location": "Beijing"}',
+                    },
+                ],
+            )
+            mock_client.chat.completions.create = AsyncMock(
+                return_value=mock_response,
+            )
+            result = await model(messages, tools=tools, tool_choice="auto")
+            call_args = mock_client.chat.completions.create.call_args[1]
+            self.assertIn("tools", call_args)
+            self.assertEqual(call_args["tools"], tools)
+            self.assertEqual(call_args["tool_choice"], "auto")
+            expected_content = [
+                TextBlock(
+                    type="text",
+                    text="I'll check the weather for you.",
+                ),
+                ToolUseBlock(
+                    type="tool_use",
+                    id="call_123",
+                    name="get_weather",
+                    input={"location": "Beijing"},
+                ),
+            ]
+            self.assertEqual(result.content, expected_content)
+
+    async def test_streaming_response_processing(self) -> None:
+        with patch("openai.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value = mock_client
+
+            model = MiniMaxChatModel(
+                model_name="MiniMax-M2.5",
+                api_key="test_key",
+                stream=True,
+            )
+            model.client = mock_client
+
+            messages = [{"role": "user", "content": "Hello"}]
+            stream_mock = self._create_stream_mock(
+                [
+                    {"content": "Hello"},
+                    {"content": " there!"},
+                ],
+            )
+
+            mock_client.chat.completions.create = AsyncMock(
+                return_value=stream_mock,
+            )
+            result = await model(messages)
+
+            call_args = mock_client.chat.completions.create.call_args[1]
+            self.assertEqual(
+                call_args["stream_options"],
+                {"include_usage": True},
+            )
+            responses = []
+            async for response in result:
+                responses.append(response)
+
+            self.assertEqual(len(responses), 2)
+            final_response = responses[-1]
+            expected_content = [TextBlock(type="text", text="Hello there!")]
+            self.assertEqual(final_response.content, expected_content)
+
+    async def test_streaming_with_think_tags(self) -> None:
+        with patch("openai.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value = mock_client
+
+            model = MiniMaxChatModel(
+                model_name="MiniMax-M2.5",
+                api_key="test_key",
+                stream=True,
+            )
+            model.client = mock_client
+
+            messages = [{"role": "user", "content": "Think about this"}]
+            stream_mock = self._create_stream_mock(
+                [
+                    {"content": "<think>Let me think"},
+                    {"content": "</think>\nHere is my answer."},
+                ],
+            )
+
+            mock_client.chat.completions.create = AsyncMock(
+                return_value=stream_mock,
+            )
+            result = await model(messages)
+
+            responses = []
+            async for response in result:
+                responses.append(response)
+
+            final_response = responses[-1]
+            has_thinking = any(
+                b.get("type") == "thinking" for b in final_response.content
+            )
+            has_text = any(
+                b.get("type") == "text" for b in final_response.content
+            )
+            self.assertTrue(has_thinking)
+            self.assertTrue(has_text)
+
+    async def test_call_with_structured_model(self) -> None:
+        with patch("openai.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value = mock_client
+
+            model = MiniMaxChatModel(
+                model_name="MiniMax-M2.5",
+                api_key="test_key",
+                stream=False,
+            )
+            model.client = mock_client
+
+            messages = [{"role": "user", "content": "Generate a person"}]
+            mock_response = self._create_mock_response_with_structured_data(
+                {"name": "John", "age": 30},
+            )
+            mock_client.chat.completions.parse = AsyncMock(
+                return_value=mock_response,
+            )
+
+            result = await model(messages, structured_model=SampleModel)
+            call_args = mock_client.chat.completions.parse.call_args[1]
+            self.assertEqual(call_args["response_format"], SampleModel)
+            self.assertNotIn("tools", call_args)
+            self.assertNotIn("tool_choice", call_args)
+            self.assertNotIn("stream", call_args)
+            self.assertIsInstance(result, ChatResponse)
+            self.assertEqual(result.metadata, {"name": "John", "age": 30})
+
+    def test_parse_think_tags(self) -> None:
+        from agentscope.model._minimax_model import _parse_think_tags
+
+        thinking, text = _parse_think_tags(
+            "<think>reasoning here</think>\nactual answer",
+        )
+        self.assertEqual(thinking, "reasoning here")
+        self.assertEqual(text, "actual answer")
+
+        thinking, text = _parse_think_tags("no thinking here")
+        self.assertEqual(thinking, "")
+        self.assertEqual(text, "no thinking here")
+
+        thinking, text = _parse_think_tags(
+            "<think>step 1</think>middle<think>step 2</think>end",
+        )
+        self.assertEqual(thinking, "step 1\nstep 2")
+        self.assertEqual(text, "middleend")
+
+    def _create_mock_response(
+        self,
+        content: str = "",
+        prompt_tokens: int = 10,
+        completion_tokens: int = 20,
+    ) -> Mock:
+        message = Mock()
+        message.content = content
+        message.tool_calls = []
+        message.parsed = None
+
+        choice = Mock()
+        choice.message = message
+
+        response = Mock()
+        response.choices = [choice]
+
+        usage = Mock()
+        usage.prompt_tokens = prompt_tokens
+        usage.completion_tokens = completion_tokens
+        response.usage = usage
+        return response
+
+    def _create_mock_response_with_tools(
+        self,
+        content: str,
+        tool_calls: list,
+    ) -> Mock:
+        response = self._create_mock_response(content)
+        tool_call_mocks = []
+        for tool_call in tool_calls:
+            tc_mock = Mock()
+            tc_mock.id = tool_call["id"]
+            tc_mock.function = Mock()
+            tc_mock.function.name = tool_call["name"]
+            tc_mock.function.arguments = tool_call["arguments"]
+            tool_call_mocks.append(tc_mock)
+        response.choices[0].message.tool_calls = tool_call_mocks
+        return response
+
+    def _create_mock_response_with_structured_data(self, data: dict) -> Mock:
+        message = Mock()
+        message.parsed = Mock()
+        message.parsed.model_dump.return_value = data
+        message.content = None
+        message.tool_calls = []
+
+        choice = Mock()
+        choice.message = message
+
+        response = Mock()
+        response.choices = [choice]
+        response.usage = None
+
+        return response
+
+    def _create_stream_mock(self, chunks_data: list) -> Any:
+        class MockStream:
+            def __init__(self, chunks_data: list) -> None:
+                self.chunks_data = chunks_data
+                self.index = 0
+
+            async def __aenter__(self) -> "MockStream":
+                return self
+
+            async def __aexit__(
+                self,
+                exc_type: Any,
+                exc_val: Any,
+                exc_tb: Any,
+            ) -> None:
+                pass
+
+            def __aiter__(self) -> "MockStream":
+                return self
+
+            async def __anext__(self) -> AsyncGenerator:
+                if self.index >= len(self.chunks_data):
+                    raise StopAsyncIteration
+                chunk_data = self.chunks_data[self.index]
+                self.index += 1
+
+                choice = Mock()
+                delta = Mock()
+                delta.content = chunk_data.get("content")
+                if "tool_calls" in chunk_data:
+                    tool_call_mocks = []
+                    for tc_data in chunk_data["tool_calls"]:
+                        tc_mock = Mock()
+                        tc_mock.id = tc_data["id"]
+                        tc_mock.index = 0
+                        tc_mock.function = Mock()
+                        tc_mock.function.name = tc_data["name"]
+                        tc_mock.function.arguments = tc_data["arguments"]
+                        tool_call_mocks.append(tc_mock)
+                    delta.tool_calls = tool_call_mocks
+                else:
+                    delta.tool_calls = []
+
+                choice.delta = delta
+
+                chunk = Mock()
+                chunk.choices = [choice]
+                chunk.usage = Mock()
+                chunk.usage.prompt_tokens = 5
+                chunk.usage.completion_tokens = 10
+                return chunk
+
+        return MockStream(chunks_data)

--- a/tests/tts_minimax_test.py
+++ b/tests/tts_minimax_test.py
@@ -1,0 +1,233 @@
+# -*- coding: utf-8 -*-
+"""The unittests for MiniMax TTS model."""
+import base64
+import json
+import sys
+from typing import AsyncGenerator
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import Mock, patch, AsyncMock, MagicMock
+
+from agentscope.message import Msg, AudioBlock, Base64Source
+from agentscope.tts import MiniMaxTTSModel
+
+
+mock_httpx = MagicMock()
+mock_httpx.AsyncClient = Mock(return_value=MagicMock())
+mock_httpx.Timeout = Mock(return_value=MagicMock())
+
+
+@patch.dict(sys.modules, {"httpx": mock_httpx})
+class MiniMaxTTSModelTest(IsolatedAsyncioTestCase):
+
+    def setUp(self) -> None:
+        self.api_key = "test_api_key"
+        self.mock_audio_bytes = b"fake_audio_data"
+        self.mock_audio_hex = self.mock_audio_bytes.hex()
+        self.mock_audio_base64 = base64.b64encode(
+            self.mock_audio_bytes,
+        ).decode("utf-8")
+
+    def test_init(self) -> None:
+        model = MiniMaxTTSModel(
+            api_key=self.api_key,
+            model_name="speech-2.8-hd",
+            voice_id="English_Graceful_Lady",
+            stream=False,
+        )
+        self.assertEqual(model.model_name, "speech-2.8-hd")
+        self.assertEqual(model.voice_id, "English_Graceful_Lady")
+        self.assertFalse(model.stream)
+        self.assertFalse(model.supports_streaming_input)
+        self.assertEqual(
+            model.api_url,
+            "https://api.minimax.io/v1/t2a_v2",
+        )
+
+    def test_init_custom_params(self) -> None:
+        model = MiniMaxTTSModel(
+            api_key=self.api_key,
+            model_name="speech-2.8-turbo",
+            voice_id="moss_audio_123",
+            stream=True,
+            api_url="https://api-uw.minimax.io/v1/t2a_v2",
+            voice_setting={"speed": 1.2, "emotion": "happy"},
+            audio_setting={"sample_rate": 24000, "format": "pcm"},
+        )
+        self.assertEqual(model.model_name, "speech-2.8-turbo")
+        self.assertEqual(model.voice_id, "moss_audio_123")
+        self.assertEqual(
+            model.api_url,
+            "https://api-uw.minimax.io/v1/t2a_v2",
+        )
+        self.assertEqual(model.voice_setting["speed"], 1.2)
+        self.assertEqual(model.audio_setting["format"], "pcm")
+
+    async def test_synthesize_none_msg(self) -> None:
+        model = MiniMaxTTSModel(
+            api_key=self.api_key,
+            stream=False,
+        )
+        response = await model.synthesize(None)
+        self.assertIsNone(response.content)
+
+    async def test_synthesize_empty_text(self) -> None:
+        model = MiniMaxTTSModel(
+            api_key=self.api_key,
+            stream=False,
+        )
+        msg = Msg(name="user", content=[], role="user")
+        response = await model.synthesize(msg)
+        self.assertIsNone(response.content)
+
+    async def test_synthesize_non_streaming(self) -> None:
+        model = MiniMaxTTSModel(
+            api_key=self.api_key,
+            stream=False,
+        )
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+            "data": {
+                "audio": self.mock_audio_hex,
+                "status": 2,
+            },
+        }
+        model._client.post = AsyncMock(return_value=mock_response)
+
+        msg = Msg(name="user", content="Hello world", role="user")
+        response = await model.synthesize(msg)
+
+        expected_content = AudioBlock(
+            type="audio",
+            source=Base64Source(
+                type="base64",
+                data=self.mock_audio_base64,
+                media_type="audio/mp3",
+            ),
+        )
+        self.assertEqual(response.content, expected_content)
+        model._client.post.assert_called_once()
+
+        call_kwargs = model._client.post.call_args
+        payload = call_kwargs[1]["json"]
+        self.assertEqual(payload["model"], "speech-2.8-hd")
+        self.assertEqual(payload["text"], "Hello world")
+        self.assertFalse(payload["stream"])
+        self.assertEqual(payload["voice_setting"]["voice_id"], "English_Graceful_Lady")
+
+    async def test_synthesize_api_error(self) -> None:
+        model = MiniMaxTTSModel(
+            api_key=self.api_key,
+            stream=False,
+        )
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {
+            "base_resp": {
+                "status_code": 1001,
+                "status_msg": "invalid parameter",
+            },
+        }
+        model._client.post = AsyncMock(return_value=mock_response)
+
+        msg = Msg(name="user", content="Hello world", role="user")
+        with self.assertRaises(RuntimeError) as ctx:
+            await model.synthesize(msg)
+        self.assertIn("invalid parameter", str(ctx.exception))
+
+    async def test_synthesize_streaming(self) -> None:
+        model = MiniMaxTTSModel(
+            api_key=self.api_key,
+            stream=True,
+        )
+
+        audio_bytes_1 = b"chunk_one"
+        audio_bytes_2 = b"chunk_two"
+
+        chunk1_json = json.dumps({
+            "base_resp": {"status_code": 0},
+            "data": {"audio": audio_bytes_1.hex(), "status": 1},
+        })
+        chunk2_json = json.dumps({
+            "base_resp": {"status_code": 0},
+            "data": {"audio": audio_bytes_2.hex(), "status": 2},
+        })
+
+        class MockStreamResponse:
+            def __init__(self) -> None:
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+            def raise_for_status(self):
+                pass
+
+            async def aiter_text(self):
+                yield chunk1_json + "\n"
+                yield chunk2_json + "\n"
+
+        model._client.stream = Mock(return_value=MockStreamResponse())
+
+        msg = Msg(name="user", content="Hello streaming", role="user")
+        result = await model.synthesize(msg)
+
+        self.assertIsInstance(result, AsyncGenerator)
+
+        chunks = [chunk async for chunk in result]
+        self.assertEqual(len(chunks), 2)
+
+        self.assertEqual(
+            chunks[0].content,
+            AudioBlock(
+                type="audio",
+                source=Base64Source(
+                    type="base64",
+                    data=base64.b64encode(audio_bytes_1).decode("utf-8"),
+                    media_type="audio/mp3",
+                ),
+            ),
+        )
+        self.assertFalse(chunks[0]["is_last"])
+
+        self.assertEqual(
+            chunks[1].content,
+            AudioBlock(
+                type="audio",
+                source=Base64Source(
+                    type="base64",
+                    data=base64.b64encode(audio_bytes_2).decode("utf-8"),
+                    media_type="audio/mp3",
+                ),
+            ),
+        )
+        self.assertTrue(chunks[1]["is_last"])
+
+    async def test_synthesize_with_custom_audio_format(self) -> None:
+        model = MiniMaxTTSModel(
+            api_key=self.api_key,
+            stream=False,
+            audio_setting={"format": "pcm", "sample_rate": 24000},
+        )
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {
+            "base_resp": {"status_code": 0},
+            "data": {"audio": self.mock_audio_hex, "status": 2},
+        }
+        model._client.post = AsyncMock(return_value=mock_response)
+
+        msg = Msg(name="user", content="PCM test", role="user")
+        response = await model.synthesize(msg)
+
+        self.assertEqual(
+            response.content["source"]["media_type"],
+            "audio/pcm",
+        )


### PR DESCRIPTION
## Summary
- Add support for **MiniMax-M2.5** and **MiniMax-M2.5-highspeed** chat models via OpenAI-compatible API
- Add support for **MiniMax TTS** models (speech-2.8-hd, speech-2.8-turbo, etc.) via T2A v2 HTTP API
- 17 comprehensive unit tests (9 chat model + 8 TTS)

## Chat Model Details

### MiniMax-M2.5 Model Features
- **OpenAI-compatible API**: Uses the `openai` SDK with MiniMax base URL
- **Interleaved Thinking**: Parses `<think>...</think>` tags into `ThinkingBlock` objects
- **Tool Calling**: Full support for function calling with `tools` and `tool_choice`
- **Streaming**: Both streaming and non-streaming modes
- **Structured Output**: Pydantic `BaseModel` support

### Usage Example
```python
from agentscope.model import MiniMaxChatModel
model = MiniMaxChatModel(model_name="MiniMax-M2.5", api_key="your-key")
```

## TTS Model Details

### MiniMax TTS Features
- **T2A v2 HTTP API**: Direct HTTP calls via `httpx`
- **Multiple Models**: speech-2.8-hd (default), speech-2.8-turbo, etc.
- **Streaming**: Newline-delimited JSON streaming
- **Voice Settings**: Configurable voice_id, speed, volume, pitch, emotion
- **Audio Formats**: mp3, pcm, flac, wav

### Usage Example
```python
from agentscope.tts import MiniMaxTTSModel
tts = MiniMaxTTSModel(api_key="your-key", model_name="speech-2.8-hd")
```

## Test plan
- [x] All 17 new unit tests pass
- [x] All 373 total tests pass (0 failures)