### PR TITLE
fix: multiple formatter and memory fixes

### DIFF
--- a/src/agentscope/formatter/_dashscope_formatter.py
+++ b/src/agentscope/formatter/_dashscope_formatter.py
@@ -147,7 +147,7 @@ def _reformat_messages(
             if "type" in item and item["type"] != "text":
                 is_all_text = False
                 break
-            if item["text"]:
+            if item.get("text"):
                 texts.append(item["text"])
 
         if is_all_text and texts:

--- a/src/agentscope/formatter/_openai_formatter.py
+++ b/src/agentscope/formatter/_openai_formatter.py
@@ -91,7 +91,12 @@ def _to_openai_image_url(url: str) -> str:
                     "utf-8",
                 )
             extension = raw_url.lower().split(".")[-1]
-            mime_type = f"image/{extension}"
+            # Note: image/jpeg is the correct MIME type, not image/jpg
+            mime_type = (
+                "image/jpeg"
+                if extension == "jpg"
+                else f"image/{extension}"
+            )
             return f"data:{mime_type};base64,{base64_image}"
 
         # No extension - detect file type using filetype

--- a/src/agentscope/memory/_working_memory/_sqlalchemy_memory.py
+++ b/src/agentscope/memory/_working_memory/_sqlalchemy_memory.py
@@ -592,8 +592,6 @@ class AsyncSQLAlchemyMemory(MemoryBase):
             if not msg_ids:
                 return 0
 
-            deleted_count = len(msg_ids)
-
             # Delete marks first
             await self.session.execute(
                 delete(self.MessageMarkTable).filter(
@@ -601,13 +599,14 @@ class AsyncSQLAlchemyMemory(MemoryBase):
                 ),
             )
 
-            # Then delete the messages
-            await self.session.execute(
+            # Then delete the messages and get actual count
+            result = await self.session.execute(
                 delete(self.MessageTable).filter(
                     self.MessageTable.session_id == self.session_id,
                     self.MessageTable.id.in_(msg_ids),
                 ),
             )
+            deleted_count = result.rowcount
 
             return deleted_count
 
@@ -639,8 +638,6 @@ class AsyncSQLAlchemyMemory(MemoryBase):
             return 0
 
         async with self._write_session():
-            deleted_count = len(composite_ids)
-
             # Delete related marks first (explicit cleanup for reliability)
             await self.session.execute(
                 delete(self.MessageMarkTable).filter(
@@ -648,13 +645,14 @@ class AsyncSQLAlchemyMemory(MemoryBase):
                 ),
             )
 
-            # Then delete the messages
-            await self.session.execute(
+            # Then delete the messages and get actual count
+            result = await self.session.execute(
                 delete(self.MessageTable).filter(
                     self.MessageTable.session_id == self.session_id,
                     self.MessageTable.id.in_(composite_ids),
                 ),
             )
+            deleted_count = result.rowcount
 
             return deleted_count
 


### PR DESCRIPTION
## Summary

Three bug fixes in this PR:

1. **DashScope formatter**: Guard against None text field in `_reformat_messages` - When content blocks have a text field set to None (e.g., `{"text": None}`), the code would crash with a TypeError when calling str.join(). Changed to use `.get("text")` instead of direct indexing.

2. **AsyncSQLAlchemyMemory**: Return actual deleted count - The `delete()` and `delete_by_mark()` methods were returning the number of message IDs provided rather than the actual number of messages deleted. Now using `result.rowcount` to return the actual count from the database.

3. **OpenAI formatter**: Fix incorrect MIME type for .jpg files - The `_to_openai_image_url` function was generating "image/jpg" as the MIME type for .jpg files, but the correct MIME type is "image/jpeg".

## Test plan
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)