### PR TITLE
fix(common): more robust JSON string loading

### DIFF
--- a/src/agentscope/_utils/_common.py
+++ b/src/agentscope/_utils/_common.py
@@ -49,10 +49,10 @@ def _json_loads_with_repair(
             Returns an empty dict if all repair attempts fail.
     """
     try:
-        repaired = repair_json(json_str, stream_stable=True)
-        result = json.loads(repaired)
-        if isinstance(result, dict):
-            return result
+        result = repair_json(json_str, stream_stable=True)
+        while not isinstance(result := json.loads(result), dict):
+            ...
+        return result
 
     except Exception:
         if len(json_str) > 100:

--- a/src/agentscope/_utils/_common.py
+++ b/src/agentscope/_utils/_common.py
@@ -50,6 +50,7 @@ def _json_loads_with_repair(
     """
     try:
         result = repair_json(json_str, stream_stable=True)
+        # For nested JSON strings like '"{\\"key\\": \\"value\\"}"'
         while not isinstance(result := json.loads(result), dict):
             ...
         return result


### PR DESCRIPTION
## AgentScope Version

1.0.17

## Description

I encountered a JSON parsing issue while working with a locally deployed vLLM model fine-tuned on the Qwen-3 series. With tool calls resolved by Hermes, I obtained the following function argument (take an example):

```py
args = '"{\\"query\\": \\"weak value amplification second order expansion average meter observable\\"}"' 
```

Currently, the JSON parsing in https://github.com/agentscope-ai/agentscope/blob/c19b8bc5723ec562fff77d3386f10de3e426f8da/src/agentscope/_utils/_common.py#L31 acts in a once-to-pass scheme, resulting in:

```py
json.loads('"{\\"query\\": \\"weak value amplification second order expansion average meter observable\\"}"')
# -> '{"query": "weak value amplification second order expansion average meter observable"}'
```

Still a string and fails the `isinstance` check. However, it can actually be parsed via `json.loads` again:

```py
json.loads('{"query": "weak value amplification second order expansion average meter observable"}')
# -> {'query': 'weak value amplification second order expansion average meter observable'}
```

Based on this observation, it is more robust to iteratively parse the raw string until a `dict` check is satisfied, and that's all about this commit. This commit is fully backward compatible and does not affect any other components, just providing a more robust JSON string parsing.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review