### PR TITLE
fix(example): add ignore for examples/agent_service/workspaces/*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,4 @@ pnpm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
+examples/agent_service/workspaces/*


### PR DESCRIPTION
## AgentScope Version
2.0.0

## Description
Add the ignore for file/directory in examples/agent_service/workspaces create by running in local.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ✅]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ✅]  Code is ready for review