### PR TITLE
fix(tool): avoid shell deadlock on large output

### DIFF
--- a/src/agentscope/tool/_coding/_shell.py
+++ b/src/agentscope/tool/_coding/_shell.py
@@ -37,9 +37,13 @@ async def execute_shell_command(
         bufsize=0,
     )
 
+    communicate_task = asyncio.create_task(proc.communicate())
+
     try:
-        await asyncio.wait_for(proc.wait(), timeout=timeout)
-        stdout, stderr = await proc.communicate()
+        stdout, stderr = await asyncio.wait_for(
+            asyncio.shield(communicate_task),
+            timeout=timeout,
+        )
         stdout_str = stdout.decode("utf-8")
         stderr_str = stderr.decode("utf-8")
         returncode = proc.returncode
@@ -52,7 +56,7 @@ async def execute_shell_command(
         returncode = -1
         try:
             proc.terminate()
-            stdout, stderr = await proc.communicate()
+            stdout, stderr = await communicate_task
             stdout_str = stdout.decode("utf-8")
             stderr_str = stderr.decode("utf-8")
             if stderr_str:

--- a/tests/tool_test.py
+++ b/tests/tool_test.py
@@ -33,9 +33,7 @@ class ToolTest(IsolatedAsyncioTestCase):
         # empty output
         res = await execute_python_code(code="a = 1 + 1")
         self.assertEqual(
-            "<returncode>0</returncode>"
-            "<stdout></stdout>"
-            "<stderr></stderr>",
+            "<returncode>0</returncode>" "<stdout></stdout>" "<stderr></stderr>",
             res.content[0]["text"],
         )
 
@@ -117,7 +115,7 @@ print("456")"""
 
         # without timeout
         normal_cmd = (
-            f"{sys.executable} -c \""  # fmt: skip
+            f'{sys.executable} -c "'  # fmt: skip
             f"import time; print('123'); "
             f"time.sleep(0.1); print('456')\""
         )
@@ -154,8 +152,7 @@ print("456")"""
 
         # large output should not deadlock on pipe buffers
         large_output_cmd = (
-            f"{sys.executable} -c \"import sys; "
-            f"sys.stdout.write('x' * 131072)\""
+            f'{sys.executable} -c "import sys; ' f"sys.stdout.write('x' * 131072)\""
         )
         res = await execute_shell_command(
             command=large_output_cmd,

--- a/tests/tool_test.py
+++ b/tests/tool_test.py
@@ -33,7 +33,9 @@ class ToolTest(IsolatedAsyncioTestCase):
         # empty output
         res = await execute_python_code(code="a = 1 + 1")
         self.assertEqual(
-            "<returncode>0</returncode>" "<stdout></stdout>" "<stderr></stderr>",
+            "<returncode>0</returncode>"
+            "<stdout></stdout>"
+            "<stderr></stderr>",
             res.content[0]["text"],
         )
 
@@ -152,7 +154,8 @@ print("456")"""
 
         # large output should not deadlock on pipe buffers
         large_output_cmd = (
-            f'{sys.executable} -c "import sys; ' f"sys.stdout.write('x' * 131072)\""
+            f'{sys.executable} -c "import sys; '
+            f"sys.stdout.write('x' * 131072)\""
         )
         res = await execute_shell_command(
             command=large_output_cmd,
@@ -165,7 +168,9 @@ print("456")"""
             ),
         )
         self.assertIn("</stdout><stderr></stderr>", actual)
-        stdout_payload = actual.split("<stdout>", 1)[1].split("</stdout>", 1)[0]
+        stdout_payload = actual.split("<stdout>", 1)[1].split("</stdout>", 1)[
+            0
+        ]
         self.assertEqual(131072, len(stdout_payload))
 
     async def test_view_text_file(self) -> None:

--- a/tests/tool_test.py
+++ b/tests/tool_test.py
@@ -152,6 +152,25 @@ print("456")"""
             actual,
         )
 
+        # large output should not deadlock on pipe buffers
+        large_output_cmd = (
+            f"{sys.executable} -c \"import sys; "
+            f"sys.stdout.write('x' * 131072)\""
+        )
+        res = await execute_shell_command(
+            command=large_output_cmd,
+            timeout=5,
+        )
+        actual = res.content[0]["text"]
+        self.assertTrue(
+            actual.startswith(
+                "<returncode>0</returncode><stdout>",
+            ),
+        )
+        self.assertIn("</stdout><stderr></stderr>", actual)
+        stdout_payload = actual.split("<stdout>", 1)[1].split("</stdout>", 1)[0]
+        self.assertEqual(131072, len(stdout_payload))
+
     async def test_view_text_file(self) -> None:
         """Test viewing text file."""
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## AgentScope Version

1.0.17

## Description

Fixes #1255.

`execute_shell_command` previously waited for the subprocess to exit before reading stdout/stderr. If the child process produced more data than the OS pipe buffer, the child could block on write while the parent was still waiting on `proc.wait()`, causing a deadlock.

This PR switches the implementation to start `proc.communicate()` immediately and wait on that task with a timeout. On timeout, the process is terminated and the same `communicate()` task is awaited so partial stdout/stderr are still preserved.

## Changes

- use a background `proc.communicate()` task instead of `proc.wait()` followed by `communicate()`
- shield the communicate task while waiting with timeout
- keep partial stdout behavior for timeout cases
- add a regression test that emits 128KB to stdout and verifies the shell tool returns successfully

## How to Test

- `./.venv/bin/pytest tests/tool_test.py -q -k execute_shell_command`
- direct manual check with a large stdout payload via `execute_shell_command`

## Checklist

- [ ] Code has been formatted with `pre-commit run --all-files` command
- [x] All tests are passing
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review