### PR TITLE
Fix Web UI frontend TypeScript type-check errors (fixes #1707)

### DIFF
--- a/examples/web_ui/frontend/src/components/ui/calendar.tsx
+++ b/examples/web_ui/frontend/src/components/ui/calendar.tsx
@@ -74,7 +74,7 @@ function Calendar({
 						: 'flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground',
 					defaultClassNames.caption_label,
 				),
-				table: 'w-full border-collapse',
+				month_grid: 'w-full border-collapse',
 				weekdays: cn('flex', defaultClassNames.weekdays),
 				weekday: cn(
 					'flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none',

--- a/examples/web_ui/frontend/src/hooks/useSkills.ts
+++ b/examples/web_ui/frontend/src/hooks/useSkills.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 
-import { skillApi } from '../api';
+import { workspaceApi } from '../api';
 import type { Skill } from '../api';
 
 /**
@@ -23,7 +23,7 @@ export function useSkills(agentId: string | null, sessionId: string | null) {
 		setLoading(true);
 		setError(null);
 		try {
-			setSkills(await skillApi.list(agentId, sessionId));
+			setSkills(await workspaceApi.skill.list(agentId, sessionId));
 		} catch (e) {
 			setError(e as Error);
 		} finally {
@@ -39,7 +39,7 @@ export function useSkills(agentId: string | null, sessionId: string | null) {
 	const add = useCallback(
 		async (skillPath: string) => {
 			if (!agentId || !sessionId) throw new Error('No agent/session selected');
-			await skillApi.add(agentId, sessionId, { skill_path: skillPath });
+			await workspaceApi.skill.add(agentId, sessionId, { skill_path: skillPath });
 			await refetch();
 		},
 		[agentId, sessionId, refetch],
@@ -49,7 +49,7 @@ export function useSkills(agentId: string | null, sessionId: string | null) {
 	const remove = useCallback(
 		async (skillName: string) => {
 			if (!agentId || !sessionId) throw new Error('No agent/session selected');
-			await skillApi.remove(skillName, agentId, sessionId);
+			await workspaceApi.skill.remove(skillName, agentId, sessionId);
 			await refetch();
 		},
 		[agentId, sessionId, refetch],

--- a/examples/web_ui/frontend/tsconfig.app.json
+++ b/examples/web_ui/frontend/tsconfig.app.json
@@ -22,6 +22,7 @@
 		"noFallthroughCasesInSwitch": true,
 
 		/* Shadcn UI */
+		"ignoreDeprecations": "6.0",
 		"baseUrl": ".",
 		"paths": {
 			"@/*": ["./src/*"]


### PR DESCRIPTION
## Problem

The Web UI frontend fails type-checking with current dependencies. Running `tsc -b` produces three errors:

1. `TS2353`: 'table' does not exist in type 'Partial<ClassNames>' for react-day-picker.
2. `TS2305`: Module has no exported member 'skillApi'.
3. `TS5101\': Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.

## Changes

Three isolated fixes in `examples/web_ui/frontend`:

**(a) Use react-day-picker v10 `month_grid` classNames key**
Replace the deprecated `table` key with `month_grid` in `src/components/ui/calendar.tsx` to match the react-day-picker v10 type definition.

**(b) Use `workspaceApi.skill` instead of missing `skillApi` export**
`src/hooks/useSkills.ts` imported a `skillApi` that was never exported from the API module. The skills endpoints live under `workspaceApi.skill`. Updated all three references (`list`, `add`, `remove`).

**(c) Configure TypeScript 6 deprecation handling**
Add `\\"ignoreDeprecations\\": \\"6.0\\"` to `tsconfig.app.json` to acknowledge the deprecated `baseUrl` option, which is still required by the shadcn/ui path alias setup.

## Validation

- `./node_modules/.bin/tsc -b` exits cleanly (verified).
- `./node_modules/.bin/vite build` requires Node.js 20.19+ (pre-existing requirement, unrelated to this change).

Fixes #1707

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>