### PR TITLE
fix(formatter): drop thinking blocks without signature for Anthropic

### DIFF
--- a/src/agentscope/formatter/_anthropic_formatter.py
+++ b/src/agentscope/formatter/_anthropic_formatter.py
@@ -76,17 +76,25 @@ class _AnthropicFormatterBase(FormatterBase, ABC):
                     )
 
                 elif isinstance(block, ThinkingBlock):
-                    # Anthropic requires the signature to be passed back in
-                    # subsequent requests so the API can verify the thinking
-                    # block.  signature is stored as an extra field and may be
-                    # absent on blocks from other providers.
-                    content_blocks.append(
-                        {
-                            "type": "thinking",
-                            "thinking": block.thinking,
-                            "signature": getattr(block, "signature", "") or "",
-                        },
-                    )
+                    # Anthropic rejects thinking blocks without a valid
+                    # signature ("Invalid `signature` in `thinking` block").
+                    # ThinkingBlocks from other providers (OpenAI, DeepSeek,
+                    # ...) carry no signature, so drop them instead of
+                    # forwarding an empty one.
+                    signature = getattr(block, "signature", None)
+                    if signature:
+                        content_blocks.append(
+                            {
+                                "type": "thinking",
+                                "thinking": block.thinking,
+                                "signature": signature,
+                            },
+                        )
+                    else:
+                        logger.debug(
+                            "Dropping ThinkingBlock without signature; "
+                            "Anthropic requires a valid signature.",
+                        )
 
                 elif isinstance(block, HintBlock):
                     if content_blocks:

--- a/tests/formatter_anthropic_test.py
+++ b/tests/formatter_anthropic_test.py
@@ -338,13 +338,17 @@ class TestAnthropicFormatter(IsolatedAsyncioTestCase):
         )
 
     async def test_chat_formatter_thinking_preserved(self) -> None:
-        """ThinkingBlock is passed back as a thinking content block."""
+        """ThinkingBlock with a signature is passed back as a thinking
+        content block."""
         fmt = AnthropicChatFormatter()
         msgs = [
             AssistantMsg(
                 name="assistant",
                 content=[
-                    ThinkingBlock(thinking="inner thoughts"),
+                    ThinkingBlock(
+                        thinking="inner thoughts",
+                        signature="sig_abc",
+                    ),
                     TextBlock(text="reply"),
                 ],
             ),
@@ -358,7 +362,7 @@ class TestAnthropicFormatter(IsolatedAsyncioTestCase):
                         {
                             "type": "thinking",
                             "thinking": "inner thoughts",
-                            "signature": "",
+                            "signature": "sig_abc",
                         },
                         {"type": "text", "text": "reply"},
                     ],
@@ -366,6 +370,48 @@ class TestAnthropicFormatter(IsolatedAsyncioTestCase):
             ],
             res,
         )
+
+    async def test_chat_formatter_thinking_without_signature_dropped(
+        self,
+    ) -> None:
+        """ThinkingBlock from another provider (no signature) is dropped
+        rather than forwarded with an empty signature, which Anthropic
+        rejects with `Invalid signature in thinking block`. An empty-string
+        signature is treated the same as a missing one."""
+        fmt = AnthropicChatFormatter()
+        msgs = [
+            AssistantMsg(
+                name="assistant",
+                content=[
+                    ThinkingBlock(thinking="from another provider"),
+                    ThinkingBlock(thinking="empty sig", signature=""),
+                    TextBlock(text="reply"),
+                ],
+            ),
+        ]
+        res = await fmt.format(msgs)
+        self.assertListEqual(
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "reply"},
+                    ],
+                },
+            ],
+            res,
+        )
+
+        # Thinking-only message produces no output (no empty assistant msg).
+        res = await fmt.format(
+            [
+                AssistantMsg(
+                    name="assistant",
+                    content=[ThinkingBlock(thinking="only thinking")],
+                ),
+            ],
+        )
+        self.assertListEqual([], res)
 
     async def test_chat_formatter_tool_result_role_forced_to_user(
         self,
@@ -531,7 +577,7 @@ class TestAnthropicFormatter(IsolatedAsyncioTestCase):
             AssistantMsg(
                 name="assistant",
                 content=[
-                    ThinkingBlock(thinking="thinking_1"),
+                    ThinkingBlock(thinking="thinking_1", signature="sig_1"),
                     TextBlock(text="text_1"),
                     ToolCallBlock(
                         id="call_1",
@@ -555,7 +601,7 @@ class TestAnthropicFormatter(IsolatedAsyncioTestCase):
                         output=[TextBlock(text="result_2")],
                         state=ToolResultState.SUCCESS,
                     ),
-                    ThinkingBlock(thinking="thinking_2"),
+                    ThinkingBlock(thinking="thinking_2", signature="sig_2"),
                     TextBlock(text="text_2"),
                     ToolCallBlock(
                         id="call_3",
@@ -579,7 +625,7 @@ class TestAnthropicFormatter(IsolatedAsyncioTestCase):
                         output=[TextBlock(text="result_4")],
                         state=ToolResultState.SUCCESS,
                     ),
-                    ThinkingBlock(thinking="thinking_3"),
+                    ThinkingBlock(thinking="thinking_3", signature="sig_3"),
                     TextBlock(text="text_3"),
                 ],
             ),
@@ -593,7 +639,7 @@ class TestAnthropicFormatter(IsolatedAsyncioTestCase):
                         {
                             "type": "thinking",
                             "thinking": "thinking_1",
-                            "signature": "",
+                            "signature": "sig_1",
                         },
                         {"type": "text", "text": "text_1"},
                         {
@@ -640,7 +686,7 @@ class TestAnthropicFormatter(IsolatedAsyncioTestCase):
                         {
                             "type": "thinking",
                             "thinking": "thinking_2",
-                            "signature": "",
+                            "signature": "sig_2",
                         },
                         {"type": "text", "text": "text_2"},
                         {
@@ -692,7 +738,7 @@ class TestAnthropicFormatter(IsolatedAsyncioTestCase):
                         {
                             "type": "thinking",
                             "thinking": "thinking_3",
-                            "signature": "",
+                            "signature": "sig_3",
                         },
                         {"type": "text", "text": "text_3"},
                     ],


### PR DESCRIPTION
## AgentScope Version

2.0.0

## Description

- Anthropic rejects `thinking` blocks with an empty `signature` (`Invalid signature in thinking block`), which broke requests that carried over `ThinkingBlock`s from other providers (OpenAI, DeepSeek, ...) where signatures don't exist.
- The Anthropic formatter now skips `ThinkingBlock`s without a valid signature (logging at debug level) instead of forwarding them with `signature: ""`.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review