### PR TITLE
feat(models): add MiniMax chat model support (M3 default)

### DIFF
--- a/scripts/model_examples/minimax_call.py
+++ b/scripts/model_examples/minimax_call.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+"""Examples of MiniMax chat model calls.
+
+The MiniMax M-series chat models (e.g. ``MiniMax-M3``) are exposed via
+MiniMax's officially recommended Anthropic-compatible API, so the
+controls and outputs match
+``scripts/model_examples/anthropic_call.py``.
+"""
+
+import asyncio
+import json
+import os
+
+from pydantic import BaseModel, Field
+
+from _utils import stream_and_collect
+from agentscope.credential import MiniMaxCredential
+from agentscope.message import (
+    Msg,
+    TextBlock,
+    ToolCallBlock,
+    ToolResultBlock,
+    ToolResultState,
+)
+from agentscope.model import MiniMaxChatModel
+from agentscope.tool import Toolkit, ToolChoice, FunctionTool
+
+
+# ---------------------------------------------------------------------------
+# Example 1: Simple user message (streaming, with extended thinking)
+# ---------------------------------------------------------------------------
+
+
+async def example_simple_call() -> None:
+    """Call MiniMax-M3 with a simple text message and extended thinking."""
+    model = MiniMaxChatModel(
+        credential=MiniMaxCredential(
+            api_key=os.environ["MINIMAX_API_KEY"],
+        ),
+        model="MiniMax-M3",
+        stream=True,
+        parameters=MiniMaxChatModel.Parameters(
+            thinking_enable=True,
+            thinking_budget=1024,
+        ),
+    )
+
+    msgs = [
+        Msg(
+            name="user",
+            content=[TextBlock(text="What is 1 + 1? Answer briefly.")],
+            role="user",
+        ),
+    ]
+
+    print("=== Simple Call ===")
+    await stream_and_collect(await model(msgs))
+
+
+# ---------------------------------------------------------------------------
+# Example 2: Tool calling (streaming)
+# ---------------------------------------------------------------------------
+
+
+def get_weather(city: str) -> str:
+    """Get the current weather for a city.
+
+    Args:
+        city: The city name to query the weather for.
+
+    Returns:
+        A description of the current weather.
+    """
+    return f"The weather in {city} is sunny and 25°C."
+
+
+async def example_tool_call() -> None:
+    """Call MiniMax-M3 with tool calling enabled."""
+    toolkit = Toolkit(tools=[FunctionTool(get_weather)])
+    tools = await toolkit.get_tool_schemas()
+
+    model = MiniMaxChatModel(
+        credential=MiniMaxCredential(
+            api_key=os.environ["MINIMAX_API_KEY"],
+        ),
+        model="MiniMax-M3",
+        stream=True,
+        parameters=MiniMaxChatModel.Parameters(
+            thinking_enable=True,
+            thinking_budget=1024,
+        ),
+    )
+
+    msgs = [
+        Msg(
+            name="user",
+            content=[TextBlock(text="What is the weather in Shanghai?")],
+            role="user",
+        ),
+    ]
+
+    print("=== Tool Call - Round 1 ===")
+    response = await stream_and_collect(
+        await model(msgs, tools=tools, tool_choice=ToolChoice(mode="auto")),
+    )
+    print(response)
+
+    tool_calls = [b for b in response.content if isinstance(b, ToolCallBlock)]
+    if tool_calls:
+        tool_result_blocks = []
+        for tool_call in tool_calls:
+            args = json.loads(tool_call.input)
+            result = get_weather(**args)
+            tool_result_blocks.append(
+                ToolResultBlock(
+                    id=tool_call.id,
+                    name=tool_call.name,
+                    output=result,
+                    state=ToolResultState.SUCCESS,
+                ),
+            )
+
+        assistant_msg = Msg(
+            name="assistant",
+            content=response.content,
+            role="assistant",
+        )
+        tool_result_msg = Msg(
+            name="tool",
+            content=tool_result_blocks,
+            role="assistant",
+        )
+        msgs = msgs + [assistant_msg, tool_result_msg]
+
+        print("=== Tool Call - Round 2 (Final) ===")
+        await stream_and_collect(await model(msgs))
+
+
+# ---------------------------------------------------------------------------
+# Example 3: Structured output
+# ---------------------------------------------------------------------------
+
+
+class MathSolution(BaseModel):
+    """Structured solution to a math problem."""
+
+    problem: str = Field(description="The original problem statement")
+    answer: float = Field(description="The final numeric answer")
+    steps: list[str] = Field(
+        description="Step-by-step reasoning leading to the answer",
+    )
+
+
+async def example_structured_output() -> None:
+    """Call MiniMax-M3 and force a structured (JSON) output."""
+    model = MiniMaxChatModel(
+        credential=MiniMaxCredential(
+            api_key=os.environ["MINIMAX_API_KEY"],
+        ),
+        model="MiniMax-M3",
+        stream=True,
+        parameters=MiniMaxChatModel.Parameters(
+            thinking_enable=True,
+            thinking_budget=1024,
+        ),
+    )
+
+    msgs = [
+        Msg(
+            name="user",
+            content=[
+                TextBlock(
+                    text=(
+                        "Solve this: A train travels at 60 km/h for "
+                        "2.5 hours. How far does it travel in km?"
+                    ),
+                ),
+            ],
+            role="user",
+        ),
+    ]
+
+    print("=== Structured Output ===")
+    response = await model.generate_structured_output(
+        msgs,
+        structured_model=MathSolution,
+    )
+    print(response.content)
+
+
+if __name__ == "__main__":
+    asyncio.run(example_simple_call())
+    asyncio.run(example_tool_call())
+    asyncio.run(example_structured_output())

--- a/scripts/model_examples/minimax_multiagent.py
+++ b/scripts/model_examples/minimax_multiagent.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""Example of MiniMax chat model calls with MiniMaxMultiAgentFormatter.
+
+The multi-agent formatter wraps prior conversation history in
+``<history></history>`` tags, enabling MiniMax-M3 to handle multi-agent
+conversations where more than one non-user agent is involved.
+"""
+
+import asyncio
+import os
+
+from _utils import stream_and_collect
+from agentscope.credential import MiniMaxCredential
+from agentscope.formatter import MiniMaxMultiAgentFormatter
+from agentscope.message import Msg, TextBlock
+from agentscope.model import MiniMaxChatModel
+
+
+async def example_multiagent() -> None:
+    """Simulate a multi-agent conversation and let MiniMax-M3 summarize.
+
+    Alice and Bob discuss the weather, then a moderator (the model) is asked
+    to summarize the conversation.
+    """
+    formatter = MiniMaxMultiAgentFormatter()
+
+    model = MiniMaxChatModel(
+        credential=MiniMaxCredential(
+            api_key=os.environ["MINIMAX_API_KEY"],
+        ),
+        model="MiniMax-M3",
+        stream=True,
+        parameters=MiniMaxChatModel.Parameters(
+            thinking_enable=True,
+            thinking_budget=1024,
+        ),
+        formatter=formatter,
+    )
+
+    msgs = [
+        Msg(
+            name="system",
+            content=[
+                TextBlock(
+                    text="You are a helpful moderator. Summarize the conversation.",
+                ),
+            ],
+            role="system",
+        ),
+        Msg(
+            name="alice",
+            content=[
+                TextBlock(
+                    text="Hi Bob! What do you think about the weather today?",
+                ),
+            ],
+            role="user",
+        ),
+        Msg(
+            name="bob",
+            content=[
+                TextBlock(
+                    text="It's quite sunny and warm, Alice. Perfect for a walk!",
+                ),
+            ],
+            role="assistant",
+        ),
+        Msg(
+            name="alice",
+            content=[
+                TextBlock(text="Agreed! I might head to the park later."),
+            ],
+            role="user",
+        ),
+        Msg(
+            name="bob",
+            content=[
+                TextBlock(
+                    text="Great idea. I'll join you if I finish work early.",
+                ),
+            ],
+            role="assistant",
+        ),
+        Msg(
+            name="moderator",
+            content=[
+                TextBlock(
+                    text="Please summarize the conversation above in one sentence.",
+                ),
+            ],
+            role="user",
+        ),
+    ]
+
+    print("=== Multi-Agent Formatter Call ===")
+    await stream_and_collect(await model(msgs))
+
+
+if __name__ == "__main__":
+    asyncio.run(example_multiagent())

--- a/scripts/model_examples/minimax_multiagent.py
+++ b/scripts/model_examples/minimax_multiagent.py
@@ -42,7 +42,10 @@ async def example_multiagent() -> None:
             name="system",
             content=[
                 TextBlock(
-                    text="You are a helpful moderator. Summarize the conversation.",
+                    text=(
+                        "You are a helpful moderator. Summarize the "
+                        "conversation."
+                    ),
                 ),
             ],
             role="system",
@@ -60,7 +63,10 @@ async def example_multiagent() -> None:
             name="bob",
             content=[
                 TextBlock(
-                    text="It's quite sunny and warm, Alice. Perfect for a walk!",
+                    text=(
+                        "It's quite sunny and warm, Alice. Perfect for a "
+                        "walk!"
+                    ),
                 ),
             ],
             role="assistant",
@@ -85,7 +91,10 @@ async def example_multiagent() -> None:
             name="moderator",
             content=[
                 TextBlock(
-                    text="Please summarize the conversation above in one sentence.",
+                    text=(
+                        "Please summarize the conversation above in one "
+                        "sentence."
+                    ),
                 ),
             ],
             role="user",

--- a/scripts/model_examples/minimax_multiagent_multimodal.py
+++ b/scripts/model_examples/minimax_multiagent_multimodal.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+"""Example of MiniMax chat model calls with MultiAgentFormatter and image
+input.
+
+Demonstrates combining MiniMaxMultiAgentFormatter with multimodal (vision)
+content: Alice shares an image in a multi-agent conversation, and the model
+is asked to summarize what everyone is looking at.
+"""
+
+import asyncio
+import os
+
+from _utils import stream_and_collect
+from agentscope.credential import MiniMaxCredential
+from agentscope.formatter import MiniMaxMultiAgentFormatter
+from agentscope.message import Msg, TextBlock, DataBlock, URLSource
+from agentscope.model import MiniMaxChatModel
+
+TEST_IMAGE_URL = (
+    "https://help-static-aliyun-doc.aliyuncs.com/file-manage"
+    "-files/zh-CN/20241022/emyrja/dog_and_girl.jpeg"
+)
+
+
+async def example_multiagent_image_url() -> None:
+    """Multi-agent conversation where Alice shares an image for the group."""
+    formatter = MiniMaxMultiAgentFormatter()
+
+    model = MiniMaxChatModel(
+        credential=MiniMaxCredential(
+            api_key=os.environ["MINIMAX_API_KEY"],
+        ),
+        model="MiniMax-M3",
+        stream=True,
+        parameters=MiniMaxChatModel.Parameters(
+            thinking_enable=True,
+            thinking_budget=1024,
+        ),
+        formatter=formatter,
+    )
+
+    image_block = DataBlock(
+        source=URLSource(url=TEST_IMAGE_URL, media_type="image/jpeg"),
+    )
+
+    msgs = [
+        Msg(
+            name="system",
+            content=[
+                TextBlock(
+                    text=(
+                        "You are a helpful moderator in a group chat. "
+                        "Summarize what the image shows and what the "
+                        "participants said."
+                    ),
+                ),
+            ],
+            role="system",
+        ),
+        Msg(
+            name="alice",
+            content=[
+                TextBlock(
+                    text="Hey everyone, look at this cute photo I took!",
+                ),
+                image_block,
+            ],
+            role="user",
+        ),
+        Msg(
+            name="bob",
+            content=[
+                TextBlock(text="Aww, that's adorable! Where was this taken?"),
+            ],
+            role="assistant",
+        ),
+        Msg(
+            name="alice",
+            content=[TextBlock(text="At the local park yesterday.")],
+            role="user",
+        ),
+        Msg(
+            name="moderator",
+            content=[
+                TextBlock(
+                    text="Please summarize the image content and the "
+                    "conversation in one paragraph.",
+                ),
+            ],
+            role="user",
+        ),
+    ]
+
+    print("=== Multi-Agent + Multimodal Call ===")
+    await stream_and_collect(await model(msgs))
+
+
+if __name__ == "__main__":
+    asyncio.run(example_multiagent_image_url())

--- a/scripts/model_examples/minimax_multimodal.py
+++ b/scripts/model_examples/minimax_multimodal.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+"""Example of MiniMax chat model multimodal (vision) calls using
+DataBlock.
+
+The MiniMax M-series chat models accept image input on the
+Anthropic-compatible endpoint, identical to Anthropic Claude.
+"""
+
+import asyncio
+import base64
+import os
+from pathlib import Path
+
+from _utils import stream_and_collect
+from agentscope.credential import MiniMaxCredential
+from agentscope.message import (
+    Msg,
+    TextBlock,
+    DataBlock,
+    URLSource,
+    Base64Source,
+)
+from agentscope.model import MiniMaxChatModel
+
+# A publicly accessible test image (dog and girl photo)
+TEST_IMAGE_URL = (
+    "https://help-static-aliyun-doc.aliyuncs.com/file-manage"
+    "-files/zh-CN/20241022/emyrja/dog_and_girl.jpeg"
+)
+
+
+def _build_model() -> MiniMaxChatModel:
+    """Build and return a MiniMaxChatModel instance."""
+    return MiniMaxChatModel(
+        credential=MiniMaxCredential(
+            api_key=os.environ["MINIMAX_API_KEY"],
+        ),
+        model="MiniMax-M3",
+        stream=True,
+        parameters=MiniMaxChatModel.Parameters(
+            thinking_enable=True,
+            thinking_budget=1024,
+        ),
+    )
+
+
+async def example_image_url() -> None:
+    """Call MiniMax-M3 with an image URL and ask what is in the image."""
+    model = _build_model()
+
+    image_block = DataBlock(
+        source=URLSource(
+            url=TEST_IMAGE_URL,
+            media_type="image/jpeg",
+        ),
+    )
+
+    msgs = [
+        Msg(
+            name="user",
+            content=[
+                TextBlock(
+                    text="What animal is in this image? Describe it briefly.",
+                ),
+                image_block,
+            ],
+            role="user",
+        ),
+    ]
+
+    print("=== Multimodal Call (Image URL) ===")
+    await stream_and_collect(await model(msgs))
+
+
+async def example_image_local_path() -> None:
+    """Call MiniMax-M3 with a local image using a ``file://`` URL.
+
+    The formatter automatically reads the file and converts it to base64.
+    """
+    model = _build_model()
+
+    abs_path = str(Path(__file__).parent / "test.jpeg")
+    image_block = DataBlock(
+        source=URLSource(
+            url=f"file://{abs_path}",
+            media_type="image/jpeg",
+        ),
+    )
+
+    msgs = [
+        Msg(
+            name="user",
+            content=[
+                TextBlock(
+                    text="What is happening in this image? Describe it briefly.",
+                ),
+                image_block,
+            ],
+            role="user",
+        ),
+    ]
+
+    print("=== Local Path Call (file://) ===")
+    await stream_and_collect(await model(msgs))
+
+
+async def example_image_base64() -> None:
+    """Call MiniMax-M3 with a local image using explicit base64 encoding.
+
+    Use ``Base64Source`` when you already have the binary data in memory or
+    want full control over the encoding step.
+    """
+    model = _build_model()
+
+    with open(Path(__file__).parent / "test.jpeg", "rb") as f:
+        data = base64.b64encode(f.read()).decode("utf-8")
+
+    image_block = DataBlock(
+        source=Base64Source(
+            data=data,
+            media_type="image/jpeg",
+        ),
+    )
+
+    msgs = [
+        Msg(
+            name="user",
+            content=[
+                TextBlock(
+                    text="What is happening in this image? Describe it briefly.",
+                ),
+                image_block,
+            ],
+            role="user",
+        ),
+    ]
+
+    print("=== Explicit Base64 Call ===")
+    await stream_and_collect(await model(msgs))
+
+
+if __name__ == "__main__":
+    asyncio.run(example_image_url())
+    asyncio.run(example_image_local_path())
+    asyncio.run(example_image_base64())

--- a/scripts/model_examples/minimax_multimodal.py
+++ b/scripts/model_examples/minimax_multimodal.py
@@ -92,7 +92,10 @@ async def example_image_local_path() -> None:
             name="user",
             content=[
                 TextBlock(
-                    text="What is happening in this image? Describe it briefly.",
+                    text=(
+                        "What is happening in this image? Describe it "
+                        "briefly."
+                    ),
                 ),
                 image_block,
             ],
@@ -127,7 +130,10 @@ async def example_image_base64() -> None:
             name="user",
             content=[
                 TextBlock(
-                    text="What is happening in this image? Describe it briefly.",
+                    text=(
+                        "What is happening in this image? Describe it "
+                        "briefly."
+                    ),
                 ),
                 image_block,
             ],

--- a/src/agentscope/credential/__init__.py
+++ b/src/agentscope/credential/__init__.py
@@ -6,6 +6,7 @@ from ._anthropic import AnthropicCredential
 from ._dashscope import DashScopeCredential
 from ._deepseek import DeepSeekCredential
 from ._gemini import GeminiCredential
+from ._minimax import MiniMaxCredential
 from ._moonshot import MoonshotCredential
 from ._ollama import OllamaCredential
 from ._openai import OpenAICredential
@@ -19,6 +20,7 @@ __all__ = [
     "DashScopeCredential",
     "DeepSeekCredential",
     "GeminiCredential",
+    "MiniMaxCredential",
     "MoonshotCredential",
     "OllamaCredential",
     "OpenAICredential",

--- a/src/agentscope/credential/_factory.py
+++ b/src/agentscope/credential/_factory.py
@@ -8,6 +8,7 @@ from ._anthropic import AnthropicCredential
 from ._dashscope import DashScopeCredential
 from ._deepseek import DeepSeekCredential
 from ._gemini import GeminiCredential
+from ._minimax import MiniMaxCredential
 from ._moonshot import MoonshotCredential
 from ._ollama import OllamaCredential
 from ._openai import OpenAICredential
@@ -38,6 +39,7 @@ class CredentialFactory:
         DashScopeCredential,
         DeepSeekCredential,
         GeminiCredential,
+        MiniMaxCredential,
         MoonshotCredential,
         OllamaCredential,
         OpenAICredential,

--- a/src/agentscope/credential/_minimax.py
+++ b/src/agentscope/credential/_minimax.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""The MiniMax credential."""
+from typing import Literal, Type, TYPE_CHECKING
+
+from pydantic import Field, SecretStr
+
+from ._base import CredentialBase
+
+if TYPE_CHECKING:
+    from ..model import ChatModelBase
+
+_MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+
+
+class MiniMaxCredential(CredentialBase):
+    """The MiniMax credential model."""
+
+    type: Literal["minimax_credential"] = "minimax_credential"
+    """The credential type."""
+
+    api_key: SecretStr = Field(
+        description="The MiniMax API key.",
+    )
+    """The API key."""
+
+    base_url: str = Field(
+        default=_MINIMAX_BASE_URL,
+        description="The base URL for the MiniMax API.",
+    )
+    """The base URL for the MiniMax API."""
+
+    @classmethod
+    def get_chat_model_class(cls) -> Type["ChatModelBase"]:
+        """Return the MiniMaxChatModel class."""
+        from ..model import MiniMaxChatModel
+
+        return MiniMaxChatModel

--- a/src/agentscope/credential/_minimax.py
+++ b/src/agentscope/credential/_minimax.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """The MiniMax credential."""
+
 from typing import Literal, Type, TYPE_CHECKING
 
 from pydantic import Field, SecretStr
@@ -9,7 +10,10 @@ from ._base import CredentialBase
 if TYPE_CHECKING:
     from ..model import ChatModelBase
 
-_MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+# MiniMax officially recommends its Anthropic-compatible endpoint for the
+# M-series chat models, see
+# https://platform.minimax.io/docs/api-reference/text-anthropic-api
+_MINIMAX_BASE_URL = "https://api.minimax.io/anthropic"
 
 
 class MiniMaxCredential(CredentialBase):
@@ -25,7 +29,11 @@ class MiniMaxCredential(CredentialBase):
 
     base_url: str = Field(
         default=_MINIMAX_BASE_URL,
-        description="The base URL for the MiniMax API.",
+        description=(
+            "The base URL for the MiniMax Anthropic-compatible API. "
+            "Defaults to ``https://api.minimax.io/anthropic`` per "
+            "MiniMax's official recommendation."
+        ),
     )
     """The base URL for the MiniMax API."""
 

--- a/src/agentscope/formatter/__init__.py
+++ b/src/agentscope/formatter/__init__.py
@@ -30,6 +30,10 @@ from ._openai_response_formatter import (
     OpenAIResponseFormatter,
     OpenAIResponseMultiAgentFormatter,
 )
+from ._minimax_formatter import (
+    MiniMaxChatFormatter,
+    MiniMaxMultiAgentFormatter,
+)
 from ._moonshot_formatter import (
     MoonshotChatFormatter,
     MoonshotMultiAgentFormatter,
@@ -55,6 +59,8 @@ __all__ = [
     "DeepSeekMultiAgentFormatter",
     "OpenAIResponseFormatter",
     "OpenAIResponseMultiAgentFormatter",
+    "MiniMaxChatFormatter",
+    "MiniMaxMultiAgentFormatter",
     "MoonshotChatFormatter",
     "MoonshotMultiAgentFormatter",
     "XAIChatFormatter",

--- a/src/agentscope/formatter/_minimax_formatter.py
+++ b/src/agentscope/formatter/_minimax_formatter.py
@@ -1,0 +1,308 @@
+# -*- coding: utf-8 -*-
+"""The MiniMax formatter for agentscope."""
+from typing import Any
+
+from pydantic import Field
+
+from ._openai_formatter import _OpenAIFormatterBase
+from .._logging import logger
+from ..message import (
+    Msg,
+    TextBlock,
+    DataBlock,
+    HintBlock,
+    ToolCallBlock,
+    ToolResultBlock,
+    ThinkingBlock,
+)
+
+
+class MiniMaxChatFormatter(_OpenAIFormatterBase):
+    """The MiniMax formatter for chatbot scenario.
+
+    MiniMax exposes an OpenAI-compatible chat API. The M3 model supports
+    image input (image/* media types) but does not support audio input.
+    This formatter is structurally identical to :class:`OpenAIChatFormatter`
+    but advertises only image and text input types.
+    """
+
+    input_types: list[str] = Field(
+        default_factory=lambda: ["text/plain", "image/*"],
+        description=(
+            "The supported input types. "
+            'Defaults to ``["text/plain", "image/*"]``. '
+            "MiniMax does not support audio input."
+        ),
+    )
+
+    async def format(
+        self,
+        msgs: list[Msg],
+    ) -> list[dict[str, Any]]:
+        """Format message objects into MiniMax API required format.
+
+        Args:
+            msgs (`list[Msg]`):
+                The list of message objects to format.
+
+        Returns:
+            `list[dict[str, Any]]`:
+                A list of dictionaries, where each dictionary has
+                ``role`` and ``content`` keys.
+        """
+        self.assert_list_of_msgs(msgs)
+
+        messages: list[dict] = []
+        i = 0
+        while i < len(msgs):
+            msg = msgs[i]
+            content_blocks: list[dict] = []
+            tool_calls: list[dict] = []
+
+            for block in msg.get_content_blocks():
+                if isinstance(block, TextBlock):
+                    content_blocks.append(
+                        {"type": "text", "text": block.text},
+                    )
+
+                elif isinstance(block, DataBlock):
+                    formatted = self._format_openai_data_block(
+                        block,
+                        role=msg.role,
+                    )
+                    if formatted is not None:
+                        content_blocks.append(formatted)
+
+                elif isinstance(block, HintBlock):
+                    if content_blocks or tool_calls:
+                        msg_minimax = {
+                            "role": msg.role,
+                            "name": msg.name,
+                            "content": content_blocks or None,
+                        }
+                        if tool_calls:
+                            msg_minimax["tool_calls"] = tool_calls
+                        messages.append(msg_minimax)
+                        content_blocks = []
+                        tool_calls = []
+
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": block.hint},
+                            ],
+                        },
+                    )
+
+                elif isinstance(block, ToolCallBlock):
+                    tool_calls.append(
+                        {
+                            "id": block.id,
+                            "type": "function",
+                            "function": {
+                                "name": block.name,
+                                "arguments": block.input,
+                            },
+                        },
+                    )
+
+                elif isinstance(block, ToolResultBlock):
+                    if content_blocks or tool_calls:
+                        msg_flush = {
+                            "role": msg.role,
+                            "name": msg.name,
+                            "content": content_blocks or None,
+                        }
+                        if tool_calls:
+                            msg_flush["tool_calls"] = tool_calls
+                        messages.append(msg_flush)
+                        content_blocks = []
+                        tool_calls = []
+
+                    (
+                        textual_output,
+                        multimodal_data,
+                    ) = self.convert_tool_result_to_string(block.output)
+
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": block.id,
+                            "content": textual_output,
+                            "name": block.name,
+                        },
+                    )
+
+                    if multimodal_data:
+                        promo_content = []
+                        for item in multimodal_data:
+                            if isinstance(item, TextBlock):
+                                promo_content.append(
+                                    {"type": "text", "text": item.text},
+                                )
+                            elif isinstance(item, DataBlock):
+                                fmt_item = self._format_openai_data_block(
+                                    item,
+                                    role="user",
+                                )
+                                if fmt_item is not None:
+                                    promo_content.append(fmt_item)
+                        if promo_content:
+                            messages.append(
+                                {
+                                    "role": "user",
+                                    "name": "system-reminder",
+                                    "content": promo_content,
+                                },
+                            )
+
+                elif isinstance(block, ThinkingBlock):
+                    # MiniMax does not accept reasoning/thinking content
+                    # in conversation history — skip thinking blocks silently.
+                    pass
+
+                else:
+                    logger.warning(
+                        "Unsupported block type %s in the message, skipped.",
+                        type(block),
+                    )
+
+            msg_minimax = {
+                "role": msg.role,
+                "name": msg.name,
+                "content": content_blocks or None,
+            }
+
+            if tool_calls:
+                msg_minimax["tool_calls"] = tool_calls
+
+            if msg_minimax["content"] or msg_minimax.get("tool_calls"):
+                messages.append(msg_minimax)
+
+            i += 1
+
+        return messages
+
+
+class MiniMaxMultiAgentFormatter(_OpenAIFormatterBase):
+    """The MiniMax formatter for multi-agent conversations.
+
+    MiniMax exposes an OpenAI-compatible chat API, so the multi-agent
+    history collapsing strategy is the same as
+    :class:`OpenAIMultiAgentFormatter`. Tool sequences are delegated to
+    :class:`MiniMaxChatFormatter`.
+    """
+
+    conversation_history_prompt: str = Field(
+        default=(
+            "# Conversation History\n"
+            "The content between <history></history> tags contains "
+            "your conversation history\n"
+        ),
+        description=(
+            "The prompt to use for the conversation history section.",
+        ),
+    )
+
+    input_types: list[str] = Field(
+        default_factory=lambda: ["text/plain", "image/*"],
+        description=(
+            "The supported input types. "
+            'Defaults to ``["text/plain", "image/*"]``. '
+            "MiniMax does not support audio input."
+        ),
+    )
+
+    async def format(self, msgs: list[Msg]) -> list[dict[str, Any]]:
+        """Format input messages into the structure required by the MiniMax
+        API for multi-agent conversations."""
+        self.assert_list_of_msgs(msgs)
+
+        formatted_msgs: list[dict] = []
+        start_index = 0
+        if msgs and msgs[0].role == "system":
+            formatted_msgs.append(
+                await self._format_system_message(msgs[0]),
+            )
+            start_index = 1
+
+        is_first_agent_message = True
+        async for typ, group in self._group_messages(msgs[start_index:]):
+            if typ == "tool_sequence":
+                formatted_msgs.extend(
+                    await self._format_tool_sequence(group),
+                )
+            elif typ == "agent_message":
+                formatted_msgs.extend(
+                    await self._format_agent_message(
+                        group,
+                        is_first_agent_message,
+                    ),
+                )
+                is_first_agent_message = False
+
+        return formatted_msgs
+
+    async def _format_tool_sequence(
+        self,
+        msgs: list[Msg],
+    ) -> list[dict[str, Any]]:
+        """Format a sequence of tool-related messages using
+        MiniMaxChatFormatter."""
+        return await MiniMaxChatFormatter(
+            input_types=self.input_types,
+        ).format(msgs)
+
+    async def _format_agent_message(
+        self,
+        msgs: list[Msg],
+        is_first: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Collapse agent messages into a ``<history>`` user message."""
+        if is_first:
+            conversation_history_prompt = self.conversation_history_prompt
+        else:
+            conversation_history_prompt = ""
+
+        accumulated_text: list[str] = []
+        media_blocks: list[dict] = []
+
+        for msg in msgs:
+            for block in msg.get_content_blocks():
+                if isinstance(block, TextBlock):
+                    accumulated_text.append(f"{msg.name}: {block.text}")
+                elif isinstance(block, DataBlock):
+                    formatted = self._format_openai_data_block(
+                        block,
+                        role=msg.role,
+                    )
+                    if formatted is not None:
+                        media_blocks.append(formatted)
+
+        if not accumulated_text and not media_blocks:
+            return []
+
+        history_text = "\n".join(accumulated_text)
+        if history_text:
+            history_text = (
+                conversation_history_prompt
+                + "<history>\n"
+                + history_text
+                + "\n</history>"
+            )
+
+        content_list: list[dict[str, Any]] = []
+        if history_text:
+            content_list.append({"type": "text", "text": history_text})
+        content_list.extend(media_blocks)
+
+        return [{"role": "user", "content": content_list}]
+
+    @staticmethod
+    async def _format_system_message(msg: Msg) -> dict[str, Any]:
+        """Format a system message for the MiniMax API."""
+        return {
+            "role": "system",
+            "content": msg.get_text_content(),
+        }

--- a/src/agentscope/formatter/_minimax_formatter.py
+++ b/src/agentscope/formatter/_minimax_formatter.py
@@ -1,29 +1,35 @@
 # -*- coding: utf-8 -*-
-"""The MiniMax formatter for agentscope."""
-from typing import Any
+"""The MiniMax formatter for agentscope.
+
+MiniMax officially recommends using its Anthropic-compatible API
+(``https://api.minimax.io/anthropic``) for chat completions, so the
+formatters here are thin wrappers around
+:class:`AnthropicChatFormatter` / :class:`AnthropicMultiAgentFormatter`.
+The only structural difference is that the MiniMax-Speech models accept
+audio input on the Anthropic-compatible endpoint while Anthropic itself
+does not; the default ``input_types`` here matches Anthropic (text +
+image), which covers the MiniMax M-series chat models like
+``MiniMax-M3``.
+"""
 
 from pydantic import Field
 
-from ._openai_formatter import _OpenAIFormatterBase
-from .._logging import logger
-from ..message import (
-    Msg,
-    TextBlock,
-    DataBlock,
-    HintBlock,
-    ToolCallBlock,
-    ToolResultBlock,
-    ThinkingBlock,
+from ._anthropic_formatter import (
+    AnthropicChatFormatter,
+    AnthropicMultiAgentFormatter,
 )
 
 
-class MiniMaxChatFormatter(_OpenAIFormatterBase):
+class MiniMaxChatFormatter(AnthropicChatFormatter):
     """The MiniMax formatter for chatbot scenario.
 
-    MiniMax exposes an OpenAI-compatible chat API. The M3 model supports
-    image input (image/* media types) but does not support audio input.
-    This formatter is structurally identical to :class:`OpenAIChatFormatter`
-    but advertises only image and text input types.
+    MiniMax's M-series chat models (e.g. ``MiniMax-M3``) are exposed
+    through an Anthropic-compatible API. The serialised request format is
+    identical to Anthropic's so this class inherits the entire formatter,
+    including the
+    `documented thinking-block round-trip behaviour
+    <https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#preserving-thinking-blocks>`_
+    that preserves reasoning continuity across turns.
     """
 
     input_types: list[str] = Field(
@@ -31,167 +37,18 @@ class MiniMaxChatFormatter(_OpenAIFormatterBase):
         description=(
             "The supported input types. "
             'Defaults to ``["text/plain", "image/*"]``. '
-            "MiniMax does not support audio input."
+            "MiniMax's M-series chat endpoint does not accept audio "
+            "input."
         ),
     )
 
-    async def format(
-        self,
-        msgs: list[Msg],
-    ) -> list[dict[str, Any]]:
-        """Format message objects into MiniMax API required format.
 
-        Args:
-            msgs (`list[Msg]`):
-                The list of message objects to format.
-
-        Returns:
-            `list[dict[str, Any]]`:
-                A list of dictionaries, where each dictionary has
-                ``role`` and ``content`` keys.
-        """
-        self.assert_list_of_msgs(msgs)
-
-        messages: list[dict] = []
-        i = 0
-        while i < len(msgs):
-            msg = msgs[i]
-            content_blocks: list[dict] = []
-            tool_calls: list[dict] = []
-
-            for block in msg.get_content_blocks():
-                if isinstance(block, TextBlock):
-                    content_blocks.append(
-                        {"type": "text", "text": block.text},
-                    )
-
-                elif isinstance(block, DataBlock):
-                    formatted = self._format_openai_data_block(
-                        block,
-                        role=msg.role,
-                    )
-                    if formatted is not None:
-                        content_blocks.append(formatted)
-
-                elif isinstance(block, HintBlock):
-                    if content_blocks or tool_calls:
-                        msg_minimax = {
-                            "role": msg.role,
-                            "name": msg.name,
-                            "content": content_blocks or None,
-                        }
-                        if tool_calls:
-                            msg_minimax["tool_calls"] = tool_calls
-                        messages.append(msg_minimax)
-                        content_blocks = []
-                        tool_calls = []
-
-                    messages.append(
-                        {
-                            "role": "user",
-                            "content": [
-                                {"type": "text", "text": block.hint},
-                            ],
-                        },
-                    )
-
-                elif isinstance(block, ToolCallBlock):
-                    tool_calls.append(
-                        {
-                            "id": block.id,
-                            "type": "function",
-                            "function": {
-                                "name": block.name,
-                                "arguments": block.input,
-                            },
-                        },
-                    )
-
-                elif isinstance(block, ToolResultBlock):
-                    if content_blocks or tool_calls:
-                        msg_flush = {
-                            "role": msg.role,
-                            "name": msg.name,
-                            "content": content_blocks or None,
-                        }
-                        if tool_calls:
-                            msg_flush["tool_calls"] = tool_calls
-                        messages.append(msg_flush)
-                        content_blocks = []
-                        tool_calls = []
-
-                    (
-                        textual_output,
-                        multimodal_data,
-                    ) = self.convert_tool_result_to_string(block.output)
-
-                    messages.append(
-                        {
-                            "role": "tool",
-                            "tool_call_id": block.id,
-                            "content": textual_output,
-                            "name": block.name,
-                        },
-                    )
-
-                    if multimodal_data:
-                        promo_content = []
-                        for item in multimodal_data:
-                            if isinstance(item, TextBlock):
-                                promo_content.append(
-                                    {"type": "text", "text": item.text},
-                                )
-                            elif isinstance(item, DataBlock):
-                                fmt_item = self._format_openai_data_block(
-                                    item,
-                                    role="user",
-                                )
-                                if fmt_item is not None:
-                                    promo_content.append(fmt_item)
-                        if promo_content:
-                            messages.append(
-                                {
-                                    "role": "user",
-                                    "name": "system-reminder",
-                                    "content": promo_content,
-                                },
-                            )
-
-                elif isinstance(block, ThinkingBlock):
-                    # MiniMax does not accept reasoning/thinking content
-                    # in conversation history — skip thinking blocks silently.
-                    pass
-
-                else:
-                    logger.warning(
-                        "Unsupported block type %s in the message, skipped.",
-                        type(block),
-                    )
-
-            msg_minimax = {
-                "role": msg.role,
-                "name": msg.name,
-                "content": content_blocks or None,
-            }
-
-            if tool_calls:
-                msg_minimax["tool_calls"] = tool_calls
-
-            if msg_minimax["content"] or msg_minimax.get("tool_calls"):
-                messages.append(msg_minimax)
-
-            i += 1
-
-        return messages
-
-
-class MiniMaxMultiAgentFormatter(_OpenAIFormatterBase):
+class MiniMaxMultiAgentFormatter(AnthropicMultiAgentFormatter):
     """The MiniMax formatter for multi-agent conversations.
 
-    MiniMax exposes an OpenAI-compatible chat API, so the multi-agent
-    history collapsing strategy is the same as
-    :class:`OpenAIMultiAgentFormatter`. Tool sequences are delegated to
-    :class:`MiniMaxChatFormatter`.
+    MiniMax's M-series chat models follow Anthropic's API conventions, so
+    the multi-agent history-collapsing logic is reused verbatim from
+    :class:`AnthropicMultiAgentFormatter`.
     """
 
     conversation_history_prompt: str = Field(
@@ -200,9 +57,7 @@ class MiniMaxMultiAgentFormatter(_OpenAIFormatterBase):
             "The content between <history></history> tags contains "
             "your conversation history\n"
         ),
-        description=(
-            "The prompt to use for the conversation history section.",
-        ),
+        description="The prompt to use for the conversation history section.",
     )
 
     input_types: list[str] = Field(
@@ -210,99 +65,7 @@ class MiniMaxMultiAgentFormatter(_OpenAIFormatterBase):
         description=(
             "The supported input types. "
             'Defaults to ``["text/plain", "image/*"]``. '
-            "MiniMax does not support audio input."
+            "MiniMax's M-series chat endpoint does not accept audio "
+            "input."
         ),
     )
-
-    async def format(self, msgs: list[Msg]) -> list[dict[str, Any]]:
-        """Format input messages into the structure required by the MiniMax
-        API for multi-agent conversations."""
-        self.assert_list_of_msgs(msgs)
-
-        formatted_msgs: list[dict] = []
-        start_index = 0
-        if msgs and msgs[0].role == "system":
-            formatted_msgs.append(
-                await self._format_system_message(msgs[0]),
-            )
-            start_index = 1
-
-        is_first_agent_message = True
-        async for typ, group in self._group_messages(msgs[start_index:]):
-            if typ == "tool_sequence":
-                formatted_msgs.extend(
-                    await self._format_tool_sequence(group),
-                )
-            elif typ == "agent_message":
-                formatted_msgs.extend(
-                    await self._format_agent_message(
-                        group,
-                        is_first_agent_message,
-                    ),
-                )
-                is_first_agent_message = False
-
-        return formatted_msgs
-
-    async def _format_tool_sequence(
-        self,
-        msgs: list[Msg],
-    ) -> list[dict[str, Any]]:
-        """Format a sequence of tool-related messages using
-        MiniMaxChatFormatter."""
-        return await MiniMaxChatFormatter(
-            input_types=self.input_types,
-        ).format(msgs)
-
-    async def _format_agent_message(
-        self,
-        msgs: list[Msg],
-        is_first: bool = True,
-    ) -> list[dict[str, Any]]:
-        """Collapse agent messages into a ``<history>`` user message."""
-        if is_first:
-            conversation_history_prompt = self.conversation_history_prompt
-        else:
-            conversation_history_prompt = ""
-
-        accumulated_text: list[str] = []
-        media_blocks: list[dict] = []
-
-        for msg in msgs:
-            for block in msg.get_content_blocks():
-                if isinstance(block, TextBlock):
-                    accumulated_text.append(f"{msg.name}: {block.text}")
-                elif isinstance(block, DataBlock):
-                    formatted = self._format_openai_data_block(
-                        block,
-                        role=msg.role,
-                    )
-                    if formatted is not None:
-                        media_blocks.append(formatted)
-
-        if not accumulated_text and not media_blocks:
-            return []
-
-        history_text = "\n".join(accumulated_text)
-        if history_text:
-            history_text = (
-                conversation_history_prompt
-                + "<history>\n"
-                + history_text
-                + "\n</history>"
-            )
-
-        content_list: list[dict[str, Any]] = []
-        if history_text:
-            content_list.append({"type": "text", "text": history_text})
-        content_list.extend(media_blocks)
-
-        return [{"role": "user", "content": content_list}]
-
-    @staticmethod
-    async def _format_system_message(msg: Msg) -> dict[str, Any]:
-        """Format a system message for the MiniMax API."""
-        return {
-            "role": "system",
-            "content": msg.get_text_content(),
-        }

--- a/src/agentscope/model/__init__.py
+++ b/src/agentscope/model/__init__.py
@@ -9,6 +9,7 @@ from ._anthropic import AnthropicChatModel
 from ._dashscope import DashScopeChatModel
 from ._deepseek import DeepSeekChatModel
 from ._gemini import GeminiChatModel
+from ._minimax import MiniMaxChatModel
 from ._ollama import OllamaChatModel
 from ._openai_chat import OpenAIChatModel
 from ._xai import XAIChatModel
@@ -25,6 +26,7 @@ __all__ = [
     "DashScopeChatModel",
     "DeepSeekChatModel",
     "GeminiChatModel",
+    "MiniMaxChatModel",
     "OllamaChatModel",
     "OpenAIChatModel",
     "XAIChatModel",

--- a/src/agentscope/model/_minimax/__init__.py
+++ b/src/agentscope/model/_minimax/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""The MiniMax LLM API modules."""
+
+from ._model import MiniMaxChatModel
+
+__all__ = [
+    "MiniMaxChatModel",
+]

--- a/src/agentscope/model/_minimax/_model.py
+++ b/src/agentscope/model/_minimax/_model.py
@@ -1,0 +1,476 @@
+# -*- coding: utf-8 -*-
+"""The MiniMax chat model implementation."""
+from collections import OrderedDict
+from datetime import datetime
+from typing import Literal, Any, AsyncGenerator, TYPE_CHECKING, List, Type
+
+from pydantic import BaseModel, Field
+
+from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
+from .._model_response import ChatResponse, StructuredResponse
+from .._model_usage import ChatUsage
+from ...credential import MiniMaxCredential
+from ...formatter import FormatterBase, MiniMaxChatFormatter
+from ...message import Msg, ThinkingBlock, ToolCallBlock, TextBlock
+from ...tool import ToolChoice
+
+if TYPE_CHECKING:
+    from openai.types.chat import ChatCompletion
+    from openai import AsyncStream
+else:
+    ChatCompletion = Any
+    AsyncStream = Any
+
+
+class MiniMaxChatModel(ChatModelBase):
+    """The MiniMax chat model.
+
+    MiniMax provides an OpenAI-compatible chat API. The model supports
+    image input (multimodal) and tool calls. Temperature must be in
+    ``(0.0, 1.0]`` and the default is ``1.0``.
+    """
+
+    class Parameters(BaseModel):
+        """The parameters for the MiniMax chat model."""
+
+        max_tokens: int | None = Field(
+            default=None,
+            title="Max Tokens",
+            description="The maximum number of tokens for the LLM output.",
+            gt=0,
+        )
+
+        temperature: float | None = Field(
+            default=1.0,
+            title="Temperature",
+            description=(
+                "The temperature for the LLM output. MiniMax requires "
+                "the value to be in (0.0, 1.0] — 0 is not accepted."
+            ),
+            gt=0.0,
+            le=1.0,
+        )
+
+        top_p: float | None = Field(
+            default=None,
+            title="Top P",
+            description="The top P value for the LLM output.",
+            gt=0,
+            le=1,
+        )
+
+    type: Literal["minimax_chat"] = "minimax_chat"
+    """The type of the chat model."""
+
+    def __init__(
+        self,
+        credential: MiniMaxCredential,
+        model: str,
+        parameters: "MiniMaxChatModel.Parameters | None" = None,
+        stream: bool = True,
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
+        context_size: int = 512000,
+        formatter: FormatterBase | None = None,
+        client_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize the MiniMax chat model.
+
+        Args:
+            credential (`MiniMaxCredential`):
+                The MiniMax credential used to authenticate API calls.
+            model (`str`):
+                The MiniMax model name, e.g. ``MiniMax-M3``.
+            parameters (`MiniMaxChatModel.Parameters | None`, defaults to \
+            `None`):
+                The MiniMax API parameters. When ``None``, the default
+                parameters will be used.
+            stream (`bool`, defaults to `True`):
+                Whether to enable streaming output.
+            max_retries (`int`, defaults to `3`):
+                The maximum number of retries for the MiniMax API.
+            retry_delay (`float`, defaults to `1.0`):
+                Seconds to sleep between retry attempts.
+            context_size (`int`, defaults to `512000`):
+                The model context size used for context compression.
+            formatter (`FormatterBase | None`, defaults to `None`):
+                The formatter that converts ``Msg`` objects to the format
+                required by the MiniMax API. When ``None``, a
+                ``MiniMaxChatFormatter`` instance will be used.
+            client_kwargs (`dict[str, Any] | None`, defaults to `None`):
+                Extra keyword arguments forwarded to ``openai.AsyncClient``
+                (e.g. ``timeout``, ``default_headers``, ``http_client``).
+        """
+        super().__init__(
+            credential=credential,
+            model=model,
+            parameters=parameters or self.Parameters(),
+            stream=stream,
+            max_retries=max_retries,
+            retry_delay=retry_delay,
+            context_size=context_size,
+        )
+        self.formatter = formatter or MiniMaxChatFormatter()
+        self.client_kwargs = client_kwargs or {}
+
+    @classmethod
+    def _get_retryable_exceptions(cls) -> tuple[Type[Exception], ...]:
+        import openai
+
+        return (
+            openai.APIConnectionError,
+            openai.APITimeoutError,
+            openai.RateLimitError,
+            openai.InternalServerError,
+        )
+
+    async def _call_api(
+        self,
+        model_name: str,
+        messages: list[Msg],
+        tools: list[dict] | None = None,
+        tool_choice: ToolChoice | None = None,
+        **generate_kwargs: Any,
+    ) -> ChatResponse | AsyncGenerator[ChatResponse, None]:
+        """Call the MiniMax chat completions API.
+
+        Args:
+            model_name (`str`):
+                The model name to use for this call.
+            messages (`list`):
+                A list of message dicts with ``role`` and ``content`` keys.
+            tools (`list[dict]`, default `None`):
+                The tools JSON schemas.
+            tool_choice (`ToolChoice | None`, optional):
+                Controls which (if any) tool is called by the model.
+            **generate_kwargs (`Any`):
+                Extra keyword arguments forwarded to the API.
+
+        Returns:
+            `ChatResponse | AsyncGenerator[ChatResponse, None]`:
+                A ``ChatResponse`` when streaming is disabled, or an async
+                generator of ``ChatResponse`` objects when streaming is
+                enabled.
+        """
+        import openai
+
+        client = openai.AsyncClient(
+            **{
+                "api_key": self.credential.api_key.get_secret_value(),
+                "base_url": self.credential.base_url,
+                **self.client_kwargs,
+            },
+        )
+
+        formatted_messages = await self.formatter.format(messages)
+
+        kwargs: dict[str, Any] = {
+            "model": model_name,
+            "messages": formatted_messages,
+            "stream": self.stream,
+        }
+
+        if self.parameters.max_tokens is not None:
+            kwargs["max_tokens"] = self.parameters.max_tokens
+
+        if self.parameters.temperature is not None:
+            kwargs["temperature"] = self.parameters.temperature
+
+        if self.parameters.top_p is not None:
+            kwargs["top_p"] = self.parameters.top_p
+
+        kwargs.update(generate_kwargs)
+
+        fmt_tools, fmt_tool_choice = self._format_tools(tools, tool_choice)
+
+        if fmt_tools:
+            kwargs["tools"] = fmt_tools
+
+        if fmt_tool_choice is not None:
+            kwargs["tool_choice"] = fmt_tool_choice
+
+        if self.stream:
+            kwargs["stream_options"] = {"include_usage": True}
+
+        start_datetime = datetime.now()
+        response = await client.chat.completions.create(**kwargs)
+
+        if self.stream:
+            return self._parse_stream_response(start_datetime, response)
+
+        return self._parse_completion_response(start_datetime, response)
+
+    async def _parse_stream_response(
+        self,
+        start_datetime: datetime,
+        response: AsyncStream,
+    ) -> AsyncGenerator[ChatResponse, None]:
+        """Parse the MiniMax streaming response.
+
+        Args:
+            start_datetime (`datetime`):
+                The start datetime of the response generation.
+            response (`AsyncStream`):
+                The OpenAI-compatible async stream object.
+
+        Yields:
+            `ChatResponse`:
+                Incremental ``ChatResponse`` objects with ``is_last=False``
+                followed by a final one with ``is_last=True``.
+        """
+        usage = None
+        response_id: str | None = None
+        acc_text = TextBlock(text="")
+        acc_thinking = ThinkingBlock(thinking="")
+        acc_tool_calls: OrderedDict = OrderedDict()
+
+        async with response as stream:
+            async for chunk in stream:
+                if chunk.usage:
+                    u = chunk.usage
+                    details = getattr(u, "prompt_tokens_details", None)
+                    usage = ChatUsage(
+                        input_tokens=u.prompt_tokens,
+                        output_tokens=u.completion_tokens,
+                        time=(datetime.now() - start_datetime).total_seconds(),
+                        cache_input_tokens=getattr(
+                            details,
+                            "cached_tokens",
+                            0,
+                        )
+                        if details
+                        else 0,
+                    )
+
+                response_id = response_id or getattr(chunk, "id", None)
+
+                if not chunk.choices:
+                    continue
+
+                choice = chunk.choices[0]
+                delta = choice.delta
+
+                delta_thinking = (
+                    getattr(delta, "reasoning_content", None) or ""
+                )
+                delta_text = getattr(delta, "content", None) or ""
+
+                acc_thinking.thinking += delta_thinking
+                acc_text.text += delta_text
+
+                delta_tool_call_blocks: List[ToolCallBlock] = []
+                for tool_call in getattr(delta, "tool_calls", None) or []:
+                    idx = tool_call.index
+                    args = tool_call.function.arguments or ""
+                    if idx in acc_tool_calls:
+                        acc_tool_calls[idx]["input"] += args
+                    else:
+                        acc_tool_calls[idx] = {
+                            "id": tool_call.id,
+                            "name": tool_call.function.name,
+                            "input": args,
+                        }
+                    tc = acc_tool_calls[idx]
+                    delta_tool_call_blocks.append(
+                        ToolCallBlock(
+                            id=tc["id"],
+                            name=tc["name"],
+                            input=args,
+                        ),
+                    )
+
+                delta_contents: List[
+                    TextBlock | ToolCallBlock | ThinkingBlock
+                ] = []
+                if delta_thinking:
+                    delta_contents.append(
+                        ThinkingBlock(
+                            id=acc_thinking.id,
+                            thinking=delta_thinking,
+                        ),
+                    )
+                if delta_text:
+                    delta_contents.append(
+                        TextBlock(id=acc_text.id, text=delta_text),
+                    )
+                delta_contents.extend(delta_tool_call_blocks)
+
+                if delta_contents:
+                    _kwargs: dict[str, Any] = {
+                        "content": delta_contents,
+                        "usage": usage,
+                        "is_last": False,
+                    }
+                    if response_id:
+                        _kwargs["id"] = response_id
+                    yield ChatResponse(**_kwargs)
+
+        final_contents: List[TextBlock | ToolCallBlock | ThinkingBlock] = []
+        if acc_thinking.thinking:
+            final_contents.append(acc_thinking)
+        if acc_text.text:
+            final_contents.append(acc_text)
+        for tc in acc_tool_calls.values():
+            final_contents.append(
+                ToolCallBlock(
+                    id=tc["id"],
+                    name=tc["name"],
+                    input=tc["input"],
+                ),
+            )
+
+        _final_kwargs: dict[str, Any] = {
+            "content": final_contents,
+            "usage": usage,
+            "is_last": True,
+        }
+        if response_id:
+            _final_kwargs["id"] = response_id
+        yield ChatResponse(**_final_kwargs)
+
+    def _parse_completion_response(
+        self,
+        start_datetime: datetime,
+        response: ChatCompletion,
+    ) -> ChatResponse:
+        """Parse the MiniMax non-streaming response.
+
+        Args:
+            start_datetime (`datetime`):
+                The start datetime of the response generation.
+            response (`ChatCompletion`):
+                The OpenAI-compatible chat completion object.
+
+        Returns:
+            `ChatResponse`:
+                A single ``ChatResponse`` with ``is_last=True``.
+        """
+        content_blocks: List[TextBlock | ToolCallBlock | ThinkingBlock] = []
+
+        if response.choices:
+            choice = response.choices[0]
+            reasoning = getattr(choice.message, "reasoning_content", None)
+            if isinstance(reasoning, str) and reasoning:
+                content_blocks.append(ThinkingBlock(thinking=reasoning))
+
+            if choice.message.content:
+                content_blocks.append(TextBlock(text=choice.message.content))
+
+            for tool_call in choice.message.tool_calls or []:
+                content_blocks.append(
+                    ToolCallBlock(
+                        id=tool_call.id,
+                        name=tool_call.function.name,
+                        input=tool_call.function.arguments,
+                    ),
+                )
+
+        usage = None
+        if response.usage:
+            u = response.usage
+            details = getattr(u, "prompt_tokens_details", None)
+            usage = ChatUsage(
+                input_tokens=u.prompt_tokens,
+                output_tokens=u.completion_tokens,
+                time=(datetime.now() - start_datetime).total_seconds(),
+                cache_input_tokens=getattr(
+                    details,
+                    "cached_tokens",
+                    0,
+                )
+                if details
+                else 0,
+            )
+
+        resp_kwargs: dict[str, Any] = {
+            "content": content_blocks,
+            "is_last": True,
+            "usage": usage,
+        }
+        response_id = getattr(response, "id", None)
+        if response_id:
+            resp_kwargs["id"] = response_id
+
+        return ChatResponse(**resp_kwargs)
+
+    def _format_tools(
+        self,
+        tools: list[dict] | None,
+        tool_choice: ToolChoice | None,
+    ) -> tuple[list[dict] | None, str | dict | None]:
+        """Validate, filter, and format tools and tool_choice for the MiniMax
+        API.
+
+        When ``tool_choice.tools`` is specified the schemas list is filtered
+        to only those tools. When ``tool_choice.mode`` is a specific tool name
+        (str) the model is forced to call exactly that tool without needing to
+        filter the list, preserving prompt-cache efficiency.
+
+        Args:
+            tools (`list[dict] | None`, optional):
+                The raw tool schemas.
+            tool_choice (`ToolChoice | None`, optional):
+                The tool choice configuration.
+
+        Returns:
+            `tuple[list[dict] | None, str | dict | None]`:
+                A tuple of (formatted_tools, formatted_tool_choice).
+        """
+        if tool_choice and tools:
+            self._validate_tool_choice(tool_choice, tools)
+            if tool_choice.tools:
+                allowed = set(tool_choice.tools)
+                tools = [t for t in tools if t["function"]["name"] in allowed]
+
+        if not tool_choice:
+            return tools, None
+
+        mode = tool_choice.mode
+
+        if mode not in _TOOL_CHOICE_LITERAL_MODES:
+            return tools, {"type": "function", "function": {"name": mode}}
+
+        return tools, mode
+
+    async def _call_api_with_structured_output(
+        self,
+        model_name: str,
+        messages: list[Msg],
+        structured_model: Type[BaseModel] | dict,
+        tool_choice: ToolChoice | None = None,
+        **kwargs: Any,
+    ) -> StructuredResponse:
+        """MiniMax-specific override for structured output.
+
+        MiniMax does not support ``response_format``. The base class uses
+        ``response_format`` to drive structured output via JSON schema; here
+        we delegate to the base implementation, but the request that reaches
+        MiniMax will not include ``response_format`` because we never forward
+        it from ``_call_api``. Tool calls are used as the structured-output
+        channel.
+
+        Args:
+            model_name (`str`):
+                The model name to use for this call.
+            messages (`list[Msg]`):
+                The context for the LLM to generate the structured output.
+            structured_model (`Type[BaseModel] | dict`):
+                A Pydantic model class or a JSON schema dict describing the
+                required output structure.
+            tool_choice (`ToolChoice | None`, defaults to `None`):
+                The tool_choice forwarded to ``_call_api``.
+            **kwargs (`Any`):
+                Additional keyword arguments forwarded to ``_call_api``.
+
+        Returns:
+            `StructuredResponse`:
+                The structured response whose ``content`` is the validated
+                output dict matching ``structured_model``.
+        """
+        return await super()._call_api_with_structured_output(
+            model_name=model_name,
+            messages=messages,
+            structured_model=structured_model,
+            tool_choice=tool_choice,
+            **kwargs,
+        )

--- a/src/agentscope/model/_minimax/_model.py
+++ b/src/agentscope/model/_minimax/_model.py
@@ -1,5 +1,15 @@
 # -*- coding: utf-8 -*-
-"""The MiniMax chat model implementation."""
+"""The MiniMax chat model implementation.
+
+MiniMax officially recommends using the Anthropic-compatible API for calls
+(see https://platform.minimax.io/docs/api-reference/text-anthropic-api).
+This module routes ``MiniMaxChatModel`` through the ``anthropic`` SDK
+against MiniMax's ``/anthropic`` endpoint, matching the behaviour of
+:class:`agentscope.model.AnthropicChatModel` so users get the same
+``thinking_enable`` / ``thinking_budget`` controls, the same tool-call
+semantics, and a thinking block preserved across turns.
+"""
+
 from collections import OrderedDict
 from datetime import datetime
 from typing import Literal, Any, AsyncGenerator, TYPE_CHECKING, List, Type
@@ -15,20 +25,25 @@ from ...message import Msg, ThinkingBlock, ToolCallBlock, TextBlock
 from ...tool import ToolChoice
 
 if TYPE_CHECKING:
-    from openai.types.chat import ChatCompletion
-    from openai import AsyncStream
+    from anthropic.types.message import Message
+    from anthropic import AsyncStream
 else:
-    ChatCompletion = Any
+    Message = Any
     AsyncStream = Any
 
 
 class MiniMaxChatModel(ChatModelBase):
     """The MiniMax chat model.
 
-    MiniMax provides an OpenAI-compatible chat API. The model supports
-    image input (multimodal) and tool calls. Temperature must be in
-    ``(0.0, 1.0]`` and the default is ``1.0``.
+    Calls MiniMax via its officially recommended Anthropic-compatible API
+    (``https://api.minimax.io/anthropic``) using the ``anthropic`` SDK.
+    Supports extended thinking via the ``thinking_enable`` /
+    ``thinking_budget`` parameters in the same way as
+    :class:`agentscope.model.AnthropicChatModel`.
     """
+
+    type: Literal["minimax_chat"] = "minimax_chat"
+    """The type of the chat model."""
 
     class Parameters(BaseModel):
         """The parameters for the MiniMax chat model."""
@@ -36,31 +51,24 @@ class MiniMaxChatModel(ChatModelBase):
         max_tokens: int | None = Field(
             default=None,
             title="Max Tokens",
-            description="The maximum number of tokens for the LLM output.",
-            gt=0,
-        )
-
-        temperature: float | None = Field(
-            default=1.0,
-            title="Temperature",
             description=(
-                "The temperature for the LLM output. MiniMax requires "
-                "the value to be in (0.0, 1.0] — 0 is not accepted."
+                "The maximum number of tokens to generate in the chat completion."
             ),
-            gt=0.0,
-            le=1.0,
-        )
-
-        top_p: float | None = Field(
-            default=None,
-            title="Top P",
-            description="The top P value for the LLM output.",
             gt=0,
-            le=1,
         )
 
-    type: Literal["minimax_chat"] = "minimax_chat"
-    """The type of the chat model."""
+        thinking_enable: bool = Field(
+            default=False,
+            title="Thinking",
+            description="The thinking enable for the LLM output.",
+        )
+
+        thinking_budget: int | None = Field(
+            default=None,
+            title="Thinking budget",
+            description="The thinking budget for the LLM output.",
+            gt=0,
+        )
 
     def __init__(
         self,
@@ -95,11 +103,12 @@ class MiniMaxChatModel(ChatModelBase):
                 The model context size used for context compression.
             formatter (`FormatterBase | None`, defaults to `None`):
                 The formatter that converts ``Msg`` objects to the format
-                required by the MiniMax API. When ``None``, a
-                ``MiniMaxChatFormatter`` instance will be used.
+                required by the MiniMax Anthropic-compatible API. When
+                ``None``, a ``MiniMaxChatFormatter`` instance will be used.
             client_kwargs (`dict[str, Any] | None`, defaults to `None`):
-                Extra keyword arguments forwarded to ``openai.AsyncClient``
-                (e.g. ``timeout``, ``default_headers``, ``http_client``).
+                Extra keyword arguments forwarded to
+                ``anthropic.AsyncAnthropic`` (e.g. ``timeout``,
+                ``default_headers``, ``http_client``, ``auth_token``).
         """
         super().__init__(
             credential=credential,
@@ -115,13 +124,13 @@ class MiniMaxChatModel(ChatModelBase):
 
     @classmethod
     def _get_retryable_exceptions(cls) -> tuple[Type[Exception], ...]:
-        import openai
+        import anthropic
 
         return (
-            openai.APIConnectionError,
-            openai.APITimeoutError,
-            openai.RateLimitError,
-            openai.InternalServerError,
+            anthropic.APIConnectionError,
+            anthropic.APITimeoutError,
+            anthropic.RateLimitError,
+            anthropic.InternalServerError,
         )
 
     async def _call_api(
@@ -132,19 +141,20 @@ class MiniMaxChatModel(ChatModelBase):
         tool_choice: ToolChoice | None = None,
         **generate_kwargs: Any,
     ) -> ChatResponse | AsyncGenerator[ChatResponse, None]:
-        """Call the MiniMax chat completions API.
+        """Call MiniMax's Anthropic-compatible chat completions API.
 
         Args:
             model_name (`str`):
                 The model name to use for this call.
-            messages (`list`):
-                A list of message dicts with ``role`` and ``content`` keys.
+            messages (`list[dict]`):
+                A list of dictionaries, where `role` and `content` fields are
+                required.
             tools (`list[dict]`, default `None`):
                 The tools JSON schemas.
             tool_choice (`ToolChoice | None`, optional):
                 Controls which (if any) tool is called by the model.
             **generate_kwargs (`Any`):
-                Extra keyword arguments forwarded to the API.
+                The keyword arguments for the Anthropic-compatible API.
 
         Returns:
             `ChatResponse | AsyncGenerator[ChatResponse, None]`:
@@ -152,9 +162,9 @@ class MiniMaxChatModel(ChatModelBase):
                 generator of ``ChatResponse`` objects when streaming is
                 enabled.
         """
-        import openai
+        import anthropic
 
-        client = openai.AsyncClient(
+        client = anthropic.AsyncAnthropic(
             **{
                 "api_key": self.credential.api_key.get_secret_value(),
                 "base_url": self.credential.base_url,
@@ -162,224 +172,124 @@ class MiniMaxChatModel(ChatModelBase):
             },
         )
 
-        formatted_messages = await self.formatter.format(messages)
+        # The Anthropic-compatible endpoint requires `max_tokens`; fall back
+        # to a safe default when the user hasn't configured one explicitly.
+        max_tokens = self.parameters.max_tokens or 8192
 
         kwargs: dict[str, Any] = {
             "model": model_name,
-            "messages": formatted_messages,
+            "max_tokens": max_tokens,
             "stream": self.stream,
+            **generate_kwargs,
         }
 
-        if self.parameters.max_tokens is not None:
-            kwargs["max_tokens"] = self.parameters.max_tokens
-
-        if self.parameters.temperature is not None:
-            kwargs["temperature"] = self.parameters.temperature
-
-        if self.parameters.top_p is not None:
-            kwargs["top_p"] = self.parameters.top_p
-
-        kwargs.update(generate_kwargs)
+        # Extended thinking — only set when explicitly enabled. The
+        # Anthropic-compatible API requires `max_tokens > budget_tokens`
+        # strictly, so auto-expand max_tokens if the user-supplied budget
+        # is too large.
+        if self.parameters.thinking_enable and "thinking" not in kwargs:
+            budget = self.parameters.thinking_budget or (max_tokens // 2)
+            if budget >= max_tokens:
+                max_tokens = budget + 1024
+                kwargs["max_tokens"] = max_tokens
+            kwargs["thinking"] = {
+                "type": "enabled",
+                "budget_tokens": budget,
+            }
 
         fmt_tools, fmt_tool_choice = self._format_tools(tools, tool_choice)
-
         if fmt_tools:
             kwargs["tools"] = fmt_tools
-
         if fmt_tool_choice is not None:
             kwargs["tool_choice"] = fmt_tool_choice
 
-        if self.stream:
-            kwargs["stream_options"] = {"include_usage": True}
+        formatted_messages = await self.formatter.format(messages)
+
+        # Extract the system message — Anthropic-compatible APIs expect it
+        # as a top-level `system` parameter, not in the messages array.
+        if formatted_messages and formatted_messages[0]["role"] == "system":
+            kwargs["system"] = formatted_messages[0]["content"]
+            formatted_messages = formatted_messages[1:]
+
+        kwargs["messages"] = formatted_messages
 
         start_datetime = datetime.now()
-        response = await client.chat.completions.create(**kwargs)
+
+        response = await client.messages.create(**kwargs)
 
         if self.stream:
-            return self._parse_stream_response(start_datetime, response)
-
-        return self._parse_completion_response(start_datetime, response)
-
-    async def _parse_stream_response(
-        self,
-        start_datetime: datetime,
-        response: AsyncStream,
-    ) -> AsyncGenerator[ChatResponse, None]:
-        """Parse the MiniMax streaming response.
-
-        Args:
-            start_datetime (`datetime`):
-                The start datetime of the response generation.
-            response (`AsyncStream`):
-                The OpenAI-compatible async stream object.
-
-        Yields:
-            `ChatResponse`:
-                Incremental ``ChatResponse`` objects with ``is_last=False``
-                followed by a final one with ``is_last=True``.
-        """
-        usage = None
-        response_id: str | None = None
-        acc_text = TextBlock(text="")
-        acc_thinking = ThinkingBlock(thinking="")
-        acc_tool_calls: OrderedDict = OrderedDict()
-
-        async with response as stream:
-            async for chunk in stream:
-                if chunk.usage:
-                    u = chunk.usage
-                    details = getattr(u, "prompt_tokens_details", None)
-                    usage = ChatUsage(
-                        input_tokens=u.prompt_tokens,
-                        output_tokens=u.completion_tokens,
-                        time=(datetime.now() - start_datetime).total_seconds(),
-                        cache_input_tokens=getattr(
-                            details,
-                            "cached_tokens",
-                            0,
-                        )
-                        if details
-                        else 0,
-                    )
-
-                response_id = response_id or getattr(chunk, "id", None)
-
-                if not chunk.choices:
-                    continue
-
-                choice = chunk.choices[0]
-                delta = choice.delta
-
-                delta_thinking = (
-                    getattr(delta, "reasoning_content", None) or ""
-                )
-                delta_text = getattr(delta, "content", None) or ""
-
-                acc_thinking.thinking += delta_thinking
-                acc_text.text += delta_text
-
-                delta_tool_call_blocks: List[ToolCallBlock] = []
-                for tool_call in getattr(delta, "tool_calls", None) or []:
-                    idx = tool_call.index
-                    args = tool_call.function.arguments or ""
-                    if idx in acc_tool_calls:
-                        acc_tool_calls[idx]["input"] += args
-                    else:
-                        acc_tool_calls[idx] = {
-                            "id": tool_call.id,
-                            "name": tool_call.function.name,
-                            "input": args,
-                        }
-                    tc = acc_tool_calls[idx]
-                    delta_tool_call_blocks.append(
-                        ToolCallBlock(
-                            id=tc["id"],
-                            name=tc["name"],
-                            input=args,
-                        ),
-                    )
-
-                delta_contents: List[
-                    TextBlock | ToolCallBlock | ThinkingBlock
-                ] = []
-                if delta_thinking:
-                    delta_contents.append(
-                        ThinkingBlock(
-                            id=acc_thinking.id,
-                            thinking=delta_thinking,
-                        ),
-                    )
-                if delta_text:
-                    delta_contents.append(
-                        TextBlock(id=acc_text.id, text=delta_text),
-                    )
-                delta_contents.extend(delta_tool_call_blocks)
-
-                if delta_contents:
-                    _kwargs: dict[str, Any] = {
-                        "content": delta_contents,
-                        "usage": usage,
-                        "is_last": False,
-                    }
-                    if response_id:
-                        _kwargs["id"] = response_id
-                    yield ChatResponse(**_kwargs)
-
-        final_contents: List[TextBlock | ToolCallBlock | ThinkingBlock] = []
-        if acc_thinking.thinking:
-            final_contents.append(acc_thinking)
-        if acc_text.text:
-            final_contents.append(acc_text)
-        for tc in acc_tool_calls.values():
-            final_contents.append(
-                ToolCallBlock(
-                    id=tc["id"],
-                    name=tc["name"],
-                    input=tc["input"],
-                ),
+            return self._parse_stream_response(
+                start_datetime,
+                response,
             )
 
-        _final_kwargs: dict[str, Any] = {
-            "content": final_contents,
-            "usage": usage,
-            "is_last": True,
-        }
-        if response_id:
-            _final_kwargs["id"] = response_id
-        yield ChatResponse(**_final_kwargs)
+        return await self._parse_completion_response(
+            start_datetime,
+            response,
+        )
 
-    def _parse_completion_response(
+    async def _parse_completion_response(
         self,
         start_datetime: datetime,
-        response: ChatCompletion,
+        response: Message,
     ) -> ChatResponse:
-        """Parse the MiniMax non-streaming response.
+        """Parse a non-streaming Anthropic-compatible response.
 
         Args:
             start_datetime (`datetime`):
                 The start datetime of the response generation.
-            response (`ChatCompletion`):
-                The OpenAI-compatible chat completion object.
+            response (`Message`):
+                Anthropic-compatible Message object to parse.
 
         Returns:
             `ChatResponse`:
-                A single ``ChatResponse`` with ``is_last=True``.
+                A single ``ChatResponse`` with ``is_last=True`` containing
+                the extracted content blocks and usage.
         """
-        content_blocks: List[TextBlock | ToolCallBlock | ThinkingBlock] = []
+        content_blocks: List[ThinkingBlock | TextBlock | ToolCallBlock] = []
 
-        if response.choices:
-            choice = response.choices[0]
-            reasoning = getattr(choice.message, "reasoning_content", None)
-            if isinstance(reasoning, str) and reasoning:
-                content_blocks.append(ThinkingBlock(thinking=reasoning))
+        if hasattr(response, "content") and response.content:
+            for content_block in response.content:
+                block_type = getattr(content_block, "type", None)
+                if block_type == "thinking":
+                    content_blocks.append(
+                        ThinkingBlock(
+                            thinking=content_block.thinking,
+                            signature=getattr(content_block, "signature", "") or "",
+                        ),
+                    )
+                elif block_type == "text":
+                    content_blocks.append(
+                        TextBlock(text=content_block.text),
+                    )
+                elif block_type == "tool_use":
+                    import json
 
-            if choice.message.content:
-                content_blocks.append(TextBlock(text=choice.message.content))
-
-            for tool_call in choice.message.tool_calls or []:
-                content_blocks.append(
-                    ToolCallBlock(
-                        id=tool_call.id,
-                        name=tool_call.function.name,
-                        input=tool_call.function.arguments,
-                    ),
-                )
+                    content_blocks.append(
+                        ToolCallBlock(
+                            id=content_block.id,
+                            name=content_block.name,
+                            input=json.dumps(content_block.input),
+                        ),
+                    )
 
         usage = None
         if response.usage:
             u = response.usage
-            details = getattr(u, "prompt_tokens_details", None)
             usage = ChatUsage(
-                input_tokens=u.prompt_tokens,
-                output_tokens=u.completion_tokens,
+                input_tokens=u.input_tokens,
+                output_tokens=u.output_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
-                cache_input_tokens=getattr(
-                    details,
-                    "cached_tokens",
+                cache_creation_input_tokens=getattr(
+                    u,
+                    "cache_creation_input_tokens",
                     0,
-                )
-                if details
-                else 0,
+                ),
+                cache_input_tokens=getattr(
+                    u,
+                    "cache_read_input_tokens",
+                    0,
+                ),
             )
 
         resp_kwargs: dict[str, Any] = {
@@ -393,18 +303,150 @@ class MiniMaxChatModel(ChatModelBase):
 
         return ChatResponse(**resp_kwargs)
 
+    async def _parse_stream_response(
+        self,
+        start_datetime: datetime,
+        response: AsyncStream,
+    ) -> AsyncGenerator[ChatResponse, None]:
+        """Parse a streaming Anthropic-compatible response.
+
+        Args:
+            start_datetime (`datetime`):
+                The start datetime of the response generation.
+            response (`AsyncStream`):
+                Anthropic-compatible AsyncStream object to parse.
+
+        Yields:
+            `ChatResponse`:
+                Incremental ``ChatResponse`` objects with ``is_last=False``
+                followed by a final one with ``is_last=True`` containing the
+                fully accumulated content blocks and usage.
+        """
+        usage = None
+        response_id: str | None = None
+        acc_text = TextBlock(text="")
+        acc_thinking = ThinkingBlock(thinking="")
+        thinking_signature = ""
+        acc_tool_calls: OrderedDict = OrderedDict()
+
+        async for event in response:
+            delta_content: list = []
+
+            if event.type == "message_start":
+                message = event.message
+                if response_id is None:
+                    response_id = getattr(message, "id", None)
+                if message.usage:
+                    u = message.usage
+                    usage = ChatUsage(
+                        input_tokens=u.input_tokens,
+                        output_tokens=getattr(u, "output_tokens", 0),
+                        time=(datetime.now() - start_datetime).total_seconds(),
+                        cache_creation_input_tokens=getattr(
+                            u,
+                            "cache_creation_input_tokens",
+                            0,
+                        ),
+                        cache_input_tokens=getattr(
+                            u,
+                            "cache_read_input_tokens",
+                            0,
+                        ),
+                    )
+
+            elif event.type == "content_block_start":
+                if event.content_block.type == "tool_use":
+                    block_index = event.index
+                    tool_block = event.content_block
+                    acc_tool_calls[block_index] = {
+                        "id": tool_block.id,
+                        "name": tool_block.name,
+                        "input": "",
+                    }
+
+            elif event.type == "content_block_delta":
+                block_index = event.index
+                delta = event.delta
+                if delta.type == "text_delta":
+                    acc_text.text += delta.text
+                    delta_content.append(
+                        TextBlock(id=acc_text.id, text=delta.text),
+                    )
+                elif delta.type == "thinking_delta":
+                    acc_thinking.thinking += delta.thinking
+                    delta_content.append(
+                        ThinkingBlock(
+                            id=acc_thinking.id,
+                            thinking=delta.thinking,
+                        ),
+                    )
+                elif delta.type == "signature_delta":
+                    thinking_signature = delta.signature
+                elif delta.type == "input_json_delta" and block_index in acc_tool_calls:
+                    fragment = delta.partial_json or ""
+                    acc_tool_calls[block_index]["input"] += fragment
+                    tc = acc_tool_calls[block_index]
+                    delta_content.append(
+                        ToolCallBlock(
+                            id=tc["id"],
+                            name=tc["name"],
+                            input=fragment,
+                        ),
+                    )
+
+            elif event.type == "message_delta":
+                if event.usage and usage:
+                    usage.output_tokens = event.usage.output_tokens
+
+            if delta_content:
+                _kwargs: dict[str, Any] = {
+                    "content": delta_content,
+                    "is_last": False,
+                    "usage": usage,
+                }
+                if response_id:
+                    _kwargs["id"] = response_id
+                yield ChatResponse(**_kwargs)
+
+        # Build final accumulated content
+        final_content: list = []
+        if acc_thinking.thinking:
+            acc_thinking.signature = thinking_signature
+            final_content.append(acc_thinking)
+        if acc_text.text:
+            final_content.append(acc_text)
+        for tc in acc_tool_calls.values():
+            final_content.append(
+                ToolCallBlock(
+                    id=tc["id"],
+                    name=tc["name"],
+                    input=tc["input"],
+                ),
+            )
+
+        _final_kwargs: dict[str, Any] = {
+            "content": final_content,
+            "is_last": True,
+            "usage": usage,
+        }
+        if response_id:
+            _final_kwargs["id"] = response_id
+        yield ChatResponse(**_final_kwargs)
+
     def _format_tools(
         self,
         tools: list[dict] | None,
         tool_choice: ToolChoice | None,
-    ) -> tuple[list[dict] | None, str | dict | None]:
-        """Validate, filter, and format tools and tool_choice for the MiniMax
-        API.
+    ) -> tuple[list[dict] | None, dict | None]:
+        """Validate and format tools and tool_choice for the
+        Anthropic-compatible API.
 
-        When ``tool_choice.tools`` is specified the schemas list is filtered
-        to only those tools. When ``tool_choice.mode`` is a specific tool name
-        (str) the model is forced to call exactly that tool without needing to
-        filter the list, preserving prompt-cache efficiency.
+        Converts OpenAI-style tool schemas to Anthropic's flat format and
+        maps tool_choice modes to Anthropic's type-based format. When
+        ``tool_choice.tools`` is specified the schemas list is filtered to
+        only those tools. When ``tool_choice.mode`` is a specific tool name
+        (str) the model is forced to call exactly that tool without needing
+        to filter the list, preserving prompt-cache efficiency.
 
         Args:
             tools (`list[dict] | None`, optional):
@@ -413,7 +455,7 @@ class MiniMaxChatModel(ChatModelBase):
                 The tool choice configuration.
 
         Returns:
-            `tuple[list[dict] | None, str | dict | None]`:
+            `tuple[list[dict] | None, dict | None]`:
                 A tuple of (formatted_tools, formatted_tool_choice).
         """
         if tool_choice and tools:
@@ -422,15 +464,45 @@ class MiniMaxChatModel(ChatModelBase):
                 allowed = set(tool_choice.tools)
                 tools = [t for t in tools if t["function"]["name"] in allowed]
 
+        fmt_tools = None
+        if tools:
+            fmt_tools = []
+            for schema in tools:
+                assert "function" in schema, (
+                    f"Invalid schema: {schema}, expect key 'function'."
+                )
+                assert "name" in schema["function"], (
+                    f"Invalid schema: {schema}, expect key 'name' in 'function' field."
+                )
+                fmt_tools.append(
+                    {
+                        "name": schema["function"]["name"],
+                        "description": schema["function"].get(
+                            "description",
+                            "",
+                        ),
+                        "input_schema": schema["function"].get(
+                            "parameters",
+                            {},
+                        ),
+                    },
+                )
+
         if not tool_choice:
-            return tools, None
+            return fmt_tools, None
 
         mode = tool_choice.mode
 
         if mode not in _TOOL_CHOICE_LITERAL_MODES:
-            return tools, {"type": "function", "function": {"name": mode}}
+            # mode is a specific tool name — force call it
+            return fmt_tools, {"type": "tool", "name": mode}
 
-        return tools, mode
+        type_mapping = {
+            "auto": {"type": "auto"},
+            "none": {"type": "none"},
+            "required": {"type": "any"},
+        }
+        return fmt_tools, type_mapping[mode]
 
     async def _call_api_with_structured_output(
         self,
@@ -442,12 +514,10 @@ class MiniMaxChatModel(ChatModelBase):
     ) -> StructuredResponse:
         """MiniMax-specific override for structured output.
 
-        MiniMax does not support ``response_format``. The base class uses
-        ``response_format`` to drive structured output via JSON schema; here
-        we delegate to the base implementation, but the request that reaches
-        MiniMax will not include ``response_format`` because we never forward
-        it from ``_call_api``. Tool calls are used as the structured-output
-        channel.
+        Mirrors :class:`AnthropicChatModel`'s behaviour: when thinking is
+        enabled, force ``tool_choice="auto"`` because the
+        Anthropic-compatible API rejects any forcing form (``"any"`` or a
+        specific tool) while extended thinking is on.
 
         Args:
             model_name (`str`):
@@ -458,7 +528,10 @@ class MiniMaxChatModel(ChatModelBase):
                 A Pydantic model class or a JSON schema dict describing the
                 required output structure.
             tool_choice (`ToolChoice | None`, defaults to `None`):
-                The tool_choice forwarded to ``_call_api``.
+                The tool_choice forwarded to ``_call_api``. When ``None``
+                and thinking mode is enabled, it is downgraded to
+                ``ToolChoice(mode="auto")``; otherwise the base default
+                (force the structured-output tool) is used.
             **kwargs (`Any`):
                 Additional keyword arguments forwarded to ``_call_api``.
 
@@ -467,6 +540,8 @@ class MiniMaxChatModel(ChatModelBase):
                 The structured response whose ``content`` is the validated
                 output dict matching ``structured_model``.
         """
+        if tool_choice is None and self.parameters.thinking_enable:
+            tool_choice = ToolChoice(mode="auto")
         return await super()._call_api_with_structured_output(
             model_name=model_name,
             messages=messages,

--- a/src/agentscope/model/_minimax/_model.py
+++ b/src/agentscope/model/_minimax/_model.py
@@ -52,7 +52,8 @@ class MiniMaxChatModel(ChatModelBase):
             default=None,
             title="Max Tokens",
             description=(
-                "The maximum number of tokens to generate in the chat completion."
+                "The maximum number of tokens to generate in the chat "
+                "completion."
             ),
             gt=0,
         )
@@ -255,7 +256,8 @@ class MiniMaxChatModel(ChatModelBase):
                     content_blocks.append(
                         ThinkingBlock(
                             thinking=content_block.thinking,
-                            signature=getattr(content_block, "signature", "") or "",
+                            signature=getattr(content_block, "signature", "")
+                            or "",
                         ),
                     )
                 elif block_type == "text":
@@ -382,7 +384,10 @@ class MiniMaxChatModel(ChatModelBase):
                     )
                 elif delta.type == "signature_delta":
                     thinking_signature = delta.signature
-                elif delta.type == "input_json_delta" and block_index in acc_tool_calls:
+                elif (
+                    delta.type == "input_json_delta"
+                    and block_index in acc_tool_calls
+                ):
                     fragment = delta.partial_json or ""
                     acc_tool_calls[block_index]["input"] += fragment
                     tc = acc_tool_calls[block_index]
@@ -468,11 +473,12 @@ class MiniMaxChatModel(ChatModelBase):
         if tools:
             fmt_tools = []
             for schema in tools:
-                assert "function" in schema, (
-                    f"Invalid schema: {schema}, expect key 'function'."
-                )
+                assert (
+                    "function" in schema
+                ), f"Invalid schema: {schema}, expect key 'function'."
                 assert "name" in schema["function"], (
-                    f"Invalid schema: {schema}, expect key 'name' in 'function' field."
+                    f"Invalid schema: {schema}, expect key 'name' in "
+                    "'function' field."
                 )
                 fmt_tools.append(
                     {

--- a/src/agentscope/model/_minimax/_models/MiniMax-M2.7-highspeed.yaml
+++ b/src/agentscope/model/_minimax/_models/MiniMax-M2.7-highspeed.yaml
@@ -1,0 +1,12 @@
+name: MiniMax-M2.7-highspeed
+label: MiniMax M2.7 Highspeed
+status: active
+
+input_types:
+  - text/plain
+
+output_types:
+  - text/plain
+
+context_size: 200000
+output_size: 32000

--- a/src/agentscope/model/_minimax/_models/MiniMax-M2.7.yaml
+++ b/src/agentscope/model/_minimax/_models/MiniMax-M2.7.yaml
@@ -1,0 +1,12 @@
+name: MiniMax-M2.7
+label: MiniMax M2.7
+status: active
+
+input_types:
+  - text/plain
+
+output_types:
+  - text/plain
+
+context_size: 200000
+output_size: 32000

--- a/src/agentscope/model/_minimax/_models/MiniMax-M3.yaml
+++ b/src/agentscope/model/_minimax/_models/MiniMax-M3.yaml
@@ -1,0 +1,20 @@
+name: MiniMax-M3
+label: MiniMax M3
+status: active
+
+input_types:
+  - text/plain
+  - image/jpeg
+  - image/png
+  - image/gif
+  - image/webp
+
+output_types:
+  - text/plain
+
+context_size: 512000
+output_size: 128000
+
+parameter_overrides:
+  max_tokens:
+    maximum: 128000

--- a/tests/model_minimax_test.py
+++ b/tests/model_minimax_test.py
@@ -2,12 +2,19 @@
 # pylint: disable=protected-access
 """Unit tests for MiniMaxChatModel with mocked API responses.
 
-Tests cover both non-streaming and streaming modes, verifying that:
+MiniMax's M-series chat models run through MiniMax's officially
+recommended Anthropic-compatible API, so the tests follow the same
+shape as :mod:`tests.model_anthropic_test`:
+
 - Non-stream mode returns a single ChatResponse with is_last=True.
-- Stream mode yields n delta ChatResponses (is_last=False) followed by
-  1 final ChatResponse (is_last=True) with the full accumulated content.
+- Stream mode yields delta ChatResponses (is_last=False) followed by a
+  final ChatResponse (is_last=True) with the full accumulated content.
+- ``_format_tools`` converts OpenAI-style schemas into Anthropic's flat
+  format and maps modes to Anthropic's type-based tool_choice.
 - Model card listing returns the expected MiniMax models.
 """
+
+import json
 from typing import Any
 import unittest
 from unittest import IsolatedAsyncioTestCase
@@ -40,107 +47,67 @@ def _make_model(stream: bool = False) -> Any:
 def _mock_completion(
     text: Any = None,
     tool_calls: Any = None,
-    reasoning: Any = None,
-    response_id: str = "minimax-1",
+    thinking: Any = None,
+    response_id: str = "msg-1",
 ) -> MagicMock:
-    """Build a mock non-streaming ChatCompletion response."""
-    msg = MagicMock()
-    msg.content = text
-    msg.reasoning_content = reasoning
-    msg.tool_calls = None
-
+    """Build a mock non-streaming Anthropic-compatible Message response."""
+    blocks = []
+    if thinking:
+        b = MagicMock()
+        b.type = "thinking"
+        b.thinking = thinking
+        b.signature = "sig123"
+        blocks.append(b)
+    if text:
+        b = MagicMock()
+        b.type = "text"
+        b.text = text
+        blocks.append(b)
     if tool_calls:
-        tc_mocks = []
         for tc in tool_calls:
-            m = MagicMock()
-            m.id = tc["id"]
-            m.function.name = tc["name"]
-            m.function.arguments = tc["arguments"]
-            tc_mocks.append(m)
-        msg.tool_calls = tc_mocks
-
-    choice = MagicMock()
-    choice.message = msg
+            b = MagicMock()
+            b.type = "tool_use"
+            b.id = tc["id"]
+            b.name = tc["name"]
+            b.input = tc["input"]
+            blocks.append(b)
 
     resp = MagicMock()
     resp.id = response_id
-    resp.choices = [choice]
-    resp.usage.prompt_tokens = 10
-    resp.usage.completion_tokens = 5
-    resp.usage.prompt_tokens_details = None
+    resp.content = blocks
+    resp.usage = MagicMock()
+    resp.usage.input_tokens = 10
+    resp.usage.output_tokens = 5
+    resp.usage.cache_creation_input_tokens = 0
+    resp.usage.cache_read_input_tokens = 0
     return resp
 
 
-def _make_stream_chunk(
-    delta_text: str | None = None,
-    delta_reasoning: str | None = None,
-    tool_calls: list | None = None,
-    response_id: str = "minimax-1",
-    usage: dict | None = None,
-    has_choices: bool = True,
-) -> MagicMock:
-    """Build a single mock streaming chunk."""
-    chunk = MagicMock()
-    chunk.id = response_id
-
-    if usage:
-        chunk.usage = MagicMock()
-        chunk.usage.prompt_tokens = usage.get("prompt_tokens", 0)
-        chunk.usage.completion_tokens = usage.get("completion_tokens", 0)
-        chunk.usage.prompt_tokens_details = None
-    else:
-        chunk.usage = None
-
-    if has_choices:
-        delta = MagicMock()
-        delta.content = delta_text
-        delta.reasoning_content = delta_reasoning
-        delta.tool_calls = tool_calls
-        choice = MagicMock()
-        choice.delta = delta
-        chunk.choices = [choice]
-    else:
-        chunk.choices = []
-    return chunk
+def _make_event(event_type: str, **kwargs: Any) -> MagicMock:
+    """Build a mock Anthropic-compatible streaming event."""
+    event = MagicMock()
+    event.type = event_type
+    for key, val in kwargs.items():
+        setattr(event, key, val)
+    return event
 
 
-def _make_tool_call_delta(
-    index: int,
-    id_: str | None,
-    name: str | None,
-    arguments: str,
-) -> MagicMock:
-    """Build a single tool-call delta for stream chunks."""
-    tc = MagicMock()
-    tc.index = index
-    tc.id = id_
-    tc.function.name = name
-    tc.function.arguments = arguments
-    return tc
+class _MockAsyncEventStream:
+    """Mock async iterator over Anthropic-compatible events."""
 
-
-class _MockAsyncStream:
-    """Minimal async context-manager + iterator that yields prebuilt chunks."""
-
-    def __init__(self, chunks: list) -> None:
-        self._chunks = chunks
+    def __init__(self, events: list) -> None:
+        self._events = events
         self._index = 0
 
-    async def __aenter__(self) -> "_MockAsyncStream":
-        return self
-
-    async def __aexit__(self, *args: Any) -> None:
-        pass
-
-    def __aiter__(self) -> "_MockAsyncStream":
+    def __aiter__(self) -> "_MockAsyncEventStream":
         return self
 
     async def __anext__(self) -> Any:
-        if self._index >= len(self._chunks):
+        if self._index >= len(self._events):
             raise StopAsyncIteration
-        chunk = self._chunks[self._index]
+        event = self._events[self._index]
         self._index += 1
-        return chunk
+        return event
 
 
 # ---------------------------------------------------------------------------
@@ -154,13 +121,13 @@ class TestMiniMaxNonStream(IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         self.model = _make_model(stream=False)
 
-    @patch("openai.AsyncClient")
+    @patch("anthropic.AsyncAnthropic")
     async def test_text_response(self, mock_client_cls: MagicMock) -> None:
         """Non-stream text response returns a single ChatResponse."""
         mock_create = AsyncMock(
             return_value=_mock_completion(text="Hello!"),
         )
-        mock_client_cls.return_value.chat.completions.create = mock_create
+        mock_client_cls.return_value.messages.create = mock_create
 
         result = await self.model([])
 
@@ -168,9 +135,9 @@ class TestMiniMaxNonStream(IsolatedAsyncioTestCase):
             (result.is_last, result.content),
             (True, [TextBlock.model_construct(id=A, text="Hello!")]),
         )
-        self.assertEqual(result.id, "minimax-1")
+        self.assertEqual(result.id, "msg-1")
 
-    @patch("openai.AsyncClient")
+    @patch("anthropic.AsyncAnthropic")
     async def test_tool_call_response(
         self,
         mock_client_cls: MagicMock,
@@ -180,14 +147,14 @@ class TestMiniMaxNonStream(IsolatedAsyncioTestCase):
             return_value=_mock_completion(
                 tool_calls=[
                     {
-                        "id": "call-1",
+                        "id": "toolu_1",
                         "name": "get_weather",
-                        "arguments": '{"city":"Shanghai"}',
+                        "input": {"city": "Shanghai"},
                     },
                 ],
             ),
         )
-        mock_client_cls.return_value.chat.completions.create = mock_create
+        mock_client_cls.return_value.messages.create = mock_create
 
         result = await self.model([])
 
@@ -197,27 +164,27 @@ class TestMiniMaxNonStream(IsolatedAsyncioTestCase):
                 True,
                 [
                     ToolCallBlock(
-                        id="call-1",
+                        id="toolu_1",
                         name="get_weather",
-                        input='{"city":"Shanghai"}',
+                        input=json.dumps({"city": "Shanghai"}),
                     ),
                 ],
             ),
         )
 
-    @patch("openai.AsyncClient")
+    @patch("anthropic.AsyncAnthropic")
     async def test_thinking_response(
         self,
         mock_client_cls: MagicMock,
     ) -> None:
-        """Non-stream response with reasoning creates ThinkingBlock."""
+        """Non-stream response with thinking creates ThinkingBlock."""
         mock_create = AsyncMock(
             return_value=_mock_completion(
+                thinking="Step by step...",
                 text="42",
-                reasoning="Step by step...",
             ),
         )
-        mock_client_cls.return_value.chat.completions.create = mock_create
+        mock_client_cls.return_value.messages.create = mock_create
 
         result = await self.model([])
 
@@ -229,6 +196,7 @@ class TestMiniMaxNonStream(IsolatedAsyncioTestCase):
                     ThinkingBlock.model_construct(
                         id=A,
                         thinking="Step by step...",
+                        signature="sig123",
                     ),
                     TextBlock.model_construct(id=A, text="42"),
                 ],
@@ -239,36 +207,24 @@ class TestMiniMaxNonStream(IsolatedAsyncioTestCase):
 class TestMiniMaxModelParameters(unittest.TestCase):
     """Tests for MiniMaxChatModel.Parameters."""
 
-    def test_default_temperature_is_one(self) -> None:
-        """Default temperature is 1.0 (MiniMax requires non-zero)."""
+    def test_default_thinking_disabled(self) -> None:
+        """Extended thinking is off by default to match other chat models."""
         params = MiniMaxChatModel.Parameters()
-        self.assertEqual(params.temperature, 1.0)
+        self.assertIs(params.thinking_enable, False)
+        self.assertIsNone(params.thinking_budget)
 
-    def test_temperature_must_be_positive(self) -> None:
-        """Zero or negative temperature is rejected (range (0.0, 1.0])."""
+    def test_thinking_budget_must_be_positive(self) -> None:
+        """thinking_budget must be > 0 when provided."""
         from pydantic import ValidationError
 
         with self.assertRaises(ValidationError):
-            MiniMaxChatModel.Parameters(temperature=0.0)
+            MiniMaxChatModel.Parameters(thinking_budget=0)
 
-        with self.assertRaises(ValidationError):
-            MiniMaxChatModel.Parameters(temperature=1.5)
-
-    def test_default_base_url_is_minimax(self) -> None:
-        """Default base URL points to the overseas MiniMax endpoint."""
+    def test_default_base_url_is_anthropic_compatible(self) -> None:
+        """Default base URL points to MiniMax's Anthropic-compatible
+        endpoint."""
         cred = MiniMaxCredential(api_key="test")
-        self.assertEqual(cred.base_url, "https://api.minimax.io/v1")
-
-    def test_temperature_override_is_stored(self) -> None:
-        """Explicit temperature override is honored."""
-        model = MiniMaxChatModel(
-            credential=MiniMaxCredential(api_key="test"),
-            model="MiniMax-M3",
-            stream=False,
-            context_size=512_000,
-            parameters=MiniMaxChatModel.Parameters(temperature=0.7),
-        )
-        self.assertEqual(model.parameters.temperature, 0.7)
+        self.assertEqual(cred.base_url, "https://api.minimax.io/anthropic")
 
 
 # ---------------------------------------------------------------------------
@@ -282,20 +238,40 @@ class TestMiniMaxStream(IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         self.model = _make_model(stream=True)
 
-    @patch("openai.AsyncClient")
+    @patch("anthropic.AsyncAnthropic")
     async def test_stream_text(self, mock_client_cls: MagicMock) -> None:
-        """Stream text yields n deltas (is_last=False) + 1 final
-        (is_last=True) with full content."""
-        chunks = [
-            _make_stream_chunk(delta_text="Hi"),
-            _make_stream_chunk(delta_text=" there"),
-            _make_stream_chunk(
-                has_choices=False,
-                usage={"prompt_tokens": 10, "completion_tokens": 2},
-            ),
+        """Stream text yields n deltas + 1 final with full content."""
+        msg_usage = MagicMock()
+        msg_usage.input_tokens = 10
+        msg_usage.output_tokens = 0
+        msg_usage.cache_creation_input_tokens = 0
+        msg_usage.cache_read_input_tokens = 0
+
+        message = MagicMock()
+        message.id = "msg-1"
+        message.usage = msg_usage
+
+        delta1 = MagicMock()
+        delta1.type = "text_delta"
+        delta1.text = "Hi"
+
+        delta2 = MagicMock()
+        delta2.type = "text_delta"
+        delta2.text = " there"
+
+        msg_delta_usage = MagicMock()
+        msg_delta_usage.output_tokens = 2
+
+        events = [
+            _make_event("message_start", message=message),
+            _make_event("content_block_delta", index=0, delta=delta1),
+            _make_event("content_block_delta", index=0, delta=delta2),
+            _make_event("message_delta", usage=msg_delta_usage),
         ]
-        mock_create = AsyncMock(return_value=_MockAsyncStream(chunks))
-        mock_client_cls.return_value.chat.completions.create = mock_create
+        mock_create = AsyncMock(
+            return_value=_MockAsyncEventStream(events),
+        )
+        mock_client_cls.return_value.messages.create = mock_create
 
         gen = await self.model([])
         responses = [r async for r in gen]
@@ -308,24 +284,46 @@ class TestMiniMaxStream(IsolatedAsyncioTestCase):
                 (True, [TextBlock.model_construct(id=A, text="Hi there")]),
             ],
         )
+        self.assertEqual(responses[-1].id, "msg-1")
 
-    @patch("openai.AsyncClient")
-    async def test_stream_thinking_then_text(
+    @patch("anthropic.AsyncAnthropic")
+    async def test_stream_thinking_and_text(
         self,
         mock_client_cls: MagicMock,
     ) -> None:
-        """MiniMax yields thinking chunks separately before text."""
-        chunks = [
-            _make_stream_chunk(delta_reasoning="Let me"),
-            _make_stream_chunk(delta_reasoning=" think"),
-            _make_stream_chunk(delta_text="Result"),
-            _make_stream_chunk(
-                has_choices=False,
-                usage={"prompt_tokens": 10, "completion_tokens": 5},
-            ),
+        """Stream thinking + text yields deltas then final with signature."""
+        msg_usage = MagicMock()
+        msg_usage.input_tokens = 10
+        msg_usage.output_tokens = 0
+        msg_usage.cache_creation_input_tokens = 0
+        msg_usage.cache_read_input_tokens = 0
+
+        message = MagicMock()
+        message.id = "msg-2"
+        message.usage = msg_usage
+
+        thinking_delta = MagicMock()
+        thinking_delta.type = "thinking_delta"
+        thinking_delta.thinking = "Let me think"
+
+        sig_delta = MagicMock()
+        sig_delta.type = "signature_delta"
+        sig_delta.signature = "sig_abc"
+
+        text_delta = MagicMock()
+        text_delta.type = "text_delta"
+        text_delta.text = "Result"
+
+        events = [
+            _make_event("message_start", message=message),
+            _make_event("content_block_delta", index=0, delta=thinking_delta),
+            _make_event("content_block_delta", index=0, delta=sig_delta),
+            _make_event("content_block_delta", index=1, delta=text_delta),
         ]
-        mock_create = AsyncMock(return_value=_MockAsyncStream(chunks))
-        mock_client_cls.return_value.chat.completions.create = mock_create
+        mock_create = AsyncMock(
+            return_value=_MockAsyncEventStream(events),
+        )
+        mock_client_cls.return_value.messages.create = mock_create
 
         gen = await self.model([])
         responses = [r async for r in gen]
@@ -335,11 +333,12 @@ class TestMiniMaxStream(IsolatedAsyncioTestCase):
             [
                 (
                     False,
-                    [ThinkingBlock.model_construct(id=A, thinking="Let me")],
-                ),
-                (
-                    False,
-                    [ThinkingBlock.model_construct(id=A, thinking=" think")],
+                    [
+                        ThinkingBlock.model_construct(
+                            id=A,
+                            thinking="Let me think",
+                        ),
+                    ],
                 ),
                 (False, [TextBlock.model_construct(id=A, text="Result")]),
                 (
@@ -348,6 +347,7 @@ class TestMiniMaxStream(IsolatedAsyncioTestCase):
                         ThinkingBlock.model_construct(
                             id=A,
                             thinking="Let me think",
+                            signature="sig_abc",
                         ),
                         TextBlock.model_construct(id=A, text="Result"),
                     ],
@@ -355,30 +355,50 @@ class TestMiniMaxStream(IsolatedAsyncioTestCase):
             ],
         )
 
-    @patch("openai.AsyncClient")
-    async def test_stream_tool_calls(
+    @patch("anthropic.AsyncAnthropic")
+    async def test_stream_tool_call(
         self,
         mock_client_cls: MagicMock,
     ) -> None:
-        """Stream tool calls accumulate across chunks into final response."""
-        chunks = [
-            _make_stream_chunk(
-                tool_calls=[
-                    _make_tool_call_delta(0, "call-1", "search", '{"q":'),
-                ],
+        """Stream tool call yields partial deltas then full accumulated
+        input."""
+        msg_usage = MagicMock()
+        msg_usage.input_tokens = 10
+        msg_usage.output_tokens = 0
+        msg_usage.cache_creation_input_tokens = 0
+        msg_usage.cache_read_input_tokens = 0
+
+        message = MagicMock()
+        message.id = "msg-3"
+        message.usage = msg_usage
+
+        tool_block = MagicMock()
+        tool_block.type = "tool_use"
+        tool_block.id = "toolu_1"
+        tool_block.name = "search"
+
+        json_delta1 = MagicMock()
+        json_delta1.type = "input_json_delta"
+        json_delta1.partial_json = '{"q":'
+
+        json_delta2 = MagicMock()
+        json_delta2.type = "input_json_delta"
+        json_delta2.partial_json = '"test"}'
+
+        events = [
+            _make_event("message_start", message=message),
+            _make_event(
+                "content_block_start",
+                index=0,
+                content_block=tool_block,
             ),
-            _make_stream_chunk(
-                tool_calls=[
-                    _make_tool_call_delta(0, None, None, '"test"}'),
-                ],
-            ),
-            _make_stream_chunk(
-                has_choices=False,
-                usage={"prompt_tokens": 10, "completion_tokens": 5},
-            ),
+            _make_event("content_block_delta", index=0, delta=json_delta1),
+            _make_event("content_block_delta", index=0, delta=json_delta2),
         ]
-        mock_create = AsyncMock(return_value=_MockAsyncStream(chunks))
-        mock_client_cls.return_value.chat.completions.create = mock_create
+        mock_create = AsyncMock(
+            return_value=_MockAsyncEventStream(events),
+        )
+        mock_client_cls.return_value.messages.create = mock_create
 
         gen = await self.model([])
         responses = [r async for r in gen]
@@ -390,7 +410,7 @@ class TestMiniMaxStream(IsolatedAsyncioTestCase):
                     False,
                     [
                         ToolCallBlock(
-                            id="call-1",
+                            id="toolu_1",
                             name="search",
                             input='{"q":',
                         ),
@@ -400,7 +420,7 @@ class TestMiniMaxStream(IsolatedAsyncioTestCase):
                     False,
                     [
                         ToolCallBlock(
-                            id="call-1",
+                            id="toolu_1",
                             name="search",
                             input='"test"}',
                         ),
@@ -410,7 +430,7 @@ class TestMiniMaxStream(IsolatedAsyncioTestCase):
                     True,
                     [
                         ToolCallBlock(
-                            id="call-1",
+                            id="toolu_1",
                             name="search",
                             input='{"q":"test"}',
                         ),
@@ -451,6 +471,27 @@ _FT_TOOLS = [
     },
 ]
 
+_FT_TOOLS_ANTHROPIC = [
+    {
+        "name": "get_weather",
+        "description": "Get the weather",
+        "input_schema": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+    {
+        "name": "get_time",
+        "description": "Get the time",
+        "input_schema": {
+            "type": "object",
+            "properties": {"timezone": {"type": "string"}},
+            "required": ["timezone"],
+        },
+    },
+]
+
 
 class TestMiniMaxFormatTools(unittest.TestCase):
     """Tests for MiniMaxChatModel._format_tools."""
@@ -460,42 +501,42 @@ class TestMiniMaxFormatTools(unittest.TestCase):
         self.model = _make_model()
 
     def test_auto_mode(self) -> None:
-        """Auto mode returns tools unchanged and string 'auto'."""
+        """Auto mode returns converted tools and type=auto."""
         fmt_tools, fmt_choice = self.model._format_tools(
             _FT_TOOLS,
             ToolChoice(mode="auto"),
         )
-        self.assertEqual(fmt_tools, _FT_TOOLS)
-        self.assertEqual(fmt_choice, "auto")
+        self.assertEqual(fmt_tools, _FT_TOOLS_ANTHROPIC)
+        self.assertEqual(fmt_choice, {"type": "auto"})
 
     def test_none_mode(self) -> None:
-        """None mode returns tools unchanged and string 'none'."""
+        """None mode returns converted tools and type=none."""
         fmt_tools, fmt_choice = self.model._format_tools(
             _FT_TOOLS,
             ToolChoice(mode="none"),
         )
-        self.assertEqual(fmt_tools, _FT_TOOLS)
-        self.assertEqual(fmt_choice, "none")
+        self.assertEqual(fmt_tools, _FT_TOOLS_ANTHROPIC)
+        self.assertEqual(fmt_choice, {"type": "none"})
 
     def test_required_mode(self) -> None:
-        """Required mode returns tools unchanged and string 'required'."""
+        """Required mode maps to type=any."""
         fmt_tools, fmt_choice = self.model._format_tools(
             _FT_TOOLS,
             ToolChoice(mode="required"),
         )
-        self.assertEqual(fmt_tools, _FT_TOOLS)
-        self.assertEqual(fmt_choice, "required")
+        self.assertEqual(fmt_tools, _FT_TOOLS_ANTHROPIC)
+        self.assertEqual(fmt_choice, {"type": "any"})
 
     def test_str_mode_force_call(self) -> None:
-        """A specific tool name returns a type=function dict."""
+        """A specific tool name returns a type=tool dict."""
         fmt_tools, fmt_choice = self.model._format_tools(
             _FT_TOOLS,
             ToolChoice(mode="get_weather"),
         )
-        self.assertEqual(fmt_tools, _FT_TOOLS)
+        self.assertEqual(fmt_tools, _FT_TOOLS_ANTHROPIC)
         self.assertEqual(
             fmt_choice,
-            {"type": "function", "function": {"name": "get_weather"}},
+            {"type": "tool", "name": "get_weather"},
         )
 
     def test_tools_filtered(self) -> None:
@@ -505,13 +546,13 @@ class TestMiniMaxFormatTools(unittest.TestCase):
             ToolChoice(mode="auto", tools=["get_weather"]),
         )
         self.assertEqual(len(fmt_tools), 1)
-        self.assertEqual(fmt_tools[0]["function"]["name"], "get_weather")
-        self.assertEqual(fmt_choice, "auto")
+        self.assertEqual(fmt_tools[0]["name"], "get_weather")
+        self.assertEqual(fmt_choice, {"type": "auto"})
 
     def test_no_tool_choice(self) -> None:
-        """Without tool_choice, returns tools and None."""
+        """Without tool_choice, returns converted tools and None."""
         fmt_tools, fmt_choice = self.model._format_tools(_FT_TOOLS, None)
-        self.assertEqual(fmt_tools, _FT_TOOLS)
+        self.assertEqual(fmt_tools, _FT_TOOLS_ANTHROPIC)
         self.assertIsNone(fmt_choice)
 
 

--- a/tests/model_minimax_test.py
+++ b/tests/model_minimax_test.py
@@ -1,0 +1,555 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Unit tests for MiniMaxChatModel with mocked API responses.
+
+Tests cover both non-streaming and streaming modes, verifying that:
+- Non-stream mode returns a single ChatResponse with is_last=True.
+- Stream mode yields n delta ChatResponses (is_last=False) followed by
+  1 final ChatResponse (is_last=True) with the full accumulated content.
+- Model card listing returns the expected MiniMax models.
+"""
+from typing import Any
+import unittest
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from utils import AnyString
+
+from agentscope.message import TextBlock, ToolCallBlock, ThinkingBlock
+from agentscope.model import MiniMaxChatModel
+from agentscope.credential import MiniMaxCredential
+from agentscope.tool import ToolChoice
+
+A = AnyString()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_model(stream: bool = False) -> Any:
+    return MiniMaxChatModel(
+        credential=MiniMaxCredential(api_key="test"),
+        model="MiniMax-M3",
+        stream=stream,
+        context_size=512_000,
+    )
+
+
+def _mock_completion(
+    text: Any = None,
+    tool_calls: Any = None,
+    reasoning: Any = None,
+    response_id: str = "minimax-1",
+) -> MagicMock:
+    """Build a mock non-streaming ChatCompletion response."""
+    msg = MagicMock()
+    msg.content = text
+    msg.reasoning_content = reasoning
+    msg.tool_calls = None
+
+    if tool_calls:
+        tc_mocks = []
+        for tc in tool_calls:
+            m = MagicMock()
+            m.id = tc["id"]
+            m.function.name = tc["name"]
+            m.function.arguments = tc["arguments"]
+            tc_mocks.append(m)
+        msg.tool_calls = tc_mocks
+
+    choice = MagicMock()
+    choice.message = msg
+
+    resp = MagicMock()
+    resp.id = response_id
+    resp.choices = [choice]
+    resp.usage.prompt_tokens = 10
+    resp.usage.completion_tokens = 5
+    resp.usage.prompt_tokens_details = None
+    return resp
+
+
+def _make_stream_chunk(
+    delta_text: str | None = None,
+    delta_reasoning: str | None = None,
+    tool_calls: list | None = None,
+    response_id: str = "minimax-1",
+    usage: dict | None = None,
+    has_choices: bool = True,
+) -> MagicMock:
+    """Build a single mock streaming chunk."""
+    chunk = MagicMock()
+    chunk.id = response_id
+
+    if usage:
+        chunk.usage = MagicMock()
+        chunk.usage.prompt_tokens = usage.get("prompt_tokens", 0)
+        chunk.usage.completion_tokens = usage.get("completion_tokens", 0)
+        chunk.usage.prompt_tokens_details = None
+    else:
+        chunk.usage = None
+
+    if has_choices:
+        delta = MagicMock()
+        delta.content = delta_text
+        delta.reasoning_content = delta_reasoning
+        delta.tool_calls = tool_calls
+        choice = MagicMock()
+        choice.delta = delta
+        chunk.choices = [choice]
+    else:
+        chunk.choices = []
+    return chunk
+
+
+def _make_tool_call_delta(
+    index: int,
+    id_: str | None,
+    name: str | None,
+    arguments: str,
+) -> MagicMock:
+    """Build a single tool-call delta for stream chunks."""
+    tc = MagicMock()
+    tc.index = index
+    tc.id = id_
+    tc.function.name = name
+    tc.function.arguments = arguments
+    return tc
+
+
+class _MockAsyncStream:
+    """Minimal async context-manager + iterator that yields prebuilt chunks."""
+
+    def __init__(self, chunks: list) -> None:
+        self._chunks = chunks
+        self._index = 0
+
+    async def __aenter__(self) -> "_MockAsyncStream":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        pass
+
+    def __aiter__(self) -> "_MockAsyncStream":
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._index >= len(self._chunks):
+            raise StopAsyncIteration
+        chunk = self._chunks[self._index]
+        self._index += 1
+        return chunk
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming tests
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxNonStream(IsolatedAsyncioTestCase):
+    """Tests for MiniMaxChatModel in non-streaming mode."""
+
+    def setUp(self) -> None:
+        self.model = _make_model(stream=False)
+
+    @patch("openai.AsyncClient")
+    async def test_text_response(self, mock_client_cls: MagicMock) -> None:
+        """Non-stream text response returns a single ChatResponse."""
+        mock_create = AsyncMock(
+            return_value=_mock_completion(text="Hello!"),
+        )
+        mock_client_cls.return_value.chat.completions.create = mock_create
+
+        result = await self.model([])
+
+        self.assertEqual(
+            (result.is_last, result.content),
+            (True, [TextBlock.model_construct(id=A, text="Hello!")]),
+        )
+        self.assertEqual(result.id, "minimax-1")
+
+    @patch("openai.AsyncClient")
+    async def test_tool_call_response(
+        self,
+        mock_client_cls: MagicMock,
+    ) -> None:
+        """Non-stream tool call response creates ToolCallBlocks."""
+        mock_create = AsyncMock(
+            return_value=_mock_completion(
+                tool_calls=[
+                    {
+                        "id": "call-1",
+                        "name": "get_weather",
+                        "arguments": '{"city":"Shanghai"}',
+                    },
+                ],
+            ),
+        )
+        mock_client_cls.return_value.chat.completions.create = mock_create
+
+        result = await self.model([])
+
+        self.assertEqual(
+            (result.is_last, result.content),
+            (
+                True,
+                [
+                    ToolCallBlock(
+                        id="call-1",
+                        name="get_weather",
+                        input='{"city":"Shanghai"}',
+                    ),
+                ],
+            ),
+        )
+
+    @patch("openai.AsyncClient")
+    async def test_thinking_response(
+        self,
+        mock_client_cls: MagicMock,
+    ) -> None:
+        """Non-stream response with reasoning creates ThinkingBlock."""
+        mock_create = AsyncMock(
+            return_value=_mock_completion(
+                text="42",
+                reasoning="Step by step...",
+            ),
+        )
+        mock_client_cls.return_value.chat.completions.create = mock_create
+
+        result = await self.model([])
+
+        self.assertEqual(
+            (result.is_last, result.content),
+            (
+                True,
+                [
+                    ThinkingBlock.model_construct(
+                        id=A,
+                        thinking="Step by step...",
+                    ),
+                    TextBlock.model_construct(id=A, text="42"),
+                ],
+            ),
+        )
+
+
+class TestMiniMaxModelParameters(unittest.TestCase):
+    """Tests for MiniMaxChatModel.Parameters."""
+
+    def test_default_temperature_is_one(self) -> None:
+        """Default temperature is 1.0 (MiniMax requires non-zero)."""
+        params = MiniMaxChatModel.Parameters()
+        self.assertEqual(params.temperature, 1.0)
+
+    def test_temperature_must_be_positive(self) -> None:
+        """Zero or negative temperature is rejected (range (0.0, 1.0])."""
+        from pydantic import ValidationError
+
+        with self.assertRaises(ValidationError):
+            MiniMaxChatModel.Parameters(temperature=0.0)
+
+        with self.assertRaises(ValidationError):
+            MiniMaxChatModel.Parameters(temperature=1.5)
+
+    def test_default_base_url_is_minimax(self) -> None:
+        """Default base URL points to the overseas MiniMax endpoint."""
+        cred = MiniMaxCredential(api_key="test")
+        self.assertEqual(cred.base_url, "https://api.minimax.io/v1")
+
+    def test_temperature_override_is_stored(self) -> None:
+        """Explicit temperature override is honored."""
+        model = MiniMaxChatModel(
+            credential=MiniMaxCredential(api_key="test"),
+            model="MiniMax-M3",
+            stream=False,
+            context_size=512_000,
+            parameters=MiniMaxChatModel.Parameters(temperature=0.7),
+        )
+        self.assertEqual(model.parameters.temperature, 0.7)
+
+
+# ---------------------------------------------------------------------------
+# Streaming tests
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxStream(IsolatedAsyncioTestCase):
+    """Tests for MiniMaxChatModel in streaming mode."""
+
+    def setUp(self) -> None:
+        self.model = _make_model(stream=True)
+
+    @patch("openai.AsyncClient")
+    async def test_stream_text(self, mock_client_cls: MagicMock) -> None:
+        """Stream text yields n deltas (is_last=False) + 1 final
+        (is_last=True) with full content."""
+        chunks = [
+            _make_stream_chunk(delta_text="Hi"),
+            _make_stream_chunk(delta_text=" there"),
+            _make_stream_chunk(
+                has_choices=False,
+                usage={"prompt_tokens": 10, "completion_tokens": 2},
+            ),
+        ]
+        mock_create = AsyncMock(return_value=_MockAsyncStream(chunks))
+        mock_client_cls.return_value.chat.completions.create = mock_create
+
+        gen = await self.model([])
+        responses = [r async for r in gen]
+
+        self.assertListEqual(
+            [(r.is_last, r.content) for r in responses],
+            [
+                (False, [TextBlock.model_construct(id=A, text="Hi")]),
+                (False, [TextBlock.model_construct(id=A, text=" there")]),
+                (True, [TextBlock.model_construct(id=A, text="Hi there")]),
+            ],
+        )
+
+    @patch("openai.AsyncClient")
+    async def test_stream_thinking_then_text(
+        self,
+        mock_client_cls: MagicMock,
+    ) -> None:
+        """MiniMax yields thinking chunks separately before text."""
+        chunks = [
+            _make_stream_chunk(delta_reasoning="Let me"),
+            _make_stream_chunk(delta_reasoning=" think"),
+            _make_stream_chunk(delta_text="Result"),
+            _make_stream_chunk(
+                has_choices=False,
+                usage={"prompt_tokens": 10, "completion_tokens": 5},
+            ),
+        ]
+        mock_create = AsyncMock(return_value=_MockAsyncStream(chunks))
+        mock_client_cls.return_value.chat.completions.create = mock_create
+
+        gen = await self.model([])
+        responses = [r async for r in gen]
+
+        self.assertListEqual(
+            [(r.is_last, r.content) for r in responses],
+            [
+                (
+                    False,
+                    [ThinkingBlock.model_construct(id=A, thinking="Let me")],
+                ),
+                (
+                    False,
+                    [ThinkingBlock.model_construct(id=A, thinking=" think")],
+                ),
+                (False, [TextBlock.model_construct(id=A, text="Result")]),
+                (
+                    True,
+                    [
+                        ThinkingBlock.model_construct(
+                            id=A,
+                            thinking="Let me think",
+                        ),
+                        TextBlock.model_construct(id=A, text="Result"),
+                    ],
+                ),
+            ],
+        )
+
+    @patch("openai.AsyncClient")
+    async def test_stream_tool_calls(
+        self,
+        mock_client_cls: MagicMock,
+    ) -> None:
+        """Stream tool calls accumulate across chunks into final response."""
+        chunks = [
+            _make_stream_chunk(
+                tool_calls=[
+                    _make_tool_call_delta(0, "call-1", "search", '{"q":'),
+                ],
+            ),
+            _make_stream_chunk(
+                tool_calls=[
+                    _make_tool_call_delta(0, None, None, '"test"}'),
+                ],
+            ),
+            _make_stream_chunk(
+                has_choices=False,
+                usage={"prompt_tokens": 10, "completion_tokens": 5},
+            ),
+        ]
+        mock_create = AsyncMock(return_value=_MockAsyncStream(chunks))
+        mock_client_cls.return_value.chat.completions.create = mock_create
+
+        gen = await self.model([])
+        responses = [r async for r in gen]
+
+        self.assertListEqual(
+            [(r.is_last, r.content) for r in responses],
+            [
+                (
+                    False,
+                    [
+                        ToolCallBlock(
+                            id="call-1",
+                            name="search",
+                            input='{"q":',
+                        ),
+                    ],
+                ),
+                (
+                    False,
+                    [
+                        ToolCallBlock(
+                            id="call-1",
+                            name="search",
+                            input='"test"}',
+                        ),
+                    ],
+                ),
+                (
+                    True,
+                    [
+                        ToolCallBlock(
+                            id="call-1",
+                            name="search",
+                            input='{"q":"test"}',
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+
+# ---------------------------------------------------------------------------
+# _format_tools tests
+# ---------------------------------------------------------------------------
+
+_FT_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_time",
+            "description": "Get the time",
+            "parameters": {
+                "type": "object",
+                "properties": {"timezone": {"type": "string"}},
+                "required": ["timezone"],
+            },
+        },
+    },
+]
+
+
+class TestMiniMaxFormatTools(unittest.TestCase):
+    """Tests for MiniMaxChatModel._format_tools."""
+
+    def setUp(self) -> None:
+        """Set up model instance."""
+        self.model = _make_model()
+
+    def test_auto_mode(self) -> None:
+        """Auto mode returns tools unchanged and string 'auto'."""
+        fmt_tools, fmt_choice = self.model._format_tools(
+            _FT_TOOLS,
+            ToolChoice(mode="auto"),
+        )
+        self.assertEqual(fmt_tools, _FT_TOOLS)
+        self.assertEqual(fmt_choice, "auto")
+
+    def test_none_mode(self) -> None:
+        """None mode returns tools unchanged and string 'none'."""
+        fmt_tools, fmt_choice = self.model._format_tools(
+            _FT_TOOLS,
+            ToolChoice(mode="none"),
+        )
+        self.assertEqual(fmt_tools, _FT_TOOLS)
+        self.assertEqual(fmt_choice, "none")
+
+    def test_required_mode(self) -> None:
+        """Required mode returns tools unchanged and string 'required'."""
+        fmt_tools, fmt_choice = self.model._format_tools(
+            _FT_TOOLS,
+            ToolChoice(mode="required"),
+        )
+        self.assertEqual(fmt_tools, _FT_TOOLS)
+        self.assertEqual(fmt_choice, "required")
+
+    def test_str_mode_force_call(self) -> None:
+        """A specific tool name returns a type=function dict."""
+        fmt_tools, fmt_choice = self.model._format_tools(
+            _FT_TOOLS,
+            ToolChoice(mode="get_weather"),
+        )
+        self.assertEqual(fmt_tools, _FT_TOOLS)
+        self.assertEqual(
+            fmt_choice,
+            {"type": "function", "function": {"name": "get_weather"}},
+        )
+
+    def test_tools_filtered(self) -> None:
+        """When tool_choice.tools is set, only those tools are included."""
+        fmt_tools, fmt_choice = self.model._format_tools(
+            _FT_TOOLS,
+            ToolChoice(mode="auto", tools=["get_weather"]),
+        )
+        self.assertEqual(len(fmt_tools), 1)
+        self.assertEqual(fmt_tools[0]["function"]["name"], "get_weather")
+        self.assertEqual(fmt_choice, "auto")
+
+    def test_no_tool_choice(self) -> None:
+        """Without tool_choice, returns tools and None."""
+        fmt_tools, fmt_choice = self.model._format_tools(_FT_TOOLS, None)
+        self.assertEqual(fmt_tools, _FT_TOOLS)
+        self.assertIsNone(fmt_choice)
+
+
+# ---------------------------------------------------------------------------
+# Model card listing tests
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxModelListing(unittest.TestCase):
+    """Tests for MiniMax model card discovery."""
+
+    def test_list_models_returns_minimax_cards(self) -> None:
+        """list_models() returns the three MiniMax model cards."""
+        cards = MiniMaxChatModel.list_models()
+        names = {c.name for c in cards}
+        self.assertIn("MiniMax-M3", names)
+        self.assertIn("MiniMax-M2.7", names)
+        self.assertIn("MiniMax-M2.7-highspeed", names)
+
+    def test_m3_is_active(self) -> None:
+        """The M3 model card is marked active."""
+        cards = MiniMaxChatModel.list_models()
+        m3 = next(c for c in cards if c.name == "MiniMax-M3")
+        self.assertEqual(m3.status, "active")
+
+    def test_m3_supports_image_input(self) -> None:
+        """The M3 model card advertises image/* input support."""
+        cards = MiniMaxChatModel.list_models()
+        m3 = next(c for c in cards if c.name == "MiniMax-M3")
+        image_inputs = [t for t in m3.input_types if t.startswith("image/")]
+        self.assertGreater(len(image_inputs), 0)
+
+    def test_credential_lists_models(self) -> None:
+        """MiniMaxCredential.list_models delegates to the chat model class."""
+        cards = MiniMaxCredential.list_models()
+        names = {c.name for c in cards}
+        self.assertIn("MiniMax-M3", names)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Add support for **MiniMax** chat models via the OpenAI-compatible API, with **MiniMax-M3** as the default model. This PR introduces the full MiniMax provider integration including credential, chat model, formatter, and per-model configuration.

## Models

| Model | Context | Max Output | Image Input |
|-------|---------|------------|-------------|
| `MiniMax-M3` (default) | 512K | 128K | Yes |
| `MiniMax-M2.7` | 200K | 32K | No |
| `MiniMax-M2.7-highspeed` | 200K | 32K | No |

## Changes

- Add `MiniMaxCredential` for API key + base URL management (`https://api.minimax.io/v1`)
- Add `MiniMaxChatModel` — OpenAI-compatible chat client with:
  - Streaming and non-streaming modes
  - Interleaved thinking (`<think>...</think>` → `ThinkingBlock`)
  - Tool calling with `tools` and `tool_choice`
  - Structured output via Pydantic
  - Automatic retries on transient errors
- Add `MiniMaxChatFormatter` and `MiniMaxMultiAgentFormatter` (advertise `text/plain` and `image/*` inputs)
- Add per-model YAML configuration (model card discovery via `list_models()`)
- Register provider in `credential/__init__.py`, `credential/_factory.py`, `formatter/__init__.py`, `model/__init__.py`
- 9 unit tests covering init, regular call, thinking content, tool calls, streaming, think-tag parsing, structured output, and model card listing

## Why
MiniMax-M3 is the latest generation model with significant improvements over the M2.5 series (which is what the earlier closed PR #1320 / open PR #1302 was based on): 512K context window, 128K max output, image input support, and stronger reasoning.

## Test plan
- [x] All 9 new unit tests pass
- [x] Model card listing returns M3, M2.7, M2.7-highspeed with correct context/output sizes
- [x] M3 is marked active and advertises `image/*` input