### PR TITLE
feat: add MemoryTool for explicit agent memory management

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -1982,6 +1982,24 @@ class Agent:
         messages = [
             SystemMsg(name="system", content=await self._get_system_prompt()),
         ]
+        # The agent's explicit memories
+        if self.state.memory_context.entries:
+            mem_lines = [
+                f"- {e.key}: {e.value}"
+                for e in sorted(
+                    self.state.memory_context.entries.values(),
+                    key=lambda e: e.created_at,
+                    reverse=True,
+                )
+            ]
+            messages.append(
+                UserMsg(
+                    name="user",
+                    content="<agent-memories>\n"
+                    + "\n".join(mem_lines)
+                    + "\n</agent-memories>",
+                ),
+            )
         # The compressed summary
         if self.state.summary:
             messages.append(

--- a/src/agentscope/state/_state.py
+++ b/src/agentscope/state/_state.py
@@ -130,6 +130,66 @@ class ToolContext(BaseModel):
         ]
 
 
+class MemoryEntry(BaseModel):
+    """A single memory entry stored by the agent."""
+
+    key: str
+    """The unique key for this memory entry."""
+    value: str
+    """The content of the memory entry."""
+    created_at: float
+    """The timestamp when this memory was created."""
+
+
+class MemoryContext(BaseModel):
+    """The memory context for explicit agent memory management.
+
+    Allows agents to store, retrieve, update, and delete named memories
+    that persist within the session. This complements the automatic
+    context compression by giving agents explicit control over what
+    information to remember."""
+
+    max_entries: int = Field(default=50, gt=0)
+    """The maximum number of memory entries to retain."""
+    entries: dict[str, MemoryEntry] = Field(default_factory=dict)
+    """The stored memory entries, keyed by name."""
+
+    def set(self, key: str, value: str, timestamp: float) -> None:
+        """Store or update a memory entry.
+
+        Args:
+            key: The unique key for the memory.
+            value: The content to store.
+            timestamp: The creation/update timestamp.
+        """
+        # Evict oldest entry if at capacity and adding a new key
+        if key not in self.entries and len(self.entries) >= self.max_entries:
+            oldest = min(
+                self.entries.values(),
+                key=lambda e: e.created_at,
+            )
+            del self.entries[oldest.key]
+        self.entries[key] = MemoryEntry(
+            key=key,
+            value=value,
+            created_at=timestamp,
+        )
+
+    def delete(self, key: str) -> bool:
+        """Delete a memory entry.
+
+        Args:
+            key: The key of the memory to delete.
+
+        Returns:
+            True if the entry was deleted, False if it didn't exist.
+        """
+        if key in self.entries:
+            del self.entries[key]
+            return True
+        return False
+
+
 class TaskContext(BaseModel):
     """The task context."""
 
@@ -174,3 +234,10 @@ class AgentState(BaseModel):
     # =================================================================
     tasks_context: TaskContext = Field(default_factory=TaskContext)
     """The task context that records the agent tasks."""
+
+    # =================================================================
+    # The memory context
+    # =================================================================
+    memory_context: MemoryContext = Field(default_factory=MemoryContext)
+    """The memory context for explicit agent memory storage and
+    retrieval."""

--- a/src/agentscope/tool/__init__.py
+++ b/src/agentscope/tool/__init__.py
@@ -8,6 +8,7 @@ from ._base import ToolBase
 from ._adapters import MCPTool, FunctionTool
 from ._builtin import (
     ResetTools,
+    MemoryTool,
     Bash,
     Edit,
     Glob,
@@ -37,6 +38,7 @@ __all__ = [
     "RegisteredTool",
     # Builtin tools
     "ResetTools",
+    "MemoryTool",
     "Bash",
     "Edit",
     "Glob",

--- a/src/agentscope/tool/_builtin/__init__.py
+++ b/src/agentscope/tool/_builtin/__init__.py
@@ -3,6 +3,7 @@
 
 from ._meta import ResetTools
 from ._skill import SkillViewer
+from ._memory import MemoryTool
 from ._bash import Bash
 from ._edit import Edit
 from ._glob import Glob
@@ -14,6 +15,7 @@ from ._write import Write
 __all__ = [
     "ResetTools",
     "SkillViewer",
+    "MemoryTool",
     "Bash",
     "Edit",
     "Glob",

--- a/src/agentscope/tool/_builtin/_memory.py
+++ b/src/agentscope/tool/_builtin/_memory.py
@@ -1,0 +1,229 @@
+# -*- coding: utf-8 -*-
+"""The memory tool for explicit agent memory management."""
+import time
+from typing import Any
+
+from .._base import ToolBase
+from ...permission import (
+    PermissionContext,
+    PermissionDecision,
+    PermissionBehavior,
+)
+from .._response import ToolChunk
+from ...message import TextBlock
+from ...state import AgentState
+
+
+class MemoryTool(ToolBase):
+    """A tool that allows the agent to explicitly store, retrieve, and
+    manage its own memories.
+
+    Unlike automatic context compression (which summarizes old conversation
+    turns), this tool gives the agent fine-grained control over what
+    specific information to remember across context windows. Memories
+    persist within the session and survive context compression.
+
+    This is inspired by Claude Code's memory system, which allows agents
+    to save facts, user preferences, decisions, and discoveries for later
+    retrieval.
+    """
+
+    name: str = "memory"
+    description: str = (
+        "Manage your persistent memory. Use this tool to store, retrieve, "
+        "update, or delete information that should be remembered across "
+        "context windows.\n\n"
+        "**Actions:**\n"
+        "- 'save': Store or update a memory entry by key. If the key "
+        "already exists, its value will be overwritten.\n"
+        "- 'retrieve': Get a specific memory by key, or list all memories "
+        "if no key is provided.\n"
+        "- 'delete': Remove a memory entry by key.\n\n"
+        "**Best practices:**\n"
+        "- Save user preferences, important decisions, and discoveries.\n"
+        "- Use descriptive, kebab-case keys (e.g., 'user-preferred-language',"
+        " 'project-database-schema').\n"
+        "- Retrieve relevant memories at the start of a new task.\n"
+        "- Delete outdated or corrected memories."
+    )
+    is_mcp: bool = False
+    is_read_only: bool = False
+    is_concurrency_safe: bool = True
+    is_external_tool: bool = False
+    is_state_injected: bool = True
+
+    @property
+    def input_schema(self) -> dict[str, Any]:  # type: ignore[override]
+        """The input schema for the memory tool."""
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["save", "retrieve", "delete"],
+                    "description": (
+                        "The action to perform on the memory store."
+                    ),
+                },
+                "key": {
+                    "type": "string",
+                    "description": (
+                        "The key of the memory entry. Required for "
+                        "'save' and 'delete'. Optional for 'retrieve' "
+                        "(if omitted, all memories are listed)."
+                    ),
+                },
+                "value": {
+                    "type": "string",
+                    "description": (
+                        "The content to store. Required for 'save'."
+                    ),
+                },
+            },
+            "required": ["action"],
+        }
+
+    async def check_permissions(
+        self,
+        tool_input: dict[str, Any],
+        context: PermissionContext,
+    ) -> PermissionDecision:
+        """The memory tool is always allowed."""
+        return PermissionDecision(
+            behavior=PermissionBehavior.ALLOW,
+            message="The memory tool is always allowed.",
+        )
+
+    async def __call__(
+        self,
+        _agent_state: AgentState,
+        action: str,
+        key: str | None = None,
+        value: str | None = None,
+    ) -> ToolChunk:
+        """Execute the memory operation.
+
+        Args:
+            _agent_state (`AgentState`):
+                The agent state injected by the framework.
+            action (`str`):
+                The action to perform: 'save', 'retrieve', or 'delete'.
+            key (`str | None`):
+                The memory key. Required for 'save' and 'delete'.
+            value (`str | None`):
+                The memory value. Required for 'save'.
+
+        Returns:
+            `ToolChunk`:
+                The result of the memory operation.
+        """
+        mem = _agent_state.memory_context
+
+        if action == "save":
+            if not key:
+                return ToolChunk(
+                    content=[
+                        TextBlock(
+                            text="Error: 'key' is required for 'save' action.",
+                        ),
+                    ],
+                )
+            if value is None:
+                return ToolChunk(
+                    content=[
+                        TextBlock(
+                            text="Error: 'value' is required for "
+                            "'save' action.",
+                        ),
+                    ],
+                )
+            existed = key in mem.entries
+            mem.set(key, value, time.time())
+            verb = "Updated" if existed else "Saved"
+            return ToolChunk(
+                content=[
+                    TextBlock(
+                        text=f"{verb} memory '{key}'.",
+                    ),
+                ],
+            )
+
+        if action == "retrieve":
+            if key:
+                entry = mem.entries.get(key)
+                if entry is None:
+                    return ToolChunk(
+                        content=[
+                            TextBlock(
+                                text=f"No memory found for key '{key}'.",
+                            ),
+                        ],
+                    )
+                return ToolChunk(
+                    content=[
+                        TextBlock(
+                            text=f"Memory '{key}':\n{entry.value}",
+                        ),
+                    ],
+                )
+
+            if not mem.entries:
+                return ToolChunk(
+                    content=[
+                        TextBlock(
+                            text="No memories stored yet.",
+                        ),
+                    ],
+                )
+
+            lines = [
+                f"- {e.key}: {e.value[:100]}{'...' if len(e.value) > 100 else ''}"
+                for e in sorted(
+                    mem.entries.values(),
+                    key=lambda e: e.created_at,
+                    reverse=True,
+                )
+            ]
+            return ToolChunk(
+                content=[
+                    TextBlock(
+                        text="Stored memories:\n" + "\n".join(lines),
+                    ),
+                ],
+            )
+
+        if action == "delete":
+            if not key:
+                return ToolChunk(
+                    content=[
+                        TextBlock(
+                            text="Error: 'key' is required for "
+                            "'delete' action.",
+                        ),
+                    ],
+                )
+            deleted = mem.delete(key)
+            if deleted:
+                return ToolChunk(
+                    content=[
+                        TextBlock(
+                            text=f"Deleted memory '{key}'.",
+                        ),
+                    ],
+                )
+            return ToolChunk(
+                content=[
+                    TextBlock(
+                        text=f"No memory found for key '{key}'.",
+                    ),
+                ],
+            )
+
+        return ToolChunk(
+            content=[
+                TextBlock(
+                    text=f"Unknown action '{action}'. "
+                    f"Valid actions: save, retrieve, delete.",
+                ),
+            ],
+        )

--- a/tests/memory_tool_test.py
+++ b/tests/memory_tool_test.py
@@ -1,0 +1,257 @@
+# -*- coding: utf-8 -*-
+"""Test cases for the MemoryTool."""
+# pylint: disable=protected-access
+import time
+from unittest.async_case import IsolatedAsyncioTestCase
+
+from agentscope.state import AgentState
+from agentscope.tool._builtin._memory import MemoryTool
+from agentscope.message import TextBlock
+
+
+class MemoryToolTest(IsolatedAsyncioTestCase):
+    """Test cases for the MemoryTool."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.tool = MemoryTool()
+        self.state = AgentState(session_id="test-session")
+
+    async def test_save_new_memory(self) -> None:
+        """Test saving a new memory entry."""
+        result = await self.tool(
+            _agent_state=self.state,
+            action="save",
+            key="test-key",
+            value="test-value",
+        )
+        self.assertIsInstance(result.content[0], TextBlock)
+        self.assertIn("Saved", result.content[0].text)
+        self.assertIn("test-key", result.content[0].text)
+        self.assertIn("test-key", self.state.memory_context.entries)
+        self.assertEqual(
+            self.state.memory_context.entries["test-key"].value,
+            "test-value",
+        )
+
+    async def test_save_update_existing_memory(self) -> None:
+        """Test updating an existing memory entry."""
+        await self.tool(
+            _agent_state=self.state,
+            action="save",
+            key="test-key",
+            value="old-value",
+        )
+        result = await self.tool(
+            _agent_state=self.state,
+            action="save",
+            key="test-key",
+            value="new-value",
+        )
+        self.assertIn("Updated", result.content[0].text)
+        self.assertEqual(
+            self.state.memory_context.entries["test-key"].value,
+            "new-value",
+        )
+
+    async def test_save_missing_key(self) -> None:
+        """Test save with missing key."""
+        result = await self.tool(
+            _agent_state=self.state,
+            action="save",
+            value="some-value",
+        )
+        self.assertIn("Error", result.content[0].text)
+        self.assertIn("key", result.content[0].text)
+
+    async def test_save_missing_value(self) -> None:
+        """Test save with missing value."""
+        result = await self.tool(
+            _agent_state=self.state,
+            action="save",
+            key="test-key",
+        )
+        self.assertIn("Error", result.content[0].text)
+        self.assertIn("value", result.content[0].text)
+
+    async def test_retrieve_existing_memory(self) -> None:
+        """Test retrieving an existing memory."""
+        await self.tool(
+            _agent_state=self.state,
+            action="save",
+            key="test-key",
+            value="test-value",
+        )
+        result = await self.tool(
+            _agent_state=self.state,
+            action="retrieve",
+            key="test-key",
+        )
+        self.assertIn("test-key", result.content[0].text)
+        self.assertIn("test-value", result.content[0].text)
+
+    async def test_retrieve_nonexistent_memory(self) -> None:
+        """Test retrieving a non-existent memory."""
+        result = await self.tool(
+            _agent_state=self.state,
+            action="retrieve",
+            key="nonexistent",
+        )
+        self.assertIn("No memory found", result.content[0].text)
+
+    async def test_retrieve_all_empty(self) -> None:
+        """Test listing all memories when none exist."""
+        result = await self.tool(
+            _agent_state=self.state,
+            action="retrieve",
+        )
+        self.assertIn("No memories stored", result.content[0].text)
+
+    async def test_retrieve_all(self) -> None:
+        """Test listing all memories."""
+        await self.tool(
+            _agent_state=self.state,
+            action="save",
+            key="key-a",
+            value="value-a",
+        )
+        await self.tool(
+            _agent_state=self.state,
+            action="save",
+            key="key-b",
+            value="value-b",
+        )
+        result = await self.tool(
+            _agent_state=self.state,
+            action="retrieve",
+        )
+        text = result.content[0].text
+        self.assertIn("key-a", text)
+        self.assertIn("key-b", text)
+
+    async def test_delete_existing_memory(self) -> None:
+        """Test deleting an existing memory."""
+        await self.tool(
+            _agent_state=self.state,
+            action="save",
+            key="test-key",
+            value="test-value",
+        )
+        result = await self.tool(
+            _agent_state=self.state,
+            action="delete",
+            key="test-key",
+        )
+        self.assertIn("Deleted", result.content[0].text)
+        self.assertNotIn("test-key", self.state.memory_context.entries)
+
+    async def test_delete_nonexistent_memory(self) -> None:
+        """Test deleting a non-existent memory."""
+        result = await self.tool(
+            _agent_state=self.state,
+            action="delete",
+            key="nonexistent",
+        )
+        self.assertIn("No memory found", result.content[0].text)
+
+    async def test_delete_missing_key(self) -> None:
+        """Test delete with missing key."""
+        result = await self.tool(
+            _agent_state=self.state,
+            action="delete",
+        )
+        self.assertIn("Error", result.content[0].text)
+        self.assertIn("key", result.content[0].text)
+
+    async def test_unknown_action(self) -> None:
+        """Test an unknown action."""
+        result = await self.tool(
+            _agent_state=self.state,
+            action="unknown",
+        )
+        self.assertIn("Unknown action", result.content[0].text)
+
+    async def test_max_entries_eviction(self) -> None:
+        """Test that old entries are evicted when max_entries is reached."""
+        self.state.memory_context.max_entries = 3
+        # Fill up to capacity
+        for i in range(3):
+            await self.tool(
+                _agent_state=self.state,
+                action="save",
+                key=f"key-{i}",
+                value=f"value-{i}",
+            )
+            time.sleep(0.01)  # Ensure different timestamps
+
+        self.assertEqual(len(self.state.memory_context.entries), 3)
+
+        # Add one more, should evict the oldest
+        await self.tool(
+            _agent_state=self.state,
+            action="save",
+            key="key-new",
+            value="value-new",
+        )
+        self.assertEqual(len(self.state.memory_context.entries), 3)
+        self.assertIn("key-new", self.state.memory_context.entries)
+        # key-0 should be evicted (oldest)
+        self.assertNotIn("key-0", self.state.memory_context.entries)
+
+    async def test_input_schema(self) -> None:
+        """Test that the input schema is valid."""
+        schema = self.tool.input_schema
+        self.assertEqual(schema["type"], "object")
+        self.assertIn("action", schema["properties"])
+        self.assertIn("key", schema["properties"])
+        self.assertIn("value", schema["properties"])
+        self.assertEqual(
+            schema["properties"]["action"]["enum"],
+            ["save", "retrieve", "delete"],
+        )
+
+    async def test_auto_inject_into_model_input(self) -> None:
+        """Test that memories are auto-injected as a UserMsg."""
+        from agentscope.agent import Agent
+        from agentscope.tool import Toolkit
+        from tests.utils import MockModel
+
+        state = AgentState(session_id="test-inject")
+        state.memory_context.set("key-a", "value-a", time.time())
+        state.memory_context.set(
+            "key-b",
+            "long-" + "x" * 200,
+            time.time(),
+        )
+
+        agent = Agent(
+            name="Test",
+            system_prompt="You are a test agent.",
+            model=MockModel(),
+            toolkit=Toolkit(),
+            state=state,
+        )
+
+        result = await agent._prepare_model_input()
+        messages = result["messages"]
+
+        mem_msg = None
+        for msg in messages:
+            content_str = (
+                msg.content
+                if isinstance(msg.content, str)
+                else " ".join(
+                    b.text
+                    for b in msg.content
+                    if hasattr(b, "text")
+                )
+            )
+            if "<agent-memories>" in content_str:
+                mem_msg = content_str
+                break
+
+        self.assertIsNotNone(mem_msg)
+        self.assertIn("key-a", mem_msg)
+        self.assertIn("value-a", mem_msg)
+        self.assertIn("key-b", mem_msg)
+        self.assertIn("x" * 200, mem_msg)


### PR DESCRIPTION
## Summary

Add `MemoryTool` — a builtin tool that allows agents to explicitly store, retrieve, update, and delete named memories that persist within a session and survive context compression.

Inspired by Claude Code's memory system.

## Motivation

AgentScope 2.0 already has automatic context compression (`compress_context`), but agents lack fine-grained control over what specific information to remember. `MemoryTool` complements automatic compression by giving agents explicit memory management capabilities.

## Changes

### New files
- `src/agentscope/tool/_builtin/_memory.py` — MemoryTool implementation
- `tests/memory_tool_test.py` — 15 test cases

### Modified files
- `src/agentscope/state/_state.py` — Added `MemoryEntry` and `MemoryContext` classes with LRU eviction (max 50 entries); `AgentState` now includes `memory_context`
- `src/agentscope/agent/_agent.py` — `_prepare_model_input()` auto-injects stored memories as a `<agent-memories>` UserMsg block
- `src/agentscope/tool/_builtin/__init__.py` — Export `MemoryTool`
- `src/agentscope/tool/__init__.py` — Export `MemoryTool`

## Usage

```python
from agentscope.tool import MemoryTool, Toolkit

toolkit = Toolkit(tools=[MemoryTool()])
```

The agent can then use three actions:
- `save` — Store or update a memory by key
- `retrieve` — Get a specific memory or list all
- `delete` — Remove a memory by key

Stored memories are automatically injected into every model call, so the agent always sees them without needing to manually retrieve.

## Design decisions

- **UserMsg injection** (not system prompt): Keeps system prompt static, allows memories to be safely compressed, consistent with `state.summary` pattern
- **LRU eviction**: Default max 50 entries prevents unbounded memory growth
- **Opt-in**: MemoryTool is added explicitly via `Toolkit(tools=[...])`, not forced on all agents
- **Full values**: No truncation in auto-injected view; LRU eviction controls total size

## Tests

28/28 passing (15 memory tool + 5 compression + 8 tool result compression)
