### PR TITLE
fix(memory): flush session before inserting message_mark records

### DIFF
--- a/src/agentscope/memory/_working_memory/_sqlalchemy_memory.py
+++ b/src/agentscope/memory/_working_memory/_sqlalchemy_memory.py
@@ -451,6 +451,11 @@ class AsyncSQLAlchemyMemory(MemoryBase):
             )
             self.session.add(message_record)
 
+        # Flush pending message inserts so that the foreign key constraint on
+        # message_mark.msg_id is satisfied when marks are inserted below.
+        if marks:
+            await self.session.flush()
+
         # Create mark records if marks are provided (use bulk insert)
         if marks:
             mark_records = [


### PR DESCRIPTION
Fixes #1395

## Problem
When `AsyncSQLAlchemyMemory.add()` is used with memory compression enabled, it stages message records via `session.add()` and then immediately calls `bulk_insert_mappings` for `message_mark` records. Because the message rows have not been flushed to the database at that point, the foreign key constraint on `message_mark.msg_id` (which references the `message` table) fails with:

```
sqlalchemy.exc.IntegrityError: ForeignKeyViolationError: insert or update on table "message_mark"
violates foreign key constraint "message_mark_msg_id_fkey"
```

## Solution
Add an explicit `await self.session.flush()` after all message records are staged but before the mark records are bulk-inserted. This ensures the parent rows exist in the database within the same transaction, satisfying the foreign key constraint.

## Testing
- Verified the fix addresses the root cause: `session.flush()` pushes pending INSERT statements to the DB without committing, making the rows visible for FK checks in the same transaction.
- The fix applies only when `marks` are provided (same condition as the bulk insert), so it has no effect on the common case with no marks.