### PR TITLE
fix(agent): add missing await on memory.add in DeepResearchAgent._summarizing

### DIFF
--- a/examples/agent/deep_research_agent/deep_research_agent.py
+++ b/examples/agent/deep_research_agent/deep_research_agent.py
@@ -970,7 +970,7 @@ class DeepResearchAgent(ReActAgent):
                 ensure_ascii=False,
             ),
         )
-        self.memory.add(summarize_result)
+        await self.memory.add(summarize_result)
         return summarize_result
 
     async def reflect_failure(self) -> ToolResponse:


### PR DESCRIPTION
## Description

In `DeepResearchAgent._summarizing()`, the call to `self.memory.add()` at line 973 is missing the `await` keyword. All other calls to `self.memory.add()` in this file correctly use `await` (lines 229, 273, 288, 358, 404, 422).

Without `await`, the coroutine is never executed, causing:
- `RuntimeWarning: coroutine 'MemoryBase.add' was never awaited`
- The summarization result is not stored in memory

## Changes

Add `await` to the `self.memory.add(summarize_result)` call in `_summarizing()`.

## Checklist

- [x] Pre-commit hooks pass
- [x] Verified all other memory.add calls in the file use await