### PR TITLE
fix: convert str return value to ToolChunk in FunctionTool

### DIFF
--- a/src/agentscope/tool/_adapters.py
+++ b/src/agentscope/tool/_adapters.py
@@ -115,6 +115,11 @@ class FunctionTool(ToolBase):
         else:
             result = self._func(**kwargs)
 
+        if isinstance(result, str):
+            return ToolChunk(
+                content=[TextBlock(text=result)],
+            )
+
         return result
 
 


### PR DESCRIPTION
## Description

Fixes #1702.

When a plain function wrapped with `FunctionTool` returns a `str` (as shown in the documentation example), `FunctionTool.__call__()` now automatically wraps the string in a `ToolChunk` containing a `TextBlock`, instead of returning the raw string. This prevents a `DeveloperOrientedException` in `Toolkit.call_tool()` which only accepts `ToolChunk`, `AsyncGenerator[ToolChunk]`, or `Generator[ToolChunk]`.

## Changes

- **src/agentscope/tool/_adapters.py**: Added `str` to `ToolChunk` conversion in `FunctionTool.__call__()`. When the wrapped function returns a string, it is wrapped in `ToolChunk(content=[TextBlock(text=result)])`.

## Testing

- All 11 existing tests in `tests/toolkit_test.py` pass.
- Manual reproduction of the issue confirms the fix works.

## Example

```python
def get_weather(location: str) -> str:
    return f"The weather in {location} is sunny."

toolkit = Toolkit(tools=[FunctionTool(get_weather)])
# Previously raised DeveloperOrientedException
# Now correctly returns ToolChunk with the weather text
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
