### PR TITLE
fix(service): add workspace root to permission context

### DIFF
--- a/src/agentscope/app/_service/_chat.py
+++ b/src/agentscope/app/_service/_chat.py
@@ -34,6 +34,26 @@ from ...event import (
     ExternalExecutionResultEvent,
 )
 from ...message import AssistantMsg, Msg, ToolCallState
+from ...permission import AdditionalWorkingDirectory
+from ...state import AgentState
+from ...workspace import WorkspaceBase
+
+
+def _ensure_workspace_working_directory(
+    agent_state: AgentState,
+    workspace: WorkspaceBase,
+) -> None:
+    """Add the workspace root to the permission context if missing."""
+    working_directory = workspace.working_directory
+    if working_directory in agent_state.permission_context.working_directories:
+        return
+
+    agent_state.permission_context.working_directories[working_directory] = (
+        AdditionalWorkingDirectory(
+            path=working_directory,
+            source="workspace",
+        )
+    )
 
 
 class ChatService:
@@ -269,6 +289,7 @@ optional):
         # ----------------------------------------------------------------
         agent_state = session_record.state
         agent_state.session_id = session_id
+        _ensure_workspace_working_directory(agent_state, workspace)
         agent = Agent(
             name=agent_record.data.name,
             system_prompt=agent_record.data.system_prompt,

--- a/src/agentscope/workspace/_base.py
+++ b/src/agentscope/workspace/_base.py
@@ -104,6 +104,11 @@ class WorkspaceBase:
     async def get_instructions(self) -> str:
         """Workspace-specific system prompt fragment."""
 
+    @property
+    @abstractmethod
+    def working_directory(self) -> str:
+        """The workspace root path visible to the agent."""
+
     # ── for Agent: tool & resource discovery ───────────────────────
 
     @abstractmethod

--- a/src/agentscope/workspace/_docker/_docker_workspace.py
+++ b/src/agentscope/workspace/_docker/_docker_workspace.py
@@ -394,6 +394,11 @@ class DockerWorkspace(WorkspaceBase):
         """
         return self.instructions.format(workdir=CONTAINER_WORKDIR)
 
+    @property
+    def working_directory(self) -> str:
+        """The container-side workspace root path."""
+        return CONTAINER_WORKDIR
+
     # ── tool / MCP / skill discovery ────────────────────────────
 
     async def list_tools(self) -> list[ToolBase]:

--- a/src/agentscope/workspace/_e2b/_e2b_workspace.py
+++ b/src/agentscope/workspace/_e2b/_e2b_workspace.py
@@ -401,6 +401,11 @@ class E2BWorkspace(WorkspaceBase):
         """
         return self.instructions.format(workdir=SANDBOX_WORKDIR)
 
+    @property
+    def working_directory(self) -> str:
+        """The sandbox-side workspace root path."""
+        return SANDBOX_WORKDIR
+
     # ── tool / MCP / skill discovery ────────────────────────────
 
     async def list_tools(self) -> list[ToolBase]:

--- a/src/agentscope/workspace/_local_workspace.py
+++ b/src/agentscope/workspace/_local_workspace.py
@@ -307,6 +307,11 @@ class LocalWorkspace(WorkspaceBase):
         """Get the workspace instructions."""
         return self.instructions
 
+    @property
+    def working_directory(self) -> str:
+        """The local workspace root path."""
+        return self.workdir
+
     async def _load_skills_file(self, skills_dir: str) -> _SkillsFile:
         """Load the .skills index file, returning an empty structure if absent.
 

--- a/tests/chat_service_test.py
+++ b/tests/chat_service_test.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""Tests for chat-service agent assembly helpers."""
+
+from unittest import TestCase
+
+from agentscope.app._service._chat import (
+    _ensure_workspace_working_directory,
+)
+from agentscope.permission import AdditionalWorkingDirectory
+from agentscope.state import AgentState
+
+
+class _FakeWorkspace:
+    """Minimal workspace stand-in for permission-context tests."""
+
+    def __init__(self, working_directory: str) -> None:
+        """Initialize the fake workspace."""
+        self._working_directory = working_directory
+
+    @property
+    def working_directory(self) -> str:
+        """Return the configured workspace root."""
+        return self._working_directory
+
+
+class TestEnsureWorkspaceWorkingDirectory(TestCase):
+    """Workspace root permission injection tests."""
+
+    def test_adds_workspace_root_to_permission_context(self) -> None:
+        """The workspace root is included in working directories."""
+        state = AgentState()
+
+        _ensure_workspace_working_directory(
+            state,
+            _FakeWorkspace("/workspace"),  # type: ignore[arg-type]
+        )
+
+        self.assertEqual(
+            state.permission_context.working_directories["/workspace"],
+            AdditionalWorkingDirectory(
+                path="/workspace",
+                source="workspace",
+            ),
+        )
+
+    def test_keeps_existing_workspace_root_entry(self) -> None:
+        """Existing working-directory entries are not overwritten."""
+        state = AgentState()
+        state.permission_context.working_directories["/workspace"] = (
+            AdditionalWorkingDirectory(
+                path="/workspace",
+                source="userSettings",
+            )
+        )
+
+        _ensure_workspace_working_directory(
+            state,
+            _FakeWorkspace("/workspace"),  # type: ignore[arg-type]
+        )
+
+        self.assertEqual(
+            state.permission_context.working_directories["/workspace"].source,
+            "userSettings",
+        )


### PR DESCRIPTION
## Summary
- add a workspace-visible root path interface to WorkspaceBase and concrete workspace backends
- include the resolved workspace root in PermissionContext.working_directories during ChatService agent assembly
- preserve existing working directory entries when already configured

Fixes #1791

## Testing
- .venv/bin/python -m pytest -p no:cacheprovider tests/chat_service_test.py tests/service_toolkit_test.py tests/permission_engine_test.py tests/permission_mode_test.py -q
- .venv/bin/python -m pytest -p no:cacheprovider tests/builtin_read_test.py tests/builtin_write_test.py tests/builtin_glob_test.py tests/builtin_grep_test.py tests/workspace_local_test.py tests/builtin_bash_test.py -q
- git diff --check
- py_compile on touched files