### PR TITLE
fix(openai): catch response_format errors during streaming to enable fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
 [project.optional-dependencies]
 # ------------ A2A protocol ------------
 a2a = [
-    "a2a-sdk",
+    "a2a-sdk==0.3.26",
     "httpx",
     # TODO: split the card resolvers from the a2a dependency
     "nacos-sdk-python>=3.0.0",

--- a/src/agentscope/model/_openai_model.py
+++ b/src/agentscope/model/_openai_model.py
@@ -269,6 +269,8 @@ class OpenAIChatModel(ChatModelBase):
         start_datetime = datetime.now()
 
         if structured_model:
+            import openai
+
             if tools or tool_choice:
                 logger.warning(
                     "structured_model is provided. Both 'tools' and "
@@ -299,12 +301,13 @@ class OpenAIChatModel(ChatModelBase):
                         response = self.client.chat.completions.stream(
                             **kwargs,
                         )
-                        return self._parse_openai_stream_response(
+                        return self._structured_stream_with_fallback(
                             start_datetime,
                             response,
                             structured_model,
+                            kwargs,
                         )
-                except Exception as e:
+                except openai.BadRequestError as e:
                     logger.warning(
                         "response_format structured output failed (%s: %s), "
                         "falling back to tool-call based structured output. "
@@ -676,6 +679,53 @@ class OpenAIChatModel(ChatModelBase):
             resp_kwargs["id"] = response_id
 
         return ChatResponse(**resp_kwargs)
+
+    async def _structured_stream_with_fallback(
+        self,
+        start_datetime: datetime,
+        response: Any,
+        structured_model: Type[BaseModel],
+        kwargs: dict,
+    ) -> AsyncGenerator[ChatResponse, None]:
+        """Wrap the streaming response_format attempt with error handling.
+
+        The OpenAI `client.chat.completions.stream()` is lazy -- the HTTP
+        request is deferred until the stream is consumed. This means errors
+        from APIs that reject ``response_format`` (e.g. DeepSeek) are raised
+        *outside* the try/except in ``__call__``, so
+        ``_structured_output_fallback`` is never set.
+
+        This wrapper catches such errors during stream consumption and
+        transparently falls back to the tool-call approach.
+        """
+        import openai
+
+        try:
+            async for chunk in self._parse_openai_stream_response(
+                start_datetime,
+                response,
+                structured_model,
+            ):
+                yield chunk
+        except openai.BadRequestError as e:
+            logger.warning(
+                "response_format structured output failed during streaming "
+                "(%s: %s), falling back to tool-call based structured "
+                "output. Subsequent calls will use tool-call directly.",
+                type(e).__name__,
+                e,
+            )
+            self._structured_output_fallback = True
+            fallback = await self._structured_via_tool_call(
+                kwargs,
+                structured_model,
+                datetime.now(),
+            )
+            if isinstance(fallback, AsyncGenerator):
+                async for chunk in fallback:
+                    yield chunk
+            else:
+                yield fallback
 
     async def _structured_via_tool_call(
         self,


### PR DESCRIPTION
## AgentScope Version

1.0.19

## Description

When `structured_model` (i.e. `response_format`) is used with `stream=True`, the `try/except` block in `OpenAIChatModel.__call__` fails to catch errors from APIs that do not support `response_format` (e.g. DeepSeek). This is because `client.chat.completions.stream()` is lazy — the actual HTTP request is deferred until the stream is consumed inside `_parse_openai_stream_response`, which has already been returned from the `try` block.
As a result, `_structured_output_fallback` is never set to `True`, and every subsequent call with `structured_model` repeats the same failure. This manifests as a crash during memory compression in `ReActAgent`, which uses `structured_model` to generate a compression summary.
### Fix
Added `_structured_stream_with_fallback`, an async generator wrapper that:
1. Delegates to `_parse_openai_stream_response` inside a `try` block
2. Catches errors raised during stream consumption (e.g. the 400 `response_format type is unavailable` from DeepSeek)
3. Sets `_structured_output_fallback = True` and transparently falls back to the tool-call approach
4. Subsequent calls skip `response_format` entirely and use tool-call directly

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review