### PR TITLE
fix(memory): skip empty assistant turns in persisted sessions

### DIFF
--- a/src/agentscope/memory/_working_memory/_in_memory_memory.py
+++ b/src/agentscope/memory/_working_memory/_in_memory_memory.py
@@ -3,8 +3,28 @@
 from copy import deepcopy
 from typing import Any
 
+from ..._logging import logger
 from ...message import Msg
 from ._base import MemoryBase
+
+
+def _message_has_meaningful_content(msg: Msg) -> bool:
+    """Check whether a message contains payload worth replaying."""
+    if isinstance(msg.content, str):
+        return msg.content != ""
+
+    for block in msg.get_content_blocks():
+        if block.get("type") != "text":
+            return True
+        if block.get("text"):
+            return True
+
+    return False
+
+
+def _is_invalid_empty_assistant_message(msg: Msg) -> bool:
+    """Check whether a persisted assistant turn is effectively empty."""
+    return msg.role == "assistant" and not _message_has_meaningful_content(msg)
 
 
 class InMemoryMemory(MemoryBase):
@@ -126,6 +146,12 @@ class InMemoryMemory(MemoryBase):
                 f"The mark should be a string, a list of strings, or None, "
                 f"but got {type(marks)}.",
             )
+
+        memories = [
+            msg
+            for msg in memories
+            if not _is_invalid_empty_assistant_message(msg)
+        ]
 
         if not allow_duplicates:
             existing_ids = {msg.id for msg, _ in self.content}
@@ -288,18 +314,31 @@ class InMemoryMemory(MemoryBase):
         self._compressed_summary = state_dict.get("_compressed_summary", "")
 
         self.content = []
+        skipped_invalid_messages = 0
         for item in state_dict.get("content", []):
             if isinstance(item, (tuple, list)) and len(item) == 2:
                 msg_dict, marks = item
                 msg = Msg.from_dict(msg_dict)
-                self.content.append((msg, marks))
 
             elif isinstance(item, dict):
                 # For compatibility with older versions
                 msg = Msg.from_dict(item)
-                self.content.append((msg, []))
+                marks = []
 
             else:
                 raise ValueError(
                     "Invalid item format in state_dict for InMemoryMemory.",
                 )
+
+            if _is_invalid_empty_assistant_message(msg):
+                skipped_invalid_messages += 1
+                continue
+
+            self.content.append((msg, marks))
+
+        if skipped_invalid_messages:
+            logger.warning(
+                "Skipped %d invalid empty assistant message(s) while "
+                "loading memory state.",
+                skipped_invalid_messages,
+            )

--- a/tests/memory_test.py
+++ b/tests/memory_test.py
@@ -600,6 +600,24 @@ class InMemoryMemoryTest(ShortTermMemoryTest):
             },
         )
 
+    async def test_skips_empty_assistant_messages(self) -> None:
+        """Test that invalid empty assistant messages are not stored."""
+        await self.memory.add(
+            [
+                Msg("user", "question", "user"),
+                Msg("assistant", [], "assistant"),
+                Msg("assistant", "", "assistant"),
+                Msg("assistant", "answer", "assistant"),
+            ],
+        )
+
+        stored_msgs = await self.memory.get_memory()
+        self.assertEqual(len(stored_msgs), 2)
+        self.assertEqual(
+            [msg.get_text_content() for msg in stored_msgs],
+            ["question", "answer"],
+        )
+
 
 class AsyncSQLAlchemyMemoryTest(ShortTermMemoryTest):
     """The SQLAlchemy short-term memory tests."""

--- a/tests/session_test.py
+++ b/tests/session_test.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 """Session module tests."""
+import json
 import os
 import sys
+import tempfile
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Union
 from unittest import IsolatedAsyncioTestCase
@@ -102,6 +104,41 @@ class SessionTest(IsolatedAsyncioTestCase):
         session_file = "./user_1.json"
         if os.path.exists(session_file):
             os.remove(session_file)
+
+    async def test_load_session_state_skips_empty_assistant_messages(
+        self,
+    ) -> None:
+        """Test that session loading drops invalid empty assistant turns."""
+        agent = MyAgent()
+        user_msg = Msg("Alice", "Hi!", "user")
+        empty_assistant_msg = Msg("Friday", [], "assistant")
+        assistant_msg = Msg("Friday", "Hello!", "assistant")
+
+        state = agent.state_dict()
+        state["memory"]["content"] = [
+            [user_msg.to_dict(), []],
+            [empty_assistant_msg.to_dict(), []],
+            [assistant_msg.to_dict(), []],
+        ]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            session = JSONSession(save_dir=temp_dir)
+            session_file = session._get_save_path("user_1", user_id="")
+
+            with open(session_file, "w", encoding="utf-8") as file:
+                json.dump({"agent": state}, file, ensure_ascii=False)
+
+            await session.load_session_state(
+                session_id="user_1",
+                agent=agent,
+            )
+
+        loaded_msgs = await agent.memory.get_memory()
+        self.assertEqual(len(loaded_msgs), 2)
+        self.assertEqual(
+            [msg.get_text_content() for msg in loaded_msgs],
+            ["Hi!", "Hello!"],
+        )
 
 
 class RedisSessionTest(IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary
- skip invalid empty assistant turns when appending to `InMemoryMemory`
- drop historical empty assistant turns while loading persisted session state to avoid replaying bad messages
- add regression coverage for both memory filtering and session restore behavior

Fixes #1426

## Testing
- `.venv_test/bin/pytest tests/session_test.py -q`
- `.venv_test/bin/pytest tests/memory_test.py -q`
- `.venv_test/bin/pytest tests/react_agent_test.py -q`
