### PR TITLE
feat(examples): add Clicks Protocol DeFi yield integration

### DIFF
--- a/examples/integration/clicks_protocol_yield/README.md
+++ b/examples/integration/clicks_protocol_yield/README.md
@@ -1,0 +1,122 @@
+# Clicks Protocol × AgentScope: DeFi Yield Agent
+
+An AgentScope example demonstrating how AI agents can autonomously manage treasury and earn yield on Base L2 using Clicks Protocol's MCP tools.
+
+## 🌳 Sample Structure
+
+```
+.
+├── README.md                 # Documentation
+├── main.py                   # Entry point: DeFi Yield Agent
+├── treasury_agent.py         # Treasury management agent with yield tools
+├── requirements.txt          # Dependencies
+└── example_output.md         # Expected output
+```
+
+## 📖 Overview
+
+This sample shows how to build an AI agent that manages its own DeFi treasury using Clicks Protocol via MCP. The agent can:
+
+1. **Check yield rates** across DeFi protocols (Morpho Blue, Aave V3) on Base
+2. **Simulate payment splits** to preview how deposits will be allocated (80% liquid, 20% yield)
+3. **Query agent status** including registration, balance, and yield earned
+4. **Monitor referral networks** for additional earnings
+
+### The Problem This Solves
+
+AI agents increasingly hold funds (tips, payments, revenue). But those funds sit idle. There's no simple way for an agent to:
+- Earn yield without manual DeFi interaction
+- Keep most funds liquid for operations
+- Auto-route to the best APY
+- Do it all through tool calls (MCP)
+
+Clicks Protocol solves this by providing 4 read-only MCP tools that any agent framework can consume. No wallet management needed for querying. Just point your agent at the MCP server.
+
+### Why AgentScope + Clicks Protocol
+
+AgentScope's MCP integration is the cleanest in the ecosystem. Three lines to connect:
+
+```python
+client = HttpStatelessClient(
+    name="clicks",
+    transport="streamable_http",
+    url="https://clicks-mcp.rechnung-613.workers.dev/mcp",
+)
+await toolkit.register_mcp_client(client)
+```
+
+The agent then discovers all Clicks tools automatically and can reason about yield strategies using ReAct.
+
+## 🚀 Getting Started
+
+### Prerequisites
+
+- Python 3.10+
+- An API key for your LLM provider (OpenAI, Anthropic, DashScope, etc.)
+
+### Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+### Usage
+
+```bash
+# With OpenAI
+OPENAI_API_KEY=sk-xxx python main.py --model openai
+
+# With DashScope (Qwen)
+DASHSCOPE_API_KEY=xxx python main.py --model dashscope
+
+# With Anthropic (Claude)
+ANTHROPIC_API_KEY=xxx python main.py --model anthropic
+```
+
+### Example Queries
+
+The agent can answer questions like:
+
+- "What's the current yield rate on Morpho Blue?"
+- "If I deposit 1000 USDC, how would it be split?"
+- "What's the status of agent 0x1234...?"
+- "How much yield has been earned across the protocol?"
+- "Compare Morpho and Aave yields right now"
+
+## 🛠️ Features
+
+- **Zero configuration**: No wallet or API keys needed (read-only MCP tools)
+- **Multi-model support**: Works with OpenAI, Anthropic, DashScope, Gemini, Ollama
+- **ReAct reasoning**: Agent reasons about DeFi data step by step
+- **Structured output**: Get typed results from yield queries
+- **Real on-chain data**: Queries live Base mainnet contracts (not mocks)
+
+## Architecture
+
+```
+┌─────────────────┐     MCP (Streamable HTTP)     ┌─────────────────────┐
+│  AgentScope      │ ──────────────────────────── │  Clicks Protocol     │
+│  ReAct Agent     │     Tool Discovery + Calls    │  MCP Server          │
+│                  │                               │  (Cloudflare Worker) │
+│  • Plan          │     clicks_get_yield_info     │                      │
+│  • Reason        │ ◄──────────────────────────── │  Base Mainnet        │
+│  • Act           │     clicks_simulate_split     │  • Morpho Blue       │
+│  • Observe       │ ◄──────────────────────────── │  • Aave V3           │
+└─────────────────┘                               └─────────────────────┘
+```
+
+## Available MCP Tools
+
+| Tool | Description | Use Case |
+|------|-------------|----------|
+| `clicks_get_yield_info` | Current APY rates (Morpho/Aave) | Compare protocols, decide where to deposit |
+| `clicks_simulate_split` | Preview payment split for amount | Calculate expected yield before depositing |
+| `clicks_get_agent_info` | Agent registration and balance | Monitor treasury status |
+| `clicks_get_referral_stats` | Referral network earnings | Track referral revenue |
+
+## Links
+
+- [Clicks Protocol](https://clicksprotocol.xyz)
+- [GitHub](https://github.com/clicks-protocol/clicks-protocol)
+- [npm SDK](https://www.npmjs.com/package/@clicks-protocol/sdk)
+- [AgentScope Docs](https://doc.agentscope.io/)

--- a/examples/integration/clicks_protocol_yield/main.py
+++ b/examples/integration/clicks_protocol_yield/main.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+"""
+Clicks Protocol DeFi Yield Agent — AgentScope Example
+
+Demonstrates how an AI agent can autonomously query DeFi yield data
+on Base L2 using Clicks Protocol's MCP tools via AgentScope.
+
+Usage:
+    OPENAI_API_KEY=sk-xxx python main.py --model openai
+    DASHSCOPE_API_KEY=xxx python main.py --model dashscope
+    ANTHROPIC_API_KEY=xxx python main.py --model anthropic
+
+No wallet or API keys needed for Clicks Protocol (read-only tools).
+"""
+
+import argparse
+import asyncio
+import os
+
+from agentscope.agent import ReActAgent
+from agentscope.mcp import HttpStatelessClient
+from agentscope.message import Msg
+from agentscope.tool import Toolkit
+
+
+# Clicks Protocol MCP endpoint (public, no auth required)
+CLICKS_MCP_URL = "https://clicks-mcp.rechnung-613.workers.dev/mcp"
+
+
+def get_model_and_formatter(provider: str):
+    """Get the model and formatter based on the provider."""
+
+    if provider == "openai":
+        from agentscope.model import OpenAIChatModel
+        from agentscope.formatter import OpenAIChatFormatter
+
+        return (
+            OpenAIChatModel(
+                model_name="gpt-4o",
+                api_key=os.environ["OPENAI_API_KEY"],
+                stream=True,
+            ),
+            OpenAIChatFormatter(),
+        )
+
+    elif provider == "anthropic":
+        from agentscope.model import AnthropicChatModel
+        from agentscope.formatter import AnthropicChatFormatter
+
+        return (
+            AnthropicChatModel(
+                model_name="claude-sonnet-4-20250514",
+                api_key=os.environ["ANTHROPIC_API_KEY"],
+                stream=True,
+            ),
+            AnthropicChatFormatter(),
+        )
+
+    elif provider == "dashscope":
+        from agentscope.model import DashScopeChatModel
+        from agentscope.formatter import DashScopeChatFormatter
+
+        return (
+            DashScopeChatModel(
+                model_name="qwen-max",
+                api_key=os.environ["DASHSCOPE_API_KEY"],
+                stream=True,
+            ),
+            DashScopeChatFormatter(),
+        )
+
+    elif provider == "ollama":
+        from agentscope.model import OllamaChatModel
+        from agentscope.formatter import OllamaChatFormatter
+
+        return (
+            OllamaChatModel(
+                model_name="llama3.1:8b",
+                stream=True,
+            ),
+            OllamaChatFormatter(),
+        )
+
+    else:
+        raise ValueError(
+            f"Unknown provider: {provider}. "
+            "Supported: openai, anthropic, dashscope, ollama"
+        )
+
+
+async def main(provider: str) -> None:
+    """Run the Clicks Protocol DeFi yield agent."""
+
+    # 1. Create toolkit and register Clicks Protocol MCP tools
+    toolkit = Toolkit()
+
+    clicks_client = HttpStatelessClient(
+        name="clicks_protocol",
+        transport="streamable_http",
+        url=CLICKS_MCP_URL,
+    )
+
+    await toolkit.register_mcp_client(clicks_client)
+
+    print(f"Registered {len(toolkit)} tools from Clicks Protocol MCP")
+    print("Available tools:")
+    for name in toolkit.get_tool_names():
+        print(f"  - {name}")
+    print()
+
+    # 2. Get model and formatter for the chosen provider
+    model, formatter = get_model_and_formatter(provider)
+
+    # 3. Create the DeFi yield agent
+    agent = ReActAgent(
+        name="ClicksAgent",
+        sys_prompt=(
+            "You are a DeFi treasury agent. You help AI agents understand "
+            "and optimize their yield on Base L2 using Clicks Protocol.\n\n"
+            "You have access to Clicks Protocol MCP tools that query real "
+            "on-chain data from Base mainnet. Use them to:\n"
+            "- Check current APY rates across Morpho Blue and Aave V3\n"
+            "- Simulate how deposits would be split (80% liquid, 20% yield)\n"
+            "- Query agent registration status and balances\n"
+            "- Monitor referral network earnings\n\n"
+            "Always provide specific numbers from tool calls. "
+            "Never make up yield rates or balances."
+        ),
+        model=model,
+        formatter=formatter,
+        toolkit=toolkit,
+    )
+
+    # 4. Run example queries
+    queries = [
+        (
+            "What are the current yield rates on Clicks Protocol? "
+            "Compare Morpho and Aave."
+        ),
+        (
+            "If an AI agent deposits 10,000 USDC into Clicks Protocol, "
+            "how would it be split? How much yield would it earn per month?"
+        ),
+        (
+            "Check the status of the Clicks Protocol referral network. "
+            "How many agents are participating?"
+        ),
+    ]
+
+    for i, query in enumerate(queries, 1):
+        print(f"\n{'='*60}")
+        print(f"Query {i}: {query}")
+        print(f"{'='*60}\n")
+
+        response = await agent(
+            Msg("user", query, "user"),
+        )
+
+        print(f"\nAgent Response:\n{response.content}\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Clicks Protocol DeFi Yield Agent"
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="openai",
+        choices=["openai", "anthropic", "dashscope", "ollama"],
+        help="LLM provider to use (default: openai)",
+    )
+    args = parser.parse_args()
+
+    asyncio.run(main(args.model))

--- a/examples/integration/clicks_protocol_yield/requirements.txt
+++ b/examples/integration/clicks_protocol_yield/requirements.txt
@@ -1,0 +1,2 @@
+agentscope>=0.1.0
+pydantic>=2.0.0

--- a/examples/integration/clicks_protocol_yield/treasury_agent.py
+++ b/examples/integration/clicks_protocol_yield/treasury_agent.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+"""
+Treasury Management Agent — Advanced Example
+
+A multi-step agent that acts as an autonomous treasury manager:
+1. Checks current yield rates across protocols
+2. Simulates optimal deposit allocation
+3. Monitors existing agent positions
+4. Generates a treasury report
+
+This demonstrates how an AgentScope ReAct agent can chain
+multiple Clicks Protocol MCP tool calls into a coherent workflow.
+
+Usage:
+    OPENAI_API_KEY=sk-xxx python treasury_agent.py
+"""
+
+import asyncio
+import os
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from agentscope.agent import ReActAgent
+from agentscope.formatter import OpenAIChatFormatter
+from agentscope.mcp import HttpStatelessClient
+from agentscope.memory import InMemoryMemory
+from agentscope.message import Msg
+from agentscope.model import OpenAIChatModel
+from agentscope.tool import Toolkit
+
+
+CLICKS_MCP_URL = "https://clicks-mcp.rechnung-613.workers.dev/mcp"
+
+
+class TreasuryReport(BaseModel):
+    """Structured output for the treasury report."""
+
+    timestamp: str = Field(description="ISO timestamp of the report")
+    active_protocol: str = Field(
+        description="Currently active yield protocol (Morpho/Aave)"
+    )
+    current_apy_percent: float = Field(
+        description="Current APY in percent"
+    )
+    recommended_action: str = Field(
+        description="What the agent should do next"
+    )
+    monthly_yield_per_10k: float = Field(
+        description="Estimated monthly yield for 10,000 USDC deposit"
+    )
+    risk_assessment: str = Field(
+        description="Brief risk assessment (low/medium/high)"
+    )
+
+
+async def main() -> None:
+    """Run the treasury management agent."""
+
+    # Setup
+    toolkit = Toolkit()
+
+    clicks = HttpStatelessClient(
+        name="clicks",
+        transport="streamable_http",
+        url=CLICKS_MCP_URL,
+    )
+    await toolkit.register_mcp_client(clicks)
+
+    model = OpenAIChatModel(
+        model_name="gpt-4o",
+        api_key=os.environ["OPENAI_API_KEY"],
+        stream=True,
+    )
+
+    # Create agent with memory so it can reference prior tool results
+    agent = ReActAgent(
+        name="TreasuryManager",
+        sys_prompt=(
+            "You are an autonomous treasury manager for AI agents. "
+            "Your job is to analyze DeFi yield opportunities on Base L2 "
+            "and produce a structured treasury report.\n\n"
+            "Steps:\n"
+            "1. Call clicks_get_yield_info to check current APY rates\n"
+            "2. Call clicks_simulate_split with amount=10000 to see "
+            "   how a $10K deposit would be allocated\n"
+            "3. Call clicks_get_referral_stats to check network activity\n"
+            "4. Synthesize findings into a treasury report\n\n"
+            "Base your analysis only on tool call results. "
+            "Include specific numbers. No speculation."
+        ),
+        model=model,
+        formatter=OpenAIChatFormatter(),
+        toolkit=toolkit,
+        memory=InMemoryMemory(),
+    )
+
+    print("Treasury Management Agent initialized")
+    print(f"Connected to Clicks Protocol MCP at {CLICKS_MCP_URL}")
+    print(f"Tools available: {toolkit.get_tool_names()}")
+    print(f"\nGenerating treasury report...\n{'='*60}\n")
+
+    # Run the multi-step analysis
+    response = await agent(
+        Msg(
+            "user",
+            f"Generate a complete treasury report as of "
+            f"{datetime.utcnow().isoformat()}Z. "
+            f"Check all yield rates, simulate a 10,000 USDC deposit, "
+            f"and assess the referral network. "
+            f"Then provide your structured recommendation.",
+            "user",
+        ),
+        structured_model=TreasuryReport,
+    )
+
+    print(f"Agent narrative:\n{response.content}\n")
+
+    if response.metadata:
+        print(f"{'='*60}")
+        print("Structured Treasury Report:")
+        print(f"{'='*60}")
+        for key, value in response.metadata.items():
+            print(f"  {key}: {value}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Clicks Protocol DeFi Yield Agent

An example demonstrating how AgentScope agents can autonomously manage DeFi treasury and earn yield on Base L2 using Clicks Protocol's MCP tools.

### What it demonstrates
- Connecting to a remote MCP server (Clicks Protocol) via Streamable HTTP
- Using MCP tools for real on-chain DeFi queries (yield rates, deposit simulations, agent status)
- Multi-model support (OpenAI, Anthropic, DashScope, Ollama)
- Structured output with Pydantic models
- Multi-step ReAct reasoning over financial data

### Files
- `main.py` — Basic yield query agent (multi-model)
- `treasury_agent.py` — Advanced treasury manager with structured reports
- `requirements.txt` — Dependencies
- `README.md` — Full documentation

### Why this matters
AgentScope has excellent MCP integration but no DeFi/yield examples. This fills that gap by showing how agents can manage their own treasury autonomously. It's the natural complement to EvoTraders: agents that trade can now also earn yield on idle funds.

### No API keys needed for Clicks Protocol
The MCP tools are read-only and publicly accessible at `https://clicks-mcp.rechnung-613.workers.dev/mcp`. Only an LLM API key is needed.

Links:
- [Clicks Protocol](https://clicksprotocol.xyz)
- [GitHub](https://github.com/clicks-protocol/clicks-protocol)
- [npm MCP Server](https://www.npmjs.com/package/@clicks-protocol/mcp-server)
