### PR TITLE
feat(model): add ollama model cards for qwen3-7b, llama3.2, and phi4-mini

### DIFF
--- a/src/agentscope/model/_ollama/_models/llama3.2-3b.yaml
+++ b/src/agentscope/model/_ollama/_models/llama3.2-3b.yaml
@@ -1,0 +1,16 @@
+name: llama3.2:3b
+label: Llama 3.2 3B
+status: active
+
+input_types:
+  - text/plain
+
+output_types:
+  - text/plain
+
+context_size: 131072
+output_size: 8192
+
+parameter_overrides:
+  max_tokens:
+    maximum: 8192

--- a/src/agentscope/model/_ollama/_models/phi4-mini.yaml
+++ b/src/agentscope/model/_ollama/_models/phi4-mini.yaml
@@ -1,0 +1,16 @@
+name: phi4-mini
+label: Phi-4 Mini
+status: active
+
+input_types:
+  - text/plain
+
+output_types:
+  - text/plain
+
+context_size: 131072
+output_size: 8192
+
+parameter_overrides:
+  max_tokens:
+    maximum: 8192

--- a/src/agentscope/model/_ollama/_models/qwen3-7b.yaml
+++ b/src/agentscope/model/_ollama/_models/qwen3-7b.yaml
@@ -1,0 +1,17 @@
+name: qwen3:7b
+label: Qwen3 7B
+status: active
+
+input_types:
+  - text/plain
+
+output_types:
+  - text/plain
+  - application/x-thinking
+
+context_size: 131072
+output_size: 8192
+
+parameter_overrides:
+  max_tokens:
+    maximum: 8192


### PR DESCRIPTION
## AgentScope Version
import agentscope; print(agentscope.__version__)

## Description
The ollama model directory has llama4, qwen3-14b, qwen3.5-9b, and deepseek-r1-14b but is missing three popular models: qwen3-7b (the default qwen3 pull tag), llama3.2-3b (the default llama3.2 pull tag), and phi4-mini. This PR adds the three missing YAML model cards following the existing pattern. No code changes.

## Checklist
- [x] Code formatted with `pre-commit run --all-files`
- [x] All tests passing
- [x] Docstrings in Google style
- [x] Related documentation updated
- [x] Code is ready for review