### PR TITLE
feat: add MiniMax chat model support

### DIFF
--- a/src/agentscope/model/__init__.py
+++ b/src/agentscope/model/__init__.py
@@ -9,6 +9,7 @@ from ._anthropic_model import AnthropicChatModel
 from ._ollama_model import OllamaChatModel
 from ._gemini_model import GeminiChatModel
 from ._trinity_model import TrinityChatModel
+from ._minimax_model import MiniMaxChatModel
 
 __all__ = [
     "ChatModelBase",
@@ -19,4 +20,5 @@ __all__ = [
     "OllamaChatModel",
     "GeminiChatModel",
     "TrinityChatModel",
+    "MiniMaxChatModel",
 ]

--- a/src/agentscope/model/_minimax_model.py
+++ b/src/agentscope/model/_minimax_model.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""MiniMax Chat model class."""
+from typing import Any
+
+from ._openai_model import OpenAIChatModel
+from ..types import JSONSerializableObject
+
+
+class MiniMaxChatModel(OpenAIChatModel):
+    """The MiniMax chat model class.
+
+    MiniMax provides an OpenAI-compatible API, so this class inherits from
+    OpenAIChatModel and sets the appropriate defaults for MiniMax's API
+    endpoint.
+
+    Available models include:
+    - MiniMax-M2.5: Flagship model with 204K context window
+    - MiniMax-M2.5-highspeed: Speed-optimized variant
+
+    Note: MiniMax does not accept a temperature of exactly 0. Use a small
+    positive value (e.g., 0.01) instead.
+    """
+
+    def __init__(
+        self,
+        model_name: str = "MiniMax-M2.5",
+        api_key: str | None = None,
+        stream: bool = True,
+        client_kwargs: dict[str, JSONSerializableObject] | None = None,
+        generate_kwargs: dict[str, JSONSerializableObject] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the MiniMax client.
+
+        Args:
+            model_name (`str`, default `"MiniMax-M2.5"`):
+                The name of the model to use. Available models:
+                "MiniMax-M2.5", "MiniMax-M2.5-highspeed".
+            api_key (`str`, default `None`):
+                The API key for MiniMax API. If not specified, it will
+                be read from the environment variable `MINIMAX_API_KEY`.
+            stream (`bool`, default `True`):
+                Whether to use streaming output or not.
+            client_kwargs (`dict[str, JSONSerializableObject] | None`, \
+             optional):
+                The extra keyword arguments to initialize the OpenAI client.
+                The `base_url` is automatically set to MiniMax's API endpoint
+                unless explicitly overridden.
+            generate_kwargs (`dict[str, JSONSerializableObject] | None`, \
+             optional):
+                The extra keyword arguments used in API generation,
+                e.g. `temperature`, `seed`.
+            **kwargs (`Any`):
+                Additional keyword arguments.
+        """
+        import os
+
+        if api_key is None:
+            api_key = os.environ.get("MINIMAX_API_KEY")
+
+        client_kwargs = client_kwargs or {}
+        client_kwargs.setdefault("base_url", "https://api.minimax.io/v1")
+
+        super().__init__(
+            model_name=model_name,
+            api_key=api_key,
+            stream=stream,
+            client_kwargs=client_kwargs,
+            generate_kwargs=generate_kwargs,
+            **kwargs,
+        )


### PR DESCRIPTION
## Summary

Adds `MiniMaxChatModel` as a dedicated model class for MiniMax's LLM API, enabling first-class support for MiniMax models in AgentScope.

### Changes

- **`src/agentscope/model/_minimax_model.py`**: New model class extending `OpenAIChatModel` with MiniMax-specific defaults (base URL, API key env var, model names)
- **`src/agentscope/model/__init__.py`**: Added `MiniMaxChatModel` to module exports

### Usage

```python
from agentscope.model import MiniMaxChatModel

model = MiniMaxChatModel(
    model_name="MiniMax-M2.5",
    api_key="your-api-key",  # or set MINIMAX_API_KEY env var
)
```

### Key Details

- Extends `OpenAIChatModel` since MiniMax API is OpenAI-compatible
- Default base URL: `https://api.minimax.io/v1`
- Default model: `MiniMax-M2.5` (204K context window)
- Also supports `MiniMax-M2.5-highspeed` for speed-optimized inference
- Reads API key from `MINIMAX_API_KEY` environment variable
- Temperature note: MiniMax does not accept exactly 0; use small positive values

## Test Plan

- [ ] Import `MiniMaxChatModel` from `agentscope.model`
- [ ] Verify default base URL is set to MiniMax endpoint
- [ ] Test chat completion with MiniMax-M2.5
- [ ] Test streaming mode
- [ ] Verify `MINIMAX_API_KEY` env var is read when api_key not provided