### PR TITLE
feat(tool): add grep and glob search tools

### DIFF
--- a/src/agentscope/tool/__init__.py
+++ b/src/agentscope/tool/__init__.py
@@ -11,6 +11,10 @@ from ._text_file import (
     write_text_file,
     insert_text_file,
 )
+from ._search import (
+    grep_search,
+    glob_search,
+)
 from ._multi_modality import (
     dashscope_text_to_image,
     dashscope_text_to_audio,
@@ -32,6 +36,8 @@ __all__ = [
     "view_text_file",
     "write_text_file",
     "insert_text_file",
+    "grep_search",
+    "glob_search",
     "dashscope_text_to_image",
     "dashscope_text_to_audio",
     "dashscope_image_to_text",

--- a/src/agentscope/tool/_search/__init__.py
+++ b/src/agentscope/tool/_search/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+"""The search tools module in agentscope."""
+from ._grep import grep_search
+from ._glob import glob_search
+
+__all__ = [
+    "grep_search",
+    "glob_search",
+]

--- a/src/agentscope/tool/_search/_glob.py
+++ b/src/agentscope/tool/_search/_glob.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-# flake8: noqa: E501
-# pylint: disable=line-too-long
 """The glob search tool in agentscope."""
 import glob as glob_module
 import os
@@ -14,20 +12,50 @@ async def glob_search(
     directory: str = ".",
     max_results: int = 100,
 ) -> ToolResponse:
-    """Find files matching a glob pattern under the given directory. Supports recursive patterns with "**" (e.g. "**/*.py" to find all Python files recursively).
+    """Find files matching a glob pattern under the given directory.
+    Supports recursive patterns with "**" (e.g. "**/*.py" to find all
+    Python files recursively).
 
     Args:
         pattern (`str`):
-            The glob pattern to match files against (e.g. "*.py", "**/*.js", "src/**/*.ts").
+            The glob pattern to match files against (e.g. "*.py",
+            "**/*.js", "src/**/*.ts"). Must be a relative pattern —
+            absolute patterns and traversal sequences ("..") are
+            rejected.
         directory (`str`, defaults to `"."`):
-            The base directory to search in. Defaults to the current working directory.
+            The base directory to search in. Defaults to the current
+            working directory.
         max_results (`int`, defaults to `100`):
             The maximum number of file paths to return.
 
     Returns:
         `ToolResponse`:
-            The tool response containing the matching file paths or an error message.
+            The tool response containing the matching file paths or an
+            error message.
     """
+    # Reject absolute patterns and traversal sequences to prevent
+    # escaping the base directory.
+    if os.path.isabs(pattern):
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text="Error: pattern must be relative, not absolute.",
+                ),
+            ],
+        )
+
+    normalized = os.path.normpath(pattern)
+    if normalized.startswith(".."):
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text="Error: pattern must not traverse outside the base directory.",
+                ),
+            ],
+        )
+
     directory = os.path.expanduser(directory)
 
     if not os.path.exists(directory):
@@ -50,17 +78,11 @@ async def glob_search(
             ],
         )
 
-    # Construct the full search pattern
     full_pattern = os.path.join(directory, pattern)
-
-    # Determine if recursive search is needed
     recursive = "**" in pattern
 
     try:
-        matches = glob_module.glob(
-            full_pattern,
-            recursive=recursive,
-        )
+        matches = glob_module.glob(full_pattern, recursive=recursive)
     except Exception as e:
         return ToolResponse(
             content=[
@@ -74,10 +96,16 @@ async def glob_search(
     # Filter out directories — only return files
     file_matches = [m for m in matches if os.path.isfile(m)]
 
-    # Sort by modification time (most recent first)
-    file_matches.sort(key=lambda f: os.path.getmtime(f), reverse=True)
+    # Sort by modification time (most recent first); treat inaccessible
+    # files as oldest so they sort to the end rather than crashing.
+    def _mtime(path: str) -> float:
+        try:
+            return os.path.getmtime(path)
+        except OSError:
+            return 0.0
 
-    # Convert to relative paths
+    file_matches.sort(key=_mtime, reverse=True)
+
     rel_paths = [os.path.relpath(m, directory) for m in file_matches]
 
     total_found = len(rel_paths)
@@ -89,13 +117,11 @@ async def glob_search(
             content=[
                 TextBlock(
                     type="text",
-                    text=f"No files found matching pattern '{pattern}' "
-                    f"in {directory}.",
+                    text=f"No files found matching pattern '{pattern}' in {directory}.",
                 ),
             ],
         )
 
-    # Format output with file sizes
     output_lines = []
     for path in rel_paths:
         full_path = os.path.join(directory, path)
@@ -123,10 +149,11 @@ async def glob_search(
         content=[
             TextBlock(
                 type="text",
-                text=f"Found {total_found} files matching "
-                f"'{pattern}':\n"
-                + "\n".join(output_lines)
-                + truncated_msg,
+                text=(
+                    f"Found {total_found} files matching '{pattern}':\n"
+                    + "\n".join(output_lines)
+                    + truncated_msg
+                ),
             ),
         ],
     )

--- a/src/agentscope/tool/_search/_glob.py
+++ b/src/agentscope/tool/_search/_glob.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa: E501
+# pylint: disable=line-too-long
+"""The glob search tool in agentscope."""
+import glob as glob_module
+import os
+
+from .._response import ToolResponse
+from ...message import TextBlock
+
+
+async def glob_search(
+    pattern: str,
+    directory: str = ".",
+    max_results: int = 100,
+) -> ToolResponse:
+    """Find files matching a glob pattern under the given directory. Supports recursive patterns with "**" (e.g. "**/*.py" to find all Python files recursively).
+
+    Args:
+        pattern (`str`):
+            The glob pattern to match files against (e.g. "*.py", "**/*.js", "src/**/*.ts").
+        directory (`str`, defaults to `"."`):
+            The base directory to search in. Defaults to the current working directory.
+        max_results (`int`, defaults to `100`):
+            The maximum number of file paths to return.
+
+    Returns:
+        `ToolResponse`:
+            The tool response containing the matching file paths or an error message.
+    """
+    directory = os.path.expanduser(directory)
+
+    if not os.path.exists(directory):
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text=f"Error: The directory {directory} does not exist.",
+                ),
+            ],
+        )
+
+    if not os.path.isdir(directory):
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text=f"Error: The path {directory} is not a directory.",
+                ),
+            ],
+        )
+
+    # Construct the full search pattern
+    full_pattern = os.path.join(directory, pattern)
+
+    # Determine if recursive search is needed
+    recursive = "**" in pattern
+
+    try:
+        matches = glob_module.glob(
+            full_pattern,
+            recursive=recursive,
+        )
+    except Exception as e:
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text=f"Error: Failed to execute glob pattern: {e}",
+                ),
+            ],
+        )
+
+    # Filter out directories — only return files
+    file_matches = [m for m in matches if os.path.isfile(m)]
+
+    # Sort by modification time (most recent first)
+    file_matches.sort(key=lambda f: os.path.getmtime(f), reverse=True)
+
+    # Convert to relative paths
+    rel_paths = [os.path.relpath(m, directory) for m in file_matches]
+
+    total_found = len(rel_paths)
+    truncated = total_found > max_results
+    rel_paths = rel_paths[:max_results]
+
+    if not rel_paths:
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text=f"No files found matching pattern '{pattern}' "
+                    f"in {directory}.",
+                ),
+            ],
+        )
+
+    # Format output with file sizes
+    output_lines = []
+    for path in rel_paths:
+        full_path = os.path.join(directory, path)
+        try:
+            size = os.path.getsize(full_path)
+            if size < 1024:
+                size_str = f"{size}B"
+            elif size < 1024 * 1024:
+                size_str = f"{size / 1024:.1f}KB"
+            else:
+                size_str = f"{size / (1024 * 1024):.1f}MB"
+        except OSError:
+            size_str = "?"
+
+        output_lines.append(f"  {path} ({size_str})")
+
+    truncated_msg = ""
+    if truncated:
+        truncated_msg = (
+            f"\n(Showing {max_results} of {total_found} matches. "
+            "Use a more specific pattern to narrow down results.)"
+        )
+
+    return ToolResponse(
+        content=[
+            TextBlock(
+                type="text",
+                text=f"Found {total_found} files matching "
+                f"'{pattern}':\n"
+                + "\n".join(output_lines)
+                + truncated_msg,
+            ),
+        ],
+    )

--- a/src/agentscope/tool/_search/_grep.py
+++ b/src/agentscope/tool/_search/_grep.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa: E501
+# pylint: disable=line-too-long
+"""The grep search tool in agentscope."""
+import os
+import re
+
+from .._response import ToolResponse
+from ...message import TextBlock
+
+
+async def grep_search(
+    pattern: str,
+    directory: str = ".",
+    include: str | None = None,
+    case_sensitive: bool = True,
+    max_results: int = 50,
+    context_lines: int = 0,
+) -> ToolResponse:
+    """Search for a regex pattern in file contents under the given directory. Returns matching lines with file paths and line numbers.
+
+    Args:
+        pattern (`str`):
+            The regex pattern to search for in file contents.
+        directory (`str`, defaults to `"."`):
+            The directory to search in. Defaults to the current working directory.
+        include (`str | None`, defaults to `None`):
+            A glob pattern to filter files (e.g. "*.py", "*.js"). If not provided, all text files will be searched.
+        case_sensitive (`bool`, defaults to `True`):
+            Whether the search is case-sensitive.
+        max_results (`int`, defaults to `50`):
+            The maximum number of matching lines to return.
+        context_lines (`int`, defaults to `0`):
+            The number of context lines to show before and after each match.
+
+    Returns:
+        `ToolResponse`:
+            The tool response containing the matching lines or an error message.
+    """
+    directory = os.path.expanduser(directory)
+
+    if not os.path.exists(directory):
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text=f"Error: The directory {directory} does not exist.",
+                ),
+            ],
+        )
+
+    if not os.path.isdir(directory):
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text=f"Error: The path {directory} is not a directory.",
+                ),
+            ],
+        )
+
+    # Compile the regex pattern
+    flags = 0 if case_sensitive else re.IGNORECASE
+    try:
+        compiled_pattern = re.compile(pattern, flags)
+    except re.error as e:
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text=f"Error: Invalid regex pattern: {e}",
+                ),
+            ],
+        )
+
+    # Compile the include glob pattern if provided
+    include_pattern = include
+
+    # Binary file extensions to skip
+    binary_extensions = {
+        ".pyc", ".pyo", ".so", ".o", ".a", ".lib", ".dll", ".dylib",
+        ".exe", ".bin", ".dat", ".db", ".sqlite", ".sqlite3",
+        ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".ico", ".svg",
+        ".mp3", ".mp4", ".avi", ".mov", ".wav", ".flac",
+        ".zip", ".tar", ".gz", ".bz2", ".xz", ".7z", ".rar",
+        ".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
+        ".woff", ".woff2", ".ttf", ".eot",
+        ".class", ".jar", ".war",
+    }
+
+    results = []
+    files_searched = 0
+    total_matches = 0
+
+    for root, _dirs, files in os.walk(directory):
+        # Skip hidden directories and common non-code directories
+        rel_root = os.path.relpath(root, directory)
+        parts = rel_root.split(os.sep)
+        if any(
+            p.startswith(".") or p in ("node_modules", "__pycache__", "venv")
+            for p in parts
+            if p != "."
+        ):
+            continue
+
+        for filename in sorted(files):
+            if filename.startswith("."):
+                continue
+
+            # Check file extension
+            _, ext = os.path.splitext(filename)
+            if ext.lower() in binary_extensions:
+                continue
+
+            # Apply include filter
+            if include_pattern is not None:
+                import fnmatch
+
+                if not fnmatch.fnmatch(filename, include_pattern):
+                    continue
+
+            filepath = os.path.join(root, filename)
+            rel_path = os.path.relpath(filepath, directory)
+
+            try:
+                with open(filepath, "r", encoding="utf-8", errors="ignore") as f:
+                    lines = f.readlines()
+            except (OSError, PermissionError):
+                continue
+
+            files_searched += 1
+
+            # Find matching lines
+            match_indices = []
+            for i, line in enumerate(lines):
+                if compiled_pattern.search(line):
+                    match_indices.append(i)
+
+            for idx in match_indices:
+                if total_matches >= max_results:
+                    break
+
+                # Collect context lines
+                start = max(0, idx - context_lines)
+                end = min(len(lines), idx + context_lines + 1)
+
+                context_block = []
+                for i in range(start, end):
+                    prefix = ">" if i == idx else " "
+                    line_text = lines[i].rstrip("\n\r")
+                    context_block.append(
+                        f"{prefix} {i + 1:>5}: {line_text}",
+                    )
+
+                results.append(
+                    {
+                        "file": rel_path,
+                        "line": idx + 1,
+                        "context": "\n".join(context_block),
+                    },
+                )
+                total_matches += 1
+
+            if total_matches >= max_results:
+                break
+
+        if total_matches >= max_results:
+            break
+
+    if not results:
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text=f"No matches found for pattern '{pattern}' in "
+                    f"{directory} ({files_searched} files searched).",
+                ),
+            ],
+        )
+
+    # Format output
+    output_lines = []
+    for r in results:
+        output_lines.append(f"--- {r['file']}:{r['line']} ---")
+        output_lines.append(r["context"])
+
+    truncated_msg = ""
+    if total_matches >= max_results:
+        truncated_msg = (
+            f"\n(Results truncated at {max_results} matches. "
+            "Use a more specific pattern or include filter to narrow "
+            "down results.)"
+        )
+
+    return ToolResponse(
+        content=[
+            TextBlock(
+                type="text",
+                text=f"Found {total_matches} matches for pattern "
+                f"'{pattern}' in {files_searched} files:\n\n"
+                + "\n".join(output_lines)
+                + truncated_msg,
+            ),
+        ],
+    )

--- a/src/agentscope/tool/_search/_grep.py
+++ b/src/agentscope/tool/_search/_grep.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-# flake8: noqa: E501
-# pylint: disable=line-too-long
 """The grep search tool in agentscope."""
+import fnmatch
 import os
 import re
 
@@ -17,26 +16,51 @@ async def grep_search(
     max_results: int = 50,
     context_lines: int = 0,
 ) -> ToolResponse:
-    """Search for a regex pattern in file contents under the given directory. Returns matching lines with file paths and line numbers.
+    """Search for a regex pattern in file contents under the given
+    directory. Returns matching lines with file paths and line numbers.
 
     Args:
         pattern (`str`):
             The regex pattern to search for in file contents.
         directory (`str`, defaults to `"."`):
-            The directory to search in. Defaults to the current working directory.
+            The directory to search in. Defaults to the current
+            working directory.
         include (`str | None`, defaults to `None`):
-            A glob pattern to filter files (e.g. "*.py", "*.js"). If not provided, all text files will be searched.
+            A glob pattern to filter files (e.g. "*.py", "*.js").
+            If not provided, all text files will be searched.
         case_sensitive (`bool`, defaults to `True`):
             Whether the search is case-sensitive.
         max_results (`int`, defaults to `50`):
             The maximum number of matching lines to return.
         context_lines (`int`, defaults to `0`):
-            The number of context lines to show before and after each match.
+            The number of context lines to show before and after
+            each match.
 
     Returns:
         `ToolResponse`:
-            The tool response containing the matching lines or an error message.
+            The tool response containing the matching lines or an
+            error message.
     """
+    if max_results <= 0:
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text="Error: max_results must be greater than 0.",
+                ),
+            ],
+        )
+
+    if context_lines < 0:
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text="Error: context_lines must be 0 or greater.",
+                ),
+            ],
+        )
+
     directory = os.path.expanduser(directory)
 
     if not os.path.exists(directory):
@@ -73,7 +97,6 @@ async def grep_search(
             ],
         )
 
-    # Compile the include glob pattern if provided
     include_pattern = include
 
     # Binary file extensions to skip
@@ -88,34 +111,29 @@ async def grep_search(
         ".class", ".jar", ".war",
     }
 
+    _hidden_or_ignored = {"node_modules", "__pycache__", "venv"}
+
     results = []
     files_searched = 0
     total_matches = 0
 
-    for root, _dirs, files in os.walk(directory):
-        # Skip hidden directories and common non-code directories
-        rel_root = os.path.relpath(root, directory)
-        parts = rel_root.split(os.sep)
-        if any(
-            p.startswith(".") or p in ("node_modules", "__pycache__", "venv")
-            for p in parts
-            if p != "."
-        ):
-            continue
+    for root, dirs, files in os.walk(directory):
+        # Prune hidden directories and common non-code directories
+        # in-place so os.walk does not descend into them.
+        dirs[:] = [
+            d for d in dirs
+            if not d.startswith(".") and d not in _hidden_or_ignored
+        ]
 
         for filename in sorted(files):
             if filename.startswith("."):
                 continue
 
-            # Check file extension
             _, ext = os.path.splitext(filename)
             if ext.lower() in binary_extensions:
                 continue
 
-            # Apply include filter
             if include_pattern is not None:
-                import fnmatch
-
                 if not fnmatch.fnmatch(filename, include_pattern):
                     continue
 
@@ -130,7 +148,6 @@ async def grep_search(
 
             files_searched += 1
 
-            # Find matching lines
             match_indices = []
             for i, line in enumerate(lines):
                 if compiled_pattern.search(line):
@@ -140,7 +157,6 @@ async def grep_search(
                 if total_matches >= max_results:
                     break
 
-                # Collect context lines
                 start = max(0, idx - context_lines)
                 end = min(len(lines), idx + context_lines + 1)
 
@@ -148,9 +164,7 @@ async def grep_search(
                 for i in range(start, end):
                     prefix = ">" if i == idx else " "
                     line_text = lines[i].rstrip("\n\r")
-                    context_block.append(
-                        f"{prefix} {i + 1:>5}: {line_text}",
-                    )
+                    context_block.append(f"{prefix} {i + 1:>5}: {line_text}")
 
                 results.append(
                     {
@@ -172,13 +186,14 @@ async def grep_search(
             content=[
                 TextBlock(
                     type="text",
-                    text=f"No matches found for pattern '{pattern}' in "
-                    f"{directory} ({files_searched} files searched).",
+                    text=(
+                        f"No matches found for pattern '{pattern}' in "
+                        f"{directory} ({files_searched} files searched)."
+                    ),
                 ),
             ],
         )
 
-    # Format output
     output_lines = []
     for r in results:
         output_lines.append(f"--- {r['file']}:{r['line']} ---")
@@ -196,10 +211,12 @@ async def grep_search(
         content=[
             TextBlock(
                 type="text",
-                text=f"Found {total_matches} matches for pattern "
-                f"'{pattern}' in {files_searched} files:\n\n"
-                + "\n".join(output_lines)
-                + truncated_msg,
+                text=(
+                    f"Found {total_matches} matches for pattern "
+                    f"'{pattern}' in {files_searched} files:\n\n"
+                    + "\n".join(output_lines)
+                    + truncated_msg
+                ),
             ),
         ],
     )

--- a/tests/search_tool_test.py
+++ b/tests/search_tool_test.py
@@ -1,0 +1,333 @@
+# -*- coding: utf-8 -*-
+"""Tests for the grep and glob search tools."""
+import asyncio
+import os
+import tempfile
+import shutil
+import unittest
+
+from agentscope.tool._search import grep_search, glob_search
+
+
+class TestGrepSearch(unittest.TestCase):
+    """Test cases for the grep_search tool."""
+
+    def setUp(self) -> None:
+        """Set up a temporary directory with test files."""
+        self.test_dir = tempfile.mkdtemp()
+
+        # Create test files
+        self._write_file(
+            "main.py",
+            "import os\nimport sys\n\ndef main():\n"
+            "    print('hello world')\n\nif __name__ == '__main__':\n"
+            "    main()\n",
+        )
+        self._write_file(
+            "utils.py",
+            "def helper():\n    return 42\n\n"
+            "def another_helper():\n    return 'hello'\n",
+        )
+        self._write_file(
+            "config.json",
+            '{"name": "test", "version": "1.0"}\n',
+        )
+        os.makedirs(os.path.join(self.test_dir, "sub"), exist_ok=True)
+        self._write_file(
+            "sub/nested.py",
+            "# A nested file\nclass MyClass:\n"
+            "    def method(self):\n        pass\n",
+        )
+        # Create a hidden directory with a file (should be skipped)
+        os.makedirs(os.path.join(self.test_dir, ".hidden"), exist_ok=True)
+        self._write_file(
+            ".hidden/secret.py",
+            "SECRET_KEY = 'should_not_match'\n",
+        )
+
+    def tearDown(self) -> None:
+        """Clean up the temporary directory."""
+        shutil.rmtree(self.test_dir)
+
+    def _write_file(self, rel_path: str, content: str) -> None:
+        """Helper to write a file in the test directory."""
+        filepath = os.path.join(self.test_dir, rel_path)
+        os.makedirs(os.path.dirname(filepath), exist_ok=True)
+        with open(filepath, "w", encoding="utf-8") as f:
+            f.write(content)
+
+    def _run(self, coro):
+        """Helper to run an async function."""
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    def test_basic_search(self) -> None:
+        """Test searching for a simple pattern."""
+        result = self._run(
+            grep_search(pattern="hello", directory=self.test_dir),
+        )
+        text = result.content[0]["text"]
+        self.assertIn("hello", text)
+        self.assertIn("main.py", text)
+
+    def test_regex_pattern(self) -> None:
+        """Test searching with a regex pattern."""
+        result = self._run(
+            grep_search(pattern=r"def \w+\(", directory=self.test_dir),
+        )
+        text = result.content[0]["text"]
+        self.assertIn("def main(", text)
+        self.assertIn("def helper(", text)
+
+    def test_case_insensitive(self) -> None:
+        """Test case-insensitive search."""
+        result = self._run(
+            grep_search(
+                pattern="HELLO",
+                directory=self.test_dir,
+                case_sensitive=False,
+            ),
+        )
+        text = result.content[0]["text"]
+        self.assertIn("hello", text)
+
+    def test_include_filter(self) -> None:
+        """Test filtering files by extension."""
+        result = self._run(
+            grep_search(
+                pattern="test",
+                directory=self.test_dir,
+                include="*.json",
+            ),
+        )
+        text = result.content[0]["text"]
+        self.assertIn("config.json", text)
+        self.assertNotIn("main.py", text)
+
+    def test_no_matches(self) -> None:
+        """Test when no matches are found."""
+        result = self._run(
+            grep_search(
+                pattern="nonexistent_pattern_xyz",
+                directory=self.test_dir,
+            ),
+        )
+        text = result.content[0]["text"]
+        self.assertIn("No matches found", text)
+
+    def test_invalid_directory(self) -> None:
+        """Test with a non-existent directory."""
+        result = self._run(
+            grep_search(
+                pattern="test",
+                directory="/nonexistent/path",
+            ),
+        )
+        text = result.content[0]["text"]
+        self.assertIn("Error", text)
+        self.assertIn("does not exist", text)
+
+    def test_invalid_regex(self) -> None:
+        """Test with an invalid regex pattern."""
+        result = self._run(
+            grep_search(
+                pattern="[invalid",
+                directory=self.test_dir,
+            ),
+        )
+        text = result.content[0]["text"]
+        self.assertIn("Error", text)
+        self.assertIn("Invalid regex", text)
+
+    def test_context_lines(self) -> None:
+        """Test displaying context lines around matches."""
+        result = self._run(
+            grep_search(
+                pattern="def main",
+                directory=self.test_dir,
+                context_lines=1,
+            ),
+        )
+        text = result.content[0]["text"]
+        # Should show context lines before and after the match
+        self.assertIn("def main():", text)
+        self.assertIn("print", text)
+        # The line before (line 3) and line after (line 5) should be present
+        self.assertIn("3:", text)
+        self.assertIn("5:", text)
+
+    def test_max_results(self) -> None:
+        """Test result truncation with max_results."""
+        result = self._run(
+            grep_search(
+                pattern="def|import|return|class|pass",
+                directory=self.test_dir,
+                max_results=3,
+            ),
+        )
+        text = result.content[0]["text"]
+        self.assertIn("truncated", text.lower())
+
+    def test_nested_files(self) -> None:
+        """Test searching in nested directories."""
+        result = self._run(
+            grep_search(
+                pattern="MyClass",
+                directory=self.test_dir,
+            ),
+        )
+        text = result.content[0]["text"]
+        self.assertIn("sub/nested.py", text.replace("\\", "/"))
+
+    def test_skips_hidden_directories(self) -> None:
+        """Test that hidden directories are skipped."""
+        result = self._run(
+            grep_search(
+                pattern="SECRET_KEY",
+                directory=self.test_dir,
+            ),
+        )
+        text = result.content[0]["text"]
+        self.assertIn("No matches found", text)
+
+    def test_not_a_directory(self) -> None:
+        """Test with a file path instead of directory."""
+        filepath = os.path.join(self.test_dir, "main.py")
+        result = self._run(
+            grep_search(
+                pattern="test",
+                directory=filepath,
+            ),
+        )
+        text = result.content[0]["text"]
+        self.assertIn("Error", text)
+        self.assertIn("not a directory", text)
+
+
+class TestGlobSearch(unittest.TestCase):
+    """Test cases for the glob_search tool."""
+
+    def setUp(self) -> None:
+        """Set up a temporary directory with test files."""
+        self.test_dir = tempfile.mkdtemp()
+
+        # Create test files
+        for name in ["main.py", "utils.py", "config.json", "readme.md"]:
+            filepath = os.path.join(self.test_dir, name)
+            with open(filepath, "w", encoding="utf-8") as f:
+                f.write(f"# {name}\n")
+
+        # Create nested structure
+        sub_dir = os.path.join(self.test_dir, "src", "core")
+        os.makedirs(sub_dir, exist_ok=True)
+        for name in ["app.py", "models.py", "styles.css"]:
+            filepath = os.path.join(sub_dir, name)
+            with open(filepath, "w", encoding="utf-8") as f:
+                f.write(f"# {name}\n")
+
+    def tearDown(self) -> None:
+        """Clean up the temporary directory."""
+        shutil.rmtree(self.test_dir)
+
+    def _run(self, coro):
+        """Helper to run an async function."""
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    def test_basic_glob(self) -> None:
+        """Test finding files with a simple pattern."""
+        result = self._run(
+            glob_search(pattern="*.py", directory=self.test_dir),
+        )
+        text = result.content[0]["text"]
+        self.assertIn("main.py", text)
+        self.assertIn("utils.py", text)
+        self.assertNotIn("config.json", text)
+
+    def test_recursive_glob(self) -> None:
+        """Test recursive file finding with **."""
+        result = self._run(
+            glob_search(pattern="**/*.py", directory=self.test_dir),
+        )
+        text = result.content[0]["text"]
+        self.assertIn("main.py", text)
+        self.assertIn("app.py", text)
+        self.assertIn("models.py", text)
+
+    def test_specific_extension(self) -> None:
+        """Test finding files with a specific extension."""
+        result = self._run(
+            glob_search(pattern="*.json", directory=self.test_dir),
+        )
+        text = result.content[0]["text"]
+        self.assertIn("config.json", text)
+        self.assertNotIn(".py", text)
+
+    def test_no_matches(self) -> None:
+        """Test when no files match."""
+        result = self._run(
+            glob_search(pattern="*.xyz", directory=self.test_dir),
+        )
+        text = result.content[0]["text"]
+        self.assertIn("No files found", text)
+
+    def test_invalid_directory(self) -> None:
+        """Test with a non-existent directory."""
+        result = self._run(
+            glob_search(
+                pattern="*.py",
+                directory="/nonexistent/path",
+            ),
+        )
+        text = result.content[0]["text"]
+        self.assertIn("Error", text)
+        self.assertIn("does not exist", text)
+
+    def test_max_results(self) -> None:
+        """Test result truncation."""
+        result = self._run(
+            glob_search(
+                pattern="**/*",
+                directory=self.test_dir,
+                max_results=2,
+            ),
+        )
+        text = result.content[0]["text"]
+        self.assertIn("Showing 2", text)
+
+    def test_file_sizes_shown(self) -> None:
+        """Test that file sizes are displayed."""
+        result = self._run(
+            glob_search(pattern="*.py", directory=self.test_dir),
+        )
+        text = result.content[0]["text"]
+        # File sizes should be shown (e.g. "10B" or "1.2KB")
+        self.assertTrue(
+            "B)" in text or "KB)" in text,
+            f"Expected file size in output: {text}",
+        )
+
+    def test_not_a_directory(self) -> None:
+        """Test with a file path instead of directory."""
+        filepath = os.path.join(self.test_dir, "main.py")
+        result = self._run(
+            glob_search(pattern="*.py", directory=filepath),
+        )
+        text = result.content[0]["text"]
+        self.assertIn("Error", text)
+        self.assertIn("not a directory", text)
+
+    def test_nested_pattern(self) -> None:
+        """Test finding files in a specific subdirectory."""
+        result = self._run(
+            glob_search(
+                pattern="src/**/*.py",
+                directory=self.test_dir,
+            ),
+        )
+        text = result.content[0]["text"]
+        self.assertIn("app.py", text)
+        self.assertIn("models.py", text)
+        self.assertNotIn("main.py", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/search_tool_test.py
+++ b/tests/search_tool_test.py
@@ -6,7 +6,7 @@ import tempfile
 import shutil
 import unittest
 
-from agentscope.tool._search import grep_search, glob_search
+from agentscope.tool import grep_search, glob_search
 
 
 class TestGrepSearch(unittest.TestCase):
@@ -58,7 +58,7 @@ class TestGrepSearch(unittest.TestCase):
 
     def _run(self, coro):
         """Helper to run an async function."""
-        return asyncio.get_event_loop().run_until_complete(coro)
+        return asyncio.run(coro)
 
     def test_basic_search(self) -> None:
         """Test searching for a simple pattern."""
@@ -230,7 +230,7 @@ class TestGlobSearch(unittest.TestCase):
 
     def _run(self, coro):
         """Helper to run an async function."""
-        return asyncio.get_event_loop().run_until_complete(coro)
+        return asyncio.run(coro)
 
     def test_basic_glob(self) -> None:
         """Test finding files with a simple pattern."""


### PR DESCRIPTION
## Summary

This PR adds two new built-in search tools as requested in #1416:

- **`grep_search`**: Search file contents by regex pattern under a given directory. Supports case-insensitive search, file extension filtering (`include`), context lines display, result truncation, and automatically skips binary files, hidden directories, and common non-code directories (`node_modules`, `__pycache__`, `venv`).

- **`glob_search`**: Find files matching glob patterns (e.g. `**/*.py`) with recursive support. Returns matching file paths sorted by modification time with file size information.

Both tools follow the existing async `ToolResponse` pattern and use only Python stdlib modules (`os`, `re`, `glob`, `fnmatch`).

### Changes

- `src/agentscope/tool/_search/__init__.py` — new search tools module
- `src/agentscope/tool/_search/_grep.py` — grep search implementation
- `src/agentscope/tool/_search/_glob.py` — glob search implementation
- `src/agentscope/tool/__init__.py` — export new tools
- `tests/search_tool_test.py` — 21 test cases covering both tools

### Usage

```python
from agentscope.tool import grep_search, glob_search

# Search for a pattern in Python files
result = await grep_search(
    pattern=r"def \w+\(",
    directory="./src",
    include="*.py",
    context_lines=2,
)

# Find all Python files recursively
result = await glob_search(
    pattern="**/*.py",
    directory="./src",
)
```

## Test Plan

- [x] All 21 new test cases pass (`pytest tests/search_tool_test.py`)
- [x] Existing toolkit tests still pass (`pytest tests/toolkit_basic_test.py`)
- [x] flake8 passes on new files
- [x] Follows existing tool implementation patterns (async, ToolResponse, TextBlock)

Closes #1416 (partially — grep and glob tools portion)