### PR TITLE
fix(agent): handle tool_result with missing id/name to prevent session corruption

### DIFF
--- a/src/agentscope/agent/_react_agent.py
+++ b/src/agentscope/agent/_react_agent.py
@@ -3,6 +3,7 @@
 # pylint: disable=not-an-iterable, too-many-lines
 # mypy: disable-error-code="list-item"
 """ReAct agent class in agentscope."""
+import uuid
 import asyncio
 from enum import Enum
 from typing import Type, Any, AsyncGenerator, Literal
@@ -635,13 +636,19 @@ class ReActAgent(ReActAgentBase):
                     "tool_use",
                 )
                 for tool_call in tool_use_blocks:
+                    # Ensure tool_call has valid id and name
+                    tc_id = tool_call.get("id")
+                    if not tc_id:
+                        tc_id = f"call_{uuid.uuid4().hex[:24]}"
+                    tc_name = tool_call.get("name") or "unknown_function"
+
                     msg_res = Msg(
                         "system",
                         [
                             ToolResultBlock(
                                 type="tool_result",
-                                id=tool_call["id"],
-                                name=tool_call["name"],
+                                id=tc_id,
+                                name=tc_name,
                                 output="The tool call has been interrupted "
                                 "by the user.",
                             ),
@@ -665,14 +672,30 @@ class ReActAgent(ReActAgentBase):
                 Return the structured output if it's verified in the finish
                 function call, otherwise return None.
         """
+        # Ensure tool_call has valid id and name to prevent session corruption
+        tool_call_id = tool_call.get("id")
+        if not tool_call_id:
+            tool_call_id = f"call_{uuid.uuid4().hex[:24]}"
+            logger.warning(
+                "Tool call missing id, generated fallback: %s",
+                tool_call_id,
+            )
+
+        tool_call_name = tool_call.get("name")
+        if not tool_call_name:
+            tool_call_name = "unknown_function"
+            logger.warning(
+                "Tool call missing name, using fallback: %s",
+                tool_call_name,
+            )
 
         tool_res_msg = Msg(
             "system",
             [
                 ToolResultBlock(
                     type="tool_result",
-                    id=tool_call["id"],
-                    name=tool_call["name"],
+                    id=tool_call_id,
+                    name=tool_call_name,
                     output=[],
                 ),
             ],


### PR DESCRIPTION
## Summary

When LLM API returns incomplete `tool_call` data (missing `id` or `name`), the saved session data becomes corrupted with `null` values, causing `pydantic.ValidationError` when loading sessions.

## Problem

- Some LLM APIs may return `tool_call` with missing or null `id`/`name` fields
- The `_acting` method in `ReActAgent` directly uses `tool_call["id"]` and `tool_call["name"]` without validation
- This results in corrupted session data: `{"id": null, "name": ""}`
- When loading such sessions, pydantic validation fails because `id` must be a string
- Users cannot access their session history anymore

## Solution

Add validation for `id` and `name` fields before creating `ToolResultBlock`:
- Generate UUID-based fallback `id` if missing (e.g., `call_550e8400e29b41d4a7164466`)
- Use `"unknown_function"` as fallback `name` if missing
- Log warnings when fallback values are used for debugging

## Limitations

When fallback values are used, the `tool_result.id` will not match the original `tool_use.id` (which was `null`). However:

1. The tool call has already failed (missing name means no function was found)
2. The primary goal is to prevent session corruption, not to recover a failed tool call
3. Users can still access their session and see the error message

For a more complete solution, the fallback should be applied at the model parsing layer so that `tool_use.id` and `tool_result.id` remain consistent. That would require changes to multiple model implementations.

## Changes

- Modified `src/agentscope/agent/_react_agent.py`:
  - `_acting` method: Added id/name validation with fallback
  - `_reasoning` method: Added id/name validation for user interruption handling

## Testing

- All pre-commit checks passed (black, flake8, pylint, mypy, etc.)
- The fix prevents session corruption when LLM returns incomplete tool_call data