### PR TITLE
fix(webui): avoid nested <button> in sidebar group action

### DIFF
--- a/examples/web_ui/frontend/src/pages/chat/index.tsx
+++ b/examples/web_ui/frontend/src/pages/chat/index.tsx
@@ -347,7 +347,7 @@ const ChatPageInner = () => {
 						{/*</SidebarGroup>*/}
 						<SidebarGroup>
 							<SidebarGroupLabel>{t('chat.session.label')}</SidebarGroupLabel>
-							<SidebarGroupAction>
+							<SidebarGroupAction asChild>
 								<Button
 									id="tour-create-session"
 									size="icon-xs"

--- a/examples/web_ui/frontend/src/pages/credential/index.tsx
+++ b/examples/web_ui/frontend/src/pages/credential/index.tsx
@@ -308,6 +308,7 @@ export const CredentialPage = () => {
 							<SidebarGroup key={type}>
 								<SidebarGroupLabel>{title}</SidebarGroupLabel>
 								<SidebarGroupAction
+									asChild
 									title={t('credential.addConfig')}
 									onClick={() => handleOpenCreate(type)}
 								>


### PR DESCRIPTION
## AgentScope Version

`2.0.0` (built from source — `main` @ `e129177b`)

## Description

**Problem.** On the Chat and Credential pages, React 19 logs a hydration error in the console:

> `In HTML, <button> cannot be a descendant of <button>. This will cause a hydration error.`
> `<button> cannot contain a nested <button>.`

The rendered markup is invalid HTML — an interactive element nested inside another interactive element.

**Root cause.** `SidebarGroupAction` (shadcn sidebar) renders a `<button>` by default — `const Comp = asChild ? Slot.Root : 'button'`. The two "add" actions wrapped a `<Button>` *inside* it, producing `<button><button>`.

**Solution.** Use the component's built-in `asChild`, so Radix `Slot` merges the action's props/handlers onto the single inner `<Button>` and only one `<button>` reaches the DOM. Two call sites:

- `examples/web_ui/frontend/src/pages/chat/index.tsx` — session-list **add** action
- `examples/web_ui/frontend/src/pages/credential/index.tsx` — credential-list **add** action

**Validation.**

- `document.querySelectorAll('button button')` on the **Credential** page: `1 → 0`.
- On the **Chat** page the `SidebarGroupAction` nesting is removed (`2 → 1`); the remaining pair is an independent `<Button>`-tooltip nesting fixed in a companion PR (`fix(webui): use asChild on Button tooltip trigger`). With both applied the Chat page reaches `0`, console clean.
- The `+` buttons render unchanged (position / size / variant), verified in-browser.
- `tsc -b`, `eslint`, `prettier --check` all pass.

**Known, non-blocking.** Radix `Slot` concatenates classNames without `tailwind-merge`, so `SidebarGroupAction`'s `w-5`/`aspect-square` and the `Button`'s `size-*` both land on the node. Under Tailwind v4 the Button size wins and rendering is correct today; flagged as latent fragility.

Refs #1677

## Checklist

- [x] Frontend formatted & linted — `prettier --check` / `eslint` / `tsc -b` green. (Repo-root `pre-commit` targets the Python package; this change is frontend-only under `examples/web_ui/frontend`.)
- [x] No tests affected — the `web_ui` example ships no test suite; verified in-browser.
- [x] Docstrings — N/A (no Python).
- [x] No documentation changes needed.
- [x] Code is ready for review.
