### PR TITLE
fix(model): move ReasoningEffort to lazy import via TYPE_CHECKING block

### DIFF
--- a/src/agentscope/model/_openai_model.py
+++ b/src/agentscope/model/_openai_model.py
@@ -11,7 +11,6 @@ from typing import (
 )
 from collections import OrderedDict
 
-from openai.types import ReasoningEffort
 from pydantic import BaseModel
 
 from . import ChatResponse
@@ -30,9 +29,11 @@ from ..tracing import trace_llm
 from ..types import JSONSerializableObject
 
 if TYPE_CHECKING:
+    from openai.types import ReasoningEffort
     from openai.types.chat import ChatCompletion
     from openai import AsyncStream
 else:
+    ReasoningEffort = "openai.types.ReasoningEffort"
     ChatCompletion = "openai.types.chat.ChatCompletion"
     AsyncStream = "openai.types.chat.AsyncStream"
 


### PR DESCRIPTION
## AgentScope Version

2.0.0beta.0

## Description

The project follows a lazy import principle (documented in CONTRIBUTING.md) to ensure `import agentscope` remains lightweight. However, `ReasoningEffort` from `openai.types` was imported at the top level in `_openai_model.py`, which violates this convention.

### Changes

- Removed the top-level import `from openai.types import ReasoningEffort`
- Added `ReasoningEffort` to the existing `if TYPE_CHECKING:` block (for static type checking)
- Added a string placeholder `ReasoningEffort = "openai.types.ReasoningEffort"` in the `else` branch (for runtime)


## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review