### PR TITLE
fix(tool): support plain return values in FunctionTool

### DIFF
--- a/src/agentscope/tool/_adapters.py
+++ b/src/agentscope/tool/_adapters.py
@@ -116,8 +116,27 @@ class FunctionTool(ToolBase):
         else:
             result = self._func(**kwargs)
 
-        if isinstance(result, (AsyncGenerator, Generator)):
-            return result
+        if isinstance(result, AsyncGenerator):
+
+            async def _stream() -> AsyncGenerator[ToolChunk, None]:
+                async for chunk in result:
+                    if isinstance(chunk, ToolChunk):
+                        yield chunk
+                    else:
+                        yield self._convert_func_result_to_chunk(chunk)
+
+            return _stream()
+
+        if isinstance(result, Generator):
+
+            async def _stream() -> AsyncGenerator[ToolChunk, None]:
+                for chunk in result:
+                    if isinstance(chunk, ToolChunk):
+                        yield chunk
+                    else:
+                        yield self._convert_func_result_to_chunk(chunk)
+
+            return _stream()
 
         return self._convert_func_result_to_chunk(result)
 

--- a/src/agentscope/tool/_adapters.py
+++ b/src/agentscope/tool/_adapters.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 """Adapters to convert functions and MCP tools to ToolProtocol."""
 import inspect
+import json
 from contextlib import _AsyncGeneratorContextManager
 from datetime import timedelta
-from typing import Callable, Any, AsyncGenerator
+from typing import Callable, Any, AsyncGenerator, Generator
 
 from mcp import ClientSession
 import mcp
@@ -32,7 +33,7 @@ class FunctionTool(ToolBase):
     This class wraps a regular Python function and makes it compatible with
     the ToolProtocol interface. It automatically extracts metadata from the
     function's signature and docstring, and normalizes the return value to
-    AsyncGenerator[ToolChunk, None].
+    ToolChunk or AsyncGenerator[ToolChunk, None].
     """
 
     is_external_tool: bool = False
@@ -115,7 +116,28 @@ class FunctionTool(ToolBase):
         else:
             result = self._func(**kwargs)
 
-        return result
+        if isinstance(result, (AsyncGenerator, Generator)):
+            return result
+
+        return self._convert_func_result_to_chunk(result)
+
+    @staticmethod
+    def _convert_func_result_to_chunk(
+        result: Any,
+    ) -> ToolChunk:
+        if isinstance(result, ToolChunk):
+            return result
+        if isinstance(result, str):
+            text = result
+        else:
+            try:
+                text = json.dumps(result, ensure_ascii=False)
+            except (TypeError, ValueError):
+                text = str(result)
+        return ToolChunk(
+            content=[TextBlock(text=text)],
+            state=ToolResultState.RUNNING,
+        )
 
 
 class MCPTool(ToolBase):

--- a/tests/toolkit_test.py
+++ b/tests/toolkit_test.py
@@ -742,6 +742,56 @@ class RegisterFunctionTest(IsolatedAsyncioTestCase):
             },
         )
 
+    async def test_sync_streaming_function_returning_plain_values(
+        self,
+    ) -> None:
+        """Test wrapping a sync generator that yields plain values."""
+
+        def stream_weather() -> Generator[Any, None, None]:
+            """Stream weather information."""
+            yield "checking"
+            yield {
+                "condition": "sunny",
+                "temperature": 22,
+            }
+
+        toolkit = Toolkit(
+            tools=[FunctionTool(stream_weather)],
+        )
+
+        state = AgentState()
+        tool_call = ToolCallBlock(
+            id="test_weather_stream",
+            name="stream_weather",
+            input=json.dumps({}),
+        )
+        expected_dict_text = json.dumps(
+            {
+                "condition": "sunny",
+                "temperature": 22,
+            },
+            ensure_ascii=False,
+        )
+
+        chunks = []
+        response = None
+        async for result in toolkit.call_tool(tool_call, state):
+            if isinstance(result, ToolChunk):
+                chunks.append(result)
+            elif isinstance(result, ToolResponse):
+                response = result
+
+        self.assertEqual(
+            [chunk.content[0].text for chunk in chunks],
+            ["checking", expected_dict_text],
+        )
+
+        self.assertIsNotNone(response)
+        self.assertEqual(
+            response.content[0].text,
+            f"checking{expected_dict_text}",
+        )
+
     async def test_async_non_streaming_function(self) -> None:
         """Test registering an asynchronous non-streaming function."""
 
@@ -945,6 +995,54 @@ class RegisterFunctionTest(IsolatedAsyncioTestCase):
                 "metadata": {},
                 "id": "test_sequence",
             },
+        )
+
+    async def test_async_streaming_function_returning_plain_values(
+        self,
+    ) -> None:
+        """Test wrapping an async generator that yields plain values."""
+
+        async def stream_status() -> AsyncGenerator[Any, None]:
+            """Stream status information."""
+            yield "started"
+            yield {
+                "done": True,
+            }
+
+        toolkit = Toolkit(
+            tools=[FunctionTool(stream_status)],
+        )
+
+        state = AgentState()
+        tool_call = ToolCallBlock(
+            id="test_status_stream",
+            name="stream_status",
+            input=json.dumps({}),
+        )
+        expected_dict_text = json.dumps(
+            {
+                "done": True,
+            },
+            ensure_ascii=False,
+        )
+
+        chunks = []
+        response = None
+        async for result in toolkit.call_tool(tool_call, state):
+            if isinstance(result, ToolChunk):
+                chunks.append(result)
+            elif isinstance(result, ToolResponse):
+                response = result
+
+        self.assertEqual(
+            [chunk.content[0].text for chunk in chunks],
+            ["started", expected_dict_text],
+        )
+
+        self.assertIsNotNone(response)
+        self.assertEqual(
+            response.content[0].text,
+            f"started{expected_dict_text}",
         )
 
 

--- a/tests/toolkit_test.py
+++ b/tests/toolkit_test.py
@@ -523,6 +523,125 @@ class RegisterFunctionTest(IsolatedAsyncioTestCase):
             },
         )
 
+    async def test_sync_function_returning_plain_string(self) -> None:
+        """Test wrapping a sync function that returns a plain string."""
+
+        def get_weather(location: str) -> str:
+            """Get weather information.
+
+            Args:
+                location: The location to get weather for
+            """
+            return f"The weather in {location} is sunny."
+
+        toolkit = Toolkit(
+            tools=[FunctionTool(get_weather)],
+        )
+
+        state = AgentState()
+        tool_call = ToolCallBlock(
+            id="test_weather",
+            name="get_weather",
+            input=json.dumps({"location": "Chengdu"}),
+        )
+
+        chunks = []
+        response = None
+        async for result in toolkit.call_tool(tool_call, state):
+            if isinstance(result, ToolChunk):
+                chunks.append(result)
+            elif isinstance(result, ToolResponse):
+                response = result
+
+        self.assertEqual(len(chunks), 1)
+        self.assertDictEqual(
+            chunks[0].model_dump(),
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "id": AnyString(),
+                        "text": "The weather in Chengdu is sunny.",
+                    },
+                ],
+                "state": "running",
+                "is_last": True,
+                "metadata": {},
+                "id": AnyString(),
+            },
+        )
+
+        self.assertIsNotNone(response)
+        self.assertDictEqual(
+            response.model_dump(),
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "id": AnyString(),
+                        "text": "The weather in Chengdu is sunny.",
+                    },
+                ],
+                "state": "success",
+                "metadata": {},
+                "id": "test_weather",
+            },
+        )
+
+    async def test_async_function_returning_json_serializable_value(
+        self,
+    ) -> None:
+        """Test wrapping an async function that returns a JSON value."""
+
+        async def get_weather(location: str) -> dict:
+            """Get weather information.
+
+            Args:
+                location: The location to get weather for
+            """
+            return {
+                "location": location,
+                "weather": {
+                    "condition": "sunny",
+                    "temperature": 22,
+                },
+            }
+
+        toolkit = Toolkit(
+            tools=[FunctionTool(get_weather)],
+        )
+
+        state = AgentState()
+        tool_call = ToolCallBlock(
+            id="test_weather_json",
+            name="get_weather",
+            input=json.dumps({"location": "成都"}),
+        )
+        expected_text = json.dumps(
+            {
+                "location": "成都",
+                "weather": {
+                    "condition": "sunny",
+                    "temperature": 22,
+                },
+            },
+            ensure_ascii=False,
+        )
+
+        chunks = []
+        response = None
+        async for result in toolkit.call_tool(tool_call, state):
+            if isinstance(result, ToolChunk):
+                chunks.append(result)
+            elif isinstance(result, ToolResponse):
+                response = result
+
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(chunks[0].content[0].text, expected_text)
+
+        self.assertIsNotNone(response)
+        self.assertEqual(response.content[0].text, expected_text)
+
     async def test_sync_streaming_function(self) -> None:
         """Test registering a synchronous streaming function."""
 


### PR DESCRIPTION
## AgentScope Version

2.0.0

## Description

Fixes #1702.

The `Wrap function as tool` documentation shows a plain Python function returning `str`:

https://docs.agentscope.io/v2/building-blocks/tool#wrap-function-as-tool

However, `FunctionTool.__call__()` previously returned the wrapped function result directly. When the wrapped function returned a plain value such as `str` or `dict`, `Toolkit.call_tool()` treated it as an invalid tool result and raised `DeveloperOrientedException`.

This PR normalizes plain Python return values in `FunctionTool` into `ToolChunk` text results.

The PR is split into two commits intentionally:

1. `fix(tool): support plain return values in FunctionTool`

   This is the minimal fix for #1702. It normalizes non-streaming plain return values while preserving existing `ToolChunk` behavior.

2. `feat(tool): normalize plain yielded values in FunctionTool streams`

   This applies the same normalization logic to values yielded by sync and async generator tools. If maintainers prefer this PR to only include the minimal bug fix, I can drop this second commit.

Validation:

```bash
pre-commit run --all-files
pytest tests
```

I also verified the documented `get_weather(...) -> str` style tool call with a local fork-branch installation. It now produces a successful tool result instead of raising `DeveloperOrientedException`.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
