### PR TITLE
fix(webui): fix frontend build with current dependencies

### DIFF
--- a/examples/web_ui/frontend/src/components/ui/calendar.tsx
+++ b/examples/web_ui/frontend/src/components/ui/calendar.tsx
@@ -74,7 +74,7 @@ function Calendar({
 						: 'flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground',
 					defaultClassNames.caption_label,
 				),
-				table: 'w-full border-collapse',
+				month_grid: cn('w-full border-collapse', defaultClassNames.month_grid),
 				weekdays: cn('flex', defaultClassNames.weekdays),
 				weekday: cn(
 					'flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none',

--- a/examples/web_ui/frontend/src/hooks/useSkills.ts
+++ b/examples/web_ui/frontend/src/hooks/useSkills.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 
-import { skillApi } from '../api';
+import { workspaceApi } from '../api';
 import type { Skill } from '../api';
 
 /**
@@ -23,7 +23,7 @@ export function useSkills(agentId: string | null, sessionId: string | null) {
 		setLoading(true);
 		setError(null);
 		try {
-			setSkills(await skillApi.list(agentId, sessionId));
+			setSkills(await workspaceApi.skill.list(agentId, sessionId));
 		} catch (e) {
 			setError(e as Error);
 		} finally {
@@ -39,7 +39,7 @@ export function useSkills(agentId: string | null, sessionId: string | null) {
 	const add = useCallback(
 		async (skillPath: string) => {
 			if (!agentId || !sessionId) throw new Error('No agent/session selected');
-			await skillApi.add(agentId, sessionId, { skill_path: skillPath });
+			await workspaceApi.skill.add(agentId, sessionId, { skill_path: skillPath });
 			await refetch();
 		},
 		[agentId, sessionId, refetch],
@@ -49,7 +49,7 @@ export function useSkills(agentId: string | null, sessionId: string | null) {
 	const remove = useCallback(
 		async (skillName: string) => {
 			if (!agentId || !sessionId) throw new Error('No agent/session selected');
-			await skillApi.remove(skillName, agentId, sessionId);
+			await workspaceApi.skill.remove(skillName, agentId, sessionId);
 			await refetch();
 		},
 		[agentId, sessionId, refetch],

--- a/examples/web_ui/frontend/tsconfig.app.json
+++ b/examples/web_ui/frontend/tsconfig.app.json
@@ -6,6 +6,7 @@
 		"module": "esnext",
 		"types": ["vite/client", "vite-plugin-svgr/client"],
 		"skipLibCheck": true,
+		"ignoreDeprecations": "6.0",
 
 		/* Bundler mode */
 		"moduleResolution": "bundler",


### PR DESCRIPTION
## Summary

- Update the calendar classNames mapping for the installed react-day-picker version by using month_grid instead of the removed table key.
- Switch the skills hook from the missing skillApi export to the existing workspaceApi.skill client.
- Add TypeScript 6 deprecation handling so the frontend project can type-check with the current compiler.

Fixes #1707

## Why

The Web UI frontend currently fails type-checking with the resolved dependency versions because a react-day-picker classNames key is no longer valid, skillApi is not exported from the API module, and TypeScript 6 reports the existing baseUrl configuration as a blocking deprecation.

## Validation

- PASS: ./node_modules/.bin/tsc -b
- PASS: ./node_modules/.bin/vite build
- PASS: pre-commit run --all-files
- PASS: pytest tests

## Notes

The local development environment was rebuilt with Python 3.11 to match the project contribution workflow. The earlier Python 3.14 pre-commit run failed because the pinned pylint v3.0.2 / astroid v3.0.3 hook crashes on Python 3.14 syntax support.