### PR TITLE
feat(formatter): translate local file path to base64 in image blocks in Anthropic formatter

### DIFF
--- a/src/agentscope/formatter/_anthropic_formatter.py
+++ b/src/agentscope/formatter/_anthropic_formatter.py
@@ -1,13 +1,98 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=too-many-branches
+# pylint: disable=too-many-branches, too-many-nested-blocks
 """The Anthropic formatter module."""
 
+import base64
+import os
 from typing import Any
+from urllib.parse import urlparse
 
 from ._truncated_formatter_base import TruncatedFormatterBase
 from .._logging import logger
 from ..message import Msg, TextBlock, ImageBlock, ToolUseBlock, ToolResultBlock
 from ..token import TokenCounterBase
+
+
+def _format_anthropic_image_block(image_block: ImageBlock) -> dict:
+    """Format an image block for Anthropic API. If the source is a URLSource
+    pointing to a local file, it will be converted to base64 format.
+
+    Args:
+        image_block (`ImageBlock`):
+            The image block to format.
+
+    Returns:
+        `dict`:
+            A dictionary in Anthropic image block format.
+
+    Raises:
+        `ValueError`:
+            If the source type or image format is not supported.
+    """
+    import filetype
+
+    # See https://platform.openai.com/docs/guides/vision for details of
+    # support image extensions.
+    support_image_extensions = {
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".gif": "image/gif",
+        ".webp": "image/webp",
+    }
+
+    source = image_block["source"]
+
+    if source["type"] == "base64":
+        return {**image_block}
+
+    url = source["url"]
+    raw_url = url.removeprefix("file://")
+
+    if os.path.exists(raw_url) and os.path.isfile(raw_url):
+        ext = os.path.splitext(raw_url)[1].lower()
+        media_type = support_image_extensions.get(ext)
+        if media_type:
+            with open(raw_url, "rb") as f:
+                data = base64.b64encode(f.read()).decode("utf-8")
+            return {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": media_type,
+                    "data": data,
+                },
+            }
+        # No extension - detect file type using filetype
+        kind = filetype.guess(raw_url)
+        if kind is not None and kind.mime.startswith("image/"):
+            with open(raw_url, "rb") as image_file:
+                data = base64.b64encode(image_file.read()).decode(
+                    "utf-8",
+                )
+            return {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": kind.mime,
+                    "data": data,
+                },
+            }
+
+    # For web urls
+    parsed_url = urlparse(raw_url)
+    if parsed_url.scheme not in ("", "file"):
+        return {
+            "type": "image",
+            "source": {
+                "type": "url",
+                "url": url,
+            },
+        }
+
+    raise ValueError(
+        f'Invalid image URL: "{url}". It should be a local file or a web URL.',
+    )
 
 
 class AnthropicChatFormatter(TruncatedFormatterBase):
@@ -63,8 +148,15 @@ class AnthropicChatFormatter(TruncatedFormatterBase):
 
             for block in msg.get_content_blocks():
                 typ = block.get("type")
-                if typ in ["thinking", "text", "image"]:
+                if typ in ["thinking", "text"]:
                     content_blocks.append({**block})
+
+                elif typ == "image":
+                    content_blocks.append(
+                        _format_anthropic_image_block(
+                            block,  # type: ignore[arg-type]
+                        ),
+                    )
 
                 elif typ == "tool_use":
                     content_blocks.append(
@@ -81,7 +173,12 @@ class AnthropicChatFormatter(TruncatedFormatterBase):
                     if output is None:
                         content_value = [{"type": "text", "text": None}]
                     elif isinstance(output, list):
-                        content_value = output
+                        content_value = [
+                            _format_anthropic_image_block(item)
+                            if item.get("type") == "image"
+                            else item
+                            for item in output
+                        ]
                     else:
                         content_value = [{"type": "text", "text": str(output)}]
                     messages.append(
@@ -207,7 +304,11 @@ class AnthropicMultiAgentFormatter(TruncatedFormatterBase):
                         )
                         accumulated_text.clear()
 
-                    conversation_blocks.append({**block})
+                    conversation_blocks.append(
+                        _format_anthropic_image_block(
+                            block,  # type: ignore[arg-type]
+                        ),
+                    )
 
         if accumulated_text:
             conversation_blocks.append(

--- a/tests/formatter_anthropic_test.py
+++ b/tests/formatter_anthropic_test.py
@@ -21,7 +21,10 @@ class TestAnthropicChatFormatterFormatter(IsolatedAsyncioTestCase):
 
     async def asyncSetUp(self) -> None:
         """Set up the test environment."""
-        self.image_url = "www.example_image.png"
+        self.image_url = "https://www.example.com/image.png"
+        self.image_path = "./image.png"
+        with open(self.image_path, "wb") as f:
+            f.write(b"fake image content")
 
         self.msgs_system = [
             Msg(
@@ -153,7 +156,7 @@ class TestAnthropicChatFormatterFormatter(IsolatedAsyncioTestCase):
                         "type": "image",
                         "source": {
                             "type": "url",
-                            "url": "www.example_image.png",
+                            "url": "https://www.example.com/image.png",
                         },
                     },
                 ],
@@ -239,7 +242,7 @@ class TestAnthropicChatFormatterFormatter(IsolatedAsyncioTestCase):
                         "type": "image",
                         "source": {
                             "type": "url",
-                            "url": "www.example_image.png",
+                            "url": "https://www.example.com/image.png",
                         },
                     },
                     {
@@ -366,7 +369,7 @@ class TestAnthropicChatFormatterFormatter(IsolatedAsyncioTestCase):
                         "type": "image",
                         "source": {
                             "type": "url",
-                            "url": "www.example_image.png",
+                            "url": "https://www.example.com/image.png",
                         },
                     },
                     {
@@ -598,4 +601,77 @@ class TestAnthropicChatFormatterFormatter(IsolatedAsyncioTestCase):
         self.assertListEqual(
             res,
             self.ground_truth_multiagent_without_first_conversation[1:],
+        )
+
+    async def test_chat_local_image_to_base64(self) -> None:
+        """Local image URL in user message and tool result should be
+        converted to base64."""
+        formatter = AnthropicChatFormatter()
+        msgs = [
+            Msg(
+                "user",
+                [
+                    TextBlock(type="text", text="Describe the image."),
+                    ImageBlock(
+                        type="image",
+                        source=URLSource(type="url", url=self.image_path),
+                    ),
+                ],
+                "user",
+            ),
+            Msg(
+                "assistant",
+                [
+                    ToolUseBlock(
+                        type="tool_use",
+                        id="tool_1",
+                        name="view_image",
+                        input={"path": "/tmp/img.png"},
+                    ),
+                ],
+                "assistant",
+            ),
+            Msg(
+                "system",
+                [
+                    ToolResultBlock(
+                        type="tool_result",
+                        id="tool_1",
+                        name="view_image",
+                        output=[
+                            ImageBlock(
+                                type="image",
+                                source=URLSource(
+                                    type="url",
+                                    url=self.image_path,
+                                ),
+                            ),
+                            TextBlock(type="text", text="Image loaded"),
+                        ],
+                    ),
+                ],
+                "system",
+            ),
+        ]
+        res = await formatter.format(msgs)
+
+        # User message: local image should be base64
+        user_img = res[0]["content"][1]
+        self.assertEqual(user_img["source"]["type"], "base64")
+        self.assertEqual(user_img["source"]["media_type"], "image/png")
+        self.assertEqual(
+            user_img["source"]["data"],
+            "ZmFrZSBpbWFnZSBjb250ZW50",
+        )
+
+        # Tool result: local image should also be base64
+        tool_result_content = res[2]["content"][0]["content"]
+        img_items = [
+            b for b in tool_result_content if b.get("type") == "image"
+        ]
+        self.assertEqual(len(img_items), 1)
+        self.assertEqual(img_items[0]["source"]["type"], "base64")
+        self.assertEqual(
+            img_items[0]["source"]["data"],
+            "ZmFrZSBpbWFnZSBjb250ZW50",
         )


### PR DESCRIPTION
## AgentScope Version

1.0.17

## Description

Anthropic SDK does not support local file path in image block, so we should translate it to base64 data.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review