### PR TITLE
feat(model): add OrcaRouter chat model

### DIFF
--- a/docs/NEWS.md
+++ b/docs/NEWS.md
@@ -2,4 +2,5 @@
 <!-- The first 10 items are automatically synced to README.md and README_zh.md via GitHub Actions. -->
 <!-- To update news in READMEs, modify this file and push to trigger the workflow. -->
 
+- **[2026-05] `FEAT`:** OrcaRouter integration — 150+ models behind one OpenAI-compatible API key via `OrcaRouterChatModel`, with `orcarouter/auto` adaptive routing.
 - **[2026-05] `RELS`:** AgentScope 2.0 released! [Docs](https://docs.agentscope.io/)

--- a/docs/NEWS_zh.md
+++ b/docs/NEWS_zh.md
@@ -2,4 +2,5 @@
 <!-- The first 10 items are automatically synced to README.md and README_zh.md via GitHub Actions. -->
 <!-- To update news in READMEs, modify this file and push to trigger the workflow. -->
 
+- **[2026-05] `新特性`:** 接入 OrcaRouter —— 通过 `OrcaRouterChatModel` 一把 OpenAI 兼容 API key 即可访问 150+ 模型，并支持 `orcarouter/auto` 自适应路由。
 - **[2026-05] `发布`:** AgentScope 2.0 已发布！[文档](https://docs.agentscope.io/)

--- a/src/agentscope/credential/__init__.py
+++ b/src/agentscope/credential/__init__.py
@@ -9,6 +9,7 @@ from ._gemini import GeminiCredential
 from ._moonshot import MoonshotCredential
 from ._ollama import OllamaCredential
 from ._openai import OpenAICredential
+from ._orcarouter import OrcaRouterCredential
 from ._xai import XAICredential
 from ._factory import CredentialFactory
 
@@ -22,6 +23,7 @@ __all__ = [
     "MoonshotCredential",
     "OllamaCredential",
     "OpenAICredential",
+    "OrcaRouterCredential",
     "XAICredential",
     "CredentialFactory",
 ]

--- a/src/agentscope/credential/_factory.py
+++ b/src/agentscope/credential/_factory.py
@@ -11,6 +11,7 @@ from ._gemini import GeminiCredential
 from ._moonshot import MoonshotCredential
 from ._ollama import OllamaCredential
 from ._openai import OpenAICredential
+from ._orcarouter import OrcaRouterCredential
 from ._xai import XAICredential
 from ._base import CredentialBase
 
@@ -41,6 +42,7 @@ class CredentialFactory:
         MoonshotCredential,
         OllamaCredential,
         OpenAICredential,
+        OrcaRouterCredential,
         XAICredential,
     ]
     _adapter: TypeAdapter[CredentialBase] | None = None

--- a/src/agentscope/credential/_orcarouter.py
+++ b/src/agentscope/credential/_orcarouter.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""The OrcaRouter credential."""
+from typing import Literal, Type, TYPE_CHECKING
+
+from pydantic import ConfigDict, Field, SecretStr
+
+from ._base import CredentialBase
+
+if TYPE_CHECKING:
+    from ..model import ChatModelBase
+
+_ORCAROUTER_BASE_URL = "https://api.orcarouter.ai/v1"
+
+
+class OrcaRouterCredential(CredentialBase):
+    """The OrcaRouter credential model.
+
+    OrcaRouter (https://www.orcarouter.ai) is an OpenAI-compatible meta-router
+    that exposes 150+ models from upstream providers (OpenAI, Anthropic,
+    Google, DeepSeek, Qwen, xAI, MiniMax, etc.) behind a single API key and
+    endpoint, plus an adaptive routing model id ``orcarouter/auto`` that
+    selects the best upstream per request.
+    """
+
+    model_config = ConfigDict(
+        title="OrcaRouter API",
+    )
+
+    type: Literal["orcarouter_credential"] = "orcarouter_credential"
+    """The credential type."""
+
+    api_key: SecretStr = Field(
+        description="The OrcaRouter API key (prefix ``sk-orca-``).",
+    )
+    """The API key."""
+
+    base_url: str = Field(
+        default=_ORCAROUTER_BASE_URL,
+        description="The base URL for the OrcaRouter API.",
+    )
+    """The base URL for the OrcaRouter API."""
+
+    @classmethod
+    def get_chat_model_class(cls) -> Type["ChatModelBase"]:
+        """Return the OrcaRouterChatModel class."""
+        from ..model import OrcaRouterChatModel
+
+        return OrcaRouterChatModel

--- a/src/agentscope/model/__init__.py
+++ b/src/agentscope/model/__init__.py
@@ -11,6 +11,7 @@ from ._deepseek import DeepSeekChatModel
 from ._gemini import GeminiChatModel
 from ._ollama import OllamaChatModel
 from ._openai_chat import OpenAIChatModel
+from ._orcarouter import OrcaRouterChatModel
 from ._xai import XAIChatModel
 from ._moonshot import MoonshotChatModel
 from ._openai_response import OpenAIResponseModel
@@ -27,6 +28,7 @@ __all__ = [
     "GeminiChatModel",
     "OllamaChatModel",
     "OpenAIChatModel",
+    "OrcaRouterChatModel",
     "XAIChatModel",
     "MoonshotChatModel",
     "OpenAIResponseModel",

--- a/src/agentscope/model/_orcarouter/__init__.py
+++ b/src/agentscope/model/_orcarouter/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""The OrcaRouter chat model modules."""
+
+from ._model import OrcaRouterChatModel
+
+__all__ = [
+    "OrcaRouterChatModel",
+]

--- a/src/agentscope/model/_orcarouter/_model.py
+++ b/src/agentscope/model/_orcarouter/_model.py
@@ -1,0 +1,413 @@
+# -*- coding: utf-8 -*-
+"""The OrcaRouter chat model implementation.
+
+OrcaRouter (https://www.orcarouter.ai) is an OpenAI-compatible meta-router
+that exposes 150+ models from upstream providers (OpenAI, Anthropic, Google,
+DeepSeek, Qwen, xAI, MiniMax, etc.) behind a single API key and endpoint,
+plus an adaptive routing model id ``orcarouter/auto`` that selects the best
+upstream per request.
+"""
+from collections import OrderedDict
+from datetime import datetime
+from typing import Literal, Any, AsyncGenerator, TYPE_CHECKING, List
+
+from pydantic import BaseModel, Field
+
+from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
+from .._model_response import ChatResponse
+from .._model_usage import ChatUsage
+from ...credential import OrcaRouterCredential
+from ...formatter import FormatterBase, OpenAIChatFormatter
+from ...message import Msg, ThinkingBlock, ToolCallBlock, TextBlock
+from ...tool import ToolChoice
+
+if TYPE_CHECKING:
+    from openai.types.chat import ChatCompletion
+    from openai import AsyncStream
+else:
+    ChatCompletion = Any
+    AsyncStream = Any
+
+_ORCAROUTER_ATTRIBUTION_REFERER = "https://www.agentscope.io/"
+_ORCAROUTER_ATTRIBUTION_TITLE = "AgentScope"
+
+
+class OrcaRouterChatModel(ChatModelBase):
+    """The OrcaRouter chat model.
+
+    Model ids follow the ``<vendor>/<model>`` namespacing convention used by
+    OrcaRouter (e.g. ``openai/gpt-5``, ``anthropic/claude-opus-4.7``,
+    ``deepseek/deepseek-v4-pro``). The special id ``orcarouter/auto`` enables
+    OrcaRouter's adaptive router (contextual bandit) which selects the best
+    upstream per request. See https://www.orcarouter.ai/models for the full
+    catalog.
+
+    .. note::
+
+        Reasoning models such as ``anthropic/claude-opus-4.7``,
+        ``openai/gpt-5`` and ``deepseek/deepseek-reasoner`` reject the
+        ``temperature`` parameter at the upstream layer; do not pass
+        ``temperature`` for those models.
+    """
+
+    class Parameters(BaseModel):
+        """The parameters for the OrcaRouter chat model."""
+
+        max_tokens: int | None = Field(
+            default=None,
+            title="Max Tokens",
+            description="The maximum number of tokens for the LLM output.",
+            gt=0,
+        )
+
+        thinking_enable: bool = Field(
+            default=False,
+            title="Thinking",
+            description=(
+                "Whether to enable reasoning for reasoning models routed "
+                "by OrcaRouter (e.g. gpt-5, o3, deepseek-reasoner). Use "
+                "reasoning_effort to control the depth of reasoning."
+            ),
+        )
+
+        reasoning_effort: (
+            Literal["none", "minimal", "low", "medium", "high", "xhigh"] | None
+        ) = Field(
+            default=None,
+            title="Reasoning Effort",
+            description=(
+                "Controls the depth of reasoning for reasoning models. "
+                "OrcaRouter passes this through to the upstream provider; "
+                "upstreams that do not understand it silently ignore it."
+            ),
+        )
+
+        temperature: float | None = Field(
+            default=None,
+            title="Temperature",
+            description="The temperature for the LLM output.",
+            ge=0,
+            le=2,
+        )
+
+        top_p: float | None = Field(
+            default=None,
+            title="Top P",
+            description="The top P value for the LLM output.",
+            gt=0,
+            le=1,
+        )
+
+        parallel_tool_calls: bool = Field(
+            default=True,
+            title="Parallel Tool Calls",
+            description="Whether to enable parallel tool calls.",
+        )
+
+    type: Literal["orcarouter_chat"] = "orcarouter_chat"
+    """The type of the chat model."""
+
+    def __init__(
+        self,
+        credential: OrcaRouterCredential,
+        model: str,
+        parameters: "OrcaRouterChatModel.Parameters | None" = None,
+        stream: bool = True,
+        max_retries: int = 3,
+        context_size: int = 128000,
+        formatter: FormatterBase | None = None,
+    ) -> None:
+        """Initialize the OrcaRouter chat model.
+
+        Args:
+            credential (`OrcaRouterCredential`):
+                The OrcaRouter credential used to authenticate API calls.
+            model (`str`):
+                The OrcaRouter model id, e.g. ``orcarouter/auto``,
+                ``openai/gpt-5``, ``anthropic/claude-opus-4.7``,
+                ``deepseek/deepseek-v4-pro``. See
+                https://www.orcarouter.ai/models for the full catalog.
+            parameters (`OrcaRouterChatModel.Parameters | None`, defaults to \
+            `None`):
+                The chat parameters. When ``None``, defaults are used.
+            stream (`bool`, defaults to `True`):
+                Whether to enable streaming output.
+            max_retries (`int`, defaults to `3`):
+                The maximum number of retries for the OrcaRouter API.
+            context_size (`int`, defaults to `128000`):
+                The model context size used for context compression.
+            formatter (`FormatterBase | None`, defaults to `None`):
+                The formatter that converts ``Msg`` objects to the format
+                required by OrcaRouter. When ``None``, an
+                ``OpenAIChatFormatter`` instance is used (OrcaRouter is
+                OpenAI-compatible).
+        """
+        super().__init__(
+            credential=credential,
+            model=model,
+            parameters=parameters or self.Parameters(),
+            stream=stream,
+            max_retries=max_retries,
+            context_size=context_size,
+        )
+        self.formatter = formatter or OpenAIChatFormatter()
+
+    async def _call_api(
+        self,
+        model_name: str,
+        messages: list[Msg],
+        tools: list[dict] | None = None,
+        tool_choice: ToolChoice | None = None,
+        **generate_kwargs: Any,
+    ) -> ChatResponse | AsyncGenerator[ChatResponse, None]:
+        """Call the OrcaRouter chat completions API."""
+        import openai
+
+        client = openai.AsyncClient(
+            api_key=self.credential.api_key.get_secret_value(),
+            base_url=self.credential.base_url,
+            default_headers={
+                "HTTP-Referer": _ORCAROUTER_ATTRIBUTION_REFERER,
+                "X-Title": _ORCAROUTER_ATTRIBUTION_TITLE,
+            },
+        )
+
+        formatted_messages = await self.formatter.format(messages)
+
+        kwargs: dict[str, Any] = {
+            "model": model_name,
+            "messages": formatted_messages,
+            "stream": self.stream,
+        }
+
+        if self.parameters.max_tokens is not None:
+            kwargs["max_tokens"] = self.parameters.max_tokens
+
+        if self.parameters.temperature is not None:
+            kwargs["temperature"] = self.parameters.temperature
+
+        if self.parameters.top_p is not None:
+            kwargs["top_p"] = self.parameters.top_p
+
+        if (
+            self.parameters.thinking_enable
+            and self.parameters.reasoning_effort
+        ):
+            kwargs["reasoning_effort"] = self.parameters.reasoning_effort
+
+        kwargs.update(generate_kwargs)
+
+        fmt_tools, fmt_tool_choice = self._format_tools(tools, tool_choice)
+
+        if fmt_tools:
+            kwargs["tools"] = fmt_tools
+            if not self.parameters.parallel_tool_calls:
+                kwargs["parallel_tool_calls"] = False
+
+        if fmt_tool_choice is not None:
+            kwargs["tool_choice"] = fmt_tool_choice
+
+        if self.stream:
+            kwargs["stream_options"] = {"include_usage": True}
+
+        start_datetime = datetime.now()
+        response = await client.chat.completions.create(**kwargs)
+
+        if self.stream:
+            return self._parse_stream_response(start_datetime, response)
+
+        return self._parse_completion_response(start_datetime, response)
+
+    async def _parse_stream_response(
+        self,
+        start_datetime: datetime,
+        response: AsyncStream,
+    ) -> AsyncGenerator[ChatResponse, None]:
+        """Parse the OrcaRouter streaming response."""
+        usage = None
+        response_id: str | None = None
+        acc_text = TextBlock(text="")
+        acc_thinking = ThinkingBlock(thinking="")
+        acc_tool_calls: OrderedDict = OrderedDict()
+
+        async with response as stream:
+            async for chunk in stream:
+                if chunk.usage:
+                    u = chunk.usage
+                    details = getattr(u, "prompt_tokens_details", None)
+                    usage = ChatUsage(
+                        input_tokens=u.prompt_tokens,
+                        output_tokens=u.completion_tokens,
+                        time=(datetime.now() - start_datetime).total_seconds(),
+                        cache_input_tokens=getattr(
+                            details,
+                            "cached_tokens",
+                            0,
+                        )
+                        if details
+                        else 0,
+                    )
+
+                response_id = response_id or getattr(chunk, "id", None)
+
+                if not chunk.choices:
+                    continue
+
+                choice = chunk.choices[0]
+                delta = choice.delta
+
+                delta_thinking = getattr(delta, "reasoning_content", None)
+                if not isinstance(delta_thinking, str):
+                    delta_thinking = getattr(delta, "reasoning", None)
+                if not isinstance(delta_thinking, str):
+                    delta_thinking = ""
+
+                delta_text = getattr(delta, "content", None) or ""
+
+                acc_thinking.thinking += delta_thinking
+                acc_text.text += delta_text
+
+                delta_tool_call_blocks: List[ToolCallBlock] = []
+                for tool_call in getattr(delta, "tool_calls", None) or []:
+                    idx = tool_call.index
+                    args = tool_call.function.arguments or ""
+                    if idx in acc_tool_calls:
+                        acc_tool_calls[idx]["input"] += args
+                    else:
+                        acc_tool_calls[idx] = {
+                            "id": tool_call.id,
+                            "name": tool_call.function.name,
+                            "input": args,
+                        }
+                    tc = acc_tool_calls[idx]
+                    delta_tool_call_blocks.append(
+                        ToolCallBlock(
+                            id=tc["id"],
+                            name=tc["name"],
+                            input=args,
+                        ),
+                    )
+
+                delta_contents: List[
+                    TextBlock | ToolCallBlock | ThinkingBlock
+                ] = []
+                if delta_thinking:
+                    delta_contents.append(
+                        ThinkingBlock(
+                            id=acc_thinking.id,
+                            thinking=delta_thinking,
+                        ),
+                    )
+                if delta_text:
+                    delta_contents.append(
+                        TextBlock(id=acc_text.id, text=delta_text),
+                    )
+                delta_contents.extend(delta_tool_call_blocks)
+
+                if delta_contents:
+                    _kwargs: dict[str, Any] = {
+                        "content": delta_contents,
+                        "usage": usage,
+                        "is_last": False,
+                    }
+                    if response_id:
+                        _kwargs["id"] = response_id
+                    yield ChatResponse(**_kwargs)
+
+        final_contents: List[TextBlock | ToolCallBlock | ThinkingBlock] = []
+        if acc_thinking.thinking:
+            final_contents.append(acc_thinking)
+        if acc_text.text:
+            final_contents.append(acc_text)
+        for tc in acc_tool_calls.values():
+            final_contents.append(
+                ToolCallBlock(id=tc["id"], name=tc["name"], input=tc["input"]),
+            )
+
+        _final_kwargs: dict[str, Any] = {
+            "content": final_contents,
+            "usage": usage,
+            "is_last": True,
+        }
+        if response_id:
+            _final_kwargs["id"] = response_id
+        yield ChatResponse(**_final_kwargs)
+
+    def _parse_completion_response(
+        self,
+        start_datetime: datetime,
+        response: ChatCompletion,
+    ) -> ChatResponse:
+        """Parse the OrcaRouter non-streaming response."""
+        content_blocks: List[TextBlock | ToolCallBlock | ThinkingBlock] = []
+
+        if response.choices:
+            choice = response.choices[0]
+            reasoning = getattr(choice.message, "reasoning_content", None)
+            if not isinstance(reasoning, str):
+                reasoning = getattr(choice.message, "reasoning", None)
+            if isinstance(reasoning, str) and reasoning:
+                content_blocks.append(ThinkingBlock(thinking=reasoning))
+
+            if choice.message.content:
+                content_blocks.append(TextBlock(text=choice.message.content))
+
+            for tool_call in choice.message.tool_calls or []:
+                content_blocks.append(
+                    ToolCallBlock(
+                        id=tool_call.id,
+                        name=tool_call.function.name,
+                        input=tool_call.function.arguments,
+                    ),
+                )
+
+        usage = None
+        if response.usage:
+            u = response.usage
+            details = getattr(u, "prompt_tokens_details", None)
+            usage = ChatUsage(
+                input_tokens=u.prompt_tokens,
+                output_tokens=u.completion_tokens,
+                time=(datetime.now() - start_datetime).total_seconds(),
+                cache_input_tokens=getattr(
+                    details,
+                    "cached_tokens",
+                    0,
+                )
+                if details
+                else 0,
+            )
+
+        resp_kwargs: dict[str, Any] = {
+            "content": content_blocks,
+            "is_last": True,
+            "usage": usage,
+        }
+        response_id = getattr(response, "id", None)
+        if response_id:
+            resp_kwargs["id"] = response_id
+
+        return ChatResponse(**resp_kwargs)
+
+    def _format_tools(
+        self,
+        tools: list[dict] | None,
+        tool_choice: ToolChoice | None,
+    ) -> tuple[list[dict] | None, str | dict | None]:
+        """Validate, filter, and format tools and tool_choice for the
+        OpenAI-compatible OrcaRouter API."""
+        if tool_choice and tools:
+            self._validate_tool_choice(tool_choice, tools)
+            if tool_choice.tools:
+                allowed = set(tool_choice.tools)
+                tools = [t for t in tools if t["function"]["name"] in allowed]
+
+        if not tool_choice:
+            return tools, None
+
+        mode = tool_choice.mode
+
+        if mode not in _TOOL_CHOICE_LITERAL_MODES:
+            return tools, {"type": "function", "function": {"name": mode}}
+
+        return tools, mode

--- a/src/agentscope/model/_orcarouter/_models/orcarouter-auto.yaml
+++ b/src/agentscope/model/_orcarouter/_models/orcarouter-auto.yaml
@@ -1,0 +1,20 @@
+name: orcarouter/auto
+label: OrcaRouter Auto
+status: active
+
+input_types:
+  - text/plain
+  - image/jpeg
+  - image/png
+  - image/gif
+  - image/webp
+
+output_types:
+  - text/plain
+
+context_size: 200000
+output_size: 32768
+
+parameter_overrides:
+  max_tokens:
+    maximum: 32768

--- a/tests/model_orcarouter_test.py
+++ b/tests/model_orcarouter_test.py
@@ -1,0 +1,433 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Unit tests for OrcaRouterChatModel with mocked API responses."""
+from typing import Any
+import unittest
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from utils import AnyString
+
+from agentscope.message import TextBlock, ToolCallBlock, ThinkingBlock
+from agentscope.model import OrcaRouterChatModel
+from agentscope.credential import OrcaRouterCredential
+from agentscope.tool import ToolChoice
+
+A = AnyString()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_model(stream: bool = False) -> Any:
+    return OrcaRouterChatModel(
+        credential=OrcaRouterCredential(api_key="sk-orca-test"),
+        model="orcarouter/auto",
+        stream=stream,
+    )
+
+
+def _mock_completion(
+    text: Any = None,
+    tool_calls: Any = None,
+    reasoning: Any = None,
+    response_id: str = "or-1",
+) -> MagicMock:
+    """Build a mock non-streaming ChatCompletion response."""
+    msg = MagicMock()
+    msg.content = text
+    msg.reasoning_content = reasoning
+    msg.tool_calls = None
+
+    if tool_calls:
+        tc_mocks = []
+        for tc in tool_calls:
+            m = MagicMock()
+            m.id = tc["id"]
+            m.function.name = tc["name"]
+            m.function.arguments = tc["arguments"]
+            tc_mocks.append(m)
+        msg.tool_calls = tc_mocks
+
+    choice = MagicMock()
+    choice.message = msg
+
+    resp = MagicMock()
+    resp.id = response_id
+    resp.choices = [choice]
+    resp.usage.prompt_tokens = 10
+    resp.usage.completion_tokens = 5
+    resp.usage.prompt_tokens_details = None
+    return resp
+
+
+def _make_stream_chunk(
+    delta_text: str | None = None,
+    delta_reasoning: str | None = None,
+    tool_calls: list | None = None,
+    response_id: str = "or-1",
+    usage: dict | None = None,
+    has_choices: bool = True,
+) -> MagicMock:
+    """Build a single mock streaming chunk."""
+    chunk = MagicMock()
+    chunk.id = response_id
+
+    if usage:
+        chunk.usage = MagicMock()
+        chunk.usage.prompt_tokens = usage.get("prompt_tokens", 0)
+        chunk.usage.completion_tokens = usage.get("completion_tokens", 0)
+        chunk.usage.prompt_tokens_details = None
+    else:
+        chunk.usage = None
+
+    if has_choices:
+        delta = MagicMock()
+        delta.content = delta_text
+        delta.reasoning_content = delta_reasoning
+        delta.tool_calls = tool_calls
+        choice = MagicMock()
+        choice.delta = delta
+        chunk.choices = [choice]
+    else:
+        chunk.choices = []
+
+    return chunk
+
+
+def _make_tool_call_delta(
+    index: int,
+    tc_id: str | None = None,
+    name: str | None = None,
+    arguments: str | None = None,
+) -> MagicMock:
+    """Build a tool_call delta item for streaming."""
+    tc = MagicMock()
+    tc.index = index
+    tc.id = tc_id
+    tc.function.name = name
+    tc.function.arguments = arguments
+    return tc
+
+
+class _MockAsyncStream:
+    """Mock async stream that acts as an async context manager + iterator."""
+
+    def __init__(self, chunks: list) -> None:
+        self._chunks = chunks
+        self._index = 0
+
+    async def __aenter__(self) -> "_MockAsyncStream":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        pass
+
+    def __aiter__(self) -> "_MockAsyncStream":
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._index >= len(self._chunks):
+            raise StopAsyncIteration
+        chunk = self._chunks[self._index]
+        self._index += 1
+        return chunk
+
+
+# ---------------------------------------------------------------------------
+# Credential / client wiring
+# ---------------------------------------------------------------------------
+
+
+class TestOrcaRouterCredential(unittest.TestCase):
+    """Tests for OrcaRouterCredential defaults."""
+
+    def test_default_base_url(self) -> None:
+        cred = OrcaRouterCredential(api_key="sk-orca-test")
+        self.assertEqual(cred.base_url, "https://api.orcarouter.ai/v1")
+
+    def test_get_chat_model_class(self) -> None:
+        self.assertIs(
+            OrcaRouterCredential.get_chat_model_class(),
+            OrcaRouterChatModel,
+        )
+
+
+class TestOrcaRouterClientWiring(IsolatedAsyncioTestCase):
+    """Verify the OpenAI AsyncClient is created with OrcaRouter base_url and
+    attribution headers."""
+
+    @patch("openai.AsyncClient")
+    async def test_client_built_with_attribution_headers(
+        self,
+        mock_client_cls: MagicMock,
+    ) -> None:
+        model = _make_model(stream=False)
+        mock_create = AsyncMock(return_value=_mock_completion(text="ok"))
+        mock_client_cls.return_value.chat.completions.create = mock_create
+
+        await model([])
+
+        mock_client_cls.assert_called_once()
+        kwargs = mock_client_cls.call_args.kwargs
+        self.assertEqual(kwargs["api_key"], "sk-orca-test")
+        self.assertEqual(kwargs["base_url"], "https://api.orcarouter.ai/v1")
+        self.assertEqual(
+            kwargs["default_headers"],
+            {
+                "HTTP-Referer": "https://www.agentscope.io/",
+                "X-Title": "AgentScope",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming tests
+# ---------------------------------------------------------------------------
+
+
+class TestOrcaRouterNonStream(IsolatedAsyncioTestCase):
+    """Tests for OrcaRouterChatModel in non-streaming mode."""
+
+    def setUp(self) -> None:
+        self.model = _make_model(stream=False)
+
+    @patch("openai.AsyncClient")
+    async def test_text_response(self, mock_client_cls: MagicMock) -> None:
+        mock_create = AsyncMock(
+            return_value=_mock_completion(text="Hello world!"),
+        )
+        mock_client_cls.return_value.chat.completions.create = mock_create
+
+        result = await self.model([])
+
+        self.assertEqual(
+            (result.is_last, result.content),
+            (True, [TextBlock.model_construct(id=A, text="Hello world!")]),
+        )
+        self.assertEqual(result.id, "or-1")
+
+    @patch("openai.AsyncClient")
+    async def test_tool_call_response(
+        self,
+        mock_client_cls: MagicMock,
+    ) -> None:
+        mock_create = AsyncMock(
+            return_value=_mock_completion(
+                tool_calls=[
+                    {
+                        "id": "call-1",
+                        "name": "get_weather",
+                        "arguments": '{"city":"Beijing"}',
+                    },
+                ],
+            ),
+        )
+        mock_client_cls.return_value.chat.completions.create = mock_create
+
+        result = await self.model([])
+
+        self.assertEqual(
+            (result.is_last, result.content),
+            (
+                True,
+                [
+                    ToolCallBlock(
+                        id="call-1",
+                        name="get_weather",
+                        input='{"city":"Beijing"}',
+                    ),
+                ],
+            ),
+        )
+
+    @patch("openai.AsyncClient")
+    async def test_thinking_response(
+        self,
+        mock_client_cls: MagicMock,
+    ) -> None:
+        mock_create = AsyncMock(
+            return_value=_mock_completion(
+                text="The answer is 42.",
+                reasoning="Let me think step by step...",
+            ),
+        )
+        mock_client_cls.return_value.chat.completions.create = mock_create
+
+        result = await self.model([])
+
+        self.assertEqual(
+            (result.is_last, result.content),
+            (
+                True,
+                [
+                    ThinkingBlock.model_construct(
+                        id=A,
+                        thinking="Let me think step by step...",
+                    ),
+                    TextBlock.model_construct(id=A, text="The answer is 42."),
+                ],
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Streaming tests
+# ---------------------------------------------------------------------------
+
+
+class TestOrcaRouterStream(IsolatedAsyncioTestCase):
+    """Tests for OrcaRouterChatModel in streaming mode."""
+
+    def setUp(self) -> None:
+        self.model = _make_model(stream=True)
+
+    @patch("openai.AsyncClient")
+    async def test_stream_text_response(
+        self,
+        mock_client_cls: MagicMock,
+    ) -> None:
+        chunks = [
+            _make_stream_chunk(delta_text="Hello"),
+            _make_stream_chunk(delta_text=" world"),
+            _make_stream_chunk(delta_text="!"),
+            _make_stream_chunk(
+                has_choices=False,
+                usage={"prompt_tokens": 10, "completion_tokens": 3},
+            ),
+        ]
+        mock_create = AsyncMock(return_value=_MockAsyncStream(chunks))
+        mock_client_cls.return_value.chat.completions.create = mock_create
+
+        gen = await self.model([])
+        responses = [r async for r in gen]
+
+        self.assertListEqual(
+            [(r.is_last, r.content) for r in responses],
+            [
+                (False, [TextBlock.model_construct(id=A, text="Hello")]),
+                (False, [TextBlock.model_construct(id=A, text=" world")]),
+                (False, [TextBlock.model_construct(id=A, text="!")]),
+                (
+                    True,
+                    [TextBlock.model_construct(id=A, text="Hello world!")],
+                ),
+            ],
+        )
+
+    @patch("openai.AsyncClient")
+    async def test_stream_tool_calls(
+        self,
+        mock_client_cls: MagicMock,
+    ) -> None:
+        chunks = [
+            _make_stream_chunk(
+                tool_calls=[
+                    _make_tool_call_delta(0, "call-1", "get_weather", '{"ci'),
+                ],
+            ),
+            _make_stream_chunk(
+                tool_calls=[
+                    _make_tool_call_delta(0, None, None, 'ty":"BJ"}'),
+                ],
+            ),
+            _make_stream_chunk(
+                has_choices=False,
+                usage={"prompt_tokens": 10, "completion_tokens": 5},
+            ),
+        ]
+        mock_create = AsyncMock(return_value=_MockAsyncStream(chunks))
+        mock_client_cls.return_value.chat.completions.create = mock_create
+
+        gen = await self.model([])
+        responses = [r async for r in gen]
+
+        self.assertEqual(responses[-1].is_last, True)
+        self.assertEqual(
+            responses[-1].content,
+            [
+                ToolCallBlock(
+                    id="call-1",
+                    name="get_weather",
+                    input='{"city":"BJ"}',
+                ),
+            ],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Parameters
+# ---------------------------------------------------------------------------
+
+
+class TestOrcaRouterParameters(unittest.TestCase):
+    """Tests for OrcaRouterChatModel.Parameters."""
+
+    def test_reasoning_effort_passed_to_kwargs(self) -> None:
+        model = OrcaRouterChatModel(
+            credential=OrcaRouterCredential(api_key="sk-orca-test"),
+            model="openai/gpt-5",
+            stream=False,
+            parameters=OrcaRouterChatModel.Parameters(
+                thinking_enable=True,
+                reasoning_effort="high",
+            ),
+        )
+        self.assertTrue(model.parameters.thinking_enable)
+        self.assertEqual(model.parameters.reasoning_effort, "high")
+
+
+# ---------------------------------------------------------------------------
+# _format_tools
+# ---------------------------------------------------------------------------
+
+_FT_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    },
+]
+
+
+class TestOrcaRouterFormatTools(unittest.TestCase):
+    """Tests for OrcaRouterChatModel._format_tools."""
+
+    def setUp(self) -> None:
+        self.model = _make_model()
+
+    def test_auto_mode(self) -> None:
+        fmt_tools, fmt_choice = self.model._format_tools(
+            _FT_TOOLS,
+            ToolChoice(mode="auto"),
+        )
+        self.assertEqual(fmt_tools, _FT_TOOLS)
+        self.assertEqual(fmt_choice, "auto")
+
+    def test_str_mode_force_call(self) -> None:
+        fmt_tools, fmt_choice = self.model._format_tools(
+            _FT_TOOLS,
+            ToolChoice(mode="get_weather"),
+        )
+        self.assertEqual(
+            fmt_choice,
+            {"type": "function", "function": {"name": "get_weather"}},
+        )
+
+    def test_no_tool_choice(self) -> None:
+        fmt_tools, fmt_choice = self.model._format_tools(_FT_TOOLS, None)
+        self.assertEqual(fmt_tools, _FT_TOOLS)
+        self.assertIsNone(fmt_choice)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1637

## AgentScope Version

1.0.20 (current `main`, commit d6c0c89)

## Description

### Background

I'm an engineer on the OrcaRouter team. [OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible meta-router that exposes 150+ models from upstream providers (OpenAI, Anthropic, Google, DeepSeek, Qwen, xAI, MiniMax, Moonshot, …) behind a single API key and endpoint, plus a virtual routing id `orcarouter/auto` that selects the cheapest / balanced / quality / adaptive upstream per request from a learned weight vector (contextual bandit, LinUCB-style). Full catalog at https://www.orcarouter.ai/models; API docs at https://docs.orcarouter.ai.

Today AgentScope users can talk to OrcaRouter by instantiating `OpenAIChatModel` with `client_kwargs={"base_url": "https://api.orcarouter.ai/v1"}` — this PR adds a first-class `OrcaRouterChatModel` so the integration is one line and the router-specific defaults (env var name, base URL, attribution headers) are handled correctly out of the box.

### Changes

- **New** `src/agentscope/model/_orcarouter_model.py` — `OrcaRouterChatModel` subclasses `OpenAIChatModel` and:
  - defaults `base_url` to `https://api.orcarouter.ai/v1` (override via `ORCAROUTER_API_BASE_URL` env or `base_url=` arg);
  - reads the API key from `ORCAROUTER_API_KEY` when `api_key` is not passed;
  - injects `HTTP-Referer: https://www.agentscope.io/` and `X-Title: AgentScope` attribution headers so requests are properly tracked in the OrcaRouter console (user-provided headers take precedence);
  - inherits everything else (streaming, tool calls, structured output with `response_format` + tool-call fallback, reasoning_effort, `extra_body` via `generate_kwargs`, etc.) from `OpenAIChatModel`, so no parser / formatter / token-counter changes are needed — the existing `OpenAIChatFormatter` and `OpenAITokenCounter` work as-is.
- **Updated** `src/agentscope/model/__init__.py` to export `OrcaRouterChatModel`.
- **New** `tests/model_orcarouter_test.py` — 6 unit tests (all passing) for: subclass relationship, default env-key + base URL + header injection, explicit overrides, `ORCAROUTER_API_BASE_URL` env override, user-supplied header precedence, and call-time model id forwarding.

### Usage

```python
import asyncio, os
from agentscope.model import OrcaRouterChatModel

os.environ["ORCAROUTER_API_KEY"] = "sk-orca-..."

async def main():
    # Adaptive router — picks the best upstream per request
    model = OrcaRouterChatModel(model_name="orcarouter/auto", stream=False)
    resp = await model([{"role": "user", "content": "Hi!"}])
    print(resp.content)

    # Or pin a specific upstream model
    model2 = OrcaRouterChatModel(
        model_name="anthropic/claude-opus-4.7",
        stream=False,
    )

asyncio.run(main())
```

`orcarouter/auto` is a virtual router (not a model id) that scores candidate upstreams by `r = w_quality·success − w_cost·norm_cost − w_latency·norm_latency − w_ratelimit·rate_limited − w_format_fail·format_violation`. Routing weights are tunable from https://www.orcarouter.ai/console/routing.

### Testing

- `pytest tests/model_orcarouter_test.py -v` → 6 passed
- `pytest tests/model_openai_test.py -v` → 9 passed (no regression on the parent class)
- `black --line-length 79 --target-version py310` clean on changed files
- `flake8 --extend-ignore=E203 --max-line-length=79` clean on changed files

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
