### PR TITLE
fix(webui): use asChild on Button tooltip trigger to avoid nested <button>

### DIFF
--- a/examples/web_ui/frontend/src/components/ui/button.tsx
+++ b/examples/web_ui/frontend/src/components/ui/button.tsx
@@ -69,7 +69,7 @@ function Button({
 
 	return (
 		<Tooltip>
-			<TooltipTrigger>
+			<TooltipTrigger asChild>
 				<Comp
 					data-slot="button"
 					data-variant={variant}


### PR DESCRIPTION
## AgentScope Version

`2.0.0` (built from source — `main` @ `e129177b`)

## Description

**Problem.** Every `<Button>` that sets the `tooltip` prop renders invalid nested buttons (`<button><button>`), triggering the same React 19 hydration error as #1769. This is the second, independent root cause behind the Chat page's hydration error, and it affects every tooltip-bearing button app-wide.

**Root cause.** In `components/ui/button.tsx`, the tooltip branch wraps the inner button in `<TooltipTrigger>` **without** `asChild`. Radix's `TooltipTrigger` renders its own `<button>`, so the inner `<Comp>` (also a button) ends up nested.

**Solution.** Add `asChild` to the `TooltipTrigger`, so Radix merges the trigger's behaviour/ref onto the existing button — exactly one `<button>` in the DOM. This mirrors the no-tooltip branch (which already renders a single `<Comp>`). One-line change in `components/ui/button.tsx`.

**Validation.**

- The only site passing `tooltip` to `Button` is `PermissionModeSelect.tsx` (the Chat-page permission selector). After this PR, the Chat page's `document.querySelectorAll('button button')` reaches `0` (together with #1769) and the console is clean.
- `tsc -b`, `eslint`, `prettier --check` all pass.

**Known, non-blocking (pre-existing, not introduced by this change).**

- `PermissionModeSelect` wraps the tooltip `Button` in a `DropdownMenuTrigger asChild`, so two Radix triggers compose on one node. This composition predates this change — the tooltip branch already returned `<Tooltip><TooltipTrigger>…`; this PR only makes the resulting DOM valid (a single `<button>` instead of two).
- A tooltip on a `disabled` button may not fire, because `Button` carries `disabled:pointer-events-none`. Also pre-existing — this PR does not touch the disabled logic.
- A deeper refactor (lifting tooltip out of `Button` so call sites use an explicit `<TooltipTrigger asChild>`, matching `InputTypeBadges`/`TextInput`, and wrapping disabled triggers in a `<span>`) is out of scope for this hydration-error fix and could be a follow-up.

Refs #1769, Refs #1677

## Checklist

- [x] Frontend formatted & linted — `prettier --check` / `eslint` / `tsc -b` green. (Repo-root `pre-commit` targets the Python package; this change is frontend-only under `examples/web_ui/frontend`.)
- [x] No tests affected — the `web_ui` example ships no test suite; verified in-browser.
- [x] Docstrings — N/A (no Python).
- [x] No documentation changes needed.
- [x] Code is ready for review.
