### PR TITLE
ci(message): build tests for the message module

### DIFF
--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -521,14 +521,10 @@ class MessageTest(IsolatedAsyncioTestCase):
                 HintBlock(hint="h"),
             ],
         )
-        block_types = ["text", "hint"]
-        blocks = list(
-            msg.get_content_blocks(
-                block_types,
-            ),  # type: ignore[arg-type]
-        )
-        self.assertEqual(len(blocks), 2)
-        types = {b.type for b in blocks}
+        text_blocks = msg.get_content_blocks("text")
+        hint_blocks = msg.get_content_blocks("hint")
+        self.assertEqual(len(text_blocks) + len(hint_blocks), 2)
+        types = {b.type for b in list(text_blocks) + list(hint_blocks)}
         self.assertSetEqual(types, {"text", "hint"})
 
         # Empty list when no block matches the type

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -1,36 +1,34 @@
 # -*- coding: utf-8 -*-
-"""Test cases for the message module."""
-
+"""A template test case."""
 import json
 from unittest.async_case import IsolatedAsyncioTestCase
 from utils import AnyString
 
-from pydantic import AnyUrl
-
 from agentscope.message import (
     UserMsg,
-    AssistantMsg,
-    SystemMsg,
-    Msg,
     TextBlock,
-    ThinkingBlock,
-    HintBlock,
     DataBlock,
-    ToolCallBlock,
-    ToolResultBlock,
     URLSource,
     Base64Source,
+    ThinkingBlock,
+    AssistantMsg,
+    SystemMsg,
+    HintBlock,
+    Msg,
+    ToolCallBlock,
+    ToolResultBlock,
 )
 
 
-class UserMsgCreationTest(IsolatedAsyncioTestCase):
-    """Test cases for UserMsg creation with various content types."""
+class MessageTest(IsolatedAsyncioTestCase):
+    """The template test case."""
 
-    async def test_string_content(self) -> None:
-        """UserMsg with plain string content."""
-        msg = UserMsg(name="user", content="hello world")
+    async def test_creating_message(self) -> None:
+        """The template test."""
+        # Test string content
+        user_msg = UserMsg(name="user", content="hello world")
         self.assertDictEqual(
-            msg.model_dump(),
+            user_msg.model_dump(),
             {
                 "id": AnyString(),
                 "name": "user",
@@ -41,20 +39,13 @@ class UserMsgCreationTest(IsolatedAsyncioTestCase):
             },
         )
 
-    async def test_empty_string_content(self) -> None:
-        """Empty string is still valid content."""
-        msg = UserMsg(name="user", content="")
-        self.assertEqual(msg.content, "")
-        self.assertEqual(msg.role, "user")
-
-    async def test_text_blocks(self) -> None:
-        """UserMsg with a list of TextBlocks."""
-        msg = UserMsg(
+        # Test list of content
+        user_msg = UserMsg(
             name="user",
             content=[TextBlock(text="1"), TextBlock(text="2")],
         )
         self.assertDictEqual(
-            msg.model_dump(),
+            user_msg.model_dump(),
             {
                 "id": AnyString(),
                 "name": "user",
@@ -68,118 +59,61 @@ class UserMsgCreationTest(IsolatedAsyncioTestCase):
             },
         )
 
-    async def test_url_data_block(self) -> None:
-        """UserMsg with a DataBlock using URLSource."""
-        msg = UserMsg(
+        # Test DataBlock content
+        user_msg = UserMsg(
             name="user",
             content=[
-                TextBlock(text="describe this"),
+                TextBlock(text="1"),
                 DataBlock(
                     source=URLSource(
-                        url=AnyUrl(
-                            "https://example.com/image.png",
-                        ),
+                        url="https://example.com/image.png",
                         media_type="image/png",
                     ),
                 ),
-            ],
-        )
-        dumped = msg.model_dump()
-        self.assertEqual(dumped["content"][1]["type"], "data")
-        self.assertEqual(
-            dumped["content"][1]["source"]["url"],
-            "https://example.com/image.png",
-        )
-        self.assertEqual(
-            dumped["content"][1]["source"]["media_type"],
-            "image/png",
-        )
-
-    async def test_base64_data_block(self) -> None:
-        """DataBlock with Base64Source stores data correctly."""
-        b64_data = "iVBORw0KGgoAAAANSUhEUgAAAAUA"
-        msg = UserMsg(
-            name="user",
-            content=[
                 DataBlock(
                     source=Base64Source(
-                        data=b64_data,
+                        data="iVBORw0KGgoAAAANSUhEUgAAAAUA",
                         media_type="image/png",
                     ),
                 ),
             ],
         )
-        dumped = msg.model_dump()
-        self.assertEqual(
-            dumped["content"][0]["source"]["data"],
-            b64_data,
+
+        self.assertDictEqual(
+            user_msg.model_dump(),
+            {
+                "id": AnyString(),
+                "name": "user",
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "1", "id": AnyString()},
+                    {
+                        "type": "data",
+                        "id": AnyString(),
+                        "source": {
+                            "type": "url",
+                            "url": "https://example.com/image.png",
+                            "media_type": "image/png",
+                        },
+                        "name": None,
+                    },
+                    {
+                        "type": "data",
+                        "id": AnyString(),
+                        "source": {
+                            "type": "base64",
+                            "data": "iVBORw0KGgoAAAANSUhEUgAAAAUA",
+                            "media_type": "image/png",
+                        },
+                        "name": None,
+                    },
+                ],
+                "metadata": {},
+                "created_at": AnyString(),
+            },
         )
-        self.assertEqual(
-            dumped["content"][0]["source"]["type"],
-            "base64",
-        )
 
-    async def test_named_data_block(self) -> None:
-        """DataBlock optional name field is preserved."""
-        msg = UserMsg(
-            name="user",
-            content=[
-                DataBlock(
-                    name="screenshot",
-                    source=Base64Source(
-                        data="abc",
-                        media_type="image/png",
-                    ),
-                ),
-            ],
-        )
-        self.assertEqual(
-            msg.model_dump()["content"][0]["name"],
-            "screenshot",
-        )
-
-    async def test_data_block_name_defaults_to_none(self) -> None:
-        """DataBlock name is None when not provided."""
-        msg = UserMsg(
-            name="user",
-            content=[
-                DataBlock(
-                    source=Base64Source(
-                        data="abc",
-                        media_type="image/png",
-                    ),
-                ),
-            ],
-        )
-        self.assertIsNone(msg.model_dump()["content"][0]["name"])
-
-    async def test_metadata(self) -> None:
-        """Metadata dict is stored and accessible."""
-        msg = UserMsg(
-            name="user",
-            content="hi",
-            metadata={"session_id": "abc123"},
-        )
-        self.assertEqual(msg.metadata, {"session_id": "abc123"})
-
-    async def test_custom_created_at(self) -> None:
-        """Custom created_at timestamp is preserved."""
-        ts = "2024-01-01T00:00:00"
-        msg = UserMsg(name="user", content="hi", created_at=ts)
-        self.assertEqual(msg.created_at, ts)
-
-
-class AssistantMsgCreationTest(IsolatedAsyncioTestCase):
-    """Test cases for AssistantMsg creation with various block types."""
-
-    async def test_string_content(self) -> None:
-        """AssistantMsg with plain string content."""
-        msg = AssistantMsg(name="bot", content="hello")
-        self.assertEqual(msg.role, "assistant")
-        self.assertEqual(msg.content, "hello")
-
-    async def test_thinking_block(self) -> None:
-        """ThinkingBlock is only allowed in assistant messages."""
+        # Test thinking content
         msg = AssistantMsg(
             name="assistant",
             content=[ThinkingBlock(thinking="thinking...")],
@@ -202,18 +136,175 @@ class AssistantMsgCreationTest(IsolatedAsyncioTestCase):
             },
         )
 
-    async def test_hint_block(self) -> None:
-        """AssistantMsg with HintBlock."""
+        # Test hint content
         msg = AssistantMsg(
             name="assistant",
             content=[HintBlock(hint="hint...")],
         )
-        dumped = msg.model_dump()
-        self.assertEqual(dumped["content"][0]["type"], "hint")
-        self.assertEqual(dumped["content"][0]["hint"], "hint...")
+        self.assertDictEqual(
+            msg.model_dump(),
+            {
+                "id": AnyString(),
+                "name": "assistant",
+                "role": "assistant",
+                "content": [
+                    {"type": "hint", "hint": "hint...", "id": AnyString()},
+                ],
+                "metadata": {},
+                "created_at": AnyString(),
+            },
+        )
 
-    async def test_tool_call_block(self) -> None:
-        """ToolCallBlock defaults await_user_confirmation to False."""
+    async def test_invalid_message(self) -> None:
+        """Test invalid message creation."""
+        # User message with thinking block should raise ValueError
+        with self.assertRaises(ValueError):
+            Msg(
+                name="user",
+                role="user",
+                content=[ThinkingBlock(thinking="thinking...")],
+            )
+
+        # User message with hint block should raise ValueError
+        with self.assertRaises(ValueError):
+            Msg(
+                name="user",
+                role="user",
+                content=[HintBlock(hint="hint...")],
+            )
+
+        # User message with tool call block should raise ValueError
+        with self.assertRaises(ValueError):
+            Msg(
+                name="user",
+                role="user",
+                content=[ToolCallBlock(id="1", name="tool", input="{}")],
+            )
+
+        # User message with tool result block should raise ValueError
+        with self.assertRaises(ValueError):
+            Msg(
+                name="user",
+                role="user",
+                content=[
+                    ToolResultBlock(
+                        id="1",
+                        name="tool",
+                        output="result",
+                        state="success",
+                    ),
+                ],
+            )
+
+        # System message with data block should raise ValueError
+        with self.assertRaises(ValueError):
+            Msg(
+                name="system",
+                role="system",
+                content=[
+                    DataBlock(
+                        source=URLSource(
+                            url="https://example.com/image.png",
+                            media_type="image/png",
+                        ),
+                    ),
+                ],
+            )
+
+        # System message with thinking block should raise ValueError
+        with self.assertRaises(ValueError):
+            Msg(
+                name="system",
+                role="system",
+                content=[ThinkingBlock(thinking="thinking...")],
+            )
+
+        # System message with hint block should raise ValueError
+        with self.assertRaises(ValueError):
+            Msg(
+                name="system",
+                role="system",
+                content=[HintBlock(hint="hint...")],
+            )
+
+        # System message with tool call block should raise ValueError
+        with self.assertRaises(ValueError):
+            Msg(
+                name="system",
+                role="system",
+                content=[ToolCallBlock(id="1", name="tool", input="{}")],
+            )
+
+        # System message with tool result block should raise ValueError
+        with self.assertRaises(ValueError):
+            Msg(
+                name="system",
+                role="system",
+                content=[
+                    ToolResultBlock(
+                        id="1",
+                        name="tool",
+                        output="result",
+                        state="success",
+                    ),
+                ],
+            )
+
+    async def test_user_msg_edge_cases(self) -> None:
+        """Test UserMsg edge cases not covered by the template."""
+        # Empty string is still valid content
+        msg = UserMsg(name="user", content="")
+        self.assertEqual(msg.content, "")
+        self.assertEqual(msg.role, "user")
+
+        # DataBlock with named field
+        msg = UserMsg(
+            name="user",
+            content=[
+                DataBlock(
+                    name="screenshot",
+                    source=Base64Source(
+                        data="abc",
+                        media_type="image/png",
+                    ),
+                ),
+            ],
+        )
+        self.assertEqual(
+            msg.model_dump()["content"][0]["name"],
+            "screenshot",
+        )
+
+        # DataBlock name defaults to None
+        msg = UserMsg(
+            name="user",
+            content=[
+                DataBlock(
+                    source=Base64Source(
+                        data="abc",
+                        media_type="image/png",
+                    ),
+                ),
+            ],
+        )
+        self.assertIsNone(msg.model_dump()["content"][0]["name"])
+
+        # Custom metadata
+        msg = UserMsg(
+            name="user",
+            content="hi",
+            metadata={"session_id": "abc123"},
+        )
+        self.assertEqual(msg.metadata, {"session_id": "abc123"})
+
+        # Custom created_at timestamp
+        ts = "2024-01-01T00:00:00"
+        msg = UserMsg(name="user", content="hi", created_at=ts)
+        self.assertEqual(msg.created_at, ts)
+
+    async def test_assistant_msg_blocks(self) -> None:
+        """Test AssistantMsg with tool call and tool result blocks."""
+        # ToolCallBlock defaults await_user_confirmation to False
         msg = AssistantMsg(
             name="assistant",
             content=[
@@ -229,8 +320,7 @@ class AssistantMsgCreationTest(IsolatedAsyncioTestCase):
         self.assertEqual(block["name"], "get_weather")
         self.assertFalse(block["await_user_confirmation"])
 
-    async def test_tool_call_block_with_confirmation(self) -> None:
-        """ToolCallBlock with await_user_confirmation set to True."""
+        # ToolCallBlock with await_user_confirmation enabled
         msg = AssistantMsg(
             name="assistant",
             content=[
@@ -245,8 +335,7 @@ class AssistantMsgCreationTest(IsolatedAsyncioTestCase):
         block = msg.model_dump()["content"][0]
         self.assertTrue(block["await_user_confirmation"])
 
-    async def test_tool_result_string_output(self) -> None:
-        """ToolResultBlock with string output."""
+        # ToolResultBlock with string output
         msg = AssistantMsg(
             name="assistant",
             content=[
@@ -263,8 +352,7 @@ class AssistantMsgCreationTest(IsolatedAsyncioTestCase):
         self.assertEqual(block["state"], "success")
         self.assertEqual(block["output"], "sunny")
 
-    async def test_tool_result_list_output(self) -> None:
-        """ToolResultBlock output can be a list of blocks."""
+        # ToolResultBlock with list output
         msg = AssistantMsg(
             name="assistant",
             content=[
@@ -289,14 +377,8 @@ class AssistantMsgCreationTest(IsolatedAsyncioTestCase):
         self.assertEqual(output[0]["type"], "text")
         self.assertEqual(output[1]["type"], "data")
 
-    async def test_all_tool_result_states(self) -> None:
-        """ToolResultBlock supports all four execution states."""
-        for state in (
-            "success",
-            "error",
-            "interrupted",
-            "running",
-        ):
+        # ToolResultBlock supports all four execution states
+        for state in ("success", "error", "interrupted", "running"):
             msg = AssistantMsg(
                 name="assistant",
                 content=[
@@ -313,8 +395,7 @@ class AssistantMsgCreationTest(IsolatedAsyncioTestCase):
                 state,
             )
 
-    async def test_mixed_blocks(self) -> None:
-        """Thinking + text + tool_call in one assistant message."""
+        # Mixed blocks in one assistant message
         msg = AssistantMsg(
             name="assistant",
             content=[
@@ -323,18 +404,17 @@ class AssistantMsgCreationTest(IsolatedAsyncioTestCase):
                 ToolCallBlock(id="c1", name="calc", input="{}"),
             ],
         )
-        types = [b["type"] for b in msg.model_dump()["content"]]
+        types = [
+            b["type"] for b in msg.model_dump()["content"]
+        ]
         self.assertEqual(
             types,
             ["thinking", "text", "tool_call"],
         )
 
-
-class SystemMsgCreationTest(IsolatedAsyncioTestCase):
-    """Test cases for SystemMsg creation."""
-
-    async def test_string_content(self) -> None:
-        """SystemMsg with plain string content."""
+    async def test_system_msg_creation(self) -> None:
+        """Test SystemMsg creation with various content types."""
+        # String content
         msg = SystemMsg(
             name="system",
             content="You are a helpful assistant.",
@@ -345,8 +425,7 @@ class SystemMsgCreationTest(IsolatedAsyncioTestCase):
             "You are a helpful assistant.",
         )
 
-    async def test_text_block(self) -> None:
-        """SystemMsg can contain a list of TextBlocks."""
+        # TextBlock content
         msg = SystemMsg(
             name="system",
             content=[TextBlock(text="Be concise.")],
@@ -356,157 +435,13 @@ class SystemMsgCreationTest(IsolatedAsyncioTestCase):
             "text",
         )
 
-
-class UserMsgValidationTest(IsolatedAsyncioTestCase):
-    """User messages can only contain text and data blocks.
-    Anything else should raise ValueError."""
-
-    async def test_rejects_thinking_block(self) -> None:
-        """ThinkingBlock in user msg raises ValueError."""
-        with self.assertRaises(ValueError):
-            Msg(
-                name="user",
-                role="user",
-                content=[ThinkingBlock(thinking="thinking...")],
-            )
-
-    async def test_rejects_hint_block(self) -> None:
-        """HintBlock in user msg raises ValueError."""
-        with self.assertRaises(ValueError):
-            Msg(
-                name="user",
-                role="user",
-                content=[HintBlock(hint="hint...")],
-            )
-
-    async def test_rejects_tool_call_block(self) -> None:
-        """ToolCallBlock in user msg raises ValueError."""
-        with self.assertRaises(ValueError):
-            Msg(
-                name="user",
-                role="user",
-                content=[
-                    ToolCallBlock(
-                        id="1",
-                        name="tool",
-                        input="{}",
-                    ),
-                ],
-            )
-
-    async def test_rejects_tool_result_block(self) -> None:
-        """ToolResultBlock in user msg raises ValueError."""
-        with self.assertRaises(ValueError):
-            Msg(
-                name="user",
-                role="user",
-                content=[
-                    ToolResultBlock(
-                        id="1",
-                        name="tool",
-                        output="result",
-                        state="success",
-                    ),
-                ],
-            )
-
-    async def test_mixed_valid_and_invalid_still_rejected(self) -> None:
-        """Even if TextBlock is present, an invalid block should
-        still cause rejection."""
-        with self.assertRaises(ValueError):
-            Msg(
-                name="user",
-                role="user",
-                content=[
-                    TextBlock(text="hi"),
-                    ThinkingBlock(thinking="nope"),
-                ],
-            )
-
-
-class SystemMsgValidationTest(IsolatedAsyncioTestCase):
-    """System messages can only contain text blocks."""
-
-    async def test_rejects_data_block(self) -> None:
-        """DataBlock in system msg raises ValueError."""
-        with self.assertRaises(ValueError):
-            Msg(
-                name="system",
-                role="system",
-                content=[
-                    DataBlock(
-                        source=URLSource(
-                            url=AnyUrl(
-                                "https://example.com/image.png",
-                            ),
-                            media_type="image/png",
-                        ),
-                    ),
-                ],
-            )
-
-    async def test_rejects_thinking_block(self) -> None:
-        """ThinkingBlock in system msg raises ValueError."""
-        with self.assertRaises(ValueError):
-            Msg(
-                name="system",
-                role="system",
-                content=[
-                    ThinkingBlock(thinking="thinking..."),
-                ],
-            )
-
-    async def test_rejects_hint_block(self) -> None:
-        """HintBlock in system msg raises ValueError."""
-        with self.assertRaises(ValueError):
-            Msg(
-                name="system",
-                role="system",
-                content=[HintBlock(hint="hint...")],
-            )
-
-    async def test_rejects_tool_call_block(self) -> None:
-        """ToolCallBlock in system msg raises ValueError."""
-        with self.assertRaises(ValueError):
-            Msg(
-                name="system",
-                role="system",
-                content=[
-                    ToolCallBlock(
-                        id="1",
-                        name="tool",
-                        input="{}",
-                    ),
-                ],
-            )
-
-    async def test_rejects_tool_result_block(self) -> None:
-        """ToolResultBlock in system msg raises ValueError."""
-        with self.assertRaises(ValueError):
-            Msg(
-                name="system",
-                role="system",
-                content=[
-                    ToolResultBlock(
-                        id="1",
-                        name="tool",
-                        output="result",
-                        state="success",
-                    ),
-                ],
-            )
-
-
-class MsgGetTextContentTest(IsolatedAsyncioTestCase):
-    """Test cases for Msg.get_text_content."""
-
-    async def test_from_string(self) -> None:
-        """String content is returned as-is."""
+    async def test_get_text_content(self) -> None:
+        """Test Msg.get_text_content with various scenarios."""
+        # String content is returned as-is
         msg = UserMsg(name="user", content="hello")
         self.assertEqual(msg.get_text_content(), "hello")
 
-    async def test_from_text_blocks(self) -> None:
-        """Multiple TextBlocks joined with default separator."""
+        # Multiple TextBlocks joined with default separator
         msg = UserMsg(
             name="user",
             content=[
@@ -516,22 +451,13 @@ class MsgGetTextContentTest(IsolatedAsyncioTestCase):
         )
         self.assertEqual(msg.get_text_content(), "foo\nbar")
 
-    async def test_custom_separator(self) -> None:
-        """Custom separator joins TextBlocks."""
-        msg = UserMsg(
-            name="user",
-            content=[
-                TextBlock(text="foo"),
-                TextBlock(text="bar"),
-            ],
-        )
+        # Custom separator
         self.assertEqual(
             msg.get_text_content(separator=" | "),
             "foo | bar",
         )
 
-    async def test_ignores_non_text_blocks(self) -> None:
-        """Only TextBlocks contribute to the result."""
+        # Non-text blocks are ignored
         msg = AssistantMsg(
             name="assistant",
             content=[
@@ -541,20 +467,16 @@ class MsgGetTextContentTest(IsolatedAsyncioTestCase):
         )
         self.assertEqual(msg.get_text_content(), "visible")
 
-    async def test_returns_none_when_no_text(self) -> None:
-        """Returns None when no TextBlock exists."""
+        # Returns None when no TextBlock exists
         msg = AssistantMsg(
             name="assistant",
             content=[ThinkingBlock(thinking="only thinking")],
         )
         self.assertIsNone(msg.get_text_content())
 
-
-class MsgGetContentBlocksTest(IsolatedAsyncioTestCase):
-    """Test cases for Msg.get_content_blocks."""
-
-    async def test_string_wrapped_to_text_block(self) -> None:
-        """String content is converted to a single TextBlock."""
+    async def test_get_content_blocks(self) -> None:
+        """Test Msg.get_content_blocks with various scenarios."""
+        # String content is converted to a single TextBlock
         msg = UserMsg(name="user", content="hello")
         blocks = list(msg.get_content_blocks())
         self.assertEqual(len(blocks), 1)
@@ -564,8 +486,7 @@ class MsgGetContentBlocksTest(IsolatedAsyncioTestCase):
             "hello",
         )
 
-    async def test_no_filter_returns_all(self) -> None:
-        """Without filter all blocks are returned."""
+        # Without filter all blocks are returned
         msg = AssistantMsg(
             name="assistant",
             content=[
@@ -575,8 +496,7 @@ class MsgGetContentBlocksTest(IsolatedAsyncioTestCase):
         )
         self.assertEqual(len(msg.get_content_blocks()), 2)
 
-    async def test_filter_by_single_type(self) -> None:
-        """Filtering by one type returns only that type."""
+        # Filtering by one type
         msg = AssistantMsg(
             name="assistant",
             content=[
@@ -594,8 +514,7 @@ class MsgGetContentBlocksTest(IsolatedAsyncioTestCase):
             1,
         )
 
-    async def test_filter_by_type_list(self) -> None:
-        """Passing a list of types returns the union."""
+        # Filtering by a list of types
         msg = AssistantMsg(
             name="assistant",
             content=[
@@ -606,14 +525,15 @@ class MsgGetContentBlocksTest(IsolatedAsyncioTestCase):
         )
         block_types = ["text", "hint"]
         blocks = list(
-            msg.get_content_blocks(block_types),  # type: ignore[arg-type]
+            msg.get_content_blocks(
+                block_types,
+            ),  # type: ignore[arg-type]
         )
         self.assertEqual(len(blocks), 2)
         types = {b.type for b in blocks}
         self.assertSetEqual(types, {"text", "hint"})
 
-    async def test_no_match_returns_empty(self) -> None:
-        """Empty list when no block matches the type."""
+        # Empty list when no block matches the type
         msg = UserMsg(
             name="user",
             content=[TextBlock(text="hi")],
@@ -623,12 +543,9 @@ class MsgGetContentBlocksTest(IsolatedAsyncioTestCase):
             0,
         )
 
-
-class MsgHasContentBlocksTest(IsolatedAsyncioTestCase):
-    """Test cases for Msg.has_content_blocks."""
-
-    async def test_with_matching_type(self) -> None:
-        """Returns True when matching blocks exist."""
+    async def test_has_content_blocks(self) -> None:
+        """Test Msg.has_content_blocks with various scenarios."""
+        # Returns True when matching blocks exist
         msg = AssistantMsg(
             name="a",
             content=[
@@ -640,35 +557,29 @@ class MsgHasContentBlocksTest(IsolatedAsyncioTestCase):
         self.assertTrue(msg.has_content_blocks("thinking"))
         self.assertTrue(msg.has_content_blocks("text"))
 
-    async def test_with_non_matching_type(self) -> None:
-        """Returns False when no matching blocks exist."""
+        # Returns False when no matching blocks exist
         msg = UserMsg(
             name="user",
             content=[TextBlock(text="hi")],
         )
         self.assertFalse(msg.has_content_blocks("thinking"))
 
-    async def test_string_content_counts_as_text(self) -> None:
-        """String content is treated as having a text block."""
+        # String content is treated as having a text block
         msg = UserMsg(name="user", content="hello")
         self.assertTrue(msg.has_content_blocks())
         self.assertTrue(msg.has_content_blocks("text"))
         self.assertFalse(msg.has_content_blocks("thinking"))
 
-
-class MsgSerializationTest(IsolatedAsyncioTestCase):
-    """Test cases for serialization round-trips."""
-
-    async def test_round_trip_string_content(self) -> None:
-        """model_dump -> model_validate preserves all fields."""
+    async def test_serialization(self) -> None:
+        """Test Msg serialization and deserialization."""
+        # model_dump -> model_validate preserves all fields
         original = UserMsg(name="user", content="hello")
         restored = Msg.model_validate(original.model_dump())
         self.assertEqual(restored.content, original.content)
         self.assertEqual(restored.role, original.role)
         self.assertEqual(restored.name, original.name)
 
-    async def test_round_trip_mixed_blocks(self) -> None:
-        """Mixed blocks survive model_dump -> model_validate."""
+        # Mixed blocks survive round-trip
         original = AssistantMsg(
             name="assistant",
             content=[
@@ -699,15 +610,13 @@ class MsgSerializationTest(IsolatedAsyncioTestCase):
             "answer",
         )
 
-    async def test_to_json(self) -> None:
-        """model_dump_json produces valid JSON."""
+        # model_dump_json produces valid JSON
         msg = UserMsg(name="user", content="hello")
         parsed = json.loads(msg.model_dump_json())
         self.assertEqual(parsed["content"], "hello")
         self.assertEqual(parsed["role"], "user")
 
-    async def test_tool_result_list_output_round_trip(self) -> None:
-        """ToolResultBlock with list output survives serialization."""
+        # ToolResultBlock with list output survives round-trip
         original = AssistantMsg(
             name="assistant",
             content=[
@@ -733,8 +642,7 @@ class MsgSerializationTest(IsolatedAsyncioTestCase):
             "file content",
         )
 
-    async def test_id_preserved_after_round_trip(self) -> None:
-        """Message id should not change during serialization."""
+        # Message id should not change during serialization
         original = UserMsg(name="user", content="test")
         restored = Msg.model_validate(original.model_dump())
         self.assertEqual(restored.id, original.id)

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -1,32 +1,33 @@
 # -*- coding: utf-8 -*-
-"""A template test case."""
+"""Test cases for the message module."""
+import json
 from unittest.async_case import IsolatedAsyncioTestCase
 from utils import AnyString
 
 from agentscope.message import (
     UserMsg,
-    TextBlock,
-    DataBlock,
-    URLSource,
-    Base64Source,
-    ThinkingBlock,
     AssistantMsg,
-    HintBlock,
+    SystemMsg,
     Msg,
+    TextBlock,
+    ThinkingBlock,
+    HintBlock,
+    DataBlock,
     ToolCallBlock,
     ToolResultBlock,
+    URLSource,
+    Base64Source,
 )
 
 
-class MessageTest(IsolatedAsyncioTestCase):
-    """The template test case."""
+class UserMsgCreationTest(IsolatedAsyncioTestCase):
+    """Test cases for UserMsg creation with various content types."""
 
-    async def test_creating_message(self) -> None:
-        """The template test."""
-        # Test string content
-        user_msg = UserMsg(name="user", content="hello world")
+    async def test_string_content(self) -> None:
+        """UserMsg with plain string content."""
+        msg = UserMsg(name="user", content="hello world")
         self.assertDictEqual(
-            user_msg.model_dump(),
+            msg.model_dump(),
             {
                 "id": AnyString(),
                 "name": "user",
@@ -37,13 +38,20 @@ class MessageTest(IsolatedAsyncioTestCase):
             },
         )
 
-        # Test list of content
-        user_msg = UserMsg(
+    async def test_empty_string_content(self) -> None:
+        """Empty string is still valid content."""
+        msg = UserMsg(name="user", content="")
+        self.assertEqual(msg.content, "")
+        self.assertEqual(msg.role, "user")
+
+    async def test_text_blocks(self) -> None:
+        """UserMsg with a list of TextBlocks."""
+        msg = UserMsg(
             name="user",
             content=[TextBlock(text="1"), TextBlock(text="2")],
         )
         self.assertDictEqual(
-            user_msg.model_dump(),
+            msg.model_dump(),
             {
                 "id": AnyString(),
                 "name": "user",
@@ -57,61 +65,100 @@ class MessageTest(IsolatedAsyncioTestCase):
             },
         )
 
-        # Test DataBlock content
-        user_msg = UserMsg(
+    async def test_url_data_block(self) -> None:
+        """UserMsg with a DataBlock using URLSource."""
+        msg = UserMsg(
             name="user",
             content=[
-                TextBlock(text="1"),
+                TextBlock(text="describe this"),
                 DataBlock(
                     source=URLSource(
                         url="https://example.com/image.png",
                         media_type="image/png",
                     ),
                 ),
+            ],
+        )
+        dumped = msg.model_dump()
+        self.assertEqual(dumped["content"][1]["type"], "data")
+        self.assertEqual(
+            dumped["content"][1]["source"]["url"],
+            "https://example.com/image.png",
+        )
+        self.assertEqual(
+            dumped["content"][1]["source"]["media_type"],
+            "image/png",
+        )
+
+    async def test_base64_data_block(self) -> None:
+        """DataBlock with Base64Source stores data correctly."""
+        b64_data = "iVBORw0KGgoAAAANSUhEUgAAAAUA"
+        msg = UserMsg(
+            name="user",
+            content=[
                 DataBlock(
                     source=Base64Source(
-                        data="iVBORw0KGgoAAAANSUhEUgAAAAUA",
+                        data=b64_data,
                         media_type="image/png",
                     ),
                 ),
             ],
         )
+        dumped = msg.model_dump()
+        self.assertEqual(dumped["content"][0]["source"]["data"], b64_data)
+        self.assertEqual(dumped["content"][0]["source"]["type"], "base64")
 
-        self.assertDictEqual(
-            user_msg.model_dump(),
-            {
-                "id": AnyString(),
-                "name": "user",
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": "1", "id": AnyString()},
-                    {
-                        "type": "data",
-                        "id": AnyString(),
-                        "source": {
-                            "type": "url",
-                            "url": "https://example.com/image.png",
-                            "media_type": "image/png",
-                        },
-                        "name": None,
-                    },
-                    {
-                        "type": "data",
-                        "id": AnyString(),
-                        "source": {
-                            "type": "base64",
-                            "data": "iVBORw0KGgoAAAANSUhEUgAAAAUA",
-                            "media_type": "image/png",
-                        },
-                        "name": None,
-                    },
-                ],
-                "metadata": {},
-                "created_at": AnyString(),
-            },
+    async def test_named_data_block(self) -> None:
+        """DataBlock optional name field is preserved."""
+        msg = UserMsg(
+            name="user",
+            content=[
+                DataBlock(
+                    name="screenshot",
+                    source=Base64Source(data="abc", media_type="image/png"),
+                ),
+            ],
         )
+        self.assertEqual(msg.model_dump()["content"][0]["name"], "screenshot")
 
-        # Test thinking content
+    async def test_data_block_name_defaults_to_none(self) -> None:
+        """DataBlock name is None when not provided."""
+        msg = UserMsg(
+            name="user",
+            content=[
+                DataBlock(
+                    source=Base64Source(data="abc", media_type="image/png"),
+                ),
+            ],
+        )
+        self.assertIsNone(msg.model_dump()["content"][0]["name"])
+
+    async def test_metadata(self) -> None:
+        """Metadata dict is stored and accessible."""
+        msg = UserMsg(
+            name="user",
+            content="hi",
+            metadata={"session_id": "abc123"},
+        )
+        self.assertEqual(msg.metadata, {"session_id": "abc123"})
+
+    async def test_custom_created_at(self) -> None:
+        """Custom created_at timestamp is preserved."""
+        ts = "2024-01-01T00:00:00"
+        msg = UserMsg(name="user", content="hi", created_at=ts)
+        self.assertEqual(msg.created_at, ts)
+
+
+class AssistantMsgCreationTest(IsolatedAsyncioTestCase):
+    """Test cases for AssistantMsg creation with various block types."""
+
+    async def test_string_content(self) -> None:
+        msg = AssistantMsg(name="bot", content="hello")
+        self.assertEqual(msg.role, "assistant")
+        self.assertEqual(msg.content, "hello")
+
+    async def test_thinking_block(self) -> None:
+        """ThinkingBlock is only allowed in assistant messages."""
         msg = AssistantMsg(
             name="assistant",
             content=[ThinkingBlock(thinking="thinking...")],
@@ -134,28 +181,145 @@ class MessageTest(IsolatedAsyncioTestCase):
             },
         )
 
-        # Test hint content
+    async def test_hint_block(self) -> None:
         msg = AssistantMsg(
             name="assistant",
             content=[HintBlock(hint="hint...")],
         )
-        self.assertDictEqual(
-            msg.model_dump(),
-            {
-                "id": AnyString(),
-                "name": "assistant",
-                "role": "assistant",
-                "content": [
-                    {"type": "hint", "hint": "hint...", "id": AnyString()},
-                ],
-                "metadata": {},
-                "created_at": AnyString(),
-            },
-        )
+        self.assertEqual(msg.model_dump()["content"][0]["type"], "hint")
+        self.assertEqual(msg.model_dump()["content"][0]["hint"], "hint...")
 
-    async def test_invalid_message(self) -> None:
-        """Test invalid message creation."""
-        # User message with thinking block should raise ValueError
+    async def test_tool_call_block(self) -> None:
+        """ToolCallBlock defaults await_user_confirmation to False."""
+        msg = AssistantMsg(
+            name="assistant",
+            content=[
+                ToolCallBlock(
+                    id="call_1",
+                    name="get_weather",
+                    input='{"city": "Beijing"}',
+                ),
+            ],
+        )
+        block = msg.model_dump()["content"][0]
+        self.assertEqual(block["type"], "tool_call")
+        self.assertEqual(block["name"], "get_weather")
+        self.assertFalse(block["await_user_confirmation"])
+
+    async def test_tool_call_block_with_confirmation(self) -> None:
+        """ToolCallBlock with await_user_confirmation set to True."""
+        msg = AssistantMsg(
+            name="assistant",
+            content=[
+                ToolCallBlock(
+                    id="call_1",
+                    name="rm_file",
+                    input='{"path": "/tmp/x"}',
+                    await_user_confirmation=True,
+                ),
+            ],
+        )
+        block = msg.model_dump()["content"][0]
+        self.assertTrue(block["await_user_confirmation"])
+
+    async def test_tool_result_string_output(self) -> None:
+        msg = AssistantMsg(
+            name="assistant",
+            content=[
+                ToolResultBlock(
+                    id="call_1",
+                    name="get_weather",
+                    output="sunny",
+                    state="success",
+                ),
+            ],
+        )
+        block = msg.model_dump()["content"][0]
+        self.assertEqual(block["type"], "tool_result")
+        self.assertEqual(block["state"], "success")
+        self.assertEqual(block["output"], "sunny")
+
+    async def test_tool_result_list_output(self) -> None:
+        """ToolResultBlock output can be a list of TextBlock and DataBlock."""
+        msg = AssistantMsg(
+            name="assistant",
+            content=[
+                ToolResultBlock(
+                    id="call_1",
+                    name="screenshot",
+                    output=[
+                        TextBlock(text="here is the screenshot"),
+                        DataBlock(
+                            source=Base64Source(
+                                data="abc",
+                                media_type="image/png",
+                            ),
+                        ),
+                    ],
+                    state="success",
+                ),
+            ],
+        )
+        output = msg.model_dump()["content"][0]["output"]
+        self.assertEqual(len(output), 2)
+        self.assertEqual(output[0]["type"], "text")
+        self.assertEqual(output[1]["type"], "data")
+
+    async def test_all_tool_result_states(self) -> None:
+        """ToolResultBlock supports success, error, interrupted, running."""
+        for state in ("success", "error", "interrupted", "running"):
+            msg = AssistantMsg(
+                name="assistant",
+                content=[
+                    ToolResultBlock(
+                        id="x",
+                        name="tool",
+                        output="out",
+                        state=state,  # type: ignore[arg-type]
+                    ),
+                ],
+            )
+            self.assertEqual(
+                msg.model_dump()["content"][0]["state"],
+                state,
+            )
+
+    async def test_mixed_blocks(self) -> None:
+        """Thinking + text + tool_call in a single assistant message."""
+        msg = AssistantMsg(
+            name="assistant",
+            content=[
+                ThinkingBlock(thinking="let me think"),
+                TextBlock(text="the answer is 42"),
+                ToolCallBlock(id="c1", name="calc", input="{}"),
+            ],
+        )
+        types = [b["type"] for b in msg.model_dump()["content"]]
+        self.assertEqual(types, ["thinking", "text", "tool_call"])
+
+
+class SystemMsgCreationTest(IsolatedAsyncioTestCase):
+    """Test cases for SystemMsg creation."""
+
+    async def test_string_content(self) -> None:
+        msg = SystemMsg(name="system", content="You are a helpful assistant.")
+        self.assertEqual(msg.role, "system")
+        self.assertEqual(msg.content, "You are a helpful assistant.")
+
+    async def test_text_block(self) -> None:
+        """SystemMsg can contain a list of TextBlocks."""
+        msg = SystemMsg(
+            name="system",
+            content=[TextBlock(text="Be concise.")],
+        )
+        self.assertEqual(msg.model_dump()["content"][0]["type"], "text")
+
+
+class UserMsgValidationTest(IsolatedAsyncioTestCase):
+    """User messages can only contain text and data blocks. Anything else
+    should raise ValueError."""
+
+    async def test_rejects_thinking_block(self) -> None:
         with self.assertRaises(ValueError):
             Msg(
                 name="user",
@@ -163,7 +327,7 @@ class MessageTest(IsolatedAsyncioTestCase):
                 content=[ThinkingBlock(thinking="thinking...")],
             )
 
-        # User message with hint block should raise ValueError
+    async def test_rejects_hint_block(self) -> None:
         with self.assertRaises(ValueError):
             Msg(
                 name="user",
@@ -171,7 +335,7 @@ class MessageTest(IsolatedAsyncioTestCase):
                 content=[HintBlock(hint="hint...")],
             )
 
-        # User message with tool call block should raise ValueError
+    async def test_rejects_tool_call_block(self) -> None:
         with self.assertRaises(ValueError):
             Msg(
                 name="user",
@@ -179,7 +343,7 @@ class MessageTest(IsolatedAsyncioTestCase):
                 content=[ToolCallBlock(id="1", name="tool", input="{}")],
             )
 
-        # User message with tool result block should raise ValueError
+    async def test_rejects_tool_result_block(self) -> None:
         with self.assertRaises(ValueError):
             Msg(
                 name="user",
@@ -194,7 +358,24 @@ class MessageTest(IsolatedAsyncioTestCase):
                 ],
             )
 
-        # System message with data block should raise ValueError
+    async def test_mixed_valid_and_invalid_still_rejected(self) -> None:
+        """Even if TextBlock is present, an invalid block should still cause
+        rejection."""
+        with self.assertRaises(ValueError):
+            Msg(
+                name="user",
+                role="user",
+                content=[
+                    TextBlock(text="hi"),
+                    ThinkingBlock(thinking="nope"),
+                ],
+            )
+
+
+class SystemMsgValidationTest(IsolatedAsyncioTestCase):
+    """System messages can only contain text blocks."""
+
+    async def test_rejects_data_block(self) -> None:
         with self.assertRaises(ValueError):
             Msg(
                 name="system",
@@ -209,7 +390,7 @@ class MessageTest(IsolatedAsyncioTestCase):
                 ],
             )
 
-        # System message with thinking block should raise ValueError
+    async def test_rejects_thinking_block(self) -> None:
         with self.assertRaises(ValueError):
             Msg(
                 name="system",
@@ -217,7 +398,7 @@ class MessageTest(IsolatedAsyncioTestCase):
                 content=[ThinkingBlock(thinking="thinking...")],
             )
 
-        # System message with hint block should raise ValueError
+    async def test_rejects_hint_block(self) -> None:
         with self.assertRaises(ValueError):
             Msg(
                 name="system",
@@ -225,7 +406,7 @@ class MessageTest(IsolatedAsyncioTestCase):
                 content=[HintBlock(hint="hint...")],
             )
 
-        # System message with tool call block should raise ValueError
+    async def test_rejects_tool_call_block(self) -> None:
         with self.assertRaises(ValueError):
             Msg(
                 name="system",
@@ -233,7 +414,7 @@ class MessageTest(IsolatedAsyncioTestCase):
                 content=[ToolCallBlock(id="1", name="tool", input="{}")],
             )
 
-        # System message with tool result block should raise ValueError
+    async def test_rejects_tool_result_block(self) -> None:
         with self.assertRaises(ValueError):
             Msg(
                 name="system",
@@ -247,3 +428,196 @@ class MessageTest(IsolatedAsyncioTestCase):
                     ),
                 ],
             )
+
+
+class MsgGetTextContentTest(IsolatedAsyncioTestCase):
+    """Test cases for Msg.get_text_content."""
+
+    async def test_from_string(self) -> None:
+        """String content is returned as-is."""
+        msg = UserMsg(name="user", content="hello")
+        self.assertEqual(msg.get_text_content(), "hello")
+
+    async def test_from_text_blocks(self) -> None:
+        """Multiple TextBlocks joined with default separator."""
+        msg = UserMsg(
+            name="user",
+            content=[TextBlock(text="foo"), TextBlock(text="bar")],
+        )
+        self.assertEqual(msg.get_text_content(), "foo\nbar")
+
+    async def test_custom_separator(self) -> None:
+        msg = UserMsg(
+            name="user",
+            content=[TextBlock(text="foo"), TextBlock(text="bar")],
+        )
+        self.assertEqual(msg.get_text_content(separator=" | "), "foo | bar")
+
+    async def test_ignores_non_text_blocks(self) -> None:
+        """Only TextBlocks contribute to the result."""
+        msg = AssistantMsg(
+            name="assistant",
+            content=[
+                ThinkingBlock(thinking="internal"),
+                TextBlock(text="visible"),
+            ],
+        )
+        self.assertEqual(msg.get_text_content(), "visible")
+
+    async def test_returns_none_when_no_text(self) -> None:
+        msg = AssistantMsg(
+            name="assistant",
+            content=[ThinkingBlock(thinking="only thinking")],
+        )
+        self.assertIsNone(msg.get_text_content())
+
+
+class MsgGetContentBlocksTest(IsolatedAsyncioTestCase):
+    """Test cases for Msg.get_content_blocks."""
+
+    async def test_string_wrapped_to_text_block(self) -> None:
+        """String content is converted to a single TextBlock."""
+        msg = UserMsg(name="user", content="hello")
+        blocks = msg.get_content_blocks()
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(blocks[0].type, "text")
+        self.assertEqual(
+            blocks[0].text,  # type: ignore[attr-defined]
+            "hello",
+        )
+
+    async def test_no_filter_returns_all(self) -> None:
+        msg = AssistantMsg(
+            name="assistant",
+            content=[
+                ThinkingBlock(thinking="t"),
+                TextBlock(text="x"),
+            ],
+        )
+        self.assertEqual(len(msg.get_content_blocks()), 2)
+
+    async def test_filter_by_single_type(self) -> None:
+        msg = AssistantMsg(
+            name="assistant",
+            content=[
+                ThinkingBlock(thinking="t"),
+                TextBlock(text="a"),
+                TextBlock(text="b"),
+            ],
+        )
+        self.assertEqual(len(msg.get_content_blocks("text")), 2)
+        self.assertEqual(len(msg.get_content_blocks("thinking")), 1)
+
+    async def test_filter_by_type_list(self) -> None:
+        """Passing a list of types returns the union."""
+        msg = AssistantMsg(
+            name="assistant",
+            content=[
+                ThinkingBlock(thinking="t"),
+                TextBlock(text="a"),
+                HintBlock(hint="h"),
+            ],
+        )
+        blocks = msg.get_content_blocks(["text", "hint"])
+        self.assertEqual(len(blocks), 2)
+        types = {b.type for b in blocks}
+        self.assertSetEqual(types, {"text", "hint"})
+
+    async def test_no_match_returns_empty(self) -> None:
+        msg = UserMsg(name="user", content=[TextBlock(text="hi")])
+        self.assertEqual(len(msg.get_content_blocks("thinking")), 0)
+
+
+class MsgHasContentBlocksTest(IsolatedAsyncioTestCase):
+    """Test cases for Msg.has_content_blocks."""
+
+    async def test_with_matching_type(self) -> None:
+        msg = AssistantMsg(
+            name="a",
+            content=[ThinkingBlock(thinking="t"), TextBlock(text="x")],
+        )
+        self.assertTrue(msg.has_content_blocks())
+        self.assertTrue(msg.has_content_blocks("thinking"))
+        self.assertTrue(msg.has_content_blocks("text"))
+
+    async def test_with_non_matching_type(self) -> None:
+        msg = UserMsg(name="user", content=[TextBlock(text="hi")])
+        self.assertFalse(msg.has_content_blocks("thinking"))
+
+    async def test_string_content_counts_as_text(self) -> None:
+        msg = UserMsg(name="user", content="hello")
+        self.assertTrue(msg.has_content_blocks())
+        self.assertTrue(msg.has_content_blocks("text"))
+        self.assertFalse(msg.has_content_blocks("thinking"))
+
+
+class MsgSerializationTest(IsolatedAsyncioTestCase):
+    """Test cases for serialization round-trips."""
+
+    async def test_round_trip_string_content(self) -> None:
+        """model_dump -> model_validate should preserve all fields."""
+        original = UserMsg(name="user", content="hello")
+        restored = Msg.model_validate(original.model_dump())
+        self.assertEqual(restored.content, original.content)
+        self.assertEqual(restored.role, original.role)
+        self.assertEqual(restored.name, original.name)
+
+    async def test_round_trip_mixed_blocks(self) -> None:
+        original = AssistantMsg(
+            name="assistant",
+            content=[
+                ThinkingBlock(thinking="hmm"),
+                TextBlock(text="answer"),
+                ToolCallBlock(
+                    id="c1",
+                    name="search",
+                    input='{"q": "test"}',
+                ),
+            ],
+        )
+        restored = Msg.model_validate(original.model_dump())
+        self.assertEqual(len(restored.get_content_blocks()), 3)
+        self.assertEqual(
+            restored.get_content_blocks("thinking")[0].thinking,  # type: ignore[attr-defined]
+            "hmm",
+        )
+        self.assertEqual(
+            restored.get_content_blocks("text")[0].text,  # type: ignore[attr-defined]
+            "answer",
+        )
+
+    async def test_to_json(self) -> None:
+        msg = UserMsg(name="user", content="hello")
+        parsed = json.loads(msg.model_dump_json())
+        self.assertEqual(parsed["content"], "hello")
+        self.assertEqual(parsed["role"], "user")
+
+    async def test_tool_result_list_output_round_trip(self) -> None:
+        """ToolResultBlock with list output survives serialization."""
+        original = AssistantMsg(
+            name="assistant",
+            content=[
+                ToolResultBlock(
+                    id="r1",
+                    name="read_file",
+                    output=[TextBlock(text="file content")],
+                    state="success",
+                ),
+            ],
+        )
+        restored = Msg.model_validate(original.model_dump())
+        result_block = restored.get_content_blocks("tool_result")[0]
+        self.assertIsInstance(
+            result_block.output,  # type: ignore[union-attr]
+            list,
+        )
+        self.assertEqual(
+            result_block.output[0].text,  # type: ignore[union-attr, index]
+            "file content",
+        )
+
+    async def test_id_preserved_after_round_trip(self) -> None:
+        """Message id should not change during serialization."""
+        original = UserMsg(name="user", content="test")
+        restored = Msg.model_validate(original.model_dump())
+        self.assertEqual(restored.id, original.id)

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -5,6 +5,8 @@ import json
 from unittest.async_case import IsolatedAsyncioTestCase
 from utils import AnyString
 
+from pydantic import AnyUrl
+
 from agentscope.message import (
     UserMsg,
     AssistantMsg,
@@ -74,7 +76,9 @@ class UserMsgCreationTest(IsolatedAsyncioTestCase):
                 TextBlock(text="describe this"),
                 DataBlock(
                     source=URLSource(
-                        url="https://example.com/image.png",
+                        url=AnyUrl(
+                            "https://example.com/image.png",
+                        ),
                         media_type="image/png",
                     ),
                 ),
@@ -432,7 +436,9 @@ class SystemMsgValidationTest(IsolatedAsyncioTestCase):
                 content=[
                     DataBlock(
                         source=URLSource(
-                            url="https://example.com/image.png",
+                            url=AnyUrl(
+                                "https://example.com/image.png",
+                            ),
                             media_type="image/png",
                         ),
                     ),
@@ -598,7 +604,10 @@ class MsgGetContentBlocksTest(IsolatedAsyncioTestCase):
                 HintBlock(hint="h"),
             ],
         )
-        blocks = list(msg.get_content_blocks(["text", "hint"]))
+        block_types = ["text", "hint"]
+        blocks = list(
+            msg.get_content_blocks(block_types),  # type: ignore[arg-type]
+        )
         self.assertEqual(len(blocks), 2)
         types = {b.type for b in blocks}
         self.assertSetEqual(types, {"text", "hint"})

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -404,9 +404,7 @@ class MessageTest(IsolatedAsyncioTestCase):
                 ToolCallBlock(id="c1", name="calc", input="{}"),
             ],
         )
-        types = [
-            b["type"] for b in msg.model_dump()["content"]
-        ]
+        types = [b["type"] for b in msg.model_dump()["content"]]
         self.assertEqual(
             types,
             ["thinking", "text", "tool_call"],

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Test cases for the message module."""
+
 import json
 from unittest.async_case import IsolatedAsyncioTestCase
 from utils import AnyString
@@ -105,8 +106,14 @@ class UserMsgCreationTest(IsolatedAsyncioTestCase):
             ],
         )
         dumped = msg.model_dump()
-        self.assertEqual(dumped["content"][0]["source"]["data"], b64_data)
-        self.assertEqual(dumped["content"][0]["source"]["type"], "base64")
+        self.assertEqual(
+            dumped["content"][0]["source"]["data"],
+            b64_data,
+        )
+        self.assertEqual(
+            dumped["content"][0]["source"]["type"],
+            "base64",
+        )
 
     async def test_named_data_block(self) -> None:
         """DataBlock optional name field is preserved."""
@@ -115,11 +122,17 @@ class UserMsgCreationTest(IsolatedAsyncioTestCase):
             content=[
                 DataBlock(
                     name="screenshot",
-                    source=Base64Source(data="abc", media_type="image/png"),
+                    source=Base64Source(
+                        data="abc",
+                        media_type="image/png",
+                    ),
                 ),
             ],
         )
-        self.assertEqual(msg.model_dump()["content"][0]["name"], "screenshot")
+        self.assertEqual(
+            msg.model_dump()["content"][0]["name"],
+            "screenshot",
+        )
 
     async def test_data_block_name_defaults_to_none(self) -> None:
         """DataBlock name is None when not provided."""
@@ -127,7 +140,10 @@ class UserMsgCreationTest(IsolatedAsyncioTestCase):
             name="user",
             content=[
                 DataBlock(
-                    source=Base64Source(data="abc", media_type="image/png"),
+                    source=Base64Source(
+                        data="abc",
+                        media_type="image/png",
+                    ),
                 ),
             ],
         )
@@ -153,6 +169,7 @@ class AssistantMsgCreationTest(IsolatedAsyncioTestCase):
     """Test cases for AssistantMsg creation with various block types."""
 
     async def test_string_content(self) -> None:
+        """AssistantMsg with plain string content."""
         msg = AssistantMsg(name="bot", content="hello")
         self.assertEqual(msg.role, "assistant")
         self.assertEqual(msg.content, "hello")
@@ -182,12 +199,14 @@ class AssistantMsgCreationTest(IsolatedAsyncioTestCase):
         )
 
     async def test_hint_block(self) -> None:
+        """AssistantMsg with HintBlock."""
         msg = AssistantMsg(
             name="assistant",
             content=[HintBlock(hint="hint...")],
         )
-        self.assertEqual(msg.model_dump()["content"][0]["type"], "hint")
-        self.assertEqual(msg.model_dump()["content"][0]["hint"], "hint...")
+        dumped = msg.model_dump()
+        self.assertEqual(dumped["content"][0]["type"], "hint")
+        self.assertEqual(dumped["content"][0]["hint"], "hint...")
 
     async def test_tool_call_block(self) -> None:
         """ToolCallBlock defaults await_user_confirmation to False."""
@@ -223,6 +242,7 @@ class AssistantMsgCreationTest(IsolatedAsyncioTestCase):
         self.assertTrue(block["await_user_confirmation"])
 
     async def test_tool_result_string_output(self) -> None:
+        """ToolResultBlock with string output."""
         msg = AssistantMsg(
             name="assistant",
             content=[
@@ -240,7 +260,7 @@ class AssistantMsgCreationTest(IsolatedAsyncioTestCase):
         self.assertEqual(block["output"], "sunny")
 
     async def test_tool_result_list_output(self) -> None:
-        """ToolResultBlock output can be a list of TextBlock and DataBlock."""
+        """ToolResultBlock output can be a list of blocks."""
         msg = AssistantMsg(
             name="assistant",
             content=[
@@ -266,8 +286,13 @@ class AssistantMsgCreationTest(IsolatedAsyncioTestCase):
         self.assertEqual(output[1]["type"], "data")
 
     async def test_all_tool_result_states(self) -> None:
-        """ToolResultBlock supports success, error, interrupted, running."""
-        for state in ("success", "error", "interrupted", "running"):
+        """ToolResultBlock supports all four execution states."""
+        for state in (
+            "success",
+            "error",
+            "interrupted",
+            "running",
+        ):
             msg = AssistantMsg(
                 name="assistant",
                 content=[
@@ -285,7 +310,7 @@ class AssistantMsgCreationTest(IsolatedAsyncioTestCase):
             )
 
     async def test_mixed_blocks(self) -> None:
-        """Thinking + text + tool_call in a single assistant message."""
+        """Thinking + text + tool_call in one assistant message."""
         msg = AssistantMsg(
             name="assistant",
             content=[
@@ -295,16 +320,26 @@ class AssistantMsgCreationTest(IsolatedAsyncioTestCase):
             ],
         )
         types = [b["type"] for b in msg.model_dump()["content"]]
-        self.assertEqual(types, ["thinking", "text", "tool_call"])
+        self.assertEqual(
+            types,
+            ["thinking", "text", "tool_call"],
+        )
 
 
 class SystemMsgCreationTest(IsolatedAsyncioTestCase):
     """Test cases for SystemMsg creation."""
 
     async def test_string_content(self) -> None:
-        msg = SystemMsg(name="system", content="You are a helpful assistant.")
+        """SystemMsg with plain string content."""
+        msg = SystemMsg(
+            name="system",
+            content="You are a helpful assistant.",
+        )
         self.assertEqual(msg.role, "system")
-        self.assertEqual(msg.content, "You are a helpful assistant.")
+        self.assertEqual(
+            msg.content,
+            "You are a helpful assistant.",
+        )
 
     async def test_text_block(self) -> None:
         """SystemMsg can contain a list of TextBlocks."""
@@ -312,14 +347,18 @@ class SystemMsgCreationTest(IsolatedAsyncioTestCase):
             name="system",
             content=[TextBlock(text="Be concise.")],
         )
-        self.assertEqual(msg.model_dump()["content"][0]["type"], "text")
+        self.assertEqual(
+            msg.model_dump()["content"][0]["type"],
+            "text",
+        )
 
 
 class UserMsgValidationTest(IsolatedAsyncioTestCase):
-    """User messages can only contain text and data blocks. Anything else
-    should raise ValueError."""
+    """User messages can only contain text and data blocks.
+    Anything else should raise ValueError."""
 
     async def test_rejects_thinking_block(self) -> None:
+        """ThinkingBlock in user msg raises ValueError."""
         with self.assertRaises(ValueError):
             Msg(
                 name="user",
@@ -328,6 +367,7 @@ class UserMsgValidationTest(IsolatedAsyncioTestCase):
             )
 
     async def test_rejects_hint_block(self) -> None:
+        """HintBlock in user msg raises ValueError."""
         with self.assertRaises(ValueError):
             Msg(
                 name="user",
@@ -336,14 +376,22 @@ class UserMsgValidationTest(IsolatedAsyncioTestCase):
             )
 
     async def test_rejects_tool_call_block(self) -> None:
+        """ToolCallBlock in user msg raises ValueError."""
         with self.assertRaises(ValueError):
             Msg(
                 name="user",
                 role="user",
-                content=[ToolCallBlock(id="1", name="tool", input="{}")],
+                content=[
+                    ToolCallBlock(
+                        id="1",
+                        name="tool",
+                        input="{}",
+                    ),
+                ],
             )
 
     async def test_rejects_tool_result_block(self) -> None:
+        """ToolResultBlock in user msg raises ValueError."""
         with self.assertRaises(ValueError):
             Msg(
                 name="user",
@@ -359,8 +407,8 @@ class UserMsgValidationTest(IsolatedAsyncioTestCase):
             )
 
     async def test_mixed_valid_and_invalid_still_rejected(self) -> None:
-        """Even if TextBlock is present, an invalid block should still cause
-        rejection."""
+        """Even if TextBlock is present, an invalid block should
+        still cause rejection."""
         with self.assertRaises(ValueError):
             Msg(
                 name="user",
@@ -376,6 +424,7 @@ class SystemMsgValidationTest(IsolatedAsyncioTestCase):
     """System messages can only contain text blocks."""
 
     async def test_rejects_data_block(self) -> None:
+        """DataBlock in system msg raises ValueError."""
         with self.assertRaises(ValueError):
             Msg(
                 name="system",
@@ -391,14 +440,18 @@ class SystemMsgValidationTest(IsolatedAsyncioTestCase):
             )
 
     async def test_rejects_thinking_block(self) -> None:
+        """ThinkingBlock in system msg raises ValueError."""
         with self.assertRaises(ValueError):
             Msg(
                 name="system",
                 role="system",
-                content=[ThinkingBlock(thinking="thinking...")],
+                content=[
+                    ThinkingBlock(thinking="thinking..."),
+                ],
             )
 
     async def test_rejects_hint_block(self) -> None:
+        """HintBlock in system msg raises ValueError."""
         with self.assertRaises(ValueError):
             Msg(
                 name="system",
@@ -407,14 +460,22 @@ class SystemMsgValidationTest(IsolatedAsyncioTestCase):
             )
 
     async def test_rejects_tool_call_block(self) -> None:
+        """ToolCallBlock in system msg raises ValueError."""
         with self.assertRaises(ValueError):
             Msg(
                 name="system",
                 role="system",
-                content=[ToolCallBlock(id="1", name="tool", input="{}")],
+                content=[
+                    ToolCallBlock(
+                        id="1",
+                        name="tool",
+                        input="{}",
+                    ),
+                ],
             )
 
     async def test_rejects_tool_result_block(self) -> None:
+        """ToolResultBlock in system msg raises ValueError."""
         with self.assertRaises(ValueError):
             Msg(
                 name="system",
@@ -442,16 +503,26 @@ class MsgGetTextContentTest(IsolatedAsyncioTestCase):
         """Multiple TextBlocks joined with default separator."""
         msg = UserMsg(
             name="user",
-            content=[TextBlock(text="foo"), TextBlock(text="bar")],
+            content=[
+                TextBlock(text="foo"),
+                TextBlock(text="bar"),
+            ],
         )
         self.assertEqual(msg.get_text_content(), "foo\nbar")
 
     async def test_custom_separator(self) -> None:
+        """Custom separator joins TextBlocks."""
         msg = UserMsg(
             name="user",
-            content=[TextBlock(text="foo"), TextBlock(text="bar")],
+            content=[
+                TextBlock(text="foo"),
+                TextBlock(text="bar"),
+            ],
         )
-        self.assertEqual(msg.get_text_content(separator=" | "), "foo | bar")
+        self.assertEqual(
+            msg.get_text_content(separator=" | "),
+            "foo | bar",
+        )
 
     async def test_ignores_non_text_blocks(self) -> None:
         """Only TextBlocks contribute to the result."""
@@ -465,6 +536,7 @@ class MsgGetTextContentTest(IsolatedAsyncioTestCase):
         self.assertEqual(msg.get_text_content(), "visible")
 
     async def test_returns_none_when_no_text(self) -> None:
+        """Returns None when no TextBlock exists."""
         msg = AssistantMsg(
             name="assistant",
             content=[ThinkingBlock(thinking="only thinking")],
@@ -478,7 +550,7 @@ class MsgGetContentBlocksTest(IsolatedAsyncioTestCase):
     async def test_string_wrapped_to_text_block(self) -> None:
         """String content is converted to a single TextBlock."""
         msg = UserMsg(name="user", content="hello")
-        blocks = msg.get_content_blocks()
+        blocks = list(msg.get_content_blocks())
         self.assertEqual(len(blocks), 1)
         self.assertEqual(blocks[0].type, "text")
         self.assertEqual(
@@ -487,6 +559,7 @@ class MsgGetContentBlocksTest(IsolatedAsyncioTestCase):
         )
 
     async def test_no_filter_returns_all(self) -> None:
+        """Without filter all blocks are returned."""
         msg = AssistantMsg(
             name="assistant",
             content=[
@@ -497,6 +570,7 @@ class MsgGetContentBlocksTest(IsolatedAsyncioTestCase):
         self.assertEqual(len(msg.get_content_blocks()), 2)
 
     async def test_filter_by_single_type(self) -> None:
+        """Filtering by one type returns only that type."""
         msg = AssistantMsg(
             name="assistant",
             content=[
@@ -505,8 +579,14 @@ class MsgGetContentBlocksTest(IsolatedAsyncioTestCase):
                 TextBlock(text="b"),
             ],
         )
-        self.assertEqual(len(msg.get_content_blocks("text")), 2)
-        self.assertEqual(len(msg.get_content_blocks("thinking")), 1)
+        self.assertEqual(
+            len(msg.get_content_blocks("text")),
+            2,
+        )
+        self.assertEqual(
+            len(msg.get_content_blocks("thinking")),
+            1,
+        )
 
     async def test_filter_by_type_list(self) -> None:
         """Passing a list of types returns the union."""
@@ -518,33 +598,49 @@ class MsgGetContentBlocksTest(IsolatedAsyncioTestCase):
                 HintBlock(hint="h"),
             ],
         )
-        blocks = msg.get_content_blocks(["text", "hint"])
+        blocks = list(msg.get_content_blocks(["text", "hint"]))
         self.assertEqual(len(blocks), 2)
         types = {b.type for b in blocks}
         self.assertSetEqual(types, {"text", "hint"})
 
     async def test_no_match_returns_empty(self) -> None:
-        msg = UserMsg(name="user", content=[TextBlock(text="hi")])
-        self.assertEqual(len(msg.get_content_blocks("thinking")), 0)
+        """Empty list when no block matches the type."""
+        msg = UserMsg(
+            name="user",
+            content=[TextBlock(text="hi")],
+        )
+        self.assertEqual(
+            len(msg.get_content_blocks("thinking")),
+            0,
+        )
 
 
 class MsgHasContentBlocksTest(IsolatedAsyncioTestCase):
     """Test cases for Msg.has_content_blocks."""
 
     async def test_with_matching_type(self) -> None:
+        """Returns True when matching blocks exist."""
         msg = AssistantMsg(
             name="a",
-            content=[ThinkingBlock(thinking="t"), TextBlock(text="x")],
+            content=[
+                ThinkingBlock(thinking="t"),
+                TextBlock(text="x"),
+            ],
         )
         self.assertTrue(msg.has_content_blocks())
         self.assertTrue(msg.has_content_blocks("thinking"))
         self.assertTrue(msg.has_content_blocks("text"))
 
     async def test_with_non_matching_type(self) -> None:
-        msg = UserMsg(name="user", content=[TextBlock(text="hi")])
+        """Returns False when no matching blocks exist."""
+        msg = UserMsg(
+            name="user",
+            content=[TextBlock(text="hi")],
+        )
         self.assertFalse(msg.has_content_blocks("thinking"))
 
     async def test_string_content_counts_as_text(self) -> None:
+        """String content is treated as having a text block."""
         msg = UserMsg(name="user", content="hello")
         self.assertTrue(msg.has_content_blocks())
         self.assertTrue(msg.has_content_blocks("text"))
@@ -555,7 +651,7 @@ class MsgSerializationTest(IsolatedAsyncioTestCase):
     """Test cases for serialization round-trips."""
 
     async def test_round_trip_string_content(self) -> None:
-        """model_dump -> model_validate should preserve all fields."""
+        """model_dump -> model_validate preserves all fields."""
         original = UserMsg(name="user", content="hello")
         restored = Msg.model_validate(original.model_dump())
         self.assertEqual(restored.content, original.content)
@@ -563,6 +659,7 @@ class MsgSerializationTest(IsolatedAsyncioTestCase):
         self.assertEqual(restored.name, original.name)
 
     async def test_round_trip_mixed_blocks(self) -> None:
+        """Mixed blocks survive model_dump -> model_validate."""
         original = AssistantMsg(
             name="assistant",
             content=[
@@ -576,17 +673,25 @@ class MsgSerializationTest(IsolatedAsyncioTestCase):
             ],
         )
         restored = Msg.model_validate(original.model_dump())
-        self.assertEqual(len(restored.get_content_blocks()), 3)
         self.assertEqual(
-            restored.get_content_blocks("thinking")[0].thinking,  # type: ignore[attr-defined]
+            len(restored.get_content_blocks()),
+            3,
+        )
+        thinking = list(
+            restored.get_content_blocks("thinking"),
+        )
+        text = list(restored.get_content_blocks("text"))
+        self.assertEqual(
+            thinking[0].thinking,  # type: ignore[attr-defined]
             "hmm",
         )
         self.assertEqual(
-            restored.get_content_blocks("text")[0].text,  # type: ignore[attr-defined]
+            text[0].text,  # type: ignore[attr-defined]
             "answer",
         )
 
     async def test_to_json(self) -> None:
+        """model_dump_json produces valid JSON."""
         msg = UserMsg(name="user", content="hello")
         parsed = json.loads(msg.model_dump_json())
         self.assertEqual(parsed["content"], "hello")
@@ -606,7 +711,10 @@ class MsgSerializationTest(IsolatedAsyncioTestCase):
             ],
         )
         restored = Msg.model_validate(original.model_dump())
-        result_block = restored.get_content_blocks("tool_result")[0]
+        result_blocks = list(
+            restored.get_content_blocks("tool_result"),
+        )
+        result_block = result_blocks[0]
         self.assertIsInstance(
             result_block.output,  # type: ignore[union-attr]
             list,


### PR DESCRIPTION
## AgentScope Version

2.0.0 (v2_dev branch)

## Description
Closes #1444

This PR adds unit tests for the message module, as tracked in #1444.

The existing `MessageTest` class covers basic message creation and invalid message validation. I added 7 more test methods to the same class to cover the remaining untested parts:

- `test_user_msg_edge_cases` — empty content, named DataBlock, metadata, custom created_at
- `test_assistant_msg_blocks` — ToolCallBlock (with/without confirmation), ToolResultBlock (string/list output, all 4 states), mixed block types
- `test_system_msg_creation` — string content and TextBlock content
- `test_get_text_content` — string return, TextBlock joining, custom separator, non-text filtering, None return
- `test_get_content_blocks` — string wrapping, no filter, single type filter, list filter, empty result
- `test_has_content_blocks` — matching/non-matching types, string content handling
- `test_serialization` — model_dump round-trip, JSON output, ToolResult list output, id preservation

## Checklist

- [x] Code has been formatted with `pre-commit run --all-files` command
- [x] All tests are passing
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review