### PR TITLE
fix(mcp): preserve $defs and $ref in MCP tool input schema

### DIFF
--- a/src/agentscope/_utils/_common.py
+++ b/src/agentscope/_utils/_common.py
@@ -216,22 +216,17 @@ def _save_base64_data(
 def _extract_json_schema_from_mcp_tool(tool: Tool) -> dict[str, Any]:
     """Extract JSON schema from MCP tool."""
 
+    parameters = dict(tool.inputSchema) if tool.inputSchema else {}
+    parameters.setdefault("type", "object")
+    parameters.setdefault("properties", {})
+    parameters.setdefault("required", [])
+
     return {
         "type": "function",
         "function": {
             "name": tool.name,
             "description": tool.description,
-            "parameters": {
-                "type": "object",
-                "properties": tool.inputSchema.get(
-                    "properties",
-                    {},
-                ),
-                "required": tool.inputSchema.get(
-                    "required",
-                    [],
-                ),
-            },
+            "parameters": parameters,
         },
     }
 

--- a/tests/mcp_sse_client_test.py
+++ b/tests/mcp_sse_client_test.py
@@ -57,6 +57,7 @@ class SseMCPClientTest(IsolatedAsyncioTestCase):
                     "name": "tool_1",
                     "description": "A test tool function.",
                     "parameters": {
+                        "title": "tool_1Arguments",
                         "type": "object",
                         "properties": {
                             "arg2": {
@@ -81,6 +82,7 @@ class SseMCPClientTest(IsolatedAsyncioTestCase):
                     "name": "tool_1",
                     "description": "A test tool function.",
                     "parameters": {
+                        "title": "tool_1Arguments",
                         "type": "object",
                         "properties": {
                             "arg1": {


### PR DESCRIPTION
## AgentScope Version

1.0.19.post1

## Description

Fix `_extract_json_schema_from_mcp_tool()` to pass the full `inputSchema` through to the LLM API instead of only extracting `properties` and `required`.

Previously, the function manually reconstructed the `parameters` object by only picking these two fields, silently discarding `$defs`, `$ref`, `additionalProperties`, and any other valid JSON Schema keywords. This broke MCP tools that use nested type definitions (e.g., recursive schemas with `$defs`/`$ref`), causing the model to receive incomplete parameter information and fail to call these tools correctly.

## Related Issues

- Closes agentscope-ai/QwenPaw#4191


## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review