### PR TITLE
fix: handle missing 'type' field in tool parameter properties for OpenAITokenCounter

### DIFF
--- a/src/agentscope/token/_openai_token_counter.py
+++ b/src/agentscope/token/_openai_token_counter.py
@@ -155,7 +155,7 @@ def _calculate_tokens_for_tools(
             for key in properties.keys():
                 func_token_count += prop_key
                 p_name = key
-                p_type = properties[key]["type"]
+                p_type = properties[key].get("type", "")
                 p_desc = (
                     properties[key].get("description", "").removesuffix(".")
                 )


### PR DESCRIPTION
Fixes #1397

## Problem
When `PlanNotebook` is enabled, some plan-related tools (e.g., `view_historical_plans`) define parameter properties that do not include a `type` field. The `_calculate_tokens_for_tools` function in `_openai_token_counter.py` attempts to access `properties[key]["type"]` directly, causing a `KeyError` when the field is absent.

## Solution
Replace the direct key access `properties[key]["type"]` with `properties[key].get("type", "")` so that missing `type` fields are handled gracefully with an empty string fallback, which is safe to encode and contributes 0 extra tokens.

## Testing
Manually verified: constructing a tool schema where a property omits the `type` field (as in the `view_historical_plans` plan tool) no longer raises a `KeyError` when token counting is invoked.