### PR TITLE
feat(model): add gpt-4o, gpt-4o-mini, and gpt-4.1-nano cards for openai-response

### DIFF
--- a/src/agentscope/model/_openai_response/_models/gpt-4.1-nano.yaml
+++ b/src/agentscope/model/_openai_response/_models/gpt-4.1-nano.yaml
@@ -1,0 +1,24 @@
+name: gpt-4.1-nano
+label: GPT-4.1 Nano
+status: active
+
+input_types:
+  - text/plain
+  - image/jpeg
+  - image/png
+  - image/gif
+  - image/webp
+
+output_types:
+  - text/plain
+
+context_size: 1047576
+output_size: 32768
+
+parameter_overrides:
+  max_tokens:
+    maximum: 32768
+  thinking_enable:
+    hidden: true
+  reasoning_effort:
+    hidden: true

--- a/src/agentscope/model/_openai_response/_models/gpt-4o-mini.yaml
+++ b/src/agentscope/model/_openai_response/_models/gpt-4o-mini.yaml
@@ -1,0 +1,24 @@
+name: gpt-4o-mini
+label: GPT-4o Mini
+status: active
+
+input_types:
+  - text/plain
+  - image/jpeg
+  - image/png
+  - image/gif
+  - image/webp
+
+output_types:
+  - text/plain
+
+context_size: 128000
+output_size: 16384
+
+parameter_overrides:
+  max_tokens:
+    maximum: 16384
+  thinking_enable:
+    hidden: true
+  reasoning_effort:
+    hidden: true

--- a/src/agentscope/model/_openai_response/_models/gpt-4o.yaml
+++ b/src/agentscope/model/_openai_response/_models/gpt-4o.yaml
@@ -1,0 +1,24 @@
+name: gpt-4o
+label: GPT-4o
+status: active
+
+input_types:
+  - text/plain
+  - image/jpeg
+  - image/png
+  - image/gif
+  - image/webp
+
+output_types:
+  - text/plain
+
+context_size: 128000
+output_size: 16384
+
+parameter_overrides:
+  max_tokens:
+    maximum: 16384
+  thinking_enable:
+    hidden: true
+  reasoning_effort:
+    hidden: true


### PR DESCRIPTION
## AgentScope Version
import agentscope; print(agentscope.__version__)

## Description

The `openai_response` model directory already has cards for `gpt-4.1`, `gpt-4.1-mini`, `o3`, `o4-mini`, `gpt-5.4`, and `gpt-5.5`, but it is missing three widely-used models that are present in the `openai_chat` directory:

- `gpt-4o` (128k context, 16k output)
- `gpt-4o-mini` (128k context, 16k output)
- `gpt-4.1-nano` (1M context, 32k output)

This PR adds the three missing YAML model cards, following the exact same structure as the existing `gpt-4.1-mini.yaml` card in `openai_response`. No code changes.

## Checklist
- [x] Code formatted with `pre-commit run --all-files`
- [x] All tests passing
- [x] Docstrings in Google style
- [x] Related documentation updated
- [x] Code is ready for review