### PR TITLE
fix(tuner): set monitor_type on monitor config instead of overwriting monitor object

### DIFF
--- a/src/agentscope/tuner/_config.py
+++ b/src/agentscope/tuner/_config.py
@@ -48,7 +48,7 @@ def _to_trinity_config(
             "%Y%m%d%H%M%S",
         )
 
-    _set_if_not_none(config, "monitor", monitor_type)
+    _set_if_not_none(config.monitor, "monitor_type", monitor_type)
 
     workflow_name = "agentscope_workflow_adapter_v1"
     if train_dataset is not None:


### PR DESCRIPTION
## AgentScope Version

1.0.17

## Description

In `agentscope.tuner._to_trinity_config`, `monitor_type` was assigned via:
`setattr(config, "monitor", monitor_type)`.

This overwrote `config.monitor` (a `MonitorConfig` object) with a string (e.g. `"wandb"`), and later caused:
`AttributeError: 'str' object has no attribute 'monitor_type'`
during config validation (`config.check_and_update()`).

### How to test
```python
from agentscope.tuner._config import _to_trinity_config
from agentscope.tuner import DatasetConfig, TunerModelConfig, AlgorithmConfig


async def wf(task, model):
    return None

cfg = _to_trinity_config(
    workflow_func=wf,
    train_dataset=DatasetConfig(path="test"),
    model=TunerModelConfig(model_path="Qwen/Qwen3-4B", max_model_len=4096),
    algorithm=AlgorithmConfig(),
    monitor_type="wandb",
)

cfg.check_and_update()
```
**Current output:**
```bash
$ python test.py
Traceback (most recent call last):
  File "/data/gaoheyang/agent_tuner/test.py", line 16, in <module>
    cfg.check_and_update()
  File "/data/gaoheyang/agent_tuner/Trinity-RFT/trinity/common/config.py", line 906, in check_and_update
    validator.validate(self)
  File "/data/gaoheyang/agent_tuner/Trinity-RFT/trinity/common/config_validator.py", line 803, in validate
    monitor_cls = MONITOR.get(config.monitor.monitor_type)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'monitor_type'
```