### PR TITLE
Fix: get_skill_instructions and _get_available_tools miss skills from non-basic ToolGroups

### DIFF
--- a/src/agentscope/tool/_toolkit.py
+++ b/src/agentscope/tool/_toolkit.py
@@ -439,7 +439,8 @@ class Toolkit:
                 The combined prompt for all registered agent skills, or None
                 if no skill is registered.
         """
-        skills = await self._get_available_skills()
+        all_group_names = [g.name for g in self.tool_groups]
+        skills = await self._get_available_skills(all_group_names)
 
         # If no skills were collected, return None
         if len(skills) == 0:
@@ -474,7 +475,8 @@ class Toolkit:
         available_tools = {}
 
         # Built-in skill viewers
-        skills = await self._get_available_skills()
+        all_group_names = [g.name for g in self.tool_groups]
+        skills = await self._get_available_skills(all_group_names)
         if len(skills):
             available_tools[
                 self.builtin_skill_viewer.tool.name


### PR DESCRIPTION
## Description

Fix #1724

`Toolkit.get_skill_instructions()` and `Toolkit._get_available_tools()` call `_get_available_skills()` without passing the `groups` parameter, resulting in only the "basic" group's skills being collected. Skills registered in other ToolGroups are not injected into the system prompt, and the model cannot see the SkillViewer tool for these skills.

## Changes

In `src/agentscope/tool/_toolkit.py`:

- **`get_skill_instructions()`** (was line 442): Pass all group names to `_get_available_skills()` so skills from all ToolGroups are collected.
- **`_get_available_tools()`** (was line 477): Same fix -- pass all group names to `_get_available_skills()` so the SkillViewer tool is registered when skills exist in non-basic groups.
