### PR TITLE
feat(model): add cache_creation_input_tokens and cache_input_tokens in ChatUsage

### DIFF
--- a/src/agentscope/model/_anthropic/_model.py
+++ b/src/agentscope/model/_anthropic/_model.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse
-from .._model_usage import ChatUsage
+from .._model_usage import ChatUsage, _to_usage_dict
 from ...credential import AnthropicCredential
 from ...formatter import FormatterBase, AnthropicChatFormatter
 from ...message import ThinkingBlock, ToolCallBlock, TextBlock
@@ -255,6 +255,7 @@ class AnthropicChatModel(ChatModelBase):
                 input_tokens=response.usage.input_tokens,
                 output_tokens=response.usage.output_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
+                metadata=response.usage.model_dump(),
             )
 
         resp_kwargs: dict[str, Any] = {
@@ -314,6 +315,7 @@ class AnthropicChatModel(ChatModelBase):
                             0,
                         ),
                         time=(datetime.now() - start_datetime).total_seconds(),
+                        metadata=_to_usage_dict(message.usage),
                     )
 
             elif event.type == "content_block_start":

--- a/src/agentscope/model/_anthropic/_model.py
+++ b/src/agentscope/model/_anthropic/_model.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse
-from .._model_usage import ChatUsage, _to_usage_dict
+from .._model_usage import ChatUsage
 from ...credential import AnthropicCredential
 from ...formatter import FormatterBase, AnthropicChatFormatter
 from ...message import ThinkingBlock, ToolCallBlock, TextBlock
@@ -251,11 +251,21 @@ class AnthropicChatModel(ChatModelBase):
 
         usage = None
         if response.usage:
+            u = response.usage
             usage = ChatUsage(
-                input_tokens=response.usage.input_tokens,
-                output_tokens=response.usage.output_tokens,
+                input_tokens=u.input_tokens,
+                output_tokens=u.output_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
-                metadata=response.usage.model_dump(),
+                cache_creation_input_tokens=getattr(
+                    u,
+                    "cache_creation_input_tokens",
+                    None,
+                ),
+                cache_input_tokens=getattr(
+                    u,
+                    "cache_read_input_tokens",
+                    None,
+                ),
             )
 
         resp_kwargs: dict[str, Any] = {
@@ -307,15 +317,21 @@ class AnthropicChatModel(ChatModelBase):
                 if response_id is None:
                     response_id = getattr(message, "id", None)
                 if message.usage:
+                    u = message.usage
                     usage = ChatUsage(
-                        input_tokens=message.usage.input_tokens,
-                        output_tokens=getattr(
-                            message.usage,
-                            "output_tokens",
-                            0,
-                        ),
+                        input_tokens=u.input_tokens,
+                        output_tokens=getattr(u, "output_tokens", 0),
                         time=(datetime.now() - start_datetime).total_seconds(),
-                        metadata=_to_usage_dict(message.usage),
+                        cache_creation_input_tokens=getattr(
+                            u,
+                            "cache_creation_input_tokens",
+                            None,
+                        ),
+                        cache_input_tokens=getattr(
+                            u,
+                            "cache_read_input_tokens",
+                            None,
+                        ),
                     )
 
             elif event.type == "content_block_start":

--- a/src/agentscope/model/_anthropic/_model.py
+++ b/src/agentscope/model/_anthropic/_model.py
@@ -259,12 +259,12 @@ class AnthropicChatModel(ChatModelBase):
                 cache_creation_input_tokens=getattr(
                     u,
                     "cache_creation_input_tokens",
-                    None,
+                    0,
                 ),
                 cache_input_tokens=getattr(
                     u,
                     "cache_read_input_tokens",
-                    None,
+                    0,
                 ),
             )
 
@@ -325,12 +325,12 @@ class AnthropicChatModel(ChatModelBase):
                         cache_creation_input_tokens=getattr(
                             u,
                             "cache_creation_input_tokens",
-                            None,
+                            0,
                         ),
                         cache_input_tokens=getattr(
                             u,
                             "cache_read_input_tokens",
-                            None,
+                            0,
                         ),
                     )
 

--- a/src/agentscope/model/_dashscope/_model.py
+++ b/src/agentscope/model/_dashscope/_model.py
@@ -11,7 +11,7 @@ from aioitertools import iter as giter
 
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse
-from .._model_usage import ChatUsage, _to_usage_dict
+from .._model_usage import ChatUsage
 from ...credential import DashScopeCredential
 from ...formatter import FormatterBase, DashScopeChatFormatter
 from ...message import Msg, TextBlock, ThinkingBlock, ToolCallBlock
@@ -366,11 +366,20 @@ class DashScopeChatModel(ChatModelBase):
 
             # The chunk usage
             if chunk.usage:
+                u = chunk.usage
+                ptd = getattr(u, "prompt_tokens_details", None)
+                if isinstance(ptd, dict):
+                    cache_creation = ptd.get("cache_creation_input_tokens")
+                    cache_read = ptd.get("cached_tokens")
+                else:
+                    cache_creation = None
+                    cache_read = getattr(u, "cached_tokens", None)
                 usage = ChatUsage(
-                    input_tokens=chunk.usage.input_tokens,
-                    output_tokens=chunk.usage.output_tokens,
+                    input_tokens=u.input_tokens,
+                    output_tokens=u.output_tokens,
                     time=(datetime.now() - start_datetime).total_seconds(),
-                    metadata=_to_usage_dict(chunk.usage),
+                    cache_creation_input_tokens=cache_creation,
+                    cache_input_tokens=cache_read,
                 )
 
             # Yield the chat response
@@ -476,11 +485,20 @@ class DashScopeChatModel(ChatModelBase):
         # Usage information
         usage = None
         if response.usage:
+            u = response.usage
+            ptd = getattr(u, "prompt_tokens_details", None)
+            if isinstance(ptd, dict):
+                cache_creation = ptd.get("cache_creation_input_tokens")
+                cache_read = ptd.get("cached_tokens")
+            else:
+                cache_creation = None
+                cache_read = getattr(u, "cached_tokens", None)
             usage = ChatUsage(
-                input_tokens=response.usage.input_tokens,
-                output_tokens=response.usage.output_tokens,
+                input_tokens=u.input_tokens,
+                output_tokens=u.output_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
-                metadata=_to_usage_dict(response.usage),
+                cache_creation_input_tokens=cache_creation,
+                cache_input_tokens=cache_read,
             )
 
         return ChatResponse(

--- a/src/agentscope/model/_dashscope/_model.py
+++ b/src/agentscope/model/_dashscope/_model.py
@@ -369,11 +369,11 @@ class DashScopeChatModel(ChatModelBase):
                 u = chunk.usage
                 ptd = getattr(u, "prompt_tokens_details", None)
                 if isinstance(ptd, dict):
-                    cache_creation = ptd.get("cache_creation_input_tokens")
-                    cache_read = ptd.get("cached_tokens")
+                    cache_creation = ptd.get("cache_creation_input_tokens", 0)
+                    cache_read = ptd.get("cached_tokens", 0)
                 else:
-                    cache_creation = None
-                    cache_read = getattr(u, "cached_tokens", None)
+                    cache_creation = 0
+                    cache_read = getattr(u, "cached_tokens", 0)
                 usage = ChatUsage(
                     input_tokens=u.input_tokens,
                     output_tokens=u.output_tokens,
@@ -488,11 +488,11 @@ class DashScopeChatModel(ChatModelBase):
             u = response.usage
             ptd = getattr(u, "prompt_tokens_details", None)
             if isinstance(ptd, dict):
-                cache_creation = ptd.get("cache_creation_input_tokens")
-                cache_read = ptd.get("cached_tokens")
+                cache_creation = ptd.get("cache_creation_input_tokens", 0)
+                cache_read = ptd.get("cached_tokens", 0)
             else:
-                cache_creation = None
-                cache_read = getattr(u, "cached_tokens", None)
+                cache_creation = 0
+                cache_read = getattr(u, "cached_tokens", 0)
             usage = ChatUsage(
                 input_tokens=u.input_tokens,
                 output_tokens=u.output_tokens,

--- a/src/agentscope/model/_dashscope/_model.py
+++ b/src/agentscope/model/_dashscope/_model.py
@@ -11,7 +11,7 @@ from aioitertools import iter as giter
 
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse
-from .._model_usage import ChatUsage
+from .._model_usage import ChatUsage, _to_usage_dict
 from ...credential import DashScopeCredential
 from ...formatter import FormatterBase, DashScopeChatFormatter
 from ...message import Msg, TextBlock, ThinkingBlock, ToolCallBlock
@@ -370,7 +370,7 @@ class DashScopeChatModel(ChatModelBase):
                     input_tokens=chunk.usage.input_tokens,
                     output_tokens=chunk.usage.output_tokens,
                     time=(datetime.now() - start_datetime).total_seconds(),
-                    metadata=chunk.usage,
+                    metadata=_to_usage_dict(chunk.usage),
                 )
 
             # Yield the chat response
@@ -480,7 +480,7 @@ class DashScopeChatModel(ChatModelBase):
                 input_tokens=response.usage.input_tokens,
                 output_tokens=response.usage.output_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
-                metadata=response.usage,
+                metadata=_to_usage_dict(response.usage),
             )
 
         return ChatResponse(

--- a/src/agentscope/model/_deepseek/_model.py
+++ b/src/agentscope/model/_deepseek/_model.py
@@ -217,7 +217,7 @@ class DeepSeekChatModel(ChatModelBase):
                         cache_input_tokens=getattr(
                             u,
                             "prompt_cache_hit_tokens",
-                            None,
+                            0,
                         ),
                     )
 
@@ -347,7 +347,7 @@ class DeepSeekChatModel(ChatModelBase):
                 cache_input_tokens=getattr(
                     u,
                     "prompt_cache_hit_tokens",
-                    None,
+                    0,
                 ),
             )
 

--- a/src/agentscope/model/_deepseek/_model.py
+++ b/src/agentscope/model/_deepseek/_model.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse
-from .._model_usage import ChatUsage, _to_usage_dict
+from .._model_usage import ChatUsage
 from ...credential import DeepSeekCredential
 from ...formatter import FormatterBase, DeepSeekChatFormatter
 from ...message import ThinkingBlock, ToolCallBlock, TextBlock
@@ -209,11 +209,16 @@ class DeepSeekChatModel(ChatModelBase):
         async with response as stream:
             async for chunk in stream:
                 if chunk.usage:
+                    u = chunk.usage
                     usage = ChatUsage(
-                        input_tokens=chunk.usage.prompt_tokens,
-                        output_tokens=chunk.usage.completion_tokens,
+                        input_tokens=u.prompt_tokens,
+                        output_tokens=u.completion_tokens,
                         time=(datetime.now() - start_datetime).total_seconds(),
-                        metadata=_to_usage_dict(chunk.usage),
+                        cache_input_tokens=getattr(
+                            u,
+                            "prompt_cache_hit_tokens",
+                            None,
+                        ),
                     )
 
                 # Capture response_id from the first chunk that carries it
@@ -334,11 +339,16 @@ class DeepSeekChatModel(ChatModelBase):
 
         usage = None
         if response.usage:
+            u = response.usage
             usage = ChatUsage(
-                input_tokens=response.usage.prompt_tokens,
-                output_tokens=response.usage.completion_tokens,
+                input_tokens=u.prompt_tokens,
+                output_tokens=u.completion_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
-                metadata=response.usage.model_dump(),
+                cache_input_tokens=getattr(
+                    u,
+                    "prompt_cache_hit_tokens",
+                    None,
+                ),
             )
 
         resp_kwargs: dict[str, Any] = {

--- a/src/agentscope/model/_deepseek/_model.py
+++ b/src/agentscope/model/_deepseek/_model.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse
-from .._model_usage import ChatUsage
+from .._model_usage import ChatUsage, _to_usage_dict
 from ...credential import DeepSeekCredential
 from ...formatter import FormatterBase, DeepSeekChatFormatter
 from ...message import ThinkingBlock, ToolCallBlock, TextBlock
@@ -213,7 +213,7 @@ class DeepSeekChatModel(ChatModelBase):
                         input_tokens=chunk.usage.prompt_tokens,
                         output_tokens=chunk.usage.completion_tokens,
                         time=(datetime.now() - start_datetime).total_seconds(),
-                        metadata=chunk.usage,
+                        metadata=_to_usage_dict(chunk.usage),
                     )
 
                 # Capture response_id from the first chunk that carries it
@@ -338,7 +338,7 @@ class DeepSeekChatModel(ChatModelBase):
                 input_tokens=response.usage.prompt_tokens,
                 output_tokens=response.usage.completion_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
-                metadata=response.usage,
+                metadata=response.usage.model_dump(),
             )
 
         resp_kwargs: dict[str, Any] = {

--- a/src/agentscope/model/_gemini/_model.py
+++ b/src/agentscope/model/_gemini/_model.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field
 
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse
-from .._model_usage import ChatUsage
+from .._model_usage import ChatUsage, _to_usage_dict
 from ...credential import GeminiCredential
 from ...formatter import FormatterBase, GeminiChatFormatter
 from ...message import ThinkingBlock, ToolCallBlock, TextBlock
@@ -449,7 +449,7 @@ class GeminiChatModel(ChatModelBase):
                 input_tokens=prompt_tokens,
                 output_tokens=total_tokens - prompt_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
-                metadata=usage_metadata,
+                metadata=_to_usage_dict(usage_metadata),
             )
         return None
 

--- a/src/agentscope/model/_gemini/_model.py
+++ b/src/agentscope/model/_gemini/_model.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field
 
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse
-from .._model_usage import ChatUsage, _to_usage_dict
+from .._model_usage import ChatUsage
 from ...credential import GeminiCredential
 from ...formatter import FormatterBase, GeminiChatFormatter
 from ...message import ThinkingBlock, ToolCallBlock, TextBlock
@@ -449,7 +449,11 @@ class GeminiChatModel(ChatModelBase):
                 input_tokens=prompt_tokens,
                 output_tokens=total_tokens - prompt_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
-                metadata=_to_usage_dict(usage_metadata),
+                cache_input_tokens=getattr(
+                    usage_metadata,
+                    "cached_content_token_count",
+                    None,
+                ),
             )
         return None
 

--- a/src/agentscope/model/_gemini/_model.py
+++ b/src/agentscope/model/_gemini/_model.py
@@ -452,7 +452,7 @@ class GeminiChatModel(ChatModelBase):
                 cache_input_tokens=getattr(
                     usage_metadata,
                     "cached_content_token_count",
-                    None,
+                    0,
                 ),
             )
         return None

--- a/src/agentscope/model/_kimi/_model.py
+++ b/src/agentscope/model/_kimi/_model.py
@@ -208,7 +208,7 @@ class KimiChatModel(ChatModelBase):
                         cache_input_tokens=getattr(
                             u,
                             "cached_tokens",
-                            None,
+                            0,
                         ),
                     )
 
@@ -335,7 +335,7 @@ class KimiChatModel(ChatModelBase):
                 input_tokens=u.prompt_tokens,
                 output_tokens=u.completion_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
-                cache_input_tokens=getattr(u, "cached_tokens", None),
+                cache_input_tokens=getattr(u, "cached_tokens", 0),
             )
 
         resp_kwargs: dict[str, Any] = {

--- a/src/agentscope/model/_kimi/_model.py
+++ b/src/agentscope/model/_kimi/_model.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse
-from .._model_usage import ChatUsage
+from .._model_usage import ChatUsage, _to_usage_dict
 from ...credential import KimiCredential
 from ...formatter import FormatterBase, KimiChatFormatter
 from ...message import ThinkingBlock, ToolCallBlock, TextBlock
@@ -204,7 +204,7 @@ class KimiChatModel(ChatModelBase):
                         input_tokens=chunk.usage.prompt_tokens,
                         output_tokens=chunk.usage.completion_tokens,
                         time=(datetime.now() - start_datetime).total_seconds(),
-                        metadata=chunk.usage,
+                        metadata=_to_usage_dict(chunk.usage),
                     )
 
                 # Capture response_id from the first chunk that carries it
@@ -329,7 +329,7 @@ class KimiChatModel(ChatModelBase):
                 input_tokens=response.usage.prompt_tokens,
                 output_tokens=response.usage.completion_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
-                metadata=response.usage,
+                metadata=response.usage.model_dump(),
             )
 
         resp_kwargs: dict[str, Any] = {

--- a/src/agentscope/model/_kimi/_model.py
+++ b/src/agentscope/model/_kimi/_model.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse
-from .._model_usage import ChatUsage, _to_usage_dict
+from .._model_usage import ChatUsage
 from ...credential import KimiCredential
 from ...formatter import FormatterBase, KimiChatFormatter
 from ...message import ThinkingBlock, ToolCallBlock, TextBlock
@@ -200,11 +200,16 @@ class KimiChatModel(ChatModelBase):
         async with response as stream:
             async for chunk in stream:
                 if chunk.usage:
+                    u = chunk.usage
                     usage = ChatUsage(
-                        input_tokens=chunk.usage.prompt_tokens,
-                        output_tokens=chunk.usage.completion_tokens,
+                        input_tokens=u.prompt_tokens,
+                        output_tokens=u.completion_tokens,
                         time=(datetime.now() - start_datetime).total_seconds(),
-                        metadata=_to_usage_dict(chunk.usage),
+                        cache_input_tokens=getattr(
+                            u,
+                            "cached_tokens",
+                            None,
+                        ),
                     )
 
                 # Capture response_id from the first chunk that carries it
@@ -325,11 +330,12 @@ class KimiChatModel(ChatModelBase):
 
         usage = None
         if response.usage:
+            u = response.usage
             usage = ChatUsage(
-                input_tokens=response.usage.prompt_tokens,
-                output_tokens=response.usage.completion_tokens,
+                input_tokens=u.prompt_tokens,
+                output_tokens=u.completion_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
-                metadata=response.usage.model_dump(),
+                cache_input_tokens=getattr(u, "cached_tokens", None),
             )
 
         resp_kwargs: dict[str, Any] = {

--- a/src/agentscope/model/_model_usage.py
+++ b/src/agentscope/model/_model_usage.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """The model usage class in agentscope."""
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Any, Literal
 
 from .._utils._mixin import DictMixin
 
@@ -22,10 +22,11 @@ class ChatUsage(DictMixin):
     type: Literal["chat"] = field(default_factory=lambda: "chat")
     """The type of the usage, must be `chat`."""
 
-    cache_creation_input_tokens: int | None = field(
-        default_factory=lambda: None,
-    )
+    cache_creation_input_tokens: int = field(default_factory=lambda: 0)
     """The number of input tokens used to create the prompt cache."""
 
-    cache_input_tokens: int | None = field(default_factory=lambda: None)
+    cache_input_tokens: int = field(default_factory=lambda: 0)
     """The number of input tokens read from the prompt cache."""
+
+    metadata: dict[str, Any] | None = field(default_factory=lambda: None)
+    """Optional metadata associated with the usage."""

--- a/src/agentscope/model/_model_usage.py
+++ b/src/agentscope/model/_model_usage.py
@@ -1,35 +1,9 @@
 # -*- coding: utf-8 -*-
 """The model usage class in agentscope."""
 from dataclasses import dataclass, field
-from typing import Literal, Any
+from typing import Literal
 
 from .._utils._mixin import DictMixin
-
-
-def _to_usage_dict(obj: Any) -> dict[str, Any]:
-    """Convert an arbitrary usage object to a plain dict, best-effort.
-
-    Handles the following common SDK types in order of preference:
-    - Already a ``dict`` — returned as-is.
-    - Pydantic v2 models (``model_dump``).
-    - Pydantic v1 models (``dict``).
-    - Protobuf messages with an instance ``to_dict`` method.
-    - Any Python object that exposes ``__dict__`` (public fields only).
-    - Fallback: ``{"_raw": str(obj)}``.
-    """
-    if isinstance(obj, dict):
-        return obj
-    if hasattr(obj, "model_dump") and callable(obj.model_dump):
-        return obj.model_dump()
-    if hasattr(obj, "dict") and callable(obj.dict):
-        return obj.dict()
-    if hasattr(obj, "to_dict") and callable(obj.to_dict):
-        result = obj.to_dict()
-        if isinstance(result, dict):
-            return result
-    if hasattr(obj, "__dict__"):
-        return {k: v for k, v in vars(obj).items() if not k.startswith("_")}
-    return {"_raw": str(obj)}
 
 
 @dataclass
@@ -48,5 +22,10 @@ class ChatUsage(DictMixin):
     type: Literal["chat"] = field(default_factory=lambda: "chat")
     """The type of the usage, must be `chat`."""
 
-    metadata: dict[str, Any] | None = field(default_factory=lambda: None)
-    """The metadata of the usage, stored as a plain dict."""
+    cache_creation_input_tokens: int | None = field(
+        default_factory=lambda: None,
+    )
+    """The number of input tokens used to create the prompt cache."""
+
+    cache_input_tokens: int | None = field(default_factory=lambda: None)
+    """The number of input tokens read from the prompt cache."""

--- a/src/agentscope/model/_model_usage.py
+++ b/src/agentscope/model/_model_usage.py
@@ -6,6 +6,32 @@ from typing import Literal, Any
 from .._utils._mixin import DictMixin
 
 
+def _to_usage_dict(obj: Any) -> dict[str, Any]:
+    """Convert an arbitrary usage object to a plain dict, best-effort.
+
+    Handles the following common SDK types in order of preference:
+    - Already a ``dict`` — returned as-is.
+    - Pydantic v2 models (``model_dump``).
+    - Pydantic v1 models (``dict``).
+    - Protobuf messages with an instance ``to_dict`` method.
+    - Any Python object that exposes ``__dict__`` (public fields only).
+    - Fallback: ``{"_raw": str(obj)}``.
+    """
+    if isinstance(obj, dict):
+        return obj
+    if hasattr(obj, "model_dump") and callable(obj.model_dump):
+        return obj.model_dump()
+    if hasattr(obj, "dict") and callable(obj.dict):
+        return obj.dict()
+    if hasattr(obj, "to_dict") and callable(obj.to_dict):
+        result = obj.to_dict()
+        if isinstance(result, dict):
+            return result
+    if hasattr(obj, "__dict__"):
+        return {k: v for k, v in vars(obj).items() if not k.startswith("_")}
+    return {"_raw": str(obj)}
+
+
 @dataclass
 class ChatUsage(DictMixin):
     """The usage of a chat model API invocation."""
@@ -23,4 +49,4 @@ class ChatUsage(DictMixin):
     """The type of the usage, must be `chat`."""
 
     metadata: dict[str, Any] | None = field(default_factory=lambda: None)
-    """The metadata of the usage."""
+    """The metadata of the usage, stored as a plain dict."""

--- a/src/agentscope/model/_openai_chat/_model.py
+++ b/src/agentscope/model/_openai_chat/_model.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse
-from .._model_usage import ChatUsage, _to_usage_dict
+from .._model_usage import ChatUsage
 from ...credential import OpenAICredential
 from ...formatter import FormatterBase, OpenAIChatFormatter
 from ...message import ThinkingBlock, ToolCallBlock, TextBlock
@@ -218,11 +218,19 @@ class OpenAIChatModel(ChatModelBase):
         async with response as stream:
             async for chunk in stream:
                 if chunk.usage:
+                    u = chunk.usage
+                    details = getattr(u, "prompt_tokens_details", None)
                     usage = ChatUsage(
-                        input_tokens=chunk.usage.prompt_tokens,
-                        output_tokens=chunk.usage.completion_tokens,
+                        input_tokens=u.prompt_tokens,
+                        output_tokens=u.completion_tokens,
                         time=(datetime.now() - start_datetime).total_seconds(),
-                        metadata=_to_usage_dict(chunk.usage),
+                        cache_input_tokens=getattr(
+                            details,
+                            "cached_tokens",
+                            None,
+                        )
+                        if details
+                        else None,
                     )
 
                 # Capture response_id from the first chunk that carries it
@@ -344,11 +352,19 @@ class OpenAIChatModel(ChatModelBase):
 
         usage = None
         if response.usage:
+            u = response.usage
+            details = getattr(u, "prompt_tokens_details", None)
             usage = ChatUsage(
-                input_tokens=response.usage.prompt_tokens,
-                output_tokens=response.usage.completion_tokens,
+                input_tokens=u.prompt_tokens,
+                output_tokens=u.completion_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
-                metadata=response.usage.model_dump(),
+                cache_input_tokens=getattr(
+                    details,
+                    "cached_tokens",
+                    None,
+                )
+                if details
+                else None,
             )
 
         resp_kwargs: dict[str, Any] = {

--- a/src/agentscope/model/_openai_chat/_model.py
+++ b/src/agentscope/model/_openai_chat/_model.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse
-from .._model_usage import ChatUsage
+from .._model_usage import ChatUsage, _to_usage_dict
 from ...credential import OpenAICredential
 from ...formatter import FormatterBase, OpenAIChatFormatter
 from ...message import ThinkingBlock, ToolCallBlock, TextBlock
@@ -222,7 +222,7 @@ class OpenAIChatModel(ChatModelBase):
                         input_tokens=chunk.usage.prompt_tokens,
                         output_tokens=chunk.usage.completion_tokens,
                         time=(datetime.now() - start_datetime).total_seconds(),
-                        metadata=chunk.usage,
+                        metadata=_to_usage_dict(chunk.usage),
                     )
 
                 # Capture response_id from the first chunk that carries it
@@ -348,7 +348,7 @@ class OpenAIChatModel(ChatModelBase):
                 input_tokens=response.usage.prompt_tokens,
                 output_tokens=response.usage.completion_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
-                metadata=response.usage,
+                metadata=response.usage.model_dump(),
             )
 
         resp_kwargs: dict[str, Any] = {

--- a/src/agentscope/model/_openai_chat/_model.py
+++ b/src/agentscope/model/_openai_chat/_model.py
@@ -227,10 +227,10 @@ class OpenAIChatModel(ChatModelBase):
                         cache_input_tokens=getattr(
                             details,
                             "cached_tokens",
-                            None,
+                            0,
                         )
                         if details
-                        else None,
+                        else 0,
                     )
 
                 # Capture response_id from the first chunk that carries it
@@ -361,10 +361,10 @@ class OpenAIChatModel(ChatModelBase):
                 cache_input_tokens=getattr(
                     details,
                     "cached_tokens",
-                    None,
+                    0,
                 )
                 if details
-                else None,
+                else 0,
             )
 
         resp_kwargs: dict[str, Any] = {

--- a/src/agentscope/model/_openai_response/_model.py
+++ b/src/agentscope/model/_openai_response/_model.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field
 
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse
-from .._model_usage import ChatUsage, _to_usage_dict
+from .._model_usage import ChatUsage
 from ...credential import OpenAICredential
 from ...formatter import FormatterBase, OpenAIResponseFormatter
 from ...message import ThinkingBlock, ToolCallBlock, TextBlock
@@ -259,11 +259,19 @@ class OpenAIResponseModel(ChatModelBase):
                 if response_id is None:
                     response_id = getattr(resp, "id", None)
                 if resp.usage:
+                    u = resp.usage
+                    details = getattr(u, "input_tokens_details", None)
                     usage = ChatUsage(
-                        input_tokens=resp.usage.input_tokens,
-                        output_tokens=resp.usage.output_tokens,
+                        input_tokens=u.input_tokens,
+                        output_tokens=u.output_tokens,
                         time=(datetime.now() - start_datetime).total_seconds(),
-                        metadata=_to_usage_dict(resp.usage),
+                        cache_input_tokens=getattr(
+                            details,
+                            "cached_tokens",
+                            None,
+                        )
+                        if details
+                        else None,
                     )
                 # Attach reasoning item IDs from the completed response so the
                 # formatter can echo them back in multi-turn history.
@@ -380,11 +388,19 @@ class OpenAIResponseModel(ChatModelBase):
 
         usage = None
         if response.usage:
+            u = response.usage
+            details = getattr(u, "input_tokens_details", None)
             usage = ChatUsage(
-                input_tokens=response.usage.input_tokens,
-                output_tokens=response.usage.output_tokens,
+                input_tokens=u.input_tokens,
+                output_tokens=u.output_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
-                metadata=response.usage.model_dump(),
+                cache_input_tokens=getattr(
+                    details,
+                    "cached_tokens",
+                    None,
+                )
+                if details
+                else None,
             )
 
         resp_kwargs: dict[str, Any] = {

--- a/src/agentscope/model/_openai_response/_model.py
+++ b/src/agentscope/model/_openai_response/_model.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field
 
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse
-from .._model_usage import ChatUsage
+from .._model_usage import ChatUsage, _to_usage_dict
 from ...credential import OpenAICredential
 from ...formatter import FormatterBase, OpenAIResponseFormatter
 from ...message import ThinkingBlock, ToolCallBlock, TextBlock
@@ -263,7 +263,7 @@ class OpenAIResponseModel(ChatModelBase):
                         input_tokens=resp.usage.input_tokens,
                         output_tokens=resp.usage.output_tokens,
                         time=(datetime.now() - start_datetime).total_seconds(),
-                        metadata=resp.usage,
+                        metadata=_to_usage_dict(resp.usage),
                     )
                 # Attach reasoning item IDs from the completed response so the
                 # formatter can echo them back in multi-turn history.
@@ -384,7 +384,7 @@ class OpenAIResponseModel(ChatModelBase):
                 input_tokens=response.usage.input_tokens,
                 output_tokens=response.usage.output_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
-                metadata=response.usage,
+                metadata=response.usage.model_dump(),
             )
 
         resp_kwargs: dict[str, Any] = {

--- a/src/agentscope/model/_openai_response/_model.py
+++ b/src/agentscope/model/_openai_response/_model.py
@@ -268,10 +268,10 @@ class OpenAIResponseModel(ChatModelBase):
                         cache_input_tokens=getattr(
                             details,
                             "cached_tokens",
-                            None,
+                            0,
                         )
                         if details
-                        else None,
+                        else 0,
                     )
                 # Attach reasoning item IDs from the completed response so the
                 # formatter can echo them back in multi-turn history.
@@ -397,10 +397,10 @@ class OpenAIResponseModel(ChatModelBase):
                 cache_input_tokens=getattr(
                     details,
                     "cached_tokens",
-                    None,
+                    0,
                 )
                 if details
-                else None,
+                else 0,
             )
 
         resp_kwargs: dict[str, Any] = {

--- a/src/agentscope/model/_xai/_model.py
+++ b/src/agentscope/model/_xai/_model.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field
 
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse
-from .._model_usage import ChatUsage, _to_usage_dict
+from .._model_usage import ChatUsage
 from ...credential import XAICredential
 from ...formatter import XAIChatFormatter
 from ...message import (
@@ -338,7 +338,11 @@ class XAIChatModel(ChatModelBase):
                 input_tokens=u.prompt_tokens,
                 output_tokens=u.completion_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
-                metadata=_to_usage_dict(u),
+                cache_input_tokens=getattr(
+                    u,
+                    "cached_prompt_text_tokens",
+                    None,
+                ),
             )
 
         final_kwargs: dict[str, Any] = {
@@ -392,7 +396,11 @@ class XAIChatModel(ChatModelBase):
                 input_tokens=u.prompt_tokens,
                 output_tokens=u.completion_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
-                metadata=_to_usage_dict(u),
+                cache_input_tokens=getattr(
+                    u,
+                    "cached_prompt_text_tokens",
+                    None,
+                ),
             )
 
         resp_kwargs: dict[str, Any] = {

--- a/src/agentscope/model/_xai/_model.py
+++ b/src/agentscope/model/_xai/_model.py
@@ -341,7 +341,7 @@ class XAIChatModel(ChatModelBase):
                 cache_input_tokens=getattr(
                     u,
                     "cached_prompt_text_tokens",
-                    None,
+                    0,
                 ),
             )
 
@@ -399,7 +399,7 @@ class XAIChatModel(ChatModelBase):
                 cache_input_tokens=getattr(
                     u,
                     "cached_prompt_text_tokens",
-                    None,
+                    0,
                 ),
             )
 

--- a/src/agentscope/model/_xai/_model.py
+++ b/src/agentscope/model/_xai/_model.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field
 
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse
-from .._model_usage import ChatUsage
+from .._model_usage import ChatUsage, _to_usage_dict
 from ...credential import XAICredential
 from ...formatter import XAIChatFormatter
 from ...message import (
@@ -338,7 +338,7 @@ class XAIChatModel(ChatModelBase):
                 input_tokens=u.prompt_tokens,
                 output_tokens=u.completion_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
-                metadata=u,
+                metadata=_to_usage_dict(u),
             )
 
         final_kwargs: dict[str, Any] = {
@@ -392,7 +392,7 @@ class XAIChatModel(ChatModelBase):
                 input_tokens=u.prompt_tokens,
                 output_tokens=u.completion_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
-                metadata=u,
+                metadata=_to_usage_dict(u),
             )
 
         resp_kwargs: dict[str, Any] = {


### PR DESCRIPTION
## AgentScope Version

[The version of AgentScope you are working on, e.g. `import agentscope; print(agentscope.__version__)`]

## Description

Add a `_to_usage_dict()` helper in `_model_usage.py` that safely converts arbitrary SDK usage objects (Pydantic v1/v2, proto-plus, plain Python objects) to a plain dict. Apply it in all 9 model files where streaming or third-party SDK response objects were incorrectly passed as metadata instead of a serialized dict, making the actual type consistent with the `dict[str, Any] | None` annotation on ChatUsage.metadata.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review