### PR TITLE
fix(model): handle structured output failures on dashscope-compatible endpoints

### DIFF
--- a/src/agentscope/model/_openai_model.py
+++ b/src/agentscope/model/_openai_model.py
@@ -14,7 +14,7 @@ from typing import (
 )
 from collections import OrderedDict
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from . import ChatResponse
 from ._model_base import ChatModelBase
@@ -297,6 +297,26 @@ class OpenAIChatModel(ChatModelBase):
                         response = await self.client.chat.completions.parse(
                             **kwargs,
                         )
+                        # Provider-agnostic post-parse validation: some
+                        # OpenAI-compatible endpoints (e.g. DashScope) reply
+                        # HTTP 200 with a body that does not conform to the
+                        # requested schema. The SDK may either raise
+                        # ``ValidationError`` mid-parse (caught below) or
+                        # silently leave ``message.parsed`` as ``None`` /
+                        # a non-matching type (caught here). Both must
+                        # drop to the tool-call fallback rather than
+                        # surfacing a confusing error to the caller.
+                        mismatch = self._structured_parse_mismatch_reason(
+                            response,
+                            structured_model,
+                        )
+                        if mismatch is not None:
+                            response = await self._fallback_to_tool_call(
+                                kwargs,
+                                structured_model,
+                                start_datetime,
+                                mismatch,
+                            )
                     else:
                         response = self.client.chat.completions.stream(
                             **kwargs,
@@ -307,19 +327,12 @@ class OpenAIChatModel(ChatModelBase):
                             structured_model,
                             kwargs,
                         )
-                except openai.BadRequestError as e:
-                    logger.warning(
-                        "response_format structured output failed (%s: %s), "
-                        "falling back to tool-call based structured output. "
-                        "Subsequent calls will use tool-call directly.",
-                        type(e).__name__,
-                        e,
-                    )
-                    self._structured_output_fallback = True
-                    response = await self._structured_via_tool_call(
+                except (openai.BadRequestError, ValidationError) as e:
+                    response = await self._fallback_to_tool_call(
                         kwargs,
                         structured_model,
                         start_datetime,
+                        f"{type(e).__name__}: {e}",
                     )
                     if isinstance(response, AsyncGenerator):
                         return response
@@ -680,6 +693,69 @@ class OpenAIChatModel(ChatModelBase):
 
         return ChatResponse(**resp_kwargs)
 
+    @staticmethod
+    def _structured_parse_mismatch_reason(
+        response: Any,
+        structured_model: Type[BaseModel],
+    ) -> str | None:
+        """Return a human-readable reason string if ``response.choices[0]
+        .message.parsed`` is not an instance of ``structured_model``, else
+        ``None``.
+
+        Covers the case where an endpoint returns HTTP 200 with a body that
+        does not match the requested ``response_format`` schema and the
+        OpenAI SDK silently leaves ``message.parsed`` as ``None`` or a
+        non-matching type instead of raising ``pydantic.ValidationError``.
+        """
+        if not getattr(response, "choices", None):
+            return "response_format returned no choices"
+        parsed = getattr(response.choices[0].message, "parsed", None)
+        if isinstance(parsed, structured_model):
+            return None
+        return (
+            "response_format returned a body that does not conform to the "
+            f"requested schema (parsed type: {type(parsed).__name__})"
+        )
+
+    @staticmethod
+    def _is_tool_choice_rejection(err: BaseException) -> bool:
+        """Return ``True`` if ``err`` looks like an endpoint rejecting a
+        forced ``tool_choice`` value.
+
+        Centralises the heuristic used by every tool-call retry path:
+        non-streaming ``BadRequestError`` from ``create()``, streaming
+        ``BadRequestError`` from ``create()``, and lazy ``APIError`` from
+        the first ``__anext__``. Substring match is intentional -- vendor
+        error messages vary (e.g. DashScope: ``"The tool_choice parameter
+        does not support being set to required..."``). If the message
+        does not mention ``tool_choice`` we re-raise instead of looping.
+        """
+        return "tool_choice" in str(err)
+
+    async def _fallback_to_tool_call(
+        self,
+        kwargs: dict,
+        structured_model: Type[BaseModel],
+        start_datetime: datetime,
+        reason: str,
+    ) -> Any:
+        """Log a warning, latch ``_structured_output_fallback``, and route
+        through ``_structured_via_tool_call``. Used by both the sync ``parse``
+        path and the streaming wrapper.
+        """
+        logger.warning(
+            "response_format structured output failed (%s), falling back "
+            "to tool-call based structured output. Subsequent calls will "
+            "use tool-call directly.",
+            reason,
+        )
+        self._structured_output_fallback = True
+        return await self._structured_via_tool_call(
+            kwargs,
+            structured_model,
+            start_datetime,
+        )
+
     async def _structured_stream_with_fallback(
         self,
         start_datetime: datetime,
@@ -696,7 +772,16 @@ class OpenAIChatModel(ChatModelBase):
         ``_structured_output_fallback`` is never set.
 
         This wrapper catches such errors during stream consumption and
-        transparently falls back to the tool-call approach.
+        transparently falls back to the tool-call approach. We catch both:
+
+        * ``openai.BadRequestError`` -- the endpoint rejects
+          ``response_format`` outright (e.g. DeepSeek), surfaced lazily on
+          first stream read.
+        * ``pydantic.ValidationError`` -- the endpoint replies HTTP 200
+          with a body that the SDK parses successfully as JSON but fails
+          to validate against the requested schema (e.g. DashScope
+          OpenAI-compat returns ``{"message": "Hi!"}`` for a schema with
+          required fields).
         """
         import openai
 
@@ -707,19 +792,12 @@ class OpenAIChatModel(ChatModelBase):
                 structured_model,
             ):
                 yield chunk
-        except openai.BadRequestError as e:
-            logger.warning(
-                "response_format structured output failed during streaming "
-                "(%s: %s), falling back to tool-call based structured "
-                "output. Subsequent calls will use tool-call directly.",
-                type(e).__name__,
-                e,
-            )
-            self._structured_output_fallback = True
-            fallback = await self._structured_via_tool_call(
+        except (openai.BadRequestError, ValidationError) as e:
+            fallback = await self._fallback_to_tool_call(
                 kwargs,
                 structured_model,
                 datetime.now(),
+                f"streaming {type(e).__name__}: {e}",
             )
             if isinstance(fallback, AsyncGenerator):
                 async for chunk in fallback:
@@ -737,7 +815,16 @@ class OpenAIChatModel(ChatModelBase):
 
         Falls back to this when the API endpoint does not support
         json_schema response_format (e.g. DashScope, DeepSeek).
+
+        Some reasoning / "thinking" models (e.g. DashScope qwen3.6 thinking
+        mode) reject any forced ``tool_choice`` with HTTP 400. When that
+        happens we retry once with ``tool_choice="auto"``; since the tools
+        list contains only the schema-derived tool, the model is highly
+        likely to call it anyway, which keeps the structured-output
+        contract intact for the caller.
         """
+        import openai
+
         kwargs.pop("response_format", None)
         format_tool = _create_tool_from_base_model(structured_model)
         kwargs["tools"] = self._format_tools_json_schemas([format_tool])
@@ -747,14 +834,96 @@ class OpenAIChatModel(ChatModelBase):
         if self.stream:
             kwargs["stream"] = True
             kwargs["stream_options"] = {"include_usage": True}
-        response = await self.client.chat.completions.create(**kwargs)
-        if self.stream:
-            return self._parse_openai_stream_response(
+            return self._tool_call_stream_with_choice_retry(
+                kwargs,
+                structured_model,
+                start_datetime,
+            )
+        try:
+            return await self.client.chat.completions.create(**kwargs)
+        except openai.BadRequestError as e:
+            if not self._is_tool_choice_rejection(e):
+                raise
+            logger.warning(
+                "tool_choice rejected by endpoint (%s: %s); retrying with "
+                "tool_choice='auto' for structured output fallback.",
+                type(e).__name__,
+                e,
+            )
+            kwargs["tool_choice"] = "auto"
+            return await self.client.chat.completions.create(**kwargs)
+
+    async def _tool_call_stream_with_choice_retry(
+        self,
+        kwargs: dict,
+        structured_model: Type[BaseModel],
+        start_datetime: datetime,
+    ) -> AsyncGenerator[ChatResponse, None]:
+        """Stream-mode counterpart of the ``tool_choice`` retry in
+        :meth:`_structured_via_tool_call`.
+
+        DashScope thinking-mode rejects forced ``tool_choice`` in two
+        observed shapes during streaming:
+
+        * **Synchronous** ``openai.BadRequestError`` raised from
+          ``client.chat.completions.create(**kwargs)`` itself (e.g.
+          ``qwen3.6-plus`` / ``qwen3.6-flash``).
+        * **Lazy** ``openai.APIError`` surfaced from an SSE error event
+          during the first ``__anext__`` (e.g.
+          ``qwen3-235b-a22b-thinking-2507``).
+
+        Both shapes are caught here -- but only when no chunk has been
+        yielded yet, so retrying with ``tool_choice="auto"`` is safe and
+        the caller never sees duplicated output.
+        """
+        import openai
+
+        try:
+            response = await self.client.chat.completions.create(**kwargs)
+        except openai.BadRequestError as e:
+            if not self._is_tool_choice_rejection(e):
+                raise
+            logger.warning(
+                "tool_choice rejected by endpoint on streaming create "
+                "(%s: %s); retrying with tool_choice='auto' for "
+                "structured output fallback.",
+                type(e).__name__,
+                e,
+            )
+            kwargs["tool_choice"] = "auto"
+            response = await self.client.chat.completions.create(**kwargs)
+
+        yielded = False
+        captured: openai.APIError | None = None
+        try:
+            async for chunk in self._parse_openai_stream_response(
                 start_datetime,
                 response,
                 structured_model,
-            )
-        return response
+            ):
+                yielded = True
+                yield chunk
+            return
+        except openai.APIError as e:
+            if yielded or not self._is_tool_choice_rejection(e):
+                raise
+            captured = e
+
+        logger.warning(
+            "tool_choice rejected during streaming iteration (%s: %s); "
+            "retrying with tool_choice='auto' for structured output "
+            "fallback.",
+            type(captured).__name__,
+            captured,
+        )
+        kwargs["tool_choice"] = "auto"
+        retry_response = await self.client.chat.completions.create(**kwargs)
+        async for chunk in self._parse_openai_stream_response(
+            start_datetime,
+            retry_response,
+            structured_model,
+        ):
+            yield chunk
 
     def _format_tools_json_schemas(
         self,

--- a/tests/model_openai_test.py
+++ b/tests/model_openai_test.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access
 """Unit tests for OpenAI API model class."""
 from typing import AsyncGenerator, Any
 from unittest.async_case import IsolatedAsyncioTestCase
@@ -365,8 +366,10 @@ class TestOpenAIChatModel(IsolatedAsyncioTestCase):
     def _create_mock_response_with_structured_data(self, data: dict) -> Mock:
         """Create a mock response with structured data."""
         message = Mock()
-        message.parsed = Mock()
-        message.parsed.model_dump.return_value = data
+        # `message.parsed` must be a real instance of the schema so that the
+        # provider-agnostic ``isinstance(parsed, structured_model)`` guard
+        # in ``__call__`` accepts the response.
+        message.parsed = SampleModel(**data)
         message.content = None
         message.reasoning_content = None
         message.tool_calls = []
@@ -379,6 +382,441 @@ class TestOpenAIChatModel(IsolatedAsyncioTestCase):
         response.usage = None
 
         return response
+
+    async def test_structured_sync_fallback_on_validation_error(
+        self,
+    ) -> None:
+        """``.parse()`` raising ``ValidationError`` (HTTP 200 + body that
+        does not match the schema) must trigger the tool-call fallback.
+
+        Regression for agentscope-ai/agentscope#1631: DashScope
+        OpenAI-compat returns arbitrary JSON when messages contain the
+        word ``json``; the OpenAI SDK then raises
+        ``pydantic.ValidationError`` which the previous code did not
+        catch, crashing ``ReActAgent.CompressionConfig``.
+        """
+        from pydantic import ValidationError
+
+        with patch("openai.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value = mock_client
+            model = OpenAIChatModel(
+                model_name="qwen3.6-flash",
+                api_key="test_key",
+                stream=False,
+            )
+            model.client = mock_client
+
+            # Construct a real ValidationError to mirror SDK behaviour.
+            try:
+                SampleModel.model_validate({})
+            except ValidationError as exc:
+                ve = exc
+            mock_client.chat.completions.parse = AsyncMock(side_effect=ve)
+
+            fallback_response = self._create_mock_response_with_tools(
+                "",
+                [
+                    {
+                        "id": "call_1",
+                        "name": "SampleModel",
+                        "arguments": '{"name": "Alice", "age": 7}',
+                    },
+                ],
+            )
+            mock_client.chat.completions.create = AsyncMock(
+                return_value=fallback_response,
+            )
+
+            result = await model(
+                [{"role": "user", "content": "x"}],
+                structured_model=SampleModel,
+            )
+
+            self.assertTrue(model._structured_output_fallback)
+            self.assertTrue(mock_client.chat.completions.create.called)
+            self.assertIsInstance(result, ChatResponse)
+            self.assertEqual(
+                result.metadata,
+                {"name": "Alice", "age": 7},
+            )
+
+    async def test_structured_sync_fallback_on_silent_mismatch(
+        self,
+    ) -> None:
+        """``.parse()`` returning ``message.parsed=None`` (silent
+        non-conforming body) must also trigger the tool-call fallback,
+        not silently propagate ``metadata=None`` to the caller."""
+        with patch("openai.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value = mock_client
+            model = OpenAIChatModel(
+                model_name="qwen3.6-flash",
+                api_key="test_key",
+                stream=False,
+            )
+            model.client = mock_client
+
+            # `.parse()` returns successfully but parsed is None
+            bad_response = self._create_mock_response("")
+            bad_response.choices[0].message.parsed = None
+            mock_client.chat.completions.parse = AsyncMock(
+                return_value=bad_response,
+            )
+
+            fallback_response = self._create_mock_response_with_tools(
+                "",
+                [
+                    {
+                        "id": "call_1",
+                        "name": "SampleModel",
+                        "arguments": '{"name": "Bob", "age": 9}',
+                    },
+                ],
+            )
+            mock_client.chat.completions.create = AsyncMock(
+                return_value=fallback_response,
+            )
+
+            result = await model(
+                [{"role": "user", "content": "x"}],
+                structured_model=SampleModel,
+            )
+
+            self.assertTrue(model._structured_output_fallback)
+            self.assertTrue(mock_client.chat.completions.create.called)
+            self.assertEqual(
+                result.metadata,
+                {"name": "Bob", "age": 9},
+            )
+
+    async def test_structured_stream_fallback_on_validation_error(
+        self,
+    ) -> None:
+        """Streaming path: ``ValidationError`` raised during stream
+        consumption must trigger transparent fallback to tool-call.
+        """
+        from pydantic import ValidationError
+
+        with patch("openai.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value = mock_client
+            model = OpenAIChatModel(
+                model_name="qwen3.6-flash",
+                api_key="test_key",
+                stream=True,
+            )
+            model.client = mock_client
+
+            try:
+                SampleModel.model_validate({})
+            except ValidationError as exc:
+                ve = exc
+
+            class _RaisingStream:
+                """Mock that raises ValidationError mid-stream consumption,
+                mirroring openai-python's stream parser behaviour when the
+                accumulated body fails schema validation."""
+
+                async def __aenter__(self) -> "_RaisingStream":
+                    return self
+
+                async def __aexit__(
+                    self,
+                    exc_type: Any,
+                    exc_val: Any,
+                    exc_tb: Any,
+                ) -> None:
+                    pass
+
+                def __aiter__(self) -> "_RaisingStream":
+                    return self
+
+                async def __anext__(self) -> Any:
+                    raise ve
+
+            mock_client.chat.completions.stream = Mock(
+                return_value=_RaisingStream(),
+            )
+
+            fallback_stream = self._create_stream_mock(
+                [
+                    {
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "name": "SampleModel",
+                                "arguments": '{"name":"C","age":3}',
+                            },
+                        ],
+                    },
+                ],
+            )
+            mock_client.chat.completions.create = AsyncMock(
+                return_value=fallback_stream,
+            )
+
+            result = await model(
+                [{"role": "user", "content": "x"}],
+                structured_model=SampleModel,
+            )
+
+            chunks = []
+            async for chunk in result:
+                chunks.append(chunk)
+
+            self.assertTrue(model._structured_output_fallback)
+            self.assertTrue(mock_client.chat.completions.create.called)
+            self.assertTrue(len(chunks) >= 1)
+            # In streaming fallback the structured payload is carried on the
+            # tool_use block (the tool name is the schema's tool name).
+            tool_blocks = [
+                b for b in chunks[-1].content if b.get("type") == "tool_use"
+            ]
+            self.assertEqual(len(tool_blocks), 1)
+            self.assertEqual(
+                tool_blocks[0]["input"],
+                {"name": "C", "age": 3},
+            )
+
+    async def test_structured_via_tool_call_retries_on_tool_choice_400(
+        self,
+    ) -> None:
+        """``_structured_via_tool_call`` must retry with
+        ``tool_choice='auto'`` when the endpoint rejects forced
+        ``tool_choice`` (e.g. DashScope thinking-mode models)."""
+        import openai
+
+        with patch("openai.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value = mock_client
+            model = OpenAIChatModel(
+                model_name="qwen3.6-flash",
+                api_key="test_key",
+                stream=False,
+            )
+            model.client = mock_client
+            # Skip the response_format attempt; go straight to fallback.
+            model._structured_output_fallback = True
+
+            http_response = Mock()
+            http_response.status_code = 400
+            http_response.request = Mock()
+            http_response.headers = {}
+            bad_request = openai.BadRequestError(
+                message=(
+                    "tool_choice required is not supported in thinking " "mode"
+                ),
+                response=http_response,
+                body=None,
+            )
+
+            success_response = self._create_mock_response_with_tools(
+                "",
+                [
+                    {
+                        "id": "call_1",
+                        "name": "SampleModel",
+                        "arguments": '{"name": "Dan", "age": 4}',
+                    },
+                ],
+            )
+            mock_client.chat.completions.create = AsyncMock(
+                side_effect=[bad_request, success_response],
+            )
+
+            result = await model(
+                [{"role": "user", "content": "x"}],
+                structured_model=SampleModel,
+            )
+
+            self.assertEqual(
+                mock_client.chat.completions.create.call_count,
+                2,
+            )
+            # Second call must downgrade to tool_choice='auto'
+            second_call_kwargs = (
+                mock_client.chat.completions.create.call_args_list[1][1]
+            )
+            self.assertEqual(second_call_kwargs["tool_choice"], "auto")
+            self.assertEqual(
+                result.metadata,
+                {"name": "Dan", "age": 4},
+            )
+
+    async def test_structured_via_tool_call_stream_retries_on_lazy_400(
+        self,
+    ) -> None:
+        """Streaming tool-call fallback: when the endpoint surfaces a
+        ``tool_choice``-related error lazily as ``openai.APIError`` during
+        stream iteration (DashScope thinking mode), the wrapper must retry
+        once with ``tool_choice='auto'`` before any chunk is yielded.
+        """
+        import openai
+
+        with patch("openai.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value = mock_client
+            model = OpenAIChatModel(
+                model_name="qwen3.6-flash",
+                api_key="test_key",
+                stream=True,
+            )
+            model.client = mock_client
+            # Skip response_format; go straight to tool-call fallback.
+            model._structured_output_fallback = True
+
+            http_request = Mock()
+
+            class _LazyApiErrorStream:
+                """Mirrors openai SDK behaviour where SSE error events
+                surface as ``APIError`` during stream iteration."""
+
+                async def __aenter__(self) -> "_LazyApiErrorStream":
+                    return self
+
+                async def __aexit__(
+                    self,
+                    exc_type: Any,
+                    exc_val: Any,
+                    exc_tb: Any,
+                ) -> None:
+                    pass
+
+                def __aiter__(self) -> "_LazyApiErrorStream":
+                    return self
+
+                async def __anext__(self) -> Any:
+                    raise openai.APIError(
+                        message=(
+                            "The tool_choice parameter does not support "
+                            "being set to required or object in thinking "
+                            "mode"
+                        ),
+                        request=http_request,
+                        body=None,
+                    )
+
+            success_stream = self._create_stream_mock(
+                [
+                    {
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "name": "SampleModel",
+                                "arguments": '{"name":"Eve","age":5}',
+                            },
+                        ],
+                    },
+                ],
+            )
+            mock_client.chat.completions.create = AsyncMock(
+                side_effect=[_LazyApiErrorStream(), success_stream],
+            )
+
+            result = await model(
+                [{"role": "user", "content": "x"}],
+                structured_model=SampleModel,
+            )
+
+            chunks = []
+            async for chunk in result:
+                chunks.append(chunk)
+
+            self.assertEqual(
+                mock_client.chat.completions.create.call_count,
+                2,
+            )
+            second_call_kwargs = (
+                mock_client.chat.completions.create.call_args_list[1][1]
+            )
+            self.assertEqual(second_call_kwargs["tool_choice"], "auto")
+            tool_blocks = [
+                b for b in chunks[-1].content if b.get("type") == "tool_use"
+            ]
+            self.assertEqual(len(tool_blocks), 1)
+            self.assertEqual(
+                tool_blocks[0]["input"],
+                {"name": "Eve", "age": 5},
+            )
+
+    async def test_structured_via_tool_call_stream_retries_on_sync_400(
+        self,
+    ) -> None:
+        """Streaming tool-call fallback: when the endpoint rejects
+        forced ``tool_choice`` *synchronously* on
+        ``client.chat.completions.create()`` (e.g. DashScope qwen3.6-plus
+        / qwen3.6-flash), the wrapper must retry once with
+        ``tool_choice='auto'`` before consuming the stream.
+        """
+        import openai
+
+        with patch("openai.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value = mock_client
+            model = OpenAIChatModel(
+                model_name="qwen3.6-plus",
+                api_key="test_key",
+                stream=True,
+            )
+            model.client = mock_client
+            model._structured_output_fallback = True
+
+            http_response = Mock()
+            http_response.status_code = 400
+            http_response.request = Mock()
+            http_response.headers = {}
+            sync_400 = openai.BadRequestError(
+                message=(
+                    "The tool_choice parameter does not support being "
+                    "set to required or object in thinking mode"
+                ),
+                response=http_response,
+                body=None,
+            )
+
+            success_stream = self._create_stream_mock(
+                [
+                    {
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "name": "SampleModel",
+                                "arguments": '{"name":"Fay","age":6}',
+                            },
+                        ],
+                    },
+                ],
+            )
+            mock_client.chat.completions.create = AsyncMock(
+                side_effect=[sync_400, success_stream],
+            )
+
+            result = await model(
+                [{"role": "user", "content": "x"}],
+                structured_model=SampleModel,
+            )
+
+            chunks = []
+            async for chunk in result:
+                chunks.append(chunk)
+
+            self.assertEqual(
+                mock_client.chat.completions.create.call_count,
+                2,
+            )
+            second_call_kwargs = (
+                mock_client.chat.completions.create.call_args_list[1][1]
+            )
+            self.assertEqual(second_call_kwargs["tool_choice"], "auto")
+            tool_blocks = [
+                b for b in chunks[-1].content if b.get("type") == "tool_use"
+            ]
+            self.assertEqual(len(tool_blocks), 1)
+            self.assertEqual(
+                tool_blocks[0]["input"],
+                {"name": "Fay", "age": 6},
+            )
 
     async def test_streaming_response_with_none_delta(self) -> None:
         """Test streaming response when a chunk has delta = None."""


### PR DESCRIPTION
## AgentScope Version
1.0.20 (`main` @ 5d9c6ce9)

Fixes #1631

## Description

OpenAI-compatible endpoints (notably DashScope's thinking-mode models such as
`qwen3-235b-a22b-thinking-2507` and the `qwen3.6-*` series) violate the
`response_format=json_schema` contract in two distinct ways. Both surfaced as
hard crashes for users invoking `OpenAIChatModel` with `structured_model=...`.

### Fix 1 — Silent schema mismatch / `ValidationError` on `parsed`

When DashScope's thinking models accept the request but return a body that does
not conform to the schema, the OpenAI SDK either:

- raises `pydantic.ValidationError` from `chat.completions.parse(...)`, or
- returns successfully with `response.choices[0].message.parsed` set to
  something that is **not** an instance of the requested model (silent miss).

Previously only `openai.BadRequestError` was caught, so both shapes propagated
and crashed the agent loop.

This PR:
- catches `(openai.BadRequestError, pydantic.ValidationError)` on both the
  sync (`__call__`) and streaming (`_structured_stream_with_fallback`) paths,
- adds an explicit `isinstance(parsed, structured_model)` guard via the new
  `_structured_parse_mismatch_reason` helper to detect the silent-mismatch
  case,
- on either signal, latches `_structured_output_fallback=True` and dispatches
  to the existing tool-call fallback (`_structured_via_tool_call` /
  `_tool_call_stream_with_choice_retry`).

Subsequent calls on the same model instance skip `response_format` entirely,
so we pay the detection cost at most once.

### Fix 2 — `tool_choice="required"` rejection on the fallback path

The tool-call fallback issues `tool_choice="required"` to force the model to
emit a structured tool call. Several DashScope models reject this with HTTP
400 (`tool_choice` not supported). Three rejection shapes are observed in the
wild:

1. sync `BadRequestError` from non-streaming `client.chat.completions.create()`
   — e.g. `qwen3-32b`, `deepseek-v3`,
2. sync `BadRequestError` from streaming `client.chat.completions.create()`
   — e.g. `qwen3.6-plus`, `qwen3.6-flash`,
3. lazy `openai.APIError` from the first `__anext__` of the stream iterator
   — e.g. `qwen3-235b-a22b-thinking-2507`.

All three paths now substring-match `"tool_choice"` in the error (via the
shared `_is_tool_choice_rejection` helper) and retry with
`tool_choice="auto"`. The streaming retry is gated on a `yielded` flag so we
never double-emit chunks if the failure happens mid-stream.

### Verification

- All 15 unit tests in `tests/model_openai_test.py` pass, including 6 new
  tests covering the validation-error path, the silent-mismatch path, the
  streaming path, and the three `tool_choice` rejection shapes.
- End-to-end against live DashScope (`dashscope.aliyuncs.com/compatible-mode/v1`)
  across `qwen-plus`, `qwen-turbo`, `qwen-max`, `qwen3-235b-a22b-thinking-2507`,
  `qwen3-32b`, `deepseek-v3`, `qwen3.6-plus`, `qwen3.6-flash`, both streaming
  and non-streaming, with `structured_model=Plan`. Models that natively support
  `response_format` stay on the fast path; models that do not transparently
  fall back and produce schema-valid output.
- `pylint` clean (10/10).

## Checklist

- [x] The pull request title starts with one of the prefixes from
      [Conventional Commits](https://www.conventionalcommits.org/).
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
