### PR TITLE
fix(webui): add dialog descriptions for accessibility

### DIFF
--- a/examples/web_ui/frontend/src/components/dialog/AgentDialog.tsx
+++ b/examples/web_ui/frontend/src/components/dialog/AgentDialog.tsx
@@ -17,6 +17,7 @@ import {
 	DialogFooter,
 	DialogHeader,
 	DialogTitle,
+	DialogDescription,
 	DialogTrigger,
 } from '@/components/ui/dialog';
 import { useAgents } from '@/hooks/useAgents';
@@ -80,6 +81,9 @@ export function AgentDialog({ onCreated, triggerId }: Props) {
 			<DialogContent className="w-[500px]! max-w-[500px]!">
 				<DialogHeader>
 					<DialogTitle>{t('dialog-agent-create.title')}</DialogTitle>
+					<DialogDescription className="sr-only">
+						{t('dialog-agent-create.description')}
+					</DialogDescription>
 				</DialogHeader>
 				<div className="no-scrollbar -mx-4 max-h-[75vh] overflow-y-auto px-4">
 					{schema && values ? (

--- a/examples/web_ui/frontend/src/components/dialog/CreateCredentialDialog.tsx
+++ b/examples/web_ui/frontend/src/components/dialog/CreateCredentialDialog.tsx
@@ -9,6 +9,7 @@ import {
 	DialogContent,
 	DialogHeader,
 	DialogTitle,
+	DialogDescription,
 	DialogFooter,
 } from '@/components/ui/dialog';
 import { Field, FieldGroup, FieldLabel } from '@/components/ui/field.tsx';
@@ -85,6 +86,9 @@ export function CreateCredentialDialog({ open, onOpenChange, onCreated, defaultT
 			<DialogContent>
 				<DialogHeader>
 					<DialogTitle>{t('dialog-credential-create.title')}</DialogTitle>
+					<DialogDescription>
+						{t('dialog-credential-create.description')}
+					</DialogDescription>
 				</DialogHeader>
 				<FieldGroup>
 					<Field>

--- a/examples/web_ui/frontend/src/components/dialog/EditAgentDialog.tsx
+++ b/examples/web_ui/frontend/src/components/dialog/EditAgentDialog.tsx
@@ -16,6 +16,7 @@ import {
 	DialogFooter,
 	DialogHeader,
 	DialogTitle,
+	DialogDescription,
 } from '@/components/ui/dialog';
 import { useAgents } from '@/hooks/useAgents';
 import { useAgentSchema } from '@/hooks/useAgentSchema';
@@ -86,6 +87,9 @@ export function EditAgentDialog({ open, onOpenChange, agent, onUpdated }: Props)
 			<DialogContent className="w-[720px] max-w-[720px]">
 				<DialogHeader>
 					<DialogTitle>{t('dialog-agent-edit.title')}</DialogTitle>
+					<DialogDescription className="sr-only">
+						{t('dialog-agent-edit.description')}
+					</DialogDescription>
 				</DialogHeader>
 				<div className="no-scrollbar -mx-4 max-h-[75vh] overflow-y-auto px-4">
 					{schema && values ? (

--- a/examples/web_ui/frontend/src/components/dialog/EditCredentialDialog.tsx
+++ b/examples/web_ui/frontend/src/components/dialog/EditCredentialDialog.tsx
@@ -9,6 +9,7 @@ import {
 	DialogContent,
 	DialogHeader,
 	DialogTitle,
+	DialogDescription,
 	DialogFooter,
 } from '@/components/ui/dialog';
 import { useCredentials } from '@/hooks/useCredentials';
@@ -81,6 +82,7 @@ export function EditCredentialDialog({ open, onOpenChange, credential, onUpdated
 			<DialogContent>
 				<DialogHeader>
 					<DialogTitle>{t('dialog-credential-edit.title')}</DialogTitle>
+					<DialogDescription>{t('dialog-credential-edit.description')}</DialogDescription>
 				</DialogHeader>
 				{loadingSchema ? (
 					<p className="text-muted-foreground text-sm">{t('common.loading')}</p>

--- a/examples/web_ui/frontend/src/components/dialog/RenameSessionDialog.tsx
+++ b/examples/web_ui/frontend/src/components/dialog/RenameSessionDialog.tsx
@@ -7,6 +7,7 @@ import {
 	DialogFooter,
 	DialogHeader,
 	DialogTitle,
+	DialogDescription,
 } from '@/components/ui/dialog';
 import { Field, FieldGroup, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
@@ -44,6 +45,7 @@ export function RenameSessionDialog({ open, onOpenChange, currentName, onConfirm
 			<DialogContent>
 				<DialogHeader>
 					<DialogTitle>{t('dialog-session-rename.title')}</DialogTitle>
+					<DialogDescription>{t('dialog-session-rename.description')}</DialogDescription>
 				</DialogHeader>
 				<FieldGroup>
 					<Field>

--- a/examples/web_ui/frontend/src/i18n/locales/en.json
+++ b/examples/web_ui/frontend/src/i18n/locales/en.json
@@ -90,6 +90,7 @@
 	},
 	"dialog-agent-create": {
 		"title": "Create agent",
+		"description": "Define a new agent's identity and behaviour.",
 		"trigger": "Create agent"
 	},
 	"agent-form": {
@@ -116,7 +117,8 @@
 		}
 	},
 	"dialog-agent-edit": {
-		"title": "Edit agent"
+		"title": "Edit agent",
+		"description": "Update this agent's configuration."
 	},
 	"dialog-agent-delete": {
 		"title": "Delete agent",
@@ -129,6 +131,7 @@
 	},
 	"dialog-session-rename": {
 		"title": "Rename session",
+		"description": "Give this session a new name.",
 		"label": "Name",
 		"placeholder": "Session name",
 		"confirm": "Rename"
@@ -139,11 +142,13 @@
 	},
 	"dialog-credential-create": {
 		"title": "Add credential",
+		"description": "Add credentials for a model provider.",
 		"selectType": "Provider",
 		"selectTypePlaceholder": "Select a provider"
 	},
 	"dialog-credential-edit": {
-		"title": "Edit Credential"
+		"title": "Edit Credential",
+		"description": "Update the saved credential for this provider."
 	},
 	"credential": {
 		"addConfig": "Add configuration",

--- a/examples/web_ui/frontend/src/i18n/locales/zh.json
+++ b/examples/web_ui/frontend/src/i18n/locales/zh.json
@@ -90,6 +90,7 @@
 	},
 	"dialog-agent-create": {
 		"title": "创建 Agent",
+		"description": "定义新 Agent 的身份与行为。",
 		"trigger": "创建 Agent"
 	},
 	"agent-form": {
@@ -116,7 +117,8 @@
 		}
 	},
 	"dialog-agent-edit": {
-		"title": "编辑 Agent"
+		"title": "编辑 Agent",
+		"description": "更新此 Agent 的配置。"
 	},
 	"dialog-agent-delete": {
 		"title": "删除 Agent",
@@ -129,6 +131,7 @@
 	},
 	"dialog-session-rename": {
 		"title": "重命名会话",
+		"description": "为该会话设置新名称。",
 		"label": "名称",
 		"placeholder": "会话名称",
 		"confirm": "重命名"
@@ -139,11 +142,13 @@
 	},
 	"dialog-credential-create": {
 		"title": "添加凭证",
+		"description": "为模型提供商添加凭证。",
 		"selectType": "提供商",
 		"selectTypePlaceholder": "选择提供商"
 	},
 	"dialog-credential-edit": {
-		"title": "编辑凭证"
+		"title": "编辑凭证",
+		"description": "更新该提供商已保存的凭证。"
 	},
 	"credential": {
 		"addConfig": "添加配置",


### PR DESCRIPTION
## AgentScope Version

`2.0.0` (built from source — `main` @ `e129177b`)

## Description

**Problem.** Opening five dialogs logs a Radix accessibility warning: `Missing 'Description' or 'aria-describedby={undefined}' for {DialogContent}`. Screen-reader users get no description of the dialog's purpose.

**Root cause.** `AgentDialog`, `EditAgentDialog`, `CreateCredentialDialog`, `EditCredentialDialog` and `RenameSessionDialog` render a `DialogTitle` but no `DialogDescription`, so Radix cannot wire up `aria-describedby`.

**Solution.** Add a meaningful `<DialogDescription>` (with en/zh i18n) to each, following the existing pattern in `MCPDialog` / `AddSkillDialog` / the schedule dialog.

- The **agent create/edit** dialogs already render a per-section description ("Agent identity" …) via `AgentFormFields`. To satisfy the a11y contract **without duplicating visible copy**, their `DialogDescription` is marked `sr-only` (still read by screen readers, hidden visually — matching the existing `sr-only` usage in `sidebar.tsx`). The other three keep a visible description.

**Validation.**

- Before: console repeatedly warns `Missing Description … for DialogContent`.
- After (Create Agent): the dialog's `aria-describedby` resolves to the description node — text "定义新 Agent 的身份与行为。" / "Define a new agent's identity and behaviour." — and the warning is gone. `document.querySelectorAll('[role=dialog] button button')` = 0.
- en/zh locales both carry all 5 new `description` keys; leaf-key sets are identical (no orphan keys).
- `tsc -b`, `eslint`, `prettier --check` all pass.

Refs #1677

## Checklist

- [x] Frontend formatted & linted — `prettier --check` / `eslint` / `tsc -b` green. (Repo-root `pre-commit` targets the Python package; this change is frontend-only under `examples/web_ui/frontend`.)
- [x] No tests affected — the `web_ui` example ships no test suite; verified in-browser.
- [x] Docstrings — N/A (no Python).
- [x] i18n updated — en/zh both carry the new description keys.
- [x] Code is ready for review.
