### PR TITLE
feat(model): add qwen-turbo and qwen-max model cards for dashscope

### DIFF
--- a/src/agentscope/model/_dashscope/_models/qwen-max.yaml
+++ b/src/agentscope/model/_dashscope/_models/qwen-max.yaml
@@ -1,0 +1,16 @@
+name: qwen-max
+label: Qwen Max
+status: active
+
+input_types:
+  - text/plain
+
+output_types:
+  - text/plain
+  - application/x-thinking
+
+context_size: 32768
+output_size: 8192
+
+parameter_overrides:
+  max_tokens: {"maximum": 8192}

--- a/src/agentscope/model/_dashscope/_models/qwen-turbo.yaml
+++ b/src/agentscope/model/_dashscope/_models/qwen-turbo.yaml
@@ -1,0 +1,17 @@
+name: qwen-turbo
+label: Qwen Turbo
+status: active
+
+input_types:
+  - text/plain
+
+output_types:
+  - text/plain
+
+context_size: 1000000
+output_size: 8192
+
+parameter_overrides:
+  max_tokens: {"maximum": 8192}
+  thinking_enable:
+    hidden: true


### PR DESCRIPTION
## AgentScope Version
import agentscope; print(agentscope.__version__)

## Description

The `dashscope` model directory has `qwen-plus`, `qwen-long`, and `qwen-max-3.7`, but is missing the two most-cited stable aliases in Alibaba Cloud documentation:

- `qwen-turbo` — lightweight/fast model; 1M context, 8192 output, no thinking
- `qwen-max` — flagship model; 32768 context, 8192 output, with thinking support

This PR adds the two missing YAML model cards, following the exact same structure as the existing `qwen-plus.yaml` card. No code changes.

## Checklist
- [x] Code formatted with `pre-commit run --all-files`
- [x] All tests passing
- [x] Docstrings in Google style
- [x] Related documentation updated
- [x] Code is ready for review