### PR TITLE
feat(bash): support cwd configuration

### DIFF
--- a/src/agentscope/tool/_builtin/_bash.py
+++ b/src/agentscope/tool/_builtin/_bash.py
@@ -154,6 +154,7 @@ easier to review tool calls and give permission.
         self,
         dangerous_files: list[str] = DEFAULT_DANGEROUS_FILES,
         dangerous_directories: list[str] = DEFAULT_DANGEROUS_DIRECTORIES,
+        cwd: str | None = None,
     ) -> None:
         """Initialize the bash tool.
 
@@ -171,12 +172,19 @@ easier to review tool calls and give permission.
                 `DEFAULT_DANGEROUS_DIRECTORIES`. Pass a custom list to
                 fully replace the defaults, or `[]` to disable the
                 directory check.
+            cwd (`str | None`, optional):
+                The working directory for command execution. If provided,
+                all commands will be executed in this directory. If
+                ``None`` (the default), commands run in the current
+                working directory of the process.
         """
 
         self._bash_parser = BashCommandParser()
 
         self.dangerous_files = list(dangerous_files)
         self.dangerous_directories = list(dangerous_directories)
+
+        self.cwd = cwd
 
     async def check_read_only(
         self,
@@ -686,6 +694,7 @@ easier to review tool calls and give permission.
                 command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
+                cwd=self.cwd,
                 **_subprocess_creation_kwargs(),
             )
 

--- a/tests/builtin_bash_test.py
+++ b/tests/builtin_bash_test.py
@@ -102,6 +102,37 @@ class BashToolTest(IsolatedAsyncioTestCase):
         self.assertEqual(chunks[0].state, "error")
         self.assertIn("timed out", chunks[0].content[0].text.lower())
 
+    async def test_cwd_default_none(self) -> None:
+        """Test that cwd defaults to None."""
+        bash_tool = Bash()
+        self.assertIsNone(bash_tool.cwd)
+
+    async def test_cwd_set_in_constructor(self) -> None:
+        """Test that cwd is set via constructor."""
+        bash_tool = Bash(cwd="/tmp")
+        self.assertEqual(bash_tool.cwd, "/tmp")
+
+    async def test_command_with_cwd(self) -> None:
+        """Test executing a command with a custom working directory."""
+        bash_tool = Bash(cwd="/tmp")
+        chunks = []
+        async for chunk in bash_tool(command="pwd"):
+            chunks.append(chunk)
+
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(chunks[0].state, "running")
+        self.assertIn("/tmp", chunks[0].content[0].text)
+
+    async def test_command_without_cwd(self) -> None:
+        """Test that command runs in process cwd when cwd is not set."""
+        bash_tool = Bash()
+        chunks = []
+        async for chunk in bash_tool(command="pwd"):
+            chunks.append(chunk)
+
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(chunks[0].state, "running")
+
 
 @unittest.skipIf(
     sys.platform == "win32",


### PR DESCRIPTION
## AgentScope Version

  `2.0.1`

  ## Description

  This PR adds current working directory support to the built-in `Bash` tool.

  ### Background

  The `Bash` tool currently does not support configuring a current working
  directory at initialization time. This makes it harder to integrate `Bash`
  with workspace-specific execution contexts.

  ### Changes

  - Added a `cwd` argument to the `Bash` constructor.
  - Passed `cwd` to `asyncio.create_subprocess_shell` when executing commands.
  - Added tests for the default `cwd`, constructor configuration, and command
    execution with a custom working directory.
  - Kept the default behavior unchanged when `cwd` is not provided.

  ### How to test

  Ran the following checks:

  uv run pre-commit run --all-files
  uv run pytest tests/builtin_bash_test.py
  uv run pytest tests --ignore=tests/workspace_docker_test.py

  Results:

  - tests/builtin_bash_test.py: 29 passed
  - Test suite excluding workspace_docker_test.py: 741 passed, 1 skipped, 1 warning
  - Pre-commit: passed

  ## Checklist

  Please check the following items before code is ready to be reviewed.

  - [x]  An issue has been created for this PR
  - [x]  I have read the CONTRIBUTING.md
    (https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)

  - [x]  Docstrings are in Google style
  - [ ]  Related documentation has been updated (e.g. links, examples, etc.) in
    documentation repository (https://github.com/agentscope-ai/docs)

  - [x]  Code is ready for review