### PR TITLE
fix(agent): guard DeepResearchAgent tool metadata access

### DIFF
--- a/examples/agent/deep_research_agent/deep_research_agent.py
+++ b/examples/agent/deep_research_agent/deep_research_agent.py
@@ -329,6 +329,10 @@ class DeepResearchAgent(ReActAgent):
 
             # Async generator handling
             async for chunk in tool_res:
+                chunk_metadata = (
+                    chunk.metadata if isinstance(chunk.metadata, dict) else {}
+                )
+
                 # Turn into a tool result block
                 tool_res_msg.content[0][  # type: ignore[index]
                     "output"
@@ -338,19 +342,19 @@ class DeepResearchAgent(ReActAgent):
                 if (
                     tool_call["name"] != self.finish_function_name
                     or tool_call["name"] == self.finish_function_name
-                    and not chunk.metadata.get("success")
+                    and not chunk_metadata.get("success")
                 ):
                     await self.print(tool_res_msg, chunk.is_last)
 
                 # Return message if generate_response is called successfully
                 if tool_call[
                     "name"
-                ] == self.finish_function_name and chunk.metadata.get(
+                ] == self.finish_function_name and chunk_metadata.get(
                     "success",
                     True,
                 ):
                     if len(self.current_subtask) == 0:
-                        return chunk.metadata.get("response_msg")
+                        return chunk_metadata.get("response_msg")
 
                 # Summarize intermediate results into a draft report
                 elif tool_call["name"] == self.summarize_function:
@@ -379,11 +383,11 @@ class DeepResearchAgent(ReActAgent):
                     )
 
                 # Update memory when an intermediate report is generated
-                if isinstance(chunk.metadata, dict) and chunk.metadata.get(
+                if chunk_metadata.get(
                     "update_memory",
                 ):
                     update_memory = True
-                    intermediate_report = chunk.metadata.get(
+                    intermediate_report = chunk_metadata.get(
                         "intermediate_report",
                     )
             return None


### PR DESCRIPTION

## AgentScope Version

`1.0.19dev`

## Description

### Background

`DeepResearchAgent._acting()` accessed `chunk.metadata.get(...)` directly when handling tool results from the finish tool path.

However, `ToolResponse.metadata` is allowed to be `None`. If the finish tool fails before setting metadata, the toolkit may return a `ToolResponse` with `metadata=None`, which causes a secondary crash:

```text
AttributeError: 'NoneType' object has no attribute 'get'
```

This masks the original tool error and breaks the Deep Research example flow.

### Purpose

Make `DeepResearchAgent` handle tool responses safely and consistently with the core `ReActAgent` behavior.

### Changes Made

- Guarded `chunk.metadata` access in `examples/agent/deep_research_agent/deep_research_agent.py`
- Normalized non-dict metadata to an empty dict before reading fields such as:
  - `success`
  - `response_msg`
  - `update_memory`
  - `intermediate_report`

### How to Test

1. Run static checks on the changed file:
   ```bash
   uv run --no-sync pre-commit run --files examples/agent/deep_research_agent/deep_research_agent.py
   ```

2. Run the Deep Research example with valid `DASHSCOPE_API_KEY` and `TAVILY_API_KEY`:
   ```bash
   cd examples/agent/deep_research_agent
   python main.py
   ```

3. Verify that the example completes normally for a standard query.

4. Verify that if a finish-tool error occurs, the agent no longer crashes with:
   ```text
   AttributeError: 'NoneType' object has no attribute 'get'
   ```

## Checklist

- [ ] Code has been formatted with `pre-commit run --all-files` command
- [ ] All tests are passing
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review

Fixes #1476.