### PR TITLE
fix(service): trust local workspace root

### DIFF
--- a/src/agentscope/app/_service/_chat.py
+++ b/src/agentscope/app/_service/_chat.py
@@ -34,6 +34,36 @@ from ...event import (
     ExternalExecutionResultEvent,
 )
 from ...message import AssistantMsg, Msg, ToolCallState
+from ...permission import AdditionalWorkingDirectory
+from ...state import AgentState
+from ...workspace import WorkspaceBase
+
+
+def _with_workspace_working_directory(
+    agent_state: AgentState,
+    workspace: WorkspaceBase,
+) -> AgentState:
+    """Include the workspace root in the session permission context."""
+    workdir = workspace.working_directory
+    if workdir is None:
+        return agent_state
+
+    permission_context = agent_state.permission_context
+    if workdir in permission_context.working_directories:
+        return agent_state
+
+    working_directories = dict(permission_context.working_directories)
+    working_directories[workdir] = AdditionalWorkingDirectory(
+        path=workdir,
+        source="workspace",
+    )
+    return agent_state.model_copy(
+        update={
+            "permission_context": permission_context.model_copy(
+                update={"working_directories": working_directories},
+            ),
+        },
+    )
 
 
 class ChatService:
@@ -267,7 +297,10 @@ optional):
         # ----------------------------------------------------------------
         # 5. Assemble the Agent.
         # ----------------------------------------------------------------
-        agent_state = session_record.state
+        agent_state = _with_workspace_working_directory(
+            session_record.state,
+            workspace,
+        )
         agent_state.session_id = session_id
         agent = Agent(
             name=agent_record.data.name,

--- a/src/agentscope/workspace/_base.py
+++ b/src/agentscope/workspace/_base.py
@@ -60,6 +60,11 @@ class WorkspaceBase:
         self.workspace_id = workspace_id or uuid.uuid4().hex
         self.is_alive = False
 
+    @property
+    def working_directory(self) -> str | None:
+        """Directory that should be trusted for local file operations."""
+        return None
+
     # ── lifecycle (developer) ──────────────────────────────────────
 
     @abstractmethod

--- a/src/agentscope/workspace/_local_workspace.py
+++ b/src/agentscope/workspace/_local_workspace.py
@@ -175,6 +175,11 @@ class LocalWorkspace(WorkspaceBase):
         self._skill_lock = asyncio.Lock()
         self._mcp_lock = asyncio.Lock()
 
+    @property
+    def working_directory(self) -> str:
+        """Return the local workspace root."""
+        return self.workdir
+
     async def initialize(self) -> None:
         """Initialise the workspace.
 

--- a/tests/service_toolkit_test.py
+++ b/tests/service_toolkit_test.py
@@ -25,6 +25,7 @@ from agentscope.app._manager import (
     SchedulerManager,
 )
 from agentscope.app._service import get_toolkit
+from agentscope.app._service._chat import _with_workspace_working_directory
 from agentscope.app.storage import (
     AgentData,
     AgentRecord,
@@ -32,6 +33,8 @@ from agentscope.app.storage import (
     SessionConfig,
     SessionRecord,
 )
+from agentscope.permission import AdditionalWorkingDirectory
+from agentscope.state import AgentState
 from agentscope.tool import ToolBase
 
 
@@ -44,10 +47,17 @@ class _FakeWorkspace:
         tools: list[ToolBase] | None = None,
         skills: list | None = None,
         mcps: list | None = None,
+        working_directory: str | None = None,
     ) -> None:
         self._tools = tools or []
         self._skills = skills or []
         self._mcps = mcps or []
+        self._working_directory = working_directory
+
+    @property
+    def working_directory(self) -> str | None:
+        """Return the configured workspace root."""
+        return self._working_directory
 
     async def list_tools(self) -> list[ToolBase]:
         """Return the configured workspace tools."""
@@ -108,6 +118,67 @@ def _make_session(
 class _NoOpStorage:
     """Storage placeholder. ``get_toolkit`` itself does not call any
     storage method — the team tools bind a reference for later use."""
+
+
+class TestWorkspacePermissionRoot(IsolatedAsyncioTestCase):
+    """Workspace roots are added to the agent permission context."""
+
+    async def test_adds_workspace_root_to_permission_context(self) -> None:
+        """A resolved workspace root becomes an allowed working directory."""
+        state = AgentState()
+        next_state = _with_workspace_working_directory(
+            state,
+            _FakeWorkspace(  # type: ignore[arg-type]
+                working_directory="/tmp/as-workspace",
+            ),
+        )
+
+        self.assertIn(
+            "/tmp/as-workspace",
+            next_state.permission_context.working_directories,
+        )
+        self.assertDictEqual(
+            next_state.permission_context.working_directories[
+                "/tmp/as-workspace"
+            ].model_dump(),
+            {
+                "path": "/tmp/as-workspace",
+                "source": "workspace",
+            },
+        )
+        self.assertNotIn(
+            "/tmp/as-workspace",
+            state.permission_context.working_directories,
+        )
+
+    async def test_keeps_existing_workspace_entry(self) -> None:
+        """Existing workspace permissions are not replaced."""
+        existing = AdditionalWorkingDirectory(
+            path="/tmp/as-workspace",
+            source="session",
+        )
+        state = AgentState(
+            permission_context={
+                "working_directories": {
+                    "/tmp/as-workspace": existing,
+                },
+            },
+        )
+
+        next_state = _with_workspace_working_directory(
+            state,
+            _FakeWorkspace(  # type: ignore[arg-type]
+                working_directory="/tmp/as-workspace",
+            ),
+        )
+
+        self.assertIs(next_state, state)
+        self.assertEqual(
+            "session",
+            next_state.permission_context.working_directories[
+                "/tmp/as-workspace"
+            ].source,
+        )
 
 
 def _tool_names(toolkit: Any) -> list[str]:


### PR DESCRIPTION
## Summary

Fixes #1791.

This adds the resolved local workspace root to the session permission context before the chat service assembles the agent. That gives `ACCEPT_EDITS` the same trusted root that the workspace tools are already operating inside, so ordinary workspace file operations do not keep asking for confirmation.

The change keeps the boundary narrow:

- `WorkspaceBase.working_directory` defaults to `None`
- `LocalWorkspace` returns its absolute `workdir`
- the chat service skips existing entries instead of overwriting user/session-supplied ones

## To verify

- `PYTHONPATH=src PYTHONUTF8=1 PYTHONIOENCODING=utf-8 python -m pytest tests/service_toolkit_test.py -q`
- `python -m ruff check src/agentscope/app/_service/_chat.py src/agentscope/workspace/_base.py src/agentscope/workspace/_local_workspace.py tests/service_toolkit_test.py`
- `PYTHONPATH=src PYTHONUTF8=1 PYTHONIOENCODING=utf-8 python -m py_compile src/agentscope/app/_service/_chat.py src/agentscope/workspace/_base.py src/agentscope/workspace/_local_workspace.py tests/service_toolkit_test.py`
- `git diff --check`

`ruff format --check` on the touched files reports existing formatter churn on current `main`, so I did not run formatter over the full files for this small service fix.
