### PR TITLE
fix(tracing): handle CancelledError when closing spans

### DIFF
--- a/src/agentscope/tracing/_trace.py
+++ b/src/agentscope/tracing/_trace.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """The tracing decorators for agent, formatter, toolkit, chat and embedding
 models."""
+import asyncio
 import inspect
 from functools import wraps
 from typing import (
@@ -89,13 +90,13 @@ def _set_span_success_status(span: Span) -> None:
     span.end()
 
 
-def _set_span_error_status(span: Span, e: Exception) -> None:
+def _set_span_error_status(span: Span, e: BaseException) -> None:
     """Set the status of the span.
     Args:
         span (`Span`):
             The OpenTelemetry span to be used for tracing.
-        e (`Exception`):
-            The exception to be recorded.
+        e (`BaseException`):
+            The BaseException to be recorded.
     """
     from opentelemetry import trace as trace_api
 
@@ -155,7 +156,7 @@ async def _trace_async_generator_wrapper(
             last_chunk = chunk
             yield chunk
 
-    except Exception as e:
+    except (asyncio.CancelledError, Exception) as e:
         has_error = True
         _set_span_error_status(span, e)
         raise e from None
@@ -263,7 +264,7 @@ def trace(
                         _set_span_success_status(span)
                         return res
 
-                    except Exception as e:
+                    except (asyncio.CancelledError, Exception) as e:
                         _set_span_error_status(span, e)
                         raise e from None
 
@@ -356,9 +357,8 @@ def trace_toolkit(
                 # Return the wrapped generator
                 return _trace_async_generator_wrapper(res, span)
 
-            except Exception as e:
+            except (asyncio.CancelledError, Exception) as e:
                 _set_span_error_status(span, e)
-                span.end()
                 raise e from None
 
     return wrapper
@@ -426,7 +426,7 @@ def trace_reply(
                 _set_span_success_status(span)
                 return res
 
-            except Exception as e:
+            except (asyncio.CancelledError, Exception) as e:
                 _set_span_error_status(span, e)
                 raise e from None
 
@@ -486,7 +486,7 @@ def trace_embedding(
                 _set_span_success_status(span)
                 return res
 
-            except Exception as e:
+            except (asyncio.CancelledError, Exception) as e:
                 _set_span_error_status(span, e)
                 raise e from None
 
@@ -557,7 +557,7 @@ def trace_format(
                 _set_span_success_status(span)
                 return res
 
-            except Exception as e:
+            except (asyncio.CancelledError, Exception) as e:
                 _set_span_error_status(span, e)
                 raise e from None
 
@@ -639,7 +639,7 @@ def trace_llm(
                 _set_span_success_status(span)
                 return res
 
-            except Exception as e:
+            except (asyncio.CancelledError, Exception) as e:
                 _set_span_error_status(span, e)
                 raise e from None
 

--- a/tests/tracing_cancelled_error_test.py
+++ b/tests/tracing_cancelled_error_test.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""The unittests for tracing handling CancelledError."""
+import asyncio
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.trace import StatusCode
+
+from agentscope import _config
+from agentscope.tracing import trace
+
+
+class TracingCancelledErrorTest(IsolatedAsyncioTestCase):
+    """Test the tracing for handling CancelledError in async functions."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up the test case"""
+
+        self._original_trace_enabled = _config.trace_enabled
+        _config.trace_enabled = True
+        self.exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(self.exporter))
+        self.tracer = provider.get_tracer(
+            "tests.tracing_cancelled_error_test",
+        )
+        self.tracer_patcher = patch(
+            "agentscope.tracing._trace._get_tracer",
+            return_value=self.tracer,
+        )
+        self.tracer_patcher.start()
+        self.addCleanup(self.tracer_patcher.stop)
+
+    async def test_trace_ends_span_for_normal_exception(self) -> None:
+        """Test that normal exceptions end the span with error status."""
+
+        @trace(name="normal_exception_case")
+        async def raise_value_error() -> None:
+            raise ValueError("normal exception")
+
+        with self.assertRaises(ValueError):
+            await raise_value_error()
+
+        finished_spans = self.exporter.get_finished_spans()
+
+        self.assertEqual(len(finished_spans), 1)
+        self.assertEqual(
+            finished_spans[0].status.status_code,
+            StatusCode.ERROR,
+        )
+
+    async def test_trace_should_end_span_for_cancelled_error(self) -> None:
+        """Test that CancelledError ends the span with error status."""
+
+        @trace(name="cancelled_error_case")
+        async def raise_cancelled_error() -> None:
+            raise asyncio.CancelledError("set cancelled error")
+
+        with self.assertRaises(asyncio.CancelledError):
+            await raise_cancelled_error()
+
+        finished_spans = self.exporter.get_finished_spans()
+
+        self.assertEqual(len(finished_spans), 1)
+        self.assertEqual(
+            finished_spans[0].status.status_code,
+            StatusCode.ERROR,
+        )
+
+    async def asyncTearDown(self) -> None:
+        """Restore tracing configuration after each test."""
+
+        _config.trace_enabled = self._original_trace_enabled


### PR DESCRIPTION
## AgentScope Version

1.0.20

## Related Issue
Closed #1618

## Description
In Python source code, `asyncio.CancelledError` inherits from `BaseException`, not from `Exception`. And `Exception` inherits from `BaseException`:
```python
@disjoint_base
class BaseException:
	...

class Exception(BaseException): ...


class CancelledError(BaseException):
    """The Future or Task was cancelled."""
```

Currently, the tracing cleanup logic in `src/agentscope/tracing/_trace.py` mainly uses `except Exception`, and spans are used with `end_on_exit=False`. This leads to:

1. When an ordinary coroutine raises a `CancelledError`, the span cannot be ended properly.
2. When an async generator is interrupted by a `CancelledError`, it may be mistakenly recorded as a success state (`OK`).

## Changes

- Explicitly handle `asyncio.CancelledError` in the tracing-related logic.
- Adjust the exception parameter type of `_set_span_error_status` to `BaseException`.
- Add tests for `CancelledError`.

## Impact Scope
`_trace` file

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review