### PR TITLE
feat(mcp): support listing skills in MCP clients

### DIFF
--- a/docs/tutorial/en/src/task_mcp.py
+++ b/docs/tutorial/en/src/task_mcp.py
@@ -82,6 +82,8 @@ stateless_client = HttpStatelessClient(
 #      - Description
 #    * - ``list_tools``
 #      - List all tools available in the MCP server.
+#    * - ``list_skills``
+#      - List all skills available in the MCP server.
 #    * - ``get_callable_function``
 #      - Get a callable function object from the MCP server by its name.
 #

--- a/docs/tutorial/zh_CN/src/task_mcp.py
+++ b/docs/tutorial/zh_CN/src/task_mcp.py
@@ -84,6 +84,8 @@ stateless_client = HttpStatelessClient(
 #      - 描述
 #    * - ``list_tools``
 #      - 列出 MCP 服务器中所有可用的工具。
+#    * - ``list_skills``
+#      - 列出 MCP 服务器中所有可用的技能。
 #    * - ``get_callable_function``
 #      - 通过名称从 MCP 服务器获取可调用的函数对象。
 #

--- a/src/agentscope/mcp/__init__.py
+++ b/src/agentscope/mcp/__init__.py
@@ -2,7 +2,7 @@
 """The MCP module in AgentScope, that provides fine-grained control over
 the MCP servers."""
 
-from ._client_base import MCPClientBase
+from ._client_base import MCPClientBase, MCPSkill
 from ._mcp_function import MCPToolFunction
 from ._stateful_client_base import StatefulClientBase
 from ._stdio_stateful_client import StdIOStatefulClient
@@ -13,6 +13,7 @@ from ._http_stateful_client import HttpStatefulClient
 __all__ = [
     "MCPToolFunction",
     "MCPClientBase",
+    "MCPSkill",
     "StatefulClientBase",
     "StdIOStatefulClient",
     "HttpStatelessClient",

--- a/src/agentscope/mcp/_client_base.py
+++ b/src/agentscope/mcp/_client_base.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """The base class for MCP clients in AgentScope."""
 from abc import abstractmethod
+from dataclasses import dataclass
 from typing import Callable, List
 
 import mcp.types
@@ -13,6 +14,20 @@ from ..message import (
     TextBlock,
     VideoBlock,
 )
+
+
+@dataclass
+class MCPSkill:
+    """Summary information about a skill available on an MCP server."""
+
+    name: str
+    """The name of the skill."""
+
+    description: str
+    """The description of the skill."""
+
+    uri: str
+    """The URI of the skill instruction resource."""
 
 
 class MCPClientBase:
@@ -36,6 +51,30 @@ class MCPClientBase:
         execution_timeout: float | None = None,
     ) -> Callable:
         """Get a tool function by its name."""
+
+    @abstractmethod
+    async def list_skills(self) -> List[MCPSkill]:
+        """List all skills available on the MCP server."""
+
+    @staticmethod
+    def _extract_skills_from_resources(
+        resources: list[mcp.types.Resource],
+    ) -> List[MCPSkill]:
+        """Extract MCP skills from resources."""
+        skills = []
+        for resource in resources:
+            uri = str(resource.uri)
+            if uri.startswith("skill://") and uri.endswith("/SKILL.md"):
+                name = uri[len("skill://") :].rsplit("/", 1)[0]
+                skills.append(
+                    MCPSkill(
+                        name=name,
+                        description=resource.description or "",
+                        uri=uri,
+                    ),
+                )
+
+        return skills
 
     @staticmethod
     def _convert_mcp_content_to_as_blocks(

--- a/src/agentscope/mcp/_http_stateless_client.py
+++ b/src/agentscope/mcp/_http_stateless_client.py
@@ -9,7 +9,7 @@ from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamablehttp_client
 
 from . import MCPToolFunction
-from ._client_base import MCPClientBase
+from ._client_base import MCPClientBase, MCPSkill
 from ..tool import ToolResponse
 
 
@@ -150,3 +150,17 @@ class HttpStatelessClient(MCPClientBase):
                 res = await session.list_tools()
                 self._tools = res.tools
                 return res.tools
+
+    async def list_skills(self) -> List[MCPSkill]:
+        """List all skills available on the MCP server.
+
+        Returns:
+            `List[MCPSkill]`:
+                A list of available MCP skills.
+        """
+        async with self.get_client() as cli:
+            read_stream, write_stream = cli[0], cli[1]
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                res = await session.list_resources()
+                return self._extract_skills_from_resources(res.resources)

--- a/src/agentscope/mcp/_stateful_client_base.py
+++ b/src/agentscope/mcp/_stateful_client_base.py
@@ -8,7 +8,7 @@ from typing import List
 import mcp
 from mcp import ClientSession
 
-from ._client_base import MCPClientBase
+from ._client_base import MCPClientBase, MCPSkill
 from ._mcp_function import MCPToolFunction
 from .._logging import logger
 
@@ -108,6 +108,18 @@ class StatefulClientBase(MCPClientBase, ABC):
         # Cache the tools for later use
         self._cached_tools = res.tools
         return res.tools
+
+    async def list_skills(self) -> List[MCPSkill]:
+        """List all skills available on the MCP server.
+
+        Returns:
+            `List[MCPSkill]`:
+                A list of available MCP skills.
+        """
+        self._validate_connection()
+
+        res = await self.session.list_resources()
+        return self._extract_skills_from_resources(res.resources)
 
     async def get_callable_function(
         self,

--- a/tests/mcp_sse_client_test.py
+++ b/tests/mcp_sse_client_test.py
@@ -28,6 +28,14 @@ def setup_server() -> None:
     """Set up the streamable HTTP MCP server."""
     sse_server = FastMCP("SSE", port=8003)
     sse_server.tool(description="A test tool function.")(tool_1)
+
+    @sse_server.resource(
+        "skill://test-sse-skill/SKILL.md",
+        description="A test SSE skill.",
+    )
+    async def test_skill() -> str:
+        return "# Test SSE Skill"
+
     sse_server.run(transport="sse")
 
 
@@ -111,6 +119,12 @@ class SseMCPClientTest(IsolatedAsyncioTestCase):
             transport="sse",
             url=f"http://127.0.0.1:{self.port}/sse",
         )
+
+        skills = await stateless_client.list_skills()
+        self.assertEqual(len(skills), 1)
+        self.assertEqual(skills[0].name, "test-sse-skill")
+        self.assertEqual(skills[0].description, "A test SSE skill.")
+        self.assertEqual(skills[0].uri, "skill://test-sse-skill/SKILL.md")
 
         func_1 = await stateless_client.get_callable_function(
             "tool_1",
@@ -267,6 +281,12 @@ class SseMCPClientTest(IsolatedAsyncioTestCase):
         await stateful_client.connect()
 
         self.assertTrue(stateful_client.is_connected)
+
+        skills = await stateful_client.list_skills()
+        self.assertEqual(len(skills), 1)
+        self.assertEqual(skills[0].name, "test-sse-skill")
+        self.assertEqual(skills[0].description, "A test SSE skill.")
+        self.assertEqual(skills[0].uri, "skill://test-sse-skill/SKILL.md")
 
         func_1 = await stateful_client.get_callable_function(
             "tool_1",

--- a/tests/mcp_streamable_http_client_test.py
+++ b/tests/mcp_streamable_http_client_test.py
@@ -48,6 +48,14 @@ def setup_server() -> None:
     sse_server.tool(
         description="A test tool function with embedded resource.",
     )(tool_2)
+
+    @sse_server.resource(
+        "skill://test-streamable-skill/SKILL.md",
+        description="A test streamable HTTP skill.",
+    )
+    async def test_skill() -> str:
+        return "# Test Streamable Skill"
+
     sse_server.run(transport="streamable-http")
 
 
@@ -74,6 +82,18 @@ class StreamableHttpMCPClientTest(IsolatedAsyncioTestCase):
             name="test_streamable_http_stateless_client",
             transport="streamable_http",
             url=f"http://127.0.0.1:{self.port}/mcp",
+        )
+
+        skills = await client.list_skills()
+        self.assertEqual(len(skills), 1)
+        self.assertEqual(skills[0].name, "test-streamable-skill")
+        self.assertEqual(
+            skills[0].description,
+            "A test streamable HTTP skill.",
+        )
+        self.assertEqual(
+            skills[0].uri,
+            "skill://test-streamable-skill/SKILL.md",
         )
 
         func_1 = await client.get_callable_function(
@@ -118,6 +138,18 @@ class StreamableHttpMCPClientTest(IsolatedAsyncioTestCase):
         await client.connect()
 
         self.assertTrue(client.is_connected)
+
+        skills = await client.list_skills()
+        self.assertEqual(len(skills), 1)
+        self.assertEqual(skills[0].name, "test-streamable-skill")
+        self.assertEqual(
+            skills[0].description,
+            "A test streamable HTTP skill.",
+        )
+        self.assertEqual(
+            skills[0].uri,
+            "skill://test-streamable-skill/SKILL.md",
+        )
 
         func_1 = await client.get_callable_function(
             "tool_1",


### PR DESCRIPTION
## AgentScope Version

`1.0.19.post1`

## Description

Fixes #1550

This PR adds `list_skills` support to MCP client classes.

FastMCP exposes skills as MCP resources whose URI follows the `skill://{name}/SKILL.md` pattern. This change lists server resources and extracts skill summaries from matching resource URIs.

Changes:
- Add `MCPSkill` for MCP skill summary information.
- Add `list_skills` to `MCPClientBase`.
- Implement `list_skills` for stateful and stateless MCP clients.
- Add SSE and streamable HTTP tests for skill listing.
- Update English and Chinese MCP tutorials.

Tests:
- `pre-commit run --all-files`
- `python -m pytest tests`

This is my first PR to AgentScope, so I am not fully familiar with the contribution workflow yet. Since issue #1550 is under the 2.0.0 milestone, please let me know if this PR should target `v2_dev` instead of `main`, and I will rework it accordingly.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
