### PR TITLE
fix(storage): expire Redis message lists

### DIFF
--- a/src/agentscope/app/storage/_redis_storage.py
+++ b/src/agentscope/app/storage/_redis_storage.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=too-many-public-methods
 """The Redis storage implementation."""
+
 from datetime import datetime
 from typing import Any, TYPE_CHECKING, Self
 
@@ -114,6 +115,10 @@ class RedisStorage(StorageBase):
     async def _set_with_ttl(self, key: str, value: str) -> None:
         """SET a key and optionally apply the sliding TTL."""
         await self._client.set(key, value)
+        await self._refresh_key_ttl(key)
+
+    async def _refresh_key_ttl(self, key: str) -> None:
+        """Apply the sliding TTL to a key, if configured."""
         if self.key_ttl is not None:
             await self._client.expire(key, self.key_ttl)
 
@@ -816,8 +821,10 @@ class RedisStorage(StorageBase):
             last_msg = Msg.model_validate_json(last_raw)
             if last_msg.id == msg.id:
                 await self._client.lset(key, -1, msg.model_dump_json())
+                await self._refresh_key_ttl(key)
                 return
         await self._client.rpush(key, msg.model_dump_json())
+        await self._refresh_key_ttl(key)
 
     async def get_message(
         self,

--- a/tests/storage_redis_test.py
+++ b/tests/storage_redis_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Unit tests for RedisStorage using fakeredis."""
+
 from unittest.async_case import IsolatedAsyncioTestCase
 
 import fakeredis.aioredis
@@ -311,6 +312,18 @@ class TestMessage(IsolatedAsyncioTestCase):
             [msg.model_dump()],
         )
 
+    async def test_upsert_refreshes_message_list_ttl(self) -> None:
+        """Message list keys expire with the session storage TTL."""
+        self.storage.key_ttl = 60
+        msg = UserMsg(name="alice", content="hello")
+
+        await self.storage.upsert_message(self.user_id, self.session_id, msg)
+
+        ttl = await self.storage._client.ttl(
+            self.storage._message_key(self.user_id, self.session_id),
+        )
+        self.assertGreater(ttl, 0)
+
     async def test_upsert_replaces_last_message_with_same_id(self) -> None:
         """Upserting a message whose id matches the last entry replaces it
         in-place (streaming overwrite), rather than creating a duplicate."""
@@ -336,6 +349,29 @@ class TestMessage(IsolatedAsyncioTestCase):
             [updated.model_dump()],
             "Duplicate must not be created; existing entry must be replaced.",
         )
+
+    async def test_replace_refreshes_message_list_ttl(self) -> None:
+        """Streaming message replacement keeps the message key expiring."""
+        self.storage.key_ttl = 60
+        msg = AssistantMsg(name="bot", content="v1")
+        await self.storage.upsert_message(self.user_id, self.session_id, msg)
+        await self.storage._client.persist(
+            self.storage._message_key(self.user_id, self.session_id),
+        )
+        updated = msg.model_copy(
+            update={"content": [TextBlock(text="v2")]},
+        )
+
+        await self.storage.upsert_message(
+            self.user_id,
+            self.session_id,
+            updated,
+        )
+
+        ttl = await self.storage._client.ttl(
+            self.storage._message_key(self.user_id, self.session_id),
+        )
+        self.assertGreater(ttl, 0)
 
     async def test_upsert_appends_when_id_differs_from_last(self) -> None:
         """Upserting a message with a different id than the last always

--- a/tests/storage_redis_test.py
+++ b/tests/storage_redis_test.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access
 """Unit tests for RedisStorage using fakeredis."""
 
 from unittest.async_case import IsolatedAsyncioTestCase


### PR DESCRIPTION
## Summary
- refresh TTL on Redis message list writes, including streaming replacements
- keep message history lists from surviving after the configured storage TTL
- add fakeredis coverage for append and replace paths

Fixes #1704

## To verify
- python -m pytest tests\storage_redis_test.py -q
- python -m black --check --line-length=79 src\agentscope\app\storage\_redis_storage.py tests\storage_redis_test.py
- python -m flake8 --extend-ignore=E203 src\agentscope\app\storage\_redis_storage.py tests\storage_redis_test.py
- python -m py_compile src\agentscope\app\storage\_redis_storage.py tests\storage_redis_test.py
- git diff --check