### PR TITLE
fix(memory): flush session before inserting mark records to fix FK constraint error

### DIFF
--- a/src/agentscope/memory/_working_memory/_sqlalchemy_memory.py
+++ b/src/agentscope/memory/_working_memory/_sqlalchemy_memory.py
@@ -451,6 +451,11 @@ class AsyncSQLAlchemyMemory(MemoryBase):
             )
             self.session.add(message_record)
 
+        # Flush pending message inserts so foreign key constraints are
+        # satisfied when mark records reference them below.
+        if marks:
+            await self.session.flush()
+
         # Create mark records if marks are provided (use bulk insert)
         if marks:
             mark_records = [


### PR DESCRIPTION
Fixes #1380

## Problem

When using `structured_model` with marks in `AsyncSQLAlchemyMemory.add()`, a foreign key constraint violation occurs:

```
sqlalchemy.exc.PendingRollbackError: ... (pymysql.err.IntegrityError) (1452, 'Cannot add or update a child row: a foreign key constraint fails (message_mark, CONSTRAINT 1 FOREIGN KEY (msg_id) REFERENCES message (id) ON DELETE CASCADE)')
```

The root cause is a timing issue in `add()`:
1. `session.add(message_record)` only stages the message row in SQLAlchemy's unit-of-work (in-memory), without issuing an INSERT yet.
2. `session.bulk_insert_mappings()` immediately executes SQL to insert mark rows, referencing `msg_id` values that do not yet exist in the database.
3. The foreign key constraint fails at step 2 because the parent rows were never flushed.

## Solution

Add `await self.session.flush()` after staging the message records and before inserting the mark records. `flush()` sends the pending `INSERT` statements for the message rows to the database within the current transaction, making them visible to the subsequent `bulk_insert_mappings()` call without committing the transaction.

## Testing

The fix satisfies the foreign key constraint by ensuring parent rows exist in the database before child rows reference them. The existing `commit()` at the end of the method atomically finalizes both the messages and their marks.