### PR TITLE
fix(anthropic): handle None input_tokens in stream message_delta event

### DIFF
--- a/src/agentscope/model/_anthropic_model.py
+++ b/src/agentscope/model/_anthropic_model.py
@@ -461,10 +461,13 @@ class AnthropicChatModel(ChatModelBase):
                     # (e.g., DashScope), the input tokens are contained in
                     # events where event.type == "message_delta", so we add
                     # this step to extract the value.
-                    final_input_tokens = getattr(
-                        event.usage,
-                        "input_tokens",
-                        0,
+                    final_input_tokens = (
+                        getattr(
+                            event.usage,
+                            "input_tokens",
+                            0,
+                        )
+                        or 0
                     )
                     if final_input_tokens > usage.input_tokens:
                         usage.input_tokens = final_input_tokens


### PR DESCRIPTION
## AgentScope Version

1.0.19.post1

## Description

getattr with a default value does not guard against the attribute existing but being None. Adding `or 0` ensures `final_input_tokens` is always an int, preventing `TypeError: '>' not supported between instances of NoneType and int`.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review