### PR TITLE
feat(deps): make ripgrep an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
     "aiofiles",
     "tree_sitter",
     "tree_sitter_bash",
-    "ripgrep",
     "jsonschema",
 ]
 
@@ -73,12 +72,18 @@ workspace = [
     "aiodocker",
     "e2b",
 ]
+# ------------ Tools ------------
+tools = [
+    "ripgrep",
+]
+
 # ------------ Full ------------
 full = [
     "agentscope[models]",
     "agentscope[service]",
     "agentscope[storage]",
     "agentscope[workspace]",
+    "agentscope[tools]",
 ]
 
 # ------------ Development ------------

--- a/src/agentscope/tool/_builtin/_grep.py
+++ b/src/agentscope/tool/_builtin/_grep.py
@@ -2,6 +2,7 @@
 """The grep tool in agentscope."""
 import asyncio
 import fnmatch
+import logging
 import os
 import shutil
 from typing import Any, List, Literal
@@ -15,6 +16,8 @@ from ...permission import (
 )
 from .._response import ToolChunk
 from ...message import TextBlock
+
+logger = logging.getLogger(__name__)
 
 
 # Version control system directories to exclude from searches
@@ -160,6 +163,13 @@ class Grep(ToolBase):
     def __init__(self) -> None:
         """Initialize the grep tool."""
         self._rg_path = shutil.which("rg")
+        if self._rg_path is None:
+            logger.warning(
+                "ripgrep (rg) binary not found. To use the Grep tool, "
+                "install ripgrep: pip install agentscope[tools] or "
+                "brew install ripgrep / apt install ripgrep / "
+                "choco install ripgrep",
+            )
 
     async def check_permissions(
         self,

--- a/src/agentscope/tool/_builtin/_grep.py
+++ b/src/agentscope/tool/_builtin/_grep.py
@@ -2,12 +2,12 @@
 """The grep tool in agentscope."""
 import asyncio
 import fnmatch
-import logging
 import os
 import shutil
 from typing import Any, List, Literal
 
 from .._base import ToolBase
+from ..._logging import logger
 from ...permission import (
     PermissionContext,
     PermissionDecision,
@@ -16,8 +16,6 @@ from ...permission import (
 )
 from .._response import ToolChunk
 from ...message import TextBlock
-
-logger = logging.getLogger(__name__)
 
 
 # Version control system directories to exclude from searches


### PR DESCRIPTION
## Summary

Move `ripgrep` from a hard (mandatory) dependency to an optional dependency under the `[tools]` extra group. This avoids source compilation of the Rust-based `ripgrep` package on systems that lack a Rust toolchain (e.g., Alibaba Cloud Linux, CentOS 9 without MSVC linker on Windows).

The `Grep` tool already handles the case where the `rg` binary is absent — it returns a clear error message telling the user how to install ripgrep. A one-time `logger.warning` is now also emitted when the `Grep` tool is instantiated without `rg` on `PATH`.

## Changes

1. **`pyproject.toml`**: Removed `ripgrep` from the hard `dependencies` list and added it to a new optional `[tools]` extra. The `[full]` extra includes `[tools]` for backward compatibility, so users who install via `pip install agentscope[full]` or `pip install agentscope[dev]` still get ripgrep automatically.

2. **`src/agentscope/tool/_builtin/_grep.py`**: Added a `logger.warning` when `rg` is not found on `PATH`, making it easier to diagnose why the Grep tool is unavailable.

## Migration guide

- `pip install agentscope` — no longer pulls in ripgrep (the Grep tool will warn and return an error if called without rg)
- `pip install agentscope[tools]` or `pip install agentscope[full]` — behaves exactly as before

Closes #1660, #1721

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>