### PR TITLE
fix: include tool group skills

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -1886,7 +1886,9 @@ class Agent:
         prompt = [self._system_prompt]
 
         # Skill related instructions
-        skill_instructions = await self.toolkit.get_skill_instructions()
+        skill_instructions = await self.toolkit.get_skill_instructions(
+            self.state.tool_context.activated_groups,
+        )
         if skill_instructions:
             prompt.append(skill_instructions)
 

--- a/src/agentscope/tool/_toolkit.py
+++ b/src/agentscope/tool/_toolkit.py
@@ -424,7 +424,10 @@ class Toolkit:
 
         return skills
 
-    async def get_skill_instructions(self) -> str | None:
+    async def get_skill_instructions(
+        self,
+        activated_groups: list[str] | None = None,
+    ) -> str | None:
         """Get the prompt for all registered agent skills, which can be
         attached to the system prompt for the agent.
 
@@ -434,13 +437,21 @@ class Toolkit:
 
         .. note:: If no skill is registered, None will be returned.
 
+        Args:
+            activated_groups (`list[str] | None`, optional):
+                The currently activated tool groups. If omitted, all groups
+                will be included for backwards compatibility.
+
         Returns:
             `str | None`:
-                The combined prompt for all registered agent skills, or None
+                The combined prompt for registered agent skills, or None
                 if no skill is registered.
         """
+        if activated_groups is None:
+            activated_groups = [_.name for _ in self.tool_groups]
+
         skills = await self._get_available_skills(
-            [_.name for _ in self.tool_groups],
+            activated_groups,
         )
 
         # If no skills were collected, return None

--- a/src/agentscope/tool/_toolkit.py
+++ b/src/agentscope/tool/_toolkit.py
@@ -439,7 +439,9 @@ class Toolkit:
                 The combined prompt for all registered agent skills, or None
                 if no skill is registered.
         """
-        skills = await self._get_available_skills()
+        skills = await self._get_available_skills(
+            [_.name for _ in self.tool_groups],
+        )
 
         # If no skills were collected, return None
         if len(skills) == 0:
@@ -474,7 +476,7 @@ class Toolkit:
         available_tools = {}
 
         # Built-in skill viewers
-        skills = await self._get_available_skills()
+        skills = await self._get_available_skills(groups)
         if len(skills):
             available_tools[
                 self.builtin_skill_viewer.tool.name

--- a/tests/toolkit_skill_test.py
+++ b/tests/toolkit_skill_test.py
@@ -173,6 +173,39 @@ Skills are a collection of instructions, scripts, and resources to extend your c
         assert result is not None
         self.assertIn("<name>repair_skill</name>", result)
 
+    async def test_get_skill_instructions_filters_inactive_group_skills(
+        self,
+    ) -> None:
+        """Test that inactive group skills are hidden from the prompt."""
+        toolkit = Toolkit(
+            skills_or_loaders=[MockSkillLoader([_make_skill("basic_skill")])],
+            tool_groups=[
+                ToolGroup(
+                    name="repair",
+                    description="Repair tools",
+                    skills_or_loaders=[
+                        MockSkillLoader([_make_skill("repair_skill")]),
+                    ],
+                ),
+            ],
+        )
+
+        inactive_result = await toolkit.get_skill_instructions(
+            activated_groups=[],
+        )
+        active_result = await toolkit.get_skill_instructions(
+            activated_groups=["repair"],
+        )
+
+        self.assertIsNotNone(inactive_result)
+        self.assertIsNotNone(active_result)
+        assert inactive_result is not None
+        assert active_result is not None
+        self.assertIn("<name>basic_skill</name>", inactive_result)
+        self.assertNotIn("<name>repair_skill</name>", inactive_result)
+        self.assertIn("<name>basic_skill</name>", active_result)
+        self.assertIn("<name>repair_skill</name>", active_result)
+
 
 class ToolkitSkillViewerTest(IsolatedAsyncioTestCase):
     """Test cases for Toolkit SkillViewer functionality."""

--- a/tests/toolkit_skill_test.py
+++ b/tests/toolkit_skill_test.py
@@ -8,7 +8,7 @@ from unittest.async_case import IsolatedAsyncioTestCase
 from utils import AnyString
 
 from agentscope.skill import SkillLoaderBase, Skill
-from agentscope.tool import Toolkit, ToolChunk, ToolResponse
+from agentscope.tool import Toolkit, ToolChunk, ToolResponse, ToolGroup
 from agentscope.message import ToolCallBlock
 from agentscope.state import AgentState
 
@@ -150,6 +150,28 @@ Skills are a collection of instructions, scripts, and resources to extend your c
 
         result = await toolkit.get_skill_instructions()
         self.assertIsNone(result)
+
+    async def test_get_skill_instructions_includes_tool_group_skills(
+        self,
+    ) -> None:
+        """Test that skill instructions include skills from custom groups."""
+        toolkit = Toolkit(
+            tool_groups=[
+                ToolGroup(
+                    name="repair",
+                    description="Repair tools",
+                    skills_or_loaders=[
+                        MockSkillLoader([_make_skill("repair_skill")]),
+                    ],
+                ),
+            ],
+        )
+
+        result = await toolkit.get_skill_instructions()
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertIn("<name>repair_skill</name>", result)
 
 
 class ToolkitSkillViewerTest(IsolatedAsyncioTestCase):
@@ -311,4 +333,43 @@ class ToolkitSkillViewerTest(IsolatedAsyncioTestCase):
                 "metadata": {},
                 "id": "test_call_2",
             },
+        )
+
+    async def test_skill_viewer_uses_active_tool_group_skills(self) -> None:
+        """Test that activated custom-group skills expose SkillViewer."""
+        skill = _make_skill("repair_skill")
+        skill.markdown = "# Repair Skill\nUse this for repair tasks."
+        toolkit = Toolkit(
+            tool_groups=[
+                ToolGroup(
+                    name="repair",
+                    description="Repair tools",
+                    skills_or_loaders=[MockSkillLoader([skill])],
+                ),
+            ],
+        )
+
+        schema_names = [
+            schema["function"]["name"]
+            for schema in await toolkit.get_tool_schemas(groups=["repair"])
+        ]
+        self.assertIn("Skill", schema_names)
+
+        tool_call = ToolCallBlock(
+            id="test_call_group_skill",
+            name="Skill",
+            input=json.dumps({"skill": "repair_skill"}),
+        )
+        state = AgentState()
+        state.tool_context.activated_groups.append("repair")
+
+        chunks = []
+        async for result in toolkit.call_tool(tool_call, state):
+            if isinstance(result, ToolChunk):
+                chunks.append(result)
+
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(
+            chunks[0].content[0].text,
+            "# Repair Skill\nUse this for repair tasks.",
         )


### PR DESCRIPTION
﻿## Summary
- collect skills from every registered tool group when building the global skill instructions
- make the built-in Skill viewer available when the currently active groups contain skills
- add regression coverage for custom ToolGroup skills in both prompt instructions and Skill viewer calls

## To verify
- `python -m pytest tests/toolkit_skill_test.py -q`
- `python -m black --check --line-length=79 src/agentscope/tool/_toolkit.py tests/toolkit_skill_test.py`
- `python -m flake8 --extend-ignore=E203 src/agentscope/tool/_toolkit.py tests/toolkit_skill_test.py`
- `python -m py_compile src/agentscope/tool/_toolkit.py tests/toolkit_skill_test.py`
- `git diff --check`

Note: the documented `pip install -e ".[dev]"` path is currently blocked on my Windows machine because the `ripgrep` wheel build needs the MSVC linker. I installed the editable package and the test/lint dependencies without `ripgrep` for this targeted verification.

Closes #1724
