### PR TITLE
fix: wrap string function tool results

### DIFF
--- a/src/agentscope/tool/_adapters.py
+++ b/src/agentscope/tool/_adapters.py
@@ -115,6 +115,9 @@ class FunctionTool(ToolBase):
         else:
             result = self._func(**kwargs)
 
+        if isinstance(result, str):
+            return ToolChunk(content=[TextBlock(text=result)])
+
         return result
 
 

--- a/tests/toolkit_test.py
+++ b/tests/toolkit_test.py
@@ -523,6 +523,39 @@ class RegisterFunctionTest(IsolatedAsyncioTestCase):
             },
         )
 
+    async def test_sync_function_returning_string(self) -> None:
+        """Test wrapping a plain function that returns text."""
+
+        def get_weather(location: str) -> str:
+            """Get weather information.
+
+            Args:
+                location: The location to get weather for
+            """
+            return f"The weather in {location} is sunny."
+
+        toolkit = Toolkit(tools=[FunctionTool(get_weather)])
+
+        state = AgentState()
+        tool_call = ToolCallBlock(
+            id="test_weather",
+            name="get_weather",
+            input=json.dumps({"location": "Chengdu"}),
+        )
+
+        chunks = []
+        response = None
+        async for result in toolkit.call_tool(tool_call, state):
+            if isinstance(result, ToolChunk):
+                chunks.append(result)
+            elif isinstance(result, ToolResponse):
+                response = result
+
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(chunks[0].content[0].text, "The weather in Chengdu is sunny.")
+        self.assertIsNotNone(response)
+        self.assertEqual(response.content[0].text, "The weather in Chengdu is sunny.")
+
     async def test_sync_streaming_function(self) -> None:
         """Test registering a synchronous streaming function."""
 


### PR DESCRIPTION
﻿## Summary
- convert plain string results from FunctionTool into text ToolChunk output
- keep existing ToolChunk and streaming result handling unchanged
- add regression coverage for the documented get_weather-style function tool

Fixes #1702.

## To verify
- python -m py_compile src\agentscope\tool\_adapters.py tests\toolkit_test.py
- python -m pytest tests\toolkit_test.py -k "sync_function_returning_string or sync_non_streaming_function" -q
- git diff --check
