### PR TITLE
fix(tool): hide bash subprocess windows on Windows

### DIFF
--- a/src/agentscope/tool/_builtin/_bash.py
+++ b/src/agentscope/tool/_builtin/_bash.py
@@ -22,7 +22,7 @@ from ...message import TextBlock
 from .._response import ToolChunk
 
 
-def _subprocess_creation_kwargs() -> dict[str, int]:
+def _subprocess_creation_kwargs() -> dict[str, Any]:
     """Return platform-specific subprocess creation options."""
     if os.name != "nt":
         return {}

--- a/src/agentscope/tool/_builtin/_bash.py
+++ b/src/agentscope/tool/_builtin/_bash.py
@@ -22,6 +22,22 @@ from ...message import TextBlock
 from .._response import ToolChunk
 
 
+def _subprocess_creation_kwargs() -> dict[str, int]:
+    """Return platform-specific subprocess creation options."""
+    if os.name != "nt":
+        return {}
+
+    import subprocess
+
+    return {
+        "creationflags": getattr(
+            subprocess,
+            "CREATE_NO_WINDOW",
+            0x08000000,
+        ),
+    }
+
+
 class Bash(ToolBase):
     """The bash tool."""
 
@@ -604,6 +620,7 @@ easier to review tool calls and give permission.
                 command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
+                **_subprocess_creation_kwargs(),
             )
 
             # Wait for completion with timeout

--- a/tests/builtin_bash_test.py
+++ b/tests/builtin_bash_test.py
@@ -3,14 +3,31 @@
 import sys
 import unittest
 from unittest.async_case import IsolatedAsyncioTestCase
+from unittest.mock import patch
 
 from agentscope.tool import ToolChunk, Bash
+from agentscope.tool._builtin._bash import _subprocess_creation_kwargs
 from agentscope.permission import (
     PermissionContext,
     PermissionBehavior,
     PermissionRule,
 )
 from agentscope.message import TextBlock
+
+
+class BashSubprocessKwargsTest(unittest.TestCase):
+    """Test platform-specific subprocess kwargs."""
+
+    def test_non_windows_subprocess_kwargs_are_empty(self) -> None:
+        with patch("agentscope.tool._builtin._bash.os.name", "posix"):
+            self.assertEqual(_subprocess_creation_kwargs(), {})
+
+    def test_windows_subprocess_kwargs_hide_console(self) -> None:
+        with patch("agentscope.tool._builtin._bash.os.name", "nt"):
+            self.assertEqual(
+                _subprocess_creation_kwargs(),
+                {"creationflags": 0x08000000},
+            )
 
 
 @unittest.skipIf(

--- a/tests/builtin_bash_test.py
+++ b/tests/builtin_bash_test.py
@@ -19,10 +19,12 @@ class BashSubprocessKwargsTest(unittest.TestCase):
     """Test platform-specific subprocess kwargs."""
 
     def test_non_windows_subprocess_kwargs_are_empty(self) -> None:
+        """On non-Windows the helper returns no extra subprocess kwargs."""
         with patch("agentscope.tool._builtin._bash.os.name", "posix"):
             self.assertEqual(_subprocess_creation_kwargs(), {})
 
     def test_windows_subprocess_kwargs_hide_console(self) -> None:
+        """On Windows the helper sets ``creationflags`` to hide the console."""
         with patch("agentscope.tool._builtin._bash.os.name", "nt"):
             self.assertEqual(
                 _subprocess_creation_kwargs(),


### PR DESCRIPTION
﻿## Summary
- pass `CREATE_NO_WINDOW` when the Bash tool starts subprocesses on Windows
- leave non-Windows subprocess creation unchanged
- add regression coverage for the platform-specific subprocess kwargs

Fixes #1714.

## To verify
- python -m py_compile src\agentscope\tool\_builtin\_bash.py tests\builtin_bash_test.py
- python -m pytest tests\builtin_bash_test.py -k "SubprocessKwargs" -q
- python -m black --check --line-length=79 src\agentscope\tool\_builtin\_bash.py tests\builtin_bash_test.py
- python -m flake8 --extend-ignore=E203 src\agentscope\tool\_builtin\_bash.py tests\builtin_bash_test.py
- git diff --check
