### PR TITLE
feat(rag): add Valkey vector store for RAG pipeline

### DIFF
--- a/examples/functionality/vector_store/valkey/README.md
+++ b/examples/functionality/vector_store/valkey/README.md
@@ -1,0 +1,155 @@
+# Valkey Vector Store
+
+This example demonstrates how to use **ValkeyStore** for vector storage and
+semantic search in AgentScope using Valkey's Search module with HNSW indexing.
+
+### Quick Start
+
+Install agentscope first, and then the Valkey dependency:
+
+```bash
+pip install "valkey-glide>=2.1.0,<3.0.0"
+```
+
+**Prerequisites:** A Valkey server with the Search module loaded on
+`localhost:6379`. The easiest way is using the bundle image:
+
+```bash
+docker run -d --name valkey -p 6379:6379 valkey/valkey-bundle:latest
+```
+
+Run the example script:
+
+```bash
+python main.py
+```
+
+## Usage
+
+### Initialize Store
+
+```python
+from agentscope.rag import ValkeyStore
+
+# Basic standalone connection
+store = ValkeyStore(
+    host="localhost",
+    port=6379,
+    index_name="my_index",
+    prefix="myapp:doc:",
+    dimensions=768,
+    distance="COSINE",
+)
+
+# Cluster mode with TLS
+store = ValkeyStore(
+    host="my-cluster.example.com",
+    port=6379,
+    dimensions=768,
+    use_tls=True,
+    use_cluster=True,
+)
+
+# Custom HNSW parameters for higher recall
+store = ValkeyStore(
+    host="localhost",
+    port=6379,
+    dimensions=768,
+    hnsw_m=32,
+    hnsw_ef_construction=400,
+    hnsw_ef_runtime=100,
+)
+```
+
+### Add Documents
+
+```python
+from agentscope.rag import Document, DocMetadata
+from agentscope.message import TextBlock
+
+doc = Document(
+    metadata=DocMetadata(
+        content=TextBlock(type="text", text="Your document text"),
+        doc_id="doc_1",
+        chunk_id=0,
+        total_chunks=1,
+    ),
+    embedding=[0.1, 0.2, ...],  # Your embedding vector
+)
+
+await store.add([doc])
+```
+
+### Search
+
+```python
+# Basic search
+results = await store.search(
+    query_embedding=[0.15, 0.25, ...],
+    limit=5,
+    score_threshold=0.8,
+)
+
+# Search with filter expression
+results = await store.search(
+    query_embedding=[0.15, 0.25, ...],
+    limit=5,
+    filter_expression="@doc_id:{my_doc}",
+)
+```
+
+### Delete
+
+```python
+# Delete by document ID (removes all chunks)
+await store.delete(ids=["doc_1", "doc_2"])
+
+# Delete specific keys directly
+await store.delete(keys=["myapp:doc:some-uuid"])
+```
+
+### Cleanup
+
+```python
+# Drop the search index (keeps data)
+await store.drop_index()
+
+# Close the connection
+await store.close()
+```
+
+## Distance Metrics
+
+| Metric | Description | Best For |
+|--------|-------------|----------|
+| **COSINE** | Cosine similarity | Text embeddings (recommended) |
+| **L2** | Euclidean distance | Spatial data |
+| **IP** | Inner product | Normalized embeddings |
+
+## Advanced Usage
+
+### Access Underlying Client
+
+```python
+client = store.get_client()
+# Use the Glide client for advanced Valkey operations
+await client.ping()
+```
+
+### HNSW Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `hnsw_m` | Max edges per node | Valkey default (16) |
+| `hnsw_ef_construction` | Vectors examined during indexing | Valkey default (200) |
+| `hnsw_ef_runtime` | Vectors examined during search | Valkey default (10) |
+| `initial_cap` | Initial index capacity | Auto |
+
+Higher `hnsw_m` and `hnsw_ef_*` values improve recall at the cost of memory
+and latency.
+
+## References
+
+- [Valkey Search Documentation](https://valkey.io/topics/search/)
+- [Valkey GLIDE Python Client](https://glide.valkey.io/)
+- [AgentScope RAG Tutorial](https://doc.agentscope.io/tutorial/task_rag.html)

--- a/examples/functionality/vector_store/valkey/main.py
+++ b/examples/functionality/vector_store/valkey/main.py
@@ -1,0 +1,284 @@
+# -*- coding: utf-8 -*-
+"""Example of using ValkeyStore in AgentScope RAG system.
+
+Requires a Valkey server with the Search module on localhost:6379.
+"""
+import asyncio
+
+from agentscope.rag import (
+    ValkeyStore,
+    Document,
+    DocMetadata,
+)
+from agentscope.message import TextBlock
+
+
+async def example_basic_operations() -> None:
+    """The example of basic CRUD operations with ValkeyStore."""
+    print("\n" + "=" * 60)
+    print("Test 1: Basic CRUD Operations")
+    print("=" * 60)
+
+    store = ValkeyStore(
+        host="localhost",
+        port=6379,
+        index_name="example_basic_idx",
+        prefix="example:basic:",
+        dimensions=4,
+        distance="COSINE",
+    )
+
+    print("✓ ValkeyStore initialized")
+
+    # Create test documents with embeddings
+    test_docs = [
+        Document(
+            metadata=DocMetadata(
+                content=TextBlock(
+                    type="text",
+                    text="Artificial Intelligence is the future",
+                ),
+                doc_id="doc_1",
+                chunk_id=0,
+                total_chunks=1,
+            ),
+            embedding=[0.1, 0.2, 0.3, 0.4],
+        ),
+        Document(
+            metadata=DocMetadata(
+                content=TextBlock(
+                    type="text",
+                    text="Machine Learning is a subset of AI",
+                ),
+                doc_id="doc_2",
+                chunk_id=0,
+                total_chunks=1,
+            ),
+            embedding=[0.2, 0.3, 0.4, 0.5],
+        ),
+        Document(
+            metadata=DocMetadata(
+                content=TextBlock(
+                    type="text",
+                    text="Deep Learning uses neural networks",
+                ),
+                doc_id="doc_3",
+                chunk_id=0,
+                total_chunks=1,
+            ),
+            embedding=[0.3, 0.4, 0.5, 0.6],
+        ),
+    ]
+
+    # Add documents (automatically creates index if needed)
+    await store.add(test_docs)
+    print(f"✓ Added {len(test_docs)} documents to the store")
+
+    # Wait briefly for indexing
+    await asyncio.sleep(0.5)
+
+    # Search for similar documents
+    query_embedding = [0.15, 0.25, 0.35, 0.45]
+    results = await store.search(
+        query_embedding=query_embedding,
+        limit=2,
+    )
+
+    print(f"\n✓ Search completed, found {len(results)} results:")
+    for i, result in enumerate(results, 1):
+        print(f"  {i}. Score: {result.score:.4f}")
+        print(f"     Content: {result.metadata.content}")
+        print(f"     Doc ID: {result.metadata.doc_id}")
+
+    # Search with score threshold
+    results_filtered = await store.search(
+        query_embedding=query_embedding,
+        limit=5,
+        score_threshold=0.99,
+    )
+    print(
+        f"\n✓ Search with threshold (>0.99): "
+        f"{len(results_filtered)} results",
+    )
+
+    # Delete by doc_id
+    await store.delete(ids=["doc_2", "doc_3"])
+    await asyncio.sleep(0.3)
+    print("\n✓ Deleted doc_2 and doc_3")
+
+    # Verify deletion
+    results_after = await store.search(
+        query_embedding=query_embedding,
+        limit=5,
+    )
+    print(f"✓ After deletion: {len(results_after)} documents remain")
+
+    # Cleanup
+    await store.drop_index()
+    await store.close()
+
+
+async def example_multiple_chunks() -> None:
+    """The example of documents with multiple chunks."""
+    print("\n" + "=" * 60)
+    print("Test 2: Documents with Multiple Chunks")
+    print("=" * 60)
+
+    store = ValkeyStore(
+        host="localhost",
+        port=6379,
+        index_name="example_chunks_idx",
+        prefix="example:chunks:",
+        dimensions=4,
+        distance="COSINE",
+    )
+
+    # Create a document split into multiple chunks
+    chunks = [
+        Document(
+            metadata=DocMetadata(
+                content=TextBlock(
+                    type="text",
+                    text="Chapter 1: Introduction to AI",
+                ),
+                doc_id="book_1",
+                chunk_id=0,
+                total_chunks=3,
+            ),
+            embedding=[0.1, 0.2, 0.3, 0.4],
+        ),
+        Document(
+            metadata=DocMetadata(
+                content=TextBlock(
+                    type="text",
+                    text="Chapter 2: Machine Learning Basics",
+                ),
+                doc_id="book_1",
+                chunk_id=1,
+                total_chunks=3,
+            ),
+            embedding=[0.2, 0.3, 0.4, 0.5],
+        ),
+        Document(
+            metadata=DocMetadata(
+                content=TextBlock(
+                    type="text",
+                    text="Chapter 3: Deep Learning Advanced",
+                ),
+                doc_id="book_1",
+                chunk_id=2,
+                total_chunks=3,
+            ),
+            embedding=[0.3, 0.4, 0.5, 0.6],
+        ),
+    ]
+
+    await store.add(chunks)
+    print(f"✓ Added document with {len(chunks)} chunks")
+
+    await asyncio.sleep(0.5)
+
+    # Search and verify chunk information
+    results = await store.search(
+        query_embedding=[0.2, 0.3, 0.4, 0.5],
+        limit=3,
+    )
+
+    print("\n✓ Search results for multi-chunk document:")
+    for i, result in enumerate(results, 1):
+        chunk_info = (
+            f"{result.metadata.chunk_id}/{result.metadata.total_chunks}"
+        )
+        print(f"  {i}. Chunk {chunk_info}")
+        print(f"     Content: {result.metadata.content}")
+        print(f"     Score: {result.score:.4f}")
+
+    # Delete entire document (all chunks)
+    await store.delete(ids=["book_1"])
+    await asyncio.sleep(0.3)
+
+    results_after = await store.search(
+        query_embedding=[0.2, 0.3, 0.4, 0.5],
+        limit=3,
+    )
+    print(f"\n✓ After deleting book_1: {len(results_after)} chunks remain")
+
+    await store.drop_index()
+    await store.close()
+
+
+async def example_distance_metrics() -> None:
+    """The example of different distance metrics."""
+    print("\n" + "=" * 60)
+    print("Test 3: Different Distance Metrics")
+    print("=" * 60)
+
+    metrics = ["COSINE", "L2", "IP"]
+
+    for metric in metrics:
+        print(f"\n--- Testing {metric} metric ---")
+        store = ValkeyStore(
+            host="localhost",
+            port=6379,
+            index_name=f"example_{metric.lower()}_idx",
+            prefix=f"example:{metric.lower()}:",
+            dimensions=4,
+            distance=metric,
+        )
+
+        docs = [
+            Document(
+                metadata=DocMetadata(
+                    content=TextBlock(
+                        type="text",
+                        text=f"Test doc for {metric}",
+                    ),
+                    doc_id=f"doc_{metric}",
+                    chunk_id=0,
+                    total_chunks=1,
+                ),
+                embedding=[0.1, 0.2, 0.3, 0.4],
+            ),
+        ]
+
+        await store.add(docs)
+        await asyncio.sleep(0.5)
+
+        results = await store.search(
+            query_embedding=[0.1, 0.2, 0.3, 0.4],
+            limit=1,
+        )
+
+        if results:
+            print(f"✓ {metric}: Score = {results[0].score:.4f}")
+        else:
+            print(f"✗ {metric}: No results returned")
+
+        await store.drop_index()
+        await store.close()
+
+
+async def main() -> None:
+    """Run all examples."""
+    print("\n" + "=" * 60)
+    print("ValkeyStore Example Suite")
+    print("=" * 60)
+
+    try:
+        await example_basic_operations()
+        await example_multiple_chunks()
+        await example_distance_metrics()
+
+        print("\n" + "=" * 60)
+        print("✓ All examples completed successfully!")
+        print("=" * 60)
+
+    except Exception as e:
+        print(f"\n✗ Example failed with error: {e}")
+        import traceback
+
+        traceback.print_exc()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,12 +128,14 @@ milvus = ["pymilvus[milvus_lite]==2.6.2", "milvus-lite==2.5.1; sys_platform != '
 ali_mysql = ["mysql-connector-python"]
 mongodb = ["pymongo"]
 oceanbase = ["pyobvector>=0.2.0,<0.3.0"]
+valkey = ["valkey-glide>=2.1.0,<3.0.0"]
 vdbs = [
     "agentscope[ali_mysql]",
     "agentscope[qdrant]",
     "agentscope[milvus]",
     "agentscope[mongodb]",
     "agentscope[oceanbase]",
+    "agentscope[valkey]",
 ]
 
 rag = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ milvus = ["pymilvus[milvus_lite]==2.6.2", "milvus-lite==2.5.1; sys_platform != '
 ali_mysql = ["mysql-connector-python"]
 mongodb = ["pymongo"]
 oceanbase = ["pyobvector>=0.2.0,<0.3.0"]
-valkey = ["valkey-glide>=2.1.0,<3.0.0"]
+valkey = ["valkey-glide>=2.4.0,<3.0.0"]
 vdbs = [
     "agentscope[ali_mysql]",
     "agentscope[qdrant]",

--- a/src/agentscope/rag/__init__.py
+++ b/src/agentscope/rag/__init__.py
@@ -21,6 +21,7 @@ from ._store import (
     OceanBaseStore,
     MongoDBStore,
     AlibabaCloudMySQLStore,
+    ValkeyStore,
 )
 from ._knowledge_base import KnowledgeBase
 from ._simple_knowledge import SimpleKnowledge
@@ -42,6 +43,7 @@ __all__ = [
     "OceanBaseStore",
     "MongoDBStore",
     "AlibabaCloudMySQLStore",
+    "ValkeyStore",
     "KnowledgeBase",
     "SimpleKnowledge",
 ]

--- a/src/agentscope/rag/_store/__init__.py
+++ b/src/agentscope/rag/_store/__init__.py
@@ -9,6 +9,7 @@ from ._milvuslite_store import MilvusLiteStore
 from ._oceanbase_store import OceanBaseStore
 from ._mongodb_store import MongoDBStore
 from ._alibabacloud_mysql_store import AlibabaCloudMySQLStore
+from ._valkey_store import ValkeyStore
 
 __all__ = [
     "VDBStoreBase",
@@ -17,4 +18,5 @@ __all__ = [
     "OceanBaseStore",
     "MongoDBStore",
     "AlibabaCloudMySQLStore",
+    "ValkeyStore",
 ]

--- a/src/agentscope/rag/_store/_valkey_store.py
+++ b/src/agentscope/rag/_store/_valkey_store.py
@@ -1,0 +1,579 @@
+# -*- coding: utf-8 -*-
+"""The Valkey vector store implementation using Valkey Search module.
+
+This implementation provides a vector database store using Valkey's Search
+module with HNSW indexing for vector similarity search. It uses the
+valkey-glide client library for async communication with Valkey.
+"""
+import json
+import struct
+import asyncio
+from typing import Any, Literal, TYPE_CHECKING
+
+from .._reader import Document
+from ._store_base import VDBStoreBase
+from .._document import DocMetadata
+from ..._utils._common import _map_text_to_uuid
+from ..._logging import logger
+from ...types import Embedding
+
+if TYPE_CHECKING:
+    from glide import GlideClient, GlideClusterClient
+else:
+    GlideClient = "glide.GlideClient"
+    GlideClusterClient = "glide.GlideClusterClient"
+
+
+def _float_list_to_bytes(floats: list[float]) -> bytes:
+    """Convert a list of floats to a binary blob (FLOAT32 little-endian)."""
+    return struct.pack(f"<{len(floats)}f", *floats)
+
+
+def _escape_tag_value(value: str) -> str:
+    """Escape special characters for Valkey Search tag queries."""
+    special = r'\{}|@$"' + "'"
+    return "".join(f"\\{c}" if c in special else c for c in value)
+
+
+class ValkeyStore(VDBStoreBase):
+    """Valkey vector store using the Valkey Search module with HNSW indexing.
+
+    This class provides a vector database store implementation using Valkey's
+    Search module for HNSW-based vector similarity search. Documents are
+    stored as Valkey Hash keys with vector embeddings and JSON-serialized
+    metadata.
+
+    .. note:: Requires a Valkey instance with the Search module loaded.
+
+    Example:
+        .. code-block:: python
+
+            store = ValkeyStore(
+                host="localhost",
+                port=6379,
+                index_name="my_index",
+                dimensions=768,
+                distance="COSINE",
+            )
+            await store.add(documents)
+            results = await store.search(query_embedding, limit=5)
+    """
+
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 6379,
+        index_name: str = "agentscope_idx",
+        prefix: str = "agentscope:doc:",
+        dimensions: int = 768,
+        distance: Literal["COSINE", "L2", "IP"] = "COSINE",
+        use_tls: bool = False,
+        use_cluster: bool = False,
+        hnsw_m: int | None = None,
+        hnsw_ef_construction: int | None = None,
+        hnsw_ef_runtime: int | None = None,
+        initial_cap: int | None = None,
+        client_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize the Valkey vector store.
+
+        Args:
+            host (`str`, defaults to "localhost"):
+                The Valkey server host.
+            port (`int`, defaults to 6379):
+                The Valkey server port.
+            index_name (`str`, defaults to "agentscope_idx"):
+                The name of the search index to create/use.
+            prefix (`str`, defaults to "agentscope:doc:"):
+                The key prefix for stored documents. The index will only
+                cover keys matching this prefix.
+            dimensions (`int`, defaults to 768):
+                The dimension of the embedding vectors.
+            distance (`Literal["COSINE", "L2", "IP"]`, defaults to "COSINE"):
+                The distance metric for vector similarity. Can be one of
+                "COSINE" (cosine similarity), "L2" (Euclidean distance),
+                or "IP" (inner product).
+            use_tls (`bool`, defaults to False):
+                Whether to use TLS for the connection.
+            use_cluster (`bool`, defaults to False):
+                Whether to connect to a Valkey cluster. If True, uses
+                GlideClusterClient instead of GlideClient.
+            hnsw_m (`int | None`, optional):
+                The number of maximum edges per node in the HNSW graph.
+                Higher values improve recall but increase memory usage.
+            hnsw_ef_construction (`int | None`, optional):
+                The number of vectors examined during index construction.
+                Higher values improve recall but slow down indexing.
+            hnsw_ef_runtime (`int | None`, optional):
+                The number of vectors examined during search.
+                Higher values improve recall but slow down queries.
+            initial_cap (`int | None`, optional):
+                Initial capacity for the number of vectors in the index.
+            client_kwargs (`dict[str, Any] | None`, optional):
+                Additional keyword arguments for the Glide client
+                configuration.
+
+        Raises:
+            ImportError: If valkey-glide is not installed.
+        """
+        try:
+            from glide import GlideClient, GlideClusterClient
+        except ImportError as e:
+            raise ImportError(
+                "valkey-glide is not installed. Please install it with "
+                "`pip install valkey-glide`.",
+            ) from e
+
+        self.index_name = index_name
+        self.prefix = prefix
+        self.dimensions = dimensions
+        self.distance = distance
+        self.hnsw_m = hnsw_m
+        self.hnsw_ef_construction = hnsw_ef_construction
+        self.hnsw_ef_runtime = hnsw_ef_runtime
+        self.initial_cap = initial_cap
+        self._use_cluster = use_cluster
+
+        self._host = host
+        self._port = port
+        self._use_tls = use_tls
+        self._client_kwargs = client_kwargs or {}
+
+        self._client: GlideClient | GlideClusterClient | None = None
+        self._client_lock = asyncio.Lock()
+        self._index_created = False
+
+    async def _get_client(
+        self,
+    ) -> "GlideClient | GlideClusterClient":
+        """Get or create the Glide client connection."""
+        if self._client is not None:
+            return self._client
+
+        async with self._client_lock:
+            # Double-check after acquiring lock
+            if self._client is not None:
+                return self._client
+
+            from glide import (
+                GlideClient,
+                GlideClusterClient,
+                GlideClientConfiguration,
+                GlideClusterClientConfiguration,
+                NodeAddress,
+            )
+
+            address = NodeAddress(host=self._host, port=self._port)
+
+            if self._use_cluster:
+                config = GlideClusterClientConfiguration(
+                    addresses=[address],
+                    use_tls=self._use_tls,
+                    client_name="agentscope_rag_store_client",
+                    **self._client_kwargs,
+                )
+                self._client = await GlideClusterClient.create(
+                    config,
+                )
+            else:
+                config = GlideClientConfiguration(
+                    addresses=[address],
+                    use_tls=self._use_tls,
+                    client_name="agentscope_rag_store_client",
+                    **self._client_kwargs,
+                )
+                self._client = await GlideClient.create(config)
+
+            return self._client
+
+    async def _ensure_index(self) -> None:
+        """Ensure the search index exists, creating it if necessary."""
+        if self._index_created:
+            return
+
+        from glide import ft
+
+        # NOTE: glide_shared is an internal module path in valkey-glide.
+        # The version constraint (<3.0.0) guards against breaking changes.
+        from glide_shared.commands.server_modules.ft_options import (
+            ft_create_options,
+        )
+
+        FtCreateOptions = ft_create_options.FtCreateOptions
+        DataType = ft_create_options.DataType
+        VectorField = ft_create_options.VectorField
+        VectorAlgorithm = ft_create_options.VectorAlgorithm
+        VectorFieldAttributesHnsw = ft_create_options.VectorFieldAttributesHnsw
+        DistanceMetricType = ft_create_options.DistanceMetricType
+        VectorType = ft_create_options.VectorType
+        TagField = ft_create_options.TagField
+        NumericField = ft_create_options.NumericField
+
+        client = await self._get_client()
+
+        # Check if index already exists
+        try:
+            existing_indices = await ft.list(client)
+            index_names = [
+                idx.decode() if isinstance(idx, bytes) else idx
+                for idx in existing_indices
+            ]
+            if self.index_name in index_names:
+                self._index_created = True
+                return
+        except Exception as e:
+            err_msg = str(e).lower()
+            if "unknown command" in err_msg or "no such module" in err_msg:
+                logger.warning(
+                    "FT._LIST unavailable, attempting FT.CREATE: %s",
+                    e,
+                )
+            else:
+                raise
+
+        # Build HNSW vector field attributes
+        hnsw_attrs = VectorFieldAttributesHnsw(
+            dimensions=self.dimensions,
+            distance_metric=getattr(
+                DistanceMetricType,
+                self.distance,
+            ),
+            type=VectorType.FLOAT32,
+            initial_cap=self.initial_cap,
+            number_of_edges=self.hnsw_m,
+            vectors_examined_on_construction=self.hnsw_ef_construction,
+            vectors_examined_on_runtime=self.hnsw_ef_runtime,
+        )
+
+        # Define the schema: vector field + metadata fields for filtering
+        schema = [
+            VectorField(
+                name="vector",
+                algorithm=VectorAlgorithm.HNSW,
+                attributes=hnsw_attrs,
+            ),
+            TagField("doc_id"),
+            NumericField("chunk_id"),
+        ]
+
+        options = FtCreateOptions(
+            data_type=DataType.HASH,
+            prefixes=[self.prefix],
+        )
+
+        await ft.create(
+            client,
+            self.index_name,
+            schema=schema,
+            options=options,
+        )
+        self._index_created = True
+
+    def _make_key(self, document: Document) -> str:
+        """Generate a deterministic Valkey key for a document."""
+        unique_id = _map_text_to_uuid(
+            json.dumps(
+                {
+                    "doc_id": document.metadata.doc_id,
+                    "chunk_id": document.metadata.chunk_id,
+                    "content": document.metadata.content,
+                },
+                ensure_ascii=False,
+            ),
+        )
+        return f"{self.prefix}{unique_id}"
+
+    async def add(self, documents: list[Document], **kwargs: Any) -> None:
+        """Add documents with embeddings to the Valkey vector store.
+
+        Each document is stored as a Valkey Hash with the following fields:
+        - ``vector``: The embedding as a binary FLOAT32 blob.
+        - ``doc_id``: The document ID (used as a tag for filtering).
+        - ``metadata``: JSON-serialized DocMetadata.
+
+        Args:
+            documents (`list[Document]`):
+                A list of Document objects to store. Each must have a
+                non-None ``embedding`` field.
+            **kwargs (`Any`):
+                Additional keyword arguments (unused).
+        """
+        await self._ensure_index()
+        client = await self._get_client()
+
+        from glide import Batch
+
+        batch = Batch(is_atomic=False)
+        for doc in documents:
+            if doc.embedding is None:
+                raise ValueError(
+                    f"Document (doc_id={doc.metadata.doc_id}, "
+                    f"chunk_id={doc.metadata.chunk_id}) has no "
+                    f"embedding.",
+                )
+
+            key = self._make_key(doc)
+            metadata_json = json.dumps(
+                {
+                    "doc_id": doc.metadata.doc_id,
+                    "chunk_id": doc.metadata.chunk_id,
+                    "total_chunks": doc.metadata.total_chunks,
+                    "content": doc.metadata.content,
+                },
+                ensure_ascii=False,
+            )
+
+            field_map: dict[str, str | bytes] = {
+                "vector": _float_list_to_bytes(doc.embedding),
+                "doc_id": doc.metadata.doc_id,
+                "chunk_id": str(doc.metadata.chunk_id),
+                "metadata": metadata_json,
+            }
+
+            batch.hset(key, field_map)  # type: ignore[arg-type]
+
+        if documents:
+            await client.exec(batch, raise_on_error=True)
+
+    async def search(
+        self,
+        query_embedding: Embedding,
+        limit: int,
+        score_threshold: float | None = None,
+        **kwargs: Any,
+    ) -> list[Document]:
+        """Search for relevant documents using vector similarity.
+
+        Uses Valkey's FT.SEARCH with a KNN vector query to find the most
+        similar documents.
+
+        Args:
+            query_embedding (`Embedding`):
+                The embedding vector to search for.
+            limit (`int`):
+                Maximum number of documents to return.
+            score_threshold (`float | None`, optional):
+                Minimum similarity score threshold. For COSINE distance,
+                scores range from 0 to 1 (higher is more similar).
+                Documents below this threshold are filtered out.
+            **kwargs (`Any`):
+                Additional keyword arguments. Supports:
+                - ``filter_expression`` (`str`): A Valkey Search filter
+                  expression to apply, e.g. ``"@doc_id:{my_doc}"``.
+
+        Returns:
+            `list[Document]`:
+                A list of Document objects with metadata and scores,
+                sorted by relevance (most similar first).
+        """
+        await self._ensure_index()
+        client = await self._get_client()
+
+        from glide import ft
+        from glide_shared.commands.server_modules.ft_options import (
+            ft_search_options,
+        )
+
+        FtSearchOptions = ft_search_options.FtSearchOptions
+        FtSearchLimit = ft_search_options.FtSearchLimit
+        ReturnField = ft_search_options.ReturnField
+
+        # Build KNN query
+        filter_expr = kwargs.pop("filter_expression", "*")
+        if "=>" in filter_expr:
+            raise ValueError(
+                "filter_expression must not contain '=>'.",
+            )
+        query = (
+            f"{filter_expr}=>"
+            f"[KNN {limit} @vector $query_vec AS vector_score]"
+        )
+
+        query_vec_bytes = _float_list_to_bytes(query_embedding)
+
+        options = FtSearchOptions(
+            params={"query_vec": query_vec_bytes},
+            return_fields=[
+                ReturnField(field_identifier="metadata"),
+                ReturnField(field_identifier="vector_score"),
+            ],
+            limit=FtSearchLimit(offset=0, count=limit),
+        )
+
+        response = await ft.search(
+            client,
+            self.index_name,
+            query,
+            options=options,
+        )
+
+        # FT.SEARCH returns [total_count: int, results: Mapping]
+        if (
+            not response
+            or len(response) < 2
+            or not isinstance(response[1], dict)
+        ):
+            return []
+
+        results_map = response[1]
+        collected: list[Document] = []
+
+        for _key, fields in results_map.items():
+            # Parse the vector score (aliased as "vector_score")
+            # Valkey returns distance (lower = more similar for COSINE)
+            # Convert to similarity: score = 1 - distance for COSINE
+            raw_score = fields.get(
+                b"vector_score",
+                fields.get("vector_score", None),
+            )
+            if raw_score is not None:
+                distance = float(
+                    raw_score.decode()
+                    if isinstance(raw_score, bytes)
+                    else raw_score,
+                )
+                if self.distance == "COSINE":
+                    score = 1.0 - distance
+                elif self.distance == "IP":
+                    score = 1.0 - distance
+                else:
+                    # L2: lower distance = more similar, invert
+                    score = 1.0 / (1.0 + distance)
+            else:
+                score = 0.0
+
+            # Apply score threshold
+            if score_threshold is not None and score < score_threshold:
+                continue
+
+            # Parse metadata
+            metadata_raw = fields.get(
+                b"metadata",
+                fields.get("metadata", "{}"),
+            )
+            if isinstance(metadata_raw, bytes):
+                metadata_raw = metadata_raw.decode()
+            metadata_dict = json.loads(metadata_raw)
+            metadata = DocMetadata(**metadata_dict)
+
+            collected.append(
+                Document(
+                    metadata=metadata,
+                    score=score,
+                ),
+            )
+
+        return collected
+
+    async def delete(
+        self,
+        ids: str | list[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Delete documents from the Valkey vector store.
+
+        Args:
+            ids (`str | list[str] | None`, optional):
+                Document IDs (doc_id values) to delete. All chunks
+                belonging to the specified doc_ids will be removed.
+            **kwargs (`Any`):
+                Additional keyword arguments. Supports:
+                - ``keys`` (`list[str]`): Specific Valkey keys to delete
+                  directly.
+        """
+        client = await self._get_client()
+
+        # If specific keys are provided, delete them directly
+        keys = kwargs.pop("keys", None)
+        if keys:
+            for key in keys:
+                await client.delete([key])
+            return
+
+        if not ids:
+            return
+
+        if isinstance(ids, str):
+            ids = [ids]
+
+        # Use FT.SEARCH to find keys matching the doc_ids, then delete
+        from glide import ft
+        from glide_shared.commands.server_modules.ft_options import (
+            ft_search_options,
+        )
+
+        FtSearchOptions = ft_search_options.FtSearchOptions
+        FtSearchLimit = ft_search_options.FtSearchLimit
+
+        await self._ensure_index()
+
+        _batch_size = 500
+        for doc_id in ids:
+            escaped_id = _escape_tag_value(doc_id)
+            query = f"@doc_id:{{{escaped_id}}}"
+
+            while True:
+                options = FtSearchOptions(
+                    limit=FtSearchLimit(
+                        offset=0,
+                        count=_batch_size,
+                    ),
+                )
+                response = await ft.search(
+                    client,
+                    self.index_name,
+                    query,
+                    options=options,
+                )
+
+                if not response or len(response) < 2:
+                    break
+
+                results_map = response[1]
+                if not results_map:
+                    break
+
+                keys_to_delete = [
+                    key.decode() if isinstance(key, bytes) else key
+                    for key in results_map
+                ]
+                if keys_to_delete:
+                    await client.delete(keys_to_delete)
+
+                # If we got fewer than batch_size, we're done
+                if len(results_map) < _batch_size:
+                    break
+
+    def get_client(self) -> "GlideClient | GlideClusterClient | None":
+        """Get the underlying Glide client for advanced operations.
+
+        Returns:
+            The GlideClient or GlideClusterClient instance, or None if
+            not yet connected.
+        """
+        return self._client
+
+    async def drop_index(self) -> None:
+        """Drop the search index without deleting the underlying data.
+
+        .. warning::
+            After dropping the index, search operations will fail until
+            a new index is created.
+        """
+        from glide import ft
+
+        client = await self._get_client()
+        existing = await ft.list(client)
+        names = [
+            i.decode() if isinstance(i, bytes) else i for i in (existing or [])
+        ]
+        if self.index_name in names:
+            await ft.dropindex(client, self.index_name)
+        self._index_created = False
+
+    async def close(self) -> None:
+        """Close the Valkey client connection."""
+        if self._client is not None:
+            await self._client.close()
+            self._client = None
+            self._index_created = False

--- a/tests/rag_store_test.py
+++ b/tests/rag_store_test.py
@@ -16,6 +16,7 @@ from agentscope.rag import (
     OceanBaseStore,
     AlibabaCloudMySQLStore,
     MongoDBStore,
+    ValkeyStore,
 )
 
 
@@ -595,3 +596,205 @@ class RAGStoreTest(IsolatedAsyncioTestCase):
         # Remove Milvus Lite database file
         if os.path.exists("./milvus_demo.db"):
             os.remove("./milvus_demo.db")
+
+    async def test_valkey_store(self) -> None:  # pylint: disable=R0915
+        """Test the ValkeyStore implementation using mocks."""
+        import json
+
+        # Create mock glide modules
+        mock_glide = MagicMock()
+        mock_glide_shared = MagicMock()
+        mock_ft_create_options = MagicMock()
+        mock_ft_search_options = MagicMock()
+
+        # Mock GlideClient and GlideClusterClient
+        mock_client_instance = AsyncMock()
+        mock_glide.GlideClient = MagicMock()
+        mock_glide.GlideClient.create = AsyncMock(
+            return_value=mock_client_instance,
+        )
+        mock_glide.GlideClusterClient = MagicMock()
+        mock_glide.GlideClientConfiguration = MagicMock()
+        mock_glide.GlideClusterClientConfiguration = MagicMock()
+        mock_glide.NodeAddress = MagicMock()
+
+        # Mock Batch
+        mock_batch_instance = MagicMock()
+        mock_batch_instance.hset = MagicMock()
+        mock_glide.Batch = MagicMock(return_value=mock_batch_instance)
+
+        # Mock ft module
+        mock_ft = MagicMock()
+        mock_ft.list = AsyncMock(return_value=[])
+        mock_ft.create = AsyncMock(return_value="OK")
+        mock_ft.dropindex = AsyncMock(return_value="OK")
+        mock_glide.ft = mock_ft
+
+        # Mock ft_create_options classes
+        mock_ft_create_options.FtCreateOptions = MagicMock()
+        mock_ft_create_options.DataType = MagicMock()
+        mock_ft_create_options.DataType.HASH = "HASH"
+        mock_ft_create_options.VectorField = MagicMock()
+        mock_ft_create_options.VectorAlgorithm = MagicMock()
+        mock_ft_create_options.VectorAlgorithm.HNSW = "HNSW"
+        mock_ft_create_options.VectorFieldAttributesHnsw = MagicMock()
+        mock_ft_create_options.DistanceMetricType = MagicMock()
+        mock_ft_create_options.DistanceMetricType.COSINE = "COSINE"
+        mock_ft_create_options.VectorType = MagicMock()
+        mock_ft_create_options.VectorType.FLOAT32 = "FLOAT32"
+        mock_ft_create_options.TagField = MagicMock()
+        mock_ft_create_options.NumericField = MagicMock()
+
+        # Mock ft_search_options classes
+        mock_ft_search_options.FtSearchOptions = MagicMock()
+        mock_ft_search_options.FtSearchLimit = MagicMock()
+        mock_ft_search_options.ReturnField = MagicMock()
+
+        # Mock hset
+        mock_client_instance.hset = AsyncMock()
+
+        # Mock exec (for batch operations)
+        mock_client_instance.exec = AsyncMock(return_value=[])
+
+        # Mock delete
+        mock_client_instance.delete = AsyncMock()
+
+        # Prepare search response
+        # Valkey FT.SEARCH returns [count, {key: {field: value}}]
+        metadata_doc = {
+            "doc_id": "doc1",
+            "chunk_id": 0,
+            "total_chunks": 2,
+            "content": {
+                "type": "text",
+                "text": "This is a test document.",
+            },
+        }
+        # COSINE distance of 0.0026 => similarity = 1 - 0.0026 = 0.9974
+        mock_search_response = [
+            1,
+            {
+                b"agentscope:doc:some-uuid": {
+                    b"metadata": json.dumps(metadata_doc).encode(),
+                    b"vector_score": b"0.0026",
+                },
+            },
+        ]
+        mock_ft.search = AsyncMock(return_value=mock_search_response)
+
+        # Mock search for delete (find keys by doc_id)
+        mock_delete_search_response = [
+            2,
+            {
+                b"agentscope:doc:uuid-1": {},
+                b"agentscope:doc:uuid-2": {},
+            },
+        ]
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "glide": mock_glide,
+                "glide.async_commands": MagicMock(),
+                "glide.async_commands.ft": mock_ft,
+                "glide_shared": mock_glide_shared,
+                "glide_shared.commands": MagicMock(),
+                "glide_shared.commands.server_modules": MagicMock(),
+                "glide_shared.commands.server_modules.ft_options": (
+                    MagicMock()
+                ),
+                "glide_shared.commands.server_modules.ft_options"
+                ".ft_create_options": mock_ft_create_options,
+                "glide_shared.commands.server_modules.ft_options"
+                ".ft_search_options": mock_ft_search_options,
+            },
+        ):
+            store = ValkeyStore(
+                host="localhost",
+                port=6379,
+                index_name="test_idx",
+                prefix="test:doc:",
+                dimensions=3,
+                distance="COSINE",
+            )
+
+            # Inject the mock client directly
+            store._client = mock_client_instance  # pylint: disable=W0212
+
+            # Test add operation
+            await store.add(
+                [
+                    Document(
+                        embedding=[0.1, 0.2, 0.3],
+                        metadata=DocMetadata(
+                            content=TextBlock(
+                                type="text",
+                                text="This is a test document.",
+                            ),
+                            doc_id="doc1",
+                            chunk_id=0,
+                            total_chunks=2,
+                        ),
+                    ),
+                    Document(
+                        embedding=[0.9, 0.1, 0.4],
+                        metadata=DocMetadata(
+                            content=TextBlock(
+                                type="text",
+                                text="This is another test document.",
+                            ),
+                            doc_id="doc1",
+                            chunk_id=1,
+                            total_chunks=2,
+                        ),
+                    ),
+                ],
+            )
+
+            # Verify exec was called (batch HSET)
+            self.assertTrue(mock_client_instance.exec.called)
+
+            # Test search operation
+            res = await store.search(
+                query_embedding=[0.15, 0.25, 0.35],
+                limit=3,
+                score_threshold=0.8,
+            )
+
+            # Verify search results
+            self.assertEqual(len(res), 1)
+            self.assertEqual(
+                round(res[0].score, 4),
+                0.9974,
+            )
+            self.assertEqual(
+                res[0].metadata.content["text"],
+                "This is a test document.",
+            )
+            self.assertEqual(res[0].metadata.doc_id, "doc1")
+            self.assertEqual(res[0].metadata.chunk_id, 0)
+            self.assertEqual(res[0].metadata.total_chunks, 2)
+
+            # Verify ft.search was called
+            self.assertTrue(mock_ft.search.called)
+
+            # Test delete operation
+            mock_ft.search = AsyncMock(
+                return_value=mock_delete_search_response,
+            )
+            await store.delete(ids="doc1")
+
+            # Verify delete was called with all keys in one batch
+            self.assertTrue(mock_client_instance.delete.called)
+            delete_call_args = mock_client_instance.delete.call_args_list[-1]
+            self.assertEqual(len(delete_call_args[0][0]), 2)
+
+            # Test drop_index
+            mock_ft.list = AsyncMock(
+                return_value=[b"test_idx"],
+            )
+            await store.drop_index()
+            mock_ft.dropindex.assert_called_once()
+            self.assertFalse(
+                store._index_created,  # pylint: disable=W0212
+            )

--- a/tests/valkey_store_integration_test.py
+++ b/tests/valkey_store_integration_test.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+"""Integration test for ValkeyStore against a live Valkey instance.
+
+Requires a Valkey server with the Search module on localhost:6379.
+Run with::
+
+    VALKEY_INTEGRATION_TEST=true pytest tests/valkey_store_integration_test.py
+"""
+import os
+import unittest
+from unittest import IsolatedAsyncioTestCase
+
+from agentscope.message import TextBlock
+from agentscope.rag import ValkeyStore, Document, DocMetadata
+
+_VALKEY_AVAILABLE = (
+    os.environ.get("VALKEY_INTEGRATION_TEST", "").lower() == "true"
+)
+
+
+@unittest.skipUnless(_VALKEY_AVAILABLE, "Requires live Valkey server")
+class ValkeyStoreIntegrationTest(IsolatedAsyncioTestCase):
+    """Integration tests against a real Valkey instance."""
+
+    async def asyncSetUp(self) -> None:
+        """Create a store with a unique index for test isolation."""
+        import uuid
+
+        self.index_name = f"test_idx_{uuid.uuid4().hex[:8]}"
+        self.prefix = f"test:doc:{self.index_name}:"
+        self.store = ValkeyStore(
+            host="localhost",
+            port=6379,
+            index_name=self.index_name,
+            prefix=self.prefix,
+            dimensions=3,
+            distance="COSINE",
+        )
+
+    async def asyncTearDown(self) -> None:
+        """Clean up: drop index and delete test keys."""
+        try:
+            await self.store.drop_index()
+        except Exception:
+            pass
+
+        # Delete any remaining test keys
+        client = self.store.get_client()
+        # Scan for keys with our prefix and delete them
+        cursor = "0"
+        while True:
+            result = await client.custom_command(
+                ["SCAN", cursor, "MATCH", f"{self.prefix}*", "COUNT", "100"],
+            )
+            cursor = (
+                result[0].decode()
+                if isinstance(
+                    result[0],
+                    bytes,
+                )
+                else str(result[0])
+            )
+            keys = result[1]
+            if keys:
+                key_list = [
+                    k.decode() if isinstance(k, bytes) else k for k in keys
+                ]
+                for key in key_list:
+                    await client.delete([key])
+            if cursor == "0":
+                break
+
+        await self.store.close()
+
+    async def test_add_and_search(self) -> None:
+        """Test adding documents and searching by vector similarity."""
+        docs = [
+            Document(
+                embedding=[0.1, 0.2, 0.3],
+                metadata=DocMetadata(
+                    content=TextBlock(
+                        type="text",
+                        text="First test document.",
+                    ),
+                    doc_id="doc1",
+                    chunk_id=0,
+                    total_chunks=2,
+                ),
+            ),
+            Document(
+                embedding=[0.9, 0.1, 0.4],
+                metadata=DocMetadata(
+                    content=TextBlock(
+                        type="text",
+                        text="Second test document.",
+                    ),
+                    doc_id="doc1",
+                    chunk_id=1,
+                    total_chunks=2,
+                ),
+            ),
+            Document(
+                embedding=[0.5, 0.5, 0.5],
+                metadata=DocMetadata(
+                    content=TextBlock(
+                        type="text",
+                        text="Third test document.",
+                    ),
+                    doc_id="doc2",
+                    chunk_id=0,
+                    total_chunks=1,
+                ),
+            ),
+        ]
+
+        await self.store.add(docs)
+
+        # Give Valkey a moment to index
+        import asyncio
+
+        await asyncio.sleep(0.5)
+
+        # Search for something close to [0.1, 0.2, 0.3]
+        results = await self.store.search(
+            query_embedding=[0.15, 0.25, 0.35],
+            limit=3,
+        )
+
+        self.assertGreater(len(results), 0)
+        # The closest match should be the first document
+        self.assertEqual(
+            results[0].metadata.content["text"],
+            "First test document.",
+        )
+        self.assertIsNotNone(results[0].score)
+        # COSINE similarity should be high for a near-identical vector
+        self.assertGreater(results[0].score, 0.9)
+
+    async def test_search_with_threshold(self) -> None:
+        """Test that score_threshold filters results."""
+        docs = [
+            Document(
+                embedding=[1.0, 0.0, 0.0],
+                metadata=DocMetadata(
+                    content=TextBlock(
+                        type="text",
+                        text="Aligned document.",
+                    ),
+                    doc_id="aligned",
+                    chunk_id=0,
+                    total_chunks=1,
+                ),
+            ),
+            Document(
+                embedding=[0.0, 1.0, 0.0],
+                metadata=DocMetadata(
+                    content=TextBlock(
+                        type="text",
+                        text="Orthogonal document.",
+                    ),
+                    doc_id="orthogonal",
+                    chunk_id=0,
+                    total_chunks=1,
+                ),
+            ),
+        ]
+
+        await self.store.add(docs)
+
+        import asyncio
+
+        await asyncio.sleep(0.5)
+
+        # Search with a high threshold — only the aligned doc
+        # should pass
+        results = await self.store.search(
+            query_embedding=[1.0, 0.0, 0.0],
+            limit=10,
+            score_threshold=0.9,
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(
+            results[0].metadata.content["text"],
+            "Aligned document.",
+        )
+
+    async def test_delete_by_doc_id(self) -> None:
+        """Test deleting documents by doc_id."""
+        docs = [
+            Document(
+                embedding=[0.1, 0.2, 0.3],
+                metadata=DocMetadata(
+                    content=TextBlock(
+                        type="text",
+                        text="To be deleted.",
+                    ),
+                    doc_id="delete_me",
+                    chunk_id=0,
+                    total_chunks=1,
+                ),
+            ),
+            Document(
+                embedding=[0.4, 0.5, 0.6],
+                metadata=DocMetadata(
+                    content=TextBlock(
+                        type="text",
+                        text="Should remain.",
+                    ),
+                    doc_id="keep_me",
+                    chunk_id=0,
+                    total_chunks=1,
+                ),
+            ),
+        ]
+
+        await self.store.add(docs)
+
+        import asyncio
+
+        await asyncio.sleep(0.5)
+
+        # Delete one doc
+        await self.store.delete(ids="delete_me")
+        await asyncio.sleep(0.3)
+
+        # Search should only find the remaining doc
+        results = await self.store.search(
+            query_embedding=[0.4, 0.5, 0.6],
+            limit=10,
+        )
+
+        doc_ids = [r.metadata.doc_id for r in results]
+        self.assertNotIn("delete_me", doc_ids)
+        self.assertIn("keep_me", doc_ids)


### PR DESCRIPTION
## AgentScope Version

1.0.20

## Description

**Background:** AgentScope's existing `RedisMemory` for session/working memory uses basic Redis commands that are already Valkey-compatible. However, there is no vector store implementation that leverages Valkey's Search module for semantic retrieval in the RAG pipeline.

**Purpose:** Add a `ValkeyStore` class that implements `VDBStoreBase`, enabling Valkey as a vector database backend for AgentScope's knowledge base and retrieval pipeline using HNSW indexing.

**Changes:**
- `src/agentscope/rag/_store/_valkey_store.py` — new `ValkeyStore(VDBStoreBase)` implementation
- `src/agentscope/rag/_store/__init__.py` — export `ValkeyStore`
- `src/agentscope/rag/__init__.py` — export `ValkeyStore` at top-level
- `pyproject.toml` — optional dependency `valkey-glide>=2.1.0,<3.0.0`, added to `vdbs` group
- `tests/rag_store_test.py` — unit test with mocks (no server required)
- `tests/valkey_store_integration_test.py` — integration test gated behind `VALKEY_INTEGRATION_TEST=true`
- `examples/functionality/vector_store/valkey/` — README and example script

**Features:**
- COSINE, L2, and IP distance metrics
- Configurable HNSW parameters (M, ef_construction, ef_runtime)
- Standalone and cluster mode via `valkey-glide` async client
- Tag-based filtering (`doc_id`) and numeric filtering (`chunk_id`)
- Paginated batch delete with tag value escaping
- Input validation (None embedding guard, query injection prevention)

**How to test:**
```bash
# Unit tests (no Valkey required)
pytest tests/rag_store_test.py::RAGStoreTest::test_valkey_store -xvs

# Integration tests (requires Valkey with Search module on localhost:6379)
VALKEY_INTEGRATION_TEST=true pytest tests/valkey_store_integration_test.py -xvs

# Example script (requires Valkey with Search module on localhost:6379)
python examples/functionality/vector_store/valkey/main.py
```

Related issue: #1627

## Checklist

- [x] Code has been formatted with `pre-commit run --all-files` command
- [x] All tests are passing
- [x] Docstrings are in Google style
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review
