### PR TITLE
fix(formatter): fix memory overhead, None tool output crash, and DeepSeek null content rejection

### DIFF
--- a/src/agentscope/formatter/_deepseek_formatter.py
+++ b/src/agentscope/formatter/_deepseek_formatter.py
@@ -105,7 +105,7 @@ class DeepSeekChatFormatter(TruncatedFormatterBase):
 
             msg_deepseek = {
                 "role": msg.role,
-                "content": content_msg or None,
+                "content": content_msg or (None if tool_calls else ""),
             }
 
             if reasoning_msg:

--- a/src/agentscope/formatter/_formatter_base.py
+++ b/src/agentscope/formatter/_formatter_base.py
@@ -68,6 +68,9 @@ class FormatterBase:
                 second element is the corresponding block.
         """
 
+        if output is None:
+            return "", []
+
         if isinstance(output, str):
             return output, []
 

--- a/src/agentscope/formatter/_truncated_formatter_base.py
+++ b/src/agentscope/formatter/_truncated_formatter_base.py
@@ -2,7 +2,6 @@
 """The truncated formatter base class, which allows to truncate the input
 messages."""
 from abc import ABC
-from copy import deepcopy
 from typing import (
     Any,
     Tuple,
@@ -66,7 +65,7 @@ class TruncatedFormatterBase(FormatterBase, ABC):
         # Check if the input messages are valid
         self.assert_list_of_msgs(msgs)
 
-        msgs = deepcopy(msgs)
+        msgs = list(msgs)
 
         while True:
             formatted_msgs = await self._format(msgs)


### PR DESCRIPTION
## AgentScope Version

1.0.19.post1

## Description

This PR addresses two issues in the formatter layer:

### Fix 1: Replace `deepcopy` with shallow copy in `TruncatedFormatterBase.format()`

**File:** `agentscope/formatter/_truncated_formatter_base.py`

Replaced `deepcopy(msgs)` with `list(msgs)` (shallow copy). The deep copy was unnecessary because:
- `_truncate()` returns new list slices without mutating elements
- `_format()` only reads message blocks to produce new dicts

A shallow copy is still required to protect the caller's original list from in-place `insert()` calls made by `DashScopeChatFormatter` and `GeminiChatFormatter` when promoting media blocks from tool results.

This avoids doubling peak memory usage on every API call in long conversations with large tool outputs (e.g., browser snapshots, shell command outputs).

### Fix 2: Fix null `content` causing 400 rejection in `DeepSeekChatFormatter`

**File:** `agentscope/formatter/_deepseek_formatter.py` Changed `content_msg or None` to `content_msg or (None if tool_calls else "")`.

When an assistant message has no text content and no tool calls (e.g., an empty turn saved on crash), the original code would set `content: null`. DeepSeek API rejects this with: 400 Bad Request: messages[N] content should be a string or a list

The fix sends `content: ""` (empty string) when no tool calls are present, which is accepted by the API. When tool calls are present, `null` remains valid per the DeepSeek API spec and is kept as-is.

### Fix 3: Guard against `None` output in `convert_tool_result_to_string()`

**File:** `agentscope/formatter/_formatter_base.py`

Added an early-return guard for `None` output at the start of `convert_tool_result_to_string()`. Although `ToolResultBlock.output` is typed as `Required[str | List[...]]`, Python does not enforce TypedDict value types
at runtime.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review