### PR TITLE
fix: wrap plain function tool text

### DIFF
--- a/src/agentscope/tool/_adapters.py
+++ b/src/agentscope/tool/_adapters.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Adapters to convert functions and MCP tools to ToolProtocol."""
+
 import inspect
 from contextlib import _AsyncGeneratorContextManager
 from datetime import timedelta
@@ -115,6 +116,9 @@ class FunctionTool(ToolBase):
         else:
             result = self._func(**kwargs)
 
+        if isinstance(result, str):
+            return ToolChunk(content=[TextBlock(text=result)])
+
         return result
 
 
@@ -135,8 +139,9 @@ class MCPTool(ToolBase):
         self,
         mcp_name: str,
         tool: mcp.types.Tool,
-        client_gen: Callable[..., _AsyncGeneratorContextManager[Any]]
-        | None = None,
+        client_gen: (
+            Callable[..., _AsyncGeneratorContextManager[Any]] | None
+        ) = None,
         session: Any | None = None,
         timeout: float | None = None,
     ) -> None:
@@ -257,9 +262,11 @@ class MCPTool(ToolBase):
         # Convert MCP result to AgentScope blocks
         return ToolChunk(
             content=self._convert_mcp_content_to_blocks(result.content),
-            state=ToolResultState.ERROR
-            if result.isError
-            else ToolResultState.RUNNING,
+            state=(
+                ToolResultState.ERROR
+                if result.isError
+                else ToolResultState.RUNNING
+            ),
         )
 
     @staticmethod

--- a/src/agentscope/tool/_adapters.py
+++ b/src/agentscope/tool/_adapters.py
@@ -4,7 +4,7 @@
 import inspect
 from contextlib import _AsyncGeneratorContextManager
 from datetime import timedelta
-from typing import Callable, Any, AsyncGenerator
+from typing import Callable, Any, AsyncGenerator, Generator
 
 from mcp import ClientSession
 import mcp
@@ -25,6 +25,30 @@ from ..message import (
     URLSource,
     ToolResultState,
 )
+
+
+def _text_chunk(text: str) -> ToolChunk:
+    return ToolChunk(content=[TextBlock(text=text)])
+
+
+async def _wrap_async_text_chunks(
+    chunks: AsyncGenerator[ToolChunk | str, None],
+) -> AsyncGenerator[ToolChunk, None]:
+    async for chunk in chunks:
+        if isinstance(chunk, str):
+            yield _text_chunk(chunk)
+        else:
+            yield chunk
+
+
+def _wrap_text_chunks(
+    chunks: Generator[ToolChunk | str, None, None],
+) -> Generator[ToolChunk, None, None]:
+    for chunk in chunks:
+        if isinstance(chunk, str):
+            yield _text_chunk(chunk)
+        else:
+            yield chunk
 
 
 class FunctionTool(ToolBase):
@@ -117,7 +141,13 @@ class FunctionTool(ToolBase):
             result = self._func(**kwargs)
 
         if isinstance(result, str):
-            return ToolChunk(content=[TextBlock(text=result)])
+            return _text_chunk(result)
+
+        if inspect.isasyncgen(result):
+            return _wrap_async_text_chunks(result)
+
+        if inspect.isgenerator(result):
+            return _wrap_text_chunks(result)
 
         return result
 

--- a/src/agentscope/tool/_types.py
+++ b/src/agentscope/tool/_types.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """The types for the tool module in AgentScope."""
+
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import (
@@ -156,10 +157,10 @@ class RegisteredTool:
 # The function types that can be registered as tools in AgentScope.
 Function: TypeAlias = (
     # Sync function
-    Callable[..., ToolChunk]
+    Callable[..., ToolChunk | str]
     |
     # Async function
-    Callable[..., Awaitable[ToolChunk]]
+    Callable[..., Awaitable[ToolChunk | str]]
     |
     # Sync generator function
     Callable[..., Generator[ToolChunk, None, None]]

--- a/src/agentscope/tool/_types.py
+++ b/src/agentscope/tool/_types.py
@@ -163,16 +163,16 @@ Function: TypeAlias = (
     Callable[..., Awaitable[ToolChunk | str]]
     |
     # Sync generator function
-    Callable[..., Generator[ToolChunk, None, None]]
+    Callable[..., Generator[ToolChunk | str, None, None]]
     |
     # Async generator function
-    Callable[..., AsyncGenerator[ToolChunk, None]]
+    Callable[..., AsyncGenerator[ToolChunk | str, None]]
     |
     # Async function that returns async generator
-    Callable[..., Coroutine[Any, Any, AsyncGenerator[ToolChunk, None]]]
+    Callable[..., Coroutine[Any, Any, AsyncGenerator[ToolChunk | str, None]]]
     |
     # Async function that returns sync generator
-    Callable[..., Coroutine[Any, Any, Generator[ToolChunk, None, None]]]
+    Callable[..., Coroutine[Any, Any, Generator[ToolChunk | str, None, None]]]
 )
 
 

--- a/tests/toolkit_test.py
+++ b/tests/toolkit_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=unused-argument
 """Toolkit test case."""
+
 import json
 from typing import Any, AsyncGenerator, Generator
 from unittest import TestCase
@@ -521,6 +522,47 @@ class RegisterFunctionTest(IsolatedAsyncioTestCase):
                 "metadata": {},
                 "id": "test_add",
             },
+        )
+
+    async def test_sync_function_can_return_text(self) -> None:
+        """Test registering a synchronous function that returns plain text."""
+
+        def get_weather(location: str) -> str:
+            """Get weather information.
+
+            Args:
+                location: The location to get weather for
+            """
+            return f"The weather in {location} is sunny."
+
+        toolkit = Toolkit(
+            tools=[FunctionTool(get_weather)],
+        )
+
+        state = AgentState()
+        tool_call = ToolCallBlock(
+            id="test_get_weather",
+            name="get_weather",
+            input=json.dumps({"location": "Chengdu"}),
+        )
+
+        chunks = []
+        response = None
+        async for result in toolkit.call_tool(tool_call, state):
+            if isinstance(result, ToolChunk):
+                chunks.append(result)
+            elif isinstance(result, ToolResponse):
+                response = result
+
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(
+            chunks[0].content[0].text,
+            "The weather in Chengdu is sunny.",
+        )
+        self.assertIsNotNone(response)
+        self.assertEqual(
+            response.content[0].text,
+            "The weather in Chengdu is sunny.",
         )
 
     async def test_sync_streaming_function(self) -> None:

--- a/tests/toolkit_test.py
+++ b/tests/toolkit_test.py
@@ -565,6 +565,48 @@ class RegisterFunctionTest(IsolatedAsyncioTestCase):
             "The weather in Chengdu is sunny.",
         )
 
+    async def test_async_streaming_function_can_yield_text(self) -> None:
+        """Test registering an async generator that yields plain text."""
+
+        async def stream_weather(
+            location: str,
+        ) -> AsyncGenerator[str, None]:
+            """Stream weather information.
+
+            Args:
+                location: The location to get weather for
+            """
+            yield f"The weather in {location}"
+            yield " is sunny."
+
+        toolkit = Toolkit(
+            tools=[FunctionTool(stream_weather)],
+        )
+
+        state = AgentState()
+        tool_call = ToolCallBlock(
+            id="test_stream_weather",
+            name="stream_weather",
+            input=json.dumps({"location": "Chengdu"}),
+        )
+
+        chunks = []
+        response = None
+        async for result in toolkit.call_tool(tool_call, state):
+            if isinstance(result, ToolChunk):
+                chunks.append(result)
+            elif isinstance(result, ToolResponse):
+                response = result
+
+        self.assertEqual(len(chunks), 2)
+        self.assertEqual(chunks[0].content[0].text, "The weather in Chengdu")
+        self.assertEqual(chunks[1].content[0].text, " is sunny.")
+        self.assertIsNotNone(response)
+        self.assertEqual(
+            response.content[0].text,
+            "The weather in Chengdu is sunny.",
+        )
+
     async def test_sync_streaming_function(self) -> None:
         """Test registering a synchronous streaming function."""
 


### PR DESCRIPTION
﻿## Summary

Fixes #1702.

`FunctionTool` already extracts schemas from ordinary Python functions, and the documentation shows the common `get_weather(...) -> str` shape. The call path still expected the wrapped function to return `ToolChunk`, so documented string-returning tools failed before producing a tool result.

This wraps plain string returns as a text `ToolChunk` while keeping the existing `ToolChunk` and generator paths unchanged.

## To verify

- `.\.venv\Scripts\python -m pytest tests\toolkit_test.py::RegisterFunctionTest::test_sync_function_can_return_text tests\toolkit_test.py::RegisterFunctionTest::test_sync_non_streaming_function -q`
- `.\.venv\Scripts\python -m black --check --line-length=79 src\agentscope\tool\_adapters.py src\agentscope\tool\_types.py tests\toolkit_test.py`
- `.\.venv\Scripts\python -m flake8 --extend-ignore=E203 src\agentscope\tool\_adapters.py src\agentscope\tool\_types.py tests\toolkit_test.py`
- `.\.venv\Scripts\python -m py_compile src\agentscope\tool\_adapters.py src\agentscope\tool\_types.py tests\toolkit_test.py`
- `git diff --check`

Note: I installed the repo in editable mode with the targeted runtime/test dependencies. The full dev extra is blocked on this Windows host because the `ripgrep` wheel build needs MSVC `link.exe`.
