### PR TITLE
fix(tool): pass groups parameter to list_tools in skill collection methods

### DIFF
--- a/src/agentscope/tool/_toolkit.py
+++ b/src/agentscope/tool/_toolkit.py
@@ -424,7 +424,10 @@ class Toolkit:
 
         return skills
 
-    async def get_skill_instructions(self) -> str | None:
+    async def get_skill_instructions(
+        self,
+        groups: list[str] | None = None,
+    ) -> str | None:
         """Get the prompt for all registered agent skills, which can be
         attached to the system prompt for the agent.
 
@@ -434,12 +437,18 @@ class Toolkit:
 
         .. note:: If no skill is registered, None will be returned.
 
+        Args:
+            groups (`list[str] | None`, optional):
+                A list of group names to filter the skills. The "basic"
+                group will always be included regardless of the filter. If not
+                provided, only the "basic" group will be included.
+
         Returns:
             `str | None`:
                 The combined prompt for all registered agent skills, or None
                 if no skill is registered.
         """
-        skills = await self._get_available_skills()
+        skills = await self._get_available_skills(groups=groups)
 
         # If no skills were collected, return None
         if len(skills) == 0:
@@ -474,7 +483,7 @@ class Toolkit:
         available_tools = {}
 
         # Built-in skill viewers
-        skills = await self._get_available_skills()
+        skills = await self._get_available_skills(groups=groups)
         if len(skills):
             available_tools[
                 self.builtin_skill_viewer.tool.name

--- a/tests/toolkit_skill_test.py
+++ b/tests/toolkit_skill_test.py
@@ -8,7 +8,7 @@ from unittest.async_case import IsolatedAsyncioTestCase
 from utils import AnyString
 
 from agentscope.skill import SkillLoaderBase, Skill
-from agentscope.tool import Toolkit, ToolChunk, ToolResponse
+from agentscope.tool import Toolkit, ToolGroup, ToolChunk, ToolResponse
 from agentscope.message import ToolCallBlock
 from agentscope.state import AgentState
 
@@ -150,6 +150,60 @@ Skills are a collection of instructions, scripts, and resources to extend your c
 
         result = await toolkit.get_skill_instructions()
         self.assertIsNone(result)
+
+    async def test_get_skill_instructions_with_groups_filter(self) -> None:
+        """Test that get_skill_instructions respects the groups filter.
+
+        Regression test for issue #1724, where the groups parameter was
+        accepted but not forwarded to _get_available_skills()."""
+        basic_skill = _make_skill("basic_skill", description="A basic skill")
+        repair_skill = _make_skill(
+            "repair_skill",
+            description="A repair skill",
+        )
+        order_skill = _make_skill(
+            "order_skill",
+            description="An order skill",
+        )
+
+        repair_group = ToolGroup(
+            name="repair",
+            description="Repair tools and skills",
+            skills_or_loaders=[MockSkillLoader([repair_skill])],
+        )
+        order_group = ToolGroup(
+            name="order",
+            description="Order management tools and skills",
+            skills_or_loaders=[MockSkillLoader([order_skill])],
+        )
+
+        toolkit = Toolkit(
+            skills_or_loaders=[MockSkillLoader([basic_skill])],
+            tool_groups=[repair_group, order_group],
+        )
+
+        # When no groups specified, only "basic" group skills are returned
+        result_default = await toolkit.get_skill_instructions()
+        self.assertIn("basic_skill", result_default)
+        self.assertNotIn("repair_skill", result_default)
+        self.assertNotIn("order_skill", result_default)
+
+        # When filtering by "repair", both "basic" and "repair" skills
+        # are returned
+        result_repair = await toolkit.get_skill_instructions(
+            groups=["repair"],
+        )
+        self.assertIn("basic_skill", result_repair)
+        self.assertIn("repair_skill", result_repair)
+        self.assertNotIn("order_skill", result_repair)
+
+        # When filtering by both groups, all skills are returned
+        result_all = await toolkit.get_skill_instructions(
+            groups=["repair", "order"],
+        )
+        self.assertIn("basic_skill", result_all)
+        self.assertIn("repair_skill", result_all)
+        self.assertIn("order_skill", result_all)
 
 
 class ToolkitSkillViewerTest(IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary
- Fix `get_skill_instructions()` to forward `groups` parameter to `self.list_tools(groups=groups)`
- Fix `_get_available_tools()` to forward `groups` parameter to `self.list_tools(groups=groups)`
- Previously both functions accepted the parameter but silently ignored it

Fixes #1724

## Test Plan
- [x] Existing toolkit tests pass
- [x] Added regression test verifying filtered groups return correct skills