### PR TITLE
fix(session): block JSONSession path traversal

### DIFF
--- a/src/agentscope/session/_json_session.py
+++ b/src/agentscope/session/_json_session.py
@@ -2,6 +2,7 @@
 """The JSON session class."""
 import json
 import os
+import re
 import aiofiles
 
 from ._session_base import SessionBase
@@ -24,6 +25,11 @@ class JSONSession(SessionBase):
         """
         self.save_dir = save_dir
 
+    @staticmethod
+    def _sanitize_identifier(identifier: str) -> str:
+        """Sanitize session identifiers to safe file-name components."""
+        return re.sub(r"[^a-zA-Z0-9._-]", "_", identifier)
+
     def _get_save_path(self, session_id: str, user_id: str) -> str:
         """The path to save the session state.
 
@@ -37,12 +43,27 @@ class JSONSession(SessionBase):
             `str`:
                 The path to save the session state.
         """
-        os.makedirs(self.save_dir, exist_ok=True)
-        if user_id:
-            file_path = f"{user_id}_{session_id}.json"
+        safe_session_id = self._sanitize_identifier(session_id)
+        if not safe_session_id:
+            raise ValueError("The session_id cannot be empty.")
+
+        safe_user_id = self._sanitize_identifier(user_id)
+
+        base_dir = os.path.realpath(self.save_dir)
+        os.makedirs(base_dir, exist_ok=True)
+
+        if safe_user_id:
+            file_path = f"{safe_user_id}_{safe_session_id}.json"
         else:
-            file_path = f"{session_id}.json"
-        return os.path.join(self.save_dir, file_path)
+            file_path = f"{safe_session_id}.json"
+
+        save_path = os.path.realpath(os.path.join(base_dir, file_path))
+        if os.path.commonpath([base_dir, save_path]) != base_dir:
+            raise ValueError(
+                "The generated session path is outside of save_dir.",
+            )
+
+        return save_path
 
     async def save_session_state(
         self,

--- a/tests/session_test.py
+++ b/tests/session_test.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 """Session module tests."""
 import os
+import tempfile
 from typing import Union
-from unittest import IsolatedAsyncioTestCase
+from unittest import IsolatedAsyncioTestCase, TestCase
 
 from agentscope.agent import ReActAgent, AgentBase
 from agentscope.formatter import DashScopeChatFormatter
@@ -99,6 +100,49 @@ class SessionTest(IsolatedAsyncioTestCase):
         session_file = "./user_1.json"
         if os.path.exists(session_file):
             os.remove(session_file)
+
+
+class JSONSessionPathSecurityTest(TestCase):
+    """Security test cases for JSONSession path handling."""
+
+    def test_get_save_path_stays_under_save_dir(self) -> None:
+        """Path traversal payloads must not escape the save directory."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            session = JSONSession(save_dir=temp_dir)
+            save_path = session._get_save_path(
+                session_id="sid",
+                user_id="../../../../tmp/evil",
+            )
+            expected_dir = os.path.realpath(temp_dir)
+            self.assertEqual(
+                os.path.dirname(save_path),
+                expected_dir,
+            )
+            self.assertNotIn("/", os.path.basename(save_path))
+            self.assertNotIn("\\", os.path.basename(save_path))
+
+    def test_save_and_load_use_sanitized_identifiers(self) -> None:
+        """Save/load should use the same sanitized path deterministically."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            session = JSONSession(save_dir=temp_dir)
+            save_path = session._get_save_path(
+                session_id="session/1",
+                user_id="user/1",
+            )
+            self.assertTrue(
+                os.path.exists(os.path.dirname(save_path)),
+            )
+            self.assertEqual(
+                os.path.basename(save_path),
+                "user_1_session_1.json",
+            )
+
+    def test_empty_session_id_raises(self) -> None:
+        """An empty session id should be rejected."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            session = JSONSession(save_dir=temp_dir)
+            with self.assertRaises(ValueError):
+                session._get_save_path(session_id="", user_id="user")
 
 
 class RedisSessionTest(IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary
- sanitize `session_id` and `user_id` before building JSON session filename
- enforce realpath containment under `save_dir` to block directory traversal
- raise `ValueError` on empty/invalid session id after sanitization
- add security tests for traversal payload, deterministic sanitization, and invalid id rejection

## Security Impact
This blocks path traversal / out-of-directory write via crafted session identifiers in `JSONSession`.

## Tests
- `PYTHONPATH=src python3 -m unittest tests.session_test.JSONSessionPathSecurityTest -v`