### PR TITLE
fix(memory): flush async sqlalchemy messages before mark insert

### DIFF
--- a/src/agentscope/memory/_working_memory/_sqlalchemy_memory.py
+++ b/src/agentscope/memory/_working_memory/_sqlalchemy_memory.py
@@ -453,6 +453,13 @@ class AsyncSQLAlchemyMemory(MemoryBase):
 
         # Create mark records if marks are provided (use bulk insert)
         if marks:
+            # Bulk insert bypasses the ORM unit-of-work autoflush behavior. If
+            # callers provide an external AsyncSession with autoflush disabled,
+            # the pending message rows above may not be visible yet and the
+            # message_mark FK insert can fail. Flush first so parent message
+            # rows exist before any related marks are inserted.
+            await self.session.flush()
+
             mark_records = [
                 {"msg_id": self._make_message_id(msg.id), "mark": mark}
                 for msg in messages_to_add

--- a/tests/memory_compression_test.py
+++ b/tests/memory_compression_test.py
@@ -4,9 +4,15 @@
 from typing import Any
 from unittest import IsolatedAsyncioTestCase
 
+from pydantic import BaseModel, Field
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
 from agentscope.agent import ReActAgent
 from agentscope.formatter import FormatterBase
-from agentscope.message import Msg, TextBlock
+from agentscope.memory import AsyncSQLAlchemyMemory
+from agentscope.message import Msg, TextBlock, ToolUseBlock
 from agentscope.model import ChatModelBase, ChatResponse
 from agentscope.token import CharTokenCounter
 
@@ -83,8 +89,83 @@ class MockFormatter(FormatterBase):
         return [{"name": _.name, "content": _.content} for _ in msgs]
 
 
+class StructuredOutputRetryModel(ChatModelBase):
+    """A test model that exercises compression and hint-mark retries."""
+
+    def __init__(self) -> None:
+        """Initialize the test model."""
+        super().__init__(model_name="mock-structured-model", stream=False)
+        self.reasoning_calls = 0
+        self.compression_calls = 0
+
+    async def __call__(
+        self,
+        messages: list[dict],
+        **kwargs: Any,
+    ) -> ChatResponse:
+        """Return deterministic responses for compression and reasoning."""
+        structured_model = kwargs.get("structured_model")
+        if structured_model is not None and kwargs.get("tools") is None:
+            self.compression_calls += 1
+            return ChatResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text="Compression summary generated.",
+                    ),
+                ],
+                metadata={
+                    "task_overview": "Summarized task.",
+                    "current_state": "Compressed existing messages.",
+                    "important_discoveries": "External sessions may disable autoflush.",
+                    "next_steps": "Continue the structured reply.",
+                    "context_to_preserve": "Keep the latest message verbatim.",
+                },
+            )
+
+        self.reasoning_calls += 1
+        if self.reasoning_calls == 1:
+            return ChatResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text="Need one more structured-output pass.",
+                    ),
+                ],
+            )
+
+        return ChatResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text="Structured response is ready.",
+                ),
+                ToolUseBlock(
+                    type="tool_use",
+                    name="generate_response",
+                    id="generate-response-1",
+                    input={"result": "done"},
+                ),
+            ],
+        )
+
+
 class MemoryCompressionTest(IsolatedAsyncioTestCase):
     """The unittest for memory compression."""
+
+    @staticmethod
+    def _create_foreign_key_engine():
+        """Create an async SQLite engine with foreign key checks enabled."""
+        engine = create_async_engine(
+            url="sqlite+aiosqlite:///:memory:",
+            poolclass=StaticPool,
+        )
+
+        @event.listens_for(engine.sync_engine, "connect")
+        def _enable_foreign_keys(dbapi_connection, _connection_record):
+            dbapi_connection.execute("PRAGMA foreign_keys=ON")
+
+        return engine
 
     async def test_no_compression_below_threshold(self) -> None:
         """Test that compression is NOT triggered when memory is below
@@ -251,3 +332,90 @@ N/A</system-info>"""
             model.received_messages,
             expected_received_messages,
         )
+
+    async def test_compression_with_external_no_autoflush_memory_session(
+        self,
+    ) -> None:
+        """Compression and structured-output retries should work with external sessions.
+
+        This covers the production path from the issue report:
+        1. Existing messages trigger compression.
+        2. Compression marks older messages as compressed.
+        3. The first reasoning pass adds a hint message with a mark.
+        4. The caller-provided AsyncSession disables autoflush.
+
+        Without flushing the pending message rows before bulk-inserting marks,
+        the hint-message insertion can violate the message_mark foreign key.
+        """
+
+        class StructuredResult(BaseModel):
+            """Structured output schema used by the regression test."""
+
+            result: str = Field(description="The final structured result.")
+
+        engine = self._create_foreign_key_engine()
+        session_factory = async_sessionmaker(
+            bind=engine,
+            expire_on_commit=False,
+            autoflush=False,
+        )
+
+        async with session_factory() as session:
+            memory = AsyncSQLAlchemyMemory(
+                session_id="compression-session",
+                user_id="compression-user",
+                engine_or_session=session,
+            )
+            model = StructuredOutputRetryModel()
+            agent = ReActAgent(
+                name="Friday",
+                sys_prompt="You are a helpful assistant.",
+                model=model,
+                formatter=MockFormatter(),
+                memory=memory,
+                compression_config=ReActAgent.CompressionConfig(
+                    enable=True,
+                    trigger_threshold=100,
+                    agent_token_counter=CharTokenCounter(),
+                    keep_recent=1,
+                ),
+            )
+
+            msgs = [
+                Msg("user", "Task kickoff", "user"),
+                Msg("assistant", "This is a long assistant note " * 60, "assistant"),
+                Msg("user", "Please continue from here.", "user"),
+            ]
+            for idx, msg in enumerate(msgs):
+                msg.id = f"seed-{idx}"
+
+            reply = await agent(msgs, structured_model=StructuredResult)
+
+            self.assertEqual(reply.metadata, {"result": "done"})
+            self.assertTrue(agent.memory._compressed_summary)
+            self.assertGreaterEqual(model.compression_calls, 1)
+            self.assertEqual(model.reasoning_calls, 2)
+
+            compressed_msgs = await memory.get_memory(
+                mark="compressed",
+                prepend_summary=False,
+            )
+            hint_msgs = await memory.get_memory(
+                mark="hint",
+                prepend_summary=False,
+            )
+            persisted_msgs = await memory.get_memory(prepend_summary=False)
+
+            self.assertTrue(
+                {"seed-0", "seed-1", "seed-2"}.issubset(
+                    {_.id for _ in compressed_msgs},
+                ),
+            )
+            self.assertEqual(hint_msgs, [])
+            self.assertGreaterEqual(len(persisted_msgs), 6)
+            self.assertEqual(
+                [_.id for _ in persisted_msgs[:3]],
+                ["seed-0", "seed-1", "seed-2"],
+            )
+
+        await engine.dispose()

--- a/tests/memory_test.py
+++ b/tests/memory_test.py
@@ -3,7 +3,9 @@
 import asyncio
 from unittest.async_case import IsolatedAsyncioTestCase
 
-from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
 
 from agentscope.memory import (
     MemoryBase,
@@ -638,6 +640,129 @@ class AsyncSQLAlchemyMemoryTest(ShortTermMemoryTest):
         await self._multi_tenant_tests()
         await self._multi_session_tests()
         await self._test_serialization()
+
+    async def test_add_with_marks_under_foreign_key_enforcement(self) -> None:
+        """Adding messages with marks should work when message FK checks are enforced."""
+        await self.memory.get_memory()
+        engine = self._create_foreign_key_engine()
+        memory = AsyncSQLAlchemyMemory(
+            session_id="session_fk_1",
+            user_id="user_fk_1",
+            engine_or_session=engine,
+        )
+
+        msg = Msg("user", "foreign-key-safe", "user")
+        msg.id = "foreign-key-safe"
+
+        await memory.add(msg, marks="hint")
+
+        all_msgs = await memory.get_memory()
+        hint_msgs = await memory.get_memory(mark="hint")
+
+        self.assertEqual([_.id for _ in all_msgs], ["foreign-key-safe"])
+        self.assertEqual([_.id for _ in hint_msgs], ["foreign-key-safe"])
+
+        await engine.dispose()
+
+    async def test_add_multiple_messages_with_multiple_marks_under_foreign_keys(
+        self,
+    ) -> None:
+        """Bulk mark insertion should preserve all message-mark rows under FK enforcement."""
+        await self.memory.get_memory()
+        engine = self._create_foreign_key_engine()
+        memory = AsyncSQLAlchemyMemory(
+            session_id="session_fk_2",
+            user_id="user_fk_2",
+            engine_or_session=engine,
+        )
+
+        msgs = [
+            Msg("user", "first", "user"),
+            Msg("assistant", "second", "assistant"),
+            Msg("system", "third", "system"),
+        ]
+        for idx, msg in enumerate(msgs):
+            msg.id = str(idx)
+
+        await memory.add(msgs, marks=["important", "todo"])
+
+        important_msgs = await memory.get_memory(mark="important")
+        todo_msgs = await memory.get_memory(mark="todo")
+
+        self.assertEqual([_.id for _ in important_msgs], ["0", "1", "2"])
+        self.assertEqual([_.id for _ in todo_msgs], ["0", "1", "2"])
+
+        await engine.dispose()
+
+    async def test_skip_duplicated_messages_with_marks_under_foreign_keys(
+        self,
+    ) -> None:
+        """Duplicate-skipping path should still insert marks safely under FK enforcement."""
+        await self.memory.get_memory()
+        engine = self._create_foreign_key_engine()
+        memory = AsyncSQLAlchemyMemory(
+            session_id="session_fk_3",
+            user_id="user_fk_3",
+            engine_or_session=engine,
+        )
+
+        msgs = [Msg("user", "first", "user"), Msg("assistant", "second", "assistant")]
+        for idx, msg in enumerate(msgs):
+            msg.id = str(idx)
+
+        await memory.add(msgs, marks="hint")
+        await memory.add(msgs, marks="hint", skip_duplicated=True)
+
+        all_msgs = await memory.get_memory()
+        hint_msgs = await memory.get_memory(mark="hint")
+
+        self.assertEqual([_.id for _ in all_msgs], ["0", "1"])
+        self.assertEqual([_.id for _ in hint_msgs], ["0", "1"])
+
+        await engine.dispose()
+
+    async def test_add_with_marks_using_external_no_autoflush_session(
+        self,
+    ) -> None:
+        """Message rows must be flushed before marks when the caller disables autoflush."""
+        await self.memory.get_memory()
+        engine = self._create_foreign_key_engine()
+        session_factory = async_sessionmaker(
+            bind=engine,
+            expire_on_commit=False,
+            autoflush=False,
+        )
+
+        async with session_factory() as session:
+            memory = AsyncSQLAlchemyMemory(
+                session_id="session_fk_4",
+                user_id="user_fk_4",
+                engine_or_session=session,
+            )
+
+            msg = Msg("user", "no-autoflush", "user")
+            msg.id = "no-autoflush"
+
+            await memory.add(msg, marks="hint")
+
+            hint_msgs = await memory.get_memory(mark="hint")
+            self.assertEqual([_.id for _ in hint_msgs], ["no-autoflush"])
+
+        await engine.dispose()
+
+    @staticmethod
+    def _create_foreign_key_engine():
+        """Create an async SQLite engine with foreign key checks enabled."""
+        engine = create_async_engine(
+            url="sqlite+aiosqlite:///:memory:",
+            poolclass=StaticPool,
+        )
+
+        @event.listens_for(engine.sync_engine, "connect")
+        def _enable_foreign_keys(dbapi_connection, _connection_record):
+            dbapi_connection.execute("PRAGMA foreign_keys=ON")
+
+        return engine
 
     async def asyncTearDown(self) -> None:
         """Clean up after unittests"""


### PR DESCRIPTION
## Summary
- flush pending async SQLAlchemy message rows before bulk-inserting message marks
- add foreign-key regression coverage for direct memory writes and caller-managed async sessions with `autoflush=False`
- add a `ReActAgent` compression regression that exercises compression, hint marks, and structured-output retries end to end

## Why this fix
`AsyncSQLAlchemyMemory.add()` stages new `message` rows through the ORM and then inserts `message_mark` rows via `bulk_insert_mappings()`. When callers provide an external `AsyncSession` with `autoflush=False`, that bulk insert bypasses ORM autoflush, so the parent `message` rows may not exist yet and the mark insert can fail with a foreign-key error.

This change flushes pending message rows before the bulk mark insert and adds regression coverage around the failing path.

## Validation
- `python -m pytest tests/memory_test.py tests/memory_compression_test.py -q`

Fixes #1395