### PR TITLE
fix(tool): support windows-style separators in glob patterns

### DIFF
--- a/src/agentscope/tool/_builtin/_glob.py
+++ b/src/agentscope/tool/_builtin/_glob.py
@@ -259,7 +259,7 @@ codebase."""  # ignore: E501
             A list of matched file paths
         """
         results: list[str] = []
-        parts = pattern.split("/")
+        parts = [p for p in re.split(r"[\\/]+", pattern) if p]
         self.match_parts(parts, 0, base_dir, results)
         return results
 

--- a/tests/builtin_glob_test.py
+++ b/tests/builtin_glob_test.py
@@ -11,6 +11,8 @@ from agentscope.permission import (
     PermissionRule,
 )
 
+from tests.utils import AnyString
+
 
 class GlobToolTest(IsolatedAsyncioTestCase):
     """The glob tool test case."""
@@ -108,11 +110,26 @@ class GlobToolTest(IsolatedAsyncioTestCase):
             path=self.temp_dir,
         )
 
-        content = chunk.content[0].text
-
-        self.assertIn("test3.py", content)
-        self.assertNotIn("test1.py", content)
-        self.assertNotIn("test2.py", content)
+        self.assertDictEqual(
+            chunk.model_dump(),
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": os.path.join(
+                            self.temp_dir,
+                            "subdir",
+                            "test3.py",
+                        ),
+                        "id": AnyString(),
+                    },
+                ],
+                "state": "running",
+                "is_last": True,
+                "metadata": {},
+                "id": AnyString(),
+            },
+        )
 
     async def test_no_matches(self) -> None:
         """Test pattern with no matches."""

--- a/tests/builtin_glob_test.py
+++ b/tests/builtin_glob_test.py
@@ -101,6 +101,19 @@ class GlobToolTest(IsolatedAsyncioTestCase):
         self.assertIn("test2.py", content)
         self.assertIn("test3.py", content)
 
+    async def test_windows_style_separator_pattern(self) -> None:
+        """Test glob patterns that use backslashes as path separators."""
+        chunk = await self.glob_tool(
+            pattern=r"subdir\*.py",
+            path=self.temp_dir,
+        )
+
+        content = chunk.content[0].text
+
+        self.assertIn("test3.py", content)
+        self.assertNotIn("test1.py", content)
+        self.assertNotIn("test2.py", content)
+
     async def test_no_matches(self) -> None:
         """Test pattern with no matches."""
         chunk = await self.glob_tool(


### PR DESCRIPTION
## AgentScope Version

  `2.0.1`

  ## Description

  This PR fixes a cross-platform issue in the built-in `Glob` tool.

  ### Background

  `Glob` currently splits glob patterns only by `/`. On Windows, users may naturally
  provide patterns with backslashes, for example:

  ```text
  subdir\*.py

  That pattern was treated as a single path component instead of subdir + *.py, so
  matching files inside subdirectories could fail.

  ### Changes

  - Updated Glob.glob_match to split patterns on both / and \.
  - Added a regression test for Windows-style separator patterns.
  - Kept the public API and output behavior unchanged.

  ### How to test

  Ran the following checks:

  uv run --extra dev python -m pytest tests/builtin_glob_test.py
  uv run --extra dev python -m pytest tests
  uv run --extra dev pre-commit run --all-files

  Results:

  - tests/builtin_glob_test.py: 11 passed
  - Full test suite: 594 passed, 163 skipped, 1 warning
  - Pre-commit: passed

  ## Checklist

  Please check the following items before code is ready to be reviewed.

  - [ ]  An issue has been created for this PR
  - [x]  I have read the CONTRIBUTING.md
    (https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)

  - [x]  Docstrings are in Google style
  - [ ]  Related documentation has been updated (e.g. links, examples, etc.) in
    documentation repository (https://github.com/agentscope-ai/docs)

  - [x]  Code is ready for review