### PR TITLE
fix(model): avoid streaming tool input regression

### DIFF
--- a/src/agentscope/_utils/_common.py
+++ b/src/agentscope/_utils/_common.py
@@ -69,6 +69,31 @@ def _json_loads_with_repair(
     return {}
 
 
+def _parse_streaming_json_dict(
+    json_str: str,
+    last_input: dict | None = None,
+) -> dict:
+    """Parse a streaming JSON dict without regressing on incomplete chunks.
+
+    If the current chunk already forms a valid JSON dict, prefer it directly.
+    Otherwise, fall back to repaired JSON and keep the previous parsed value
+    only when repair would shrink the intermediate structure.
+    """
+    json_str = json_str or "{}"
+    try:
+        result = json.loads(json_str)
+        if isinstance(result, dict):
+            return result
+    except Exception:
+        pass
+
+    repaired_input = _json_loads_with_repair(json_str)
+    last_input = last_input or {}
+    if len(json.dumps(last_input)) > len(json.dumps(repaired_input)):
+        return last_input
+    return repaired_input
+
+
 def _is_accessible_local_file(url: str) -> bool:
     """Check if the given URL is a local URL."""
     # First identify if it's an uri with 'file://' schema,

--- a/src/agentscope/model/_anthropic_model.py
+++ b/src/agentscope/model/_anthropic_model.py
@@ -2,7 +2,6 @@
 # pylint: disable=too-many-branches, too-many-statements
 """The Anthropic API model classes."""
 import copy
-import json
 import warnings
 from datetime import datetime
 from typing import (
@@ -23,6 +22,7 @@ from ._model_usage import ChatUsage
 from .._logging import logger
 from .._utils._common import (
     _json_loads_with_repair,
+    _parse_streaming_json_dict,
     _create_tool_from_base_model,
 )
 from ..message import TextBlock, ToolUseBlock, ThinkingBlock
@@ -475,16 +475,10 @@ class AnthropicChatModel(ChatModelBase):
 
                     # If parsing the tool input in streaming mode
                     if self.stream_tool_parsing:
-                        repaired_input = _json_loads_with_repair(
-                            input_str or "{}",
+                        repaired_input = _parse_streaming_json_dict(
+                            input_str,
+                            last_input_objs.get(tool_id),
                         )
-                        # If the new repaired input is shorter than one in the
-                        # last chunk, use the last one to avoid regression
-                        last_input = last_input_objs.get(tool_id, {})
-                        if len(json.dumps(last_input)) > len(
-                            json.dumps(repaired_input),
-                        ):
-                            repaired_input = last_input
                         last_input_objs[tool_id] = repaired_input
 
                     else:

--- a/src/agentscope/model/_dashscope_model.py
+++ b/src/agentscope/model/_dashscope_model.py
@@ -25,6 +25,7 @@ from ._model_response import ChatResponse
 from ._model_usage import ChatUsage
 from .._utils._common import (
     _json_loads_with_repair,
+    _parse_streaming_json_dict,
     _create_tool_from_base_model,
 )
 from ..message import TextBlock, ToolUseBlock, ThinkingBlock
@@ -413,16 +414,10 @@ class DashScopeChatModel(ChatModelBase):
 
                 # If parsing the tool input in streaming mode
                 if self.stream_tool_parsing:
-                    repaired_input = _json_loads_with_repair(
-                        input_str or "{}",
+                    repaired_input = _parse_streaming_json_dict(
+                        input_str,
+                        last_input_objs.get(tool_id),
                     )
-                    # If the new repaired input is shorter than one in the last
-                    # chunk, use the last one to avoid regression
-                    last_input = last_input_objs.get(tool_id, {})
-                    if len(json.dumps(last_input)) > len(
-                        json.dumps(repaired_input),
-                    ):
-                        repaired_input = last_input
                     last_input_objs[tool_id] = repaired_input
 
                 else:

--- a/src/agentscope/model/_openai_model.py
+++ b/src/agentscope/model/_openai_model.py
@@ -2,7 +2,6 @@
 # pylint: disable=too-many-branches
 """OpenAI Chat model class."""
 import copy
-import json
 import warnings
 from datetime import datetime
 from typing import (
@@ -21,7 +20,10 @@ from . import ChatResponse
 from ._model_base import ChatModelBase
 from ._model_usage import ChatUsage
 from .._logging import logger
-from .._utils._common import _json_loads_with_repair
+from .._utils._common import (
+    _json_loads_with_repair,
+    _parse_streaming_json_dict,
+)
 from ..message import (
     ToolUseBlock,
     TextBlock,
@@ -458,16 +460,10 @@ class OpenAIChatModel(ChatModelBase):
 
                     # If parsing the tool input in streaming mode
                     if self.stream_tool_parsing:
-                        repaired_input = _json_loads_with_repair(
-                            input_str or "{}",
+                        repaired_input = _parse_streaming_json_dict(
+                            input_str,
+                            last_input_objs.get(tool_id),
                         )
-                        # If the new repaired input is shorter than one in the
-                        # last chunk, use the last one to avoid regression
-                        last_input = last_input_objs.get(tool_id, {})
-                        if len(json.dumps(last_input)) > len(
-                            json.dumps(repaired_input),
-                        ):
-                            repaired_input = last_input
                         last_input_objs[tool_id] = repaired_input
 
                     else:

--- a/tests/model_anthropic_test.py
+++ b/tests/model_anthropic_test.py
@@ -326,6 +326,78 @@ class TestAnthropicChatModel(IsolatedAsyncioTestCase):
             ]
             self.assertEqual(final_response.content, expected_content)
 
+    async def test_streaming_tool_input_prefers_valid_final_json(self) -> None:
+        """Test streaming tool input keeps the final valid JSON dict."""
+        with patch("anthropic.AsyncAnthropic") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value = mock_client
+
+            model = AnthropicChatModel(
+                model_name="claude-3-sonnet-20240229",
+                api_key="test_key",
+                stream=True,
+            )
+            model.client = mock_client
+
+            events = [
+                AnthropicEventMock(
+                    "message_start",
+                    message=Mock(usage=Mock(input_tokens=10, output_tokens=0)),
+                ),
+                AnthropicEventMock(
+                    "content_block_start",
+                    index=0,
+                    content_block=AnthropicContentBlockMock(
+                        "tool_use",
+                        id="tool_123",
+                        name="score",
+                    ),
+                ),
+                AnthropicEventMock(
+                    "content_block_delta",
+                    index=0,
+                    delta=Mock(
+                        type="input_json_delta",
+                        partial_json='{"points": ',
+                    ),
+                ),
+                AnthropicEventMock(
+                    "content_block_delta",
+                    index=0,
+                    delta=Mock(
+                        type="input_json_delta",
+                        partial_json="1}",
+                    ),
+                ),
+                AnthropicEventMock(
+                    "message_delta",
+                    usage=Mock(output_tokens=5),
+                ),
+            ]
+
+            async def mock_stream() -> AsyncGenerator:
+                for event in events:
+                    yield event
+
+            mock_client.messages.create = AsyncMock(return_value=mock_stream())
+            result = await model([{"role": "user", "content": "Score it"}])
+
+            responses = []
+            async for response in result:
+                responses.append(response)
+
+            final_response = responses[-1]
+            expected_content = [
+                ToolUseBlock(
+                    type="tool_use",
+                    id="tool_123",
+                    name="score",
+                    input={"points": 1},
+                    raw_input='{"points": 1}',
+                ),
+            ]
+            self.assertEqual(final_response.content, expected_content)
+
     async def test_generate_kwargs_integration(self) -> None:
         """Test integration of generate_kwargs."""
         with patch("anthropic.AsyncAnthropic") as mock_client_class:

--- a/tests/model_dashscope_test.py
+++ b/tests/model_dashscope_test.py
@@ -340,6 +340,62 @@ class TestDashScopeChatModel(IsolatedAsyncioTestCase):
             ]
             self.assertEqual(final_response.content, expected_content)
 
+    async def test_streaming_tool_input_prefers_valid_final_json(self) -> None:
+        """Test streaming tool input keeps the final valid JSON dict."""
+        model = DashScopeChatModel(
+            model_name="qwen-turbo",
+            api_key="test_key",
+            stream=True,
+        )
+
+        chunks = [
+            self._create_mock_chunk(
+                tool_calls=[
+                    {
+                        "index": 0,
+                        "id": "call_123",
+                        "function": {
+                            "name": "score",
+                            "arguments": '{"points": ',
+                        },
+                    },
+                ],
+            ),
+            self._create_mock_chunk(
+                tool_calls=[
+                    {
+                        "index": 0,
+                        "id": "call_123",
+                        "function": {
+                            "arguments": "1}",
+                        },
+                    },
+                ],
+            ),
+        ]
+
+        with patch(
+            "dashscope.aigc.generation.AioGeneration.call",
+        ) as mock_call:
+            mock_call.return_value = self._create_async_generator(chunks)
+            result = await model([{"role": "user", "content": "Score it"}])
+
+            responses = []
+            async for response in result:
+                responses.append(response)
+
+            final_response = responses[-1]
+            expected_content = [
+                ToolUseBlock(
+                    type="tool_use",
+                    id="call_123",
+                    name="score",
+                    input={"points": 1},
+                    raw_input='{"points": 1}',
+                ),
+            ]
+            self.assertEqual(final_response.content, expected_content)
+
     def test_tools_schema_validation_through_api(self) -> None:
         """Test tools schema validation through API call."""
         model = DashScopeChatModel(

--- a/tests/model_openai_test.py
+++ b/tests/model_openai_test.py
@@ -249,6 +249,64 @@ class TestOpenAIChatModel(IsolatedAsyncioTestCase):
             expected_content = [TextBlock(type="text", text="Hello there!")]
             self.assertEqual(final_response.content, expected_content)
 
+    async def test_streaming_tool_input_prefers_valid_final_json(self) -> None:
+        """Test streaming tool input keeps the final valid JSON dict."""
+        with patch("openai.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value = mock_client
+
+            model = OpenAIChatModel(
+                model_name="gpt-4",
+                api_key="test_key",
+                stream=True,
+            )
+            model.client = mock_client
+
+            stream_mock = self._create_stream_mock(
+                [
+                    {
+                        "tool_calls": [
+                            {
+                                "id": "call_123",
+                                "name": "score",
+                                "arguments": '{"points": ',
+                            },
+                        ],
+                    },
+                    {
+                        "tool_calls": [
+                            {
+                                "id": "call_123",
+                                "name": "score",
+                                "arguments": "1}",
+                            },
+                        ],
+                    },
+                ],
+            )
+
+            mock_client.chat.completions.create = AsyncMock(
+                return_value=stream_mock,
+            )
+
+            result = await model([{"role": "user", "content": "Score it"}])
+
+            responses = []
+            async for response in result:
+                responses.append(response)
+
+            final_response = responses[-1]
+            expected_content = [
+                ToolUseBlock(
+                    type="tool_use",
+                    id="call_123",
+                    name="score",
+                    input={"points": 1},
+                    raw_input='{"points": 1}',
+                ),
+            ]
+            self.assertEqual(final_response.content, expected_content)
+
     # Auxiliary methods - ensure all Mock objects have complete attributes
     def _create_mock_response(
         self,


### PR DESCRIPTION
## AgentScope Version

1.0.17

## Description

Fixes #1351

This PR fixes an edge case in streaming tool argument parsing.

Previously, when a partial tool input such as `{"points": ` was repaired into an intermediate dict like `{"points": ""}`, the streaming parser compared repaired JSON lengths to avoid regressions. That could incorrectly keep the repaired intermediate value even after the final valid input `{"points": 1}` arrived, because the final serialized JSON is shorter.

Incorrect streaming example before this fix:

```python
chunk_1 = '{"points": '
repaired_chunk_1 = {"points": ""}

chunk_2 = '{"points": 1}'
repaired_chunk_2 = {"points": 1}

# Previous behavior:
# len(json.dumps(repaired_chunk_1)) == 14
# len(json.dumps(repaired_chunk_2)) == 13
# The parser incorrectly keeps the older repaired value.
final_input = {"points": ""}
```

Correct behavior after this fix:

```python
chunk_1 = '{"points": '
parsed_chunk_1 = {"points": ""}  # still only an intermediate repaired value

chunk_2 = '{"points": 1}'
parsed_chunk_2 = {"points": 1}   # valid final JSON dict

# New behavior:
# once the accumulated input string is already valid JSON,
# prefer the current parsed dict directly.
final_input = {"points": 1}
```

Changes made in this PR:
- add a small shared helper for streaming JSON dict parsing
- prefer the current value immediately when the accumulated `input_str` is already a valid JSON dict
- keep the previous parsed value only when the current chunk still needs repair and would regress
- reuse the same logic in OpenAI, Anthropic, and DashScope streaming tool parsing
- add regression tests for all three providers

How to test:
- run `uv run pytest tests/model_openai_test.py tests/model_anthropic_test.py tests/model_dashscope_test.py`
- run `uv run pre-commit run --all-files`
- verify the new streaming regression cases now keep the final valid tool input, such as `{"points": 1}`, instead of the repaired intermediate value

## Checklist

- [x] Code has been formatted with `pre-commit run --all-files` command
- [x] All tests are passing
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review