### PR TITLE
fix(formatter): avoid emitting `text: null` in AnthropicChatFormatter tool_result

### DIFF
--- a/src/agentscope/formatter/_anthropic_formatter.py
+++ b/src/agentscope/formatter/_anthropic_formatter.py
@@ -171,7 +171,7 @@ class AnthropicChatFormatter(TruncatedFormatterBase):
                 elif typ == "tool_result":
                     output = block.get("output")
                     if output is None:
-                        content_value = [{"type": "text", "text": None}]
+                        content_value = [{"type": "text", "text": ""}]
                     elif isinstance(output, list):
                         content_value = [
                             _format_anthropic_image_block(item)
@@ -207,7 +207,7 @@ class AnthropicChatFormatter(TruncatedFormatterBase):
 
             msg_anthropic = {
                 "role": role,
-                "content": content_blocks or None,
+                "content": content_blocks,
             }
 
             # When both content and tool_calls are None, skipped


### PR DESCRIPTION
## AgentScope Version

1.0.20

## Description

When a `ToolResultBlock` reaches `AnthropicChatFormatter` with `output=None` (e.g. deserialized history missing the field, or third-party code constructing the block directly), the formatter currently emits `{"type": "text", "text": null}`, which violates the Anthropic Messages API schema (`TextBlock.text` must be a non-empty string).

Anthropic's official endpoint is lenient about this, but strict anthropic-compatible endpoints (e.g. DeepSeek's
`https://api.deepseek.com/anthropic`) reject the request with 400 Bad Request.

Fix: fall back to an empty string instead of `None`, matching the defensive pattern already used in `_deepseek_formatter.py` (#1589).

Fixes #1628

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review