### PR TITLE
fix(workspace): skip invalid MCP entries

### DIFF
--- a/src/agentscope/workspace/_local_workspace.py
+++ b/src/agentscope/workspace/_local_workspace.py
@@ -192,18 +192,43 @@ class LocalWorkspace(WorkspaceBase):
         # Restore or seed MCPs
         mcp_file = os.path.join(self.workdir, ".mcp")
         if await aiofiles.ospath.exists(mcp_file):
-            async with aiofiles.open(mcp_file, "r", encoding="utf-8") as f:
-                self._mcps = [
-                    MCPClient.model_validate(m)
-                    for m in json.loads(await f.read())
-                ]
+            self._mcps = []
+            try:
+                async with aiofiles.open(mcp_file, "r", encoding="utf-8") as f:
+                    mcp_configs = json.loads(await f.read())
+                for mcp_config in mcp_configs:
+                    try:
+                        self._mcps.append(MCPClient.model_validate(mcp_config))
+                    except Exception as e:
+                        logger.warning(
+                            "Skipping invalid MCP config in %s: %s",
+                            mcp_file,
+                            str(e),
+                        )
+            except Exception as e:
+                logger.warning(
+                    "Failed to load MCP configs from %s: %s",
+                    mcp_file,
+                    str(e),
+                )
         else:
             self._mcps = list(self.default_mcps)
             await self._save_mcp_file()
 
+        available_mcps: list[MCPClient] = []
         for mcp in self._mcps:
             if mcp.is_stateful and not mcp.is_connected:
-                await mcp.connect()
+                try:
+                    await mcp.connect()
+                except Exception as e:
+                    logger.warning(
+                        "Failed to connect MCP %r: %s",
+                        mcp.name,
+                        str(e),
+                    )
+                    continue
+            available_mcps.append(mcp)
+        self._mcps = available_mcps
 
         # Seed skills
         skills_dir = os.path.join(self.workdir, "skills")

--- a/tests/workspace_local_test.py
+++ b/tests/workspace_local_test.py
@@ -728,6 +728,40 @@ description: {description}
         self.assertFalse(os.path.exists(invalid_target_no_md))
         self.assertFalse(os.path.exists(invalid_target_bad_fm))
 
+    async def test_initialize_skips_invalid_mcp_entries(self) -> None:
+        """Test that a bad .mcp entry does not kill the workspace."""
+        mcp_file = os.path.join(self.temp_dir.name, ".mcp")
+        with open(mcp_file, "w", encoding="utf-8") as f:
+            json.dump(
+                [
+                    {
+                        "name": "bad_mcp",
+                        "is_stateful": False,
+                        "mcp_config": {
+                            "type": "stdio_mcp",
+                            "command": "echo",
+                            "args": ["hello"],
+                        },
+                    },
+                    {
+                        "name": "ok_http",
+                        "is_stateful": False,
+                        "mcp_config": {
+                            "type": "http_mcp",
+                            "url": "http://localhost:8765/mcp",
+                        },
+                    },
+                ],
+                f,
+            )
+
+        workspace = LocalWorkspace(workdir=self.temp_dir.name)
+        await workspace.initialize()
+
+        self.assertTrue(workspace.is_alive)
+        mcps = await workspace.list_mcps()
+        self.assertEqual([mcp.name for mcp in mcps], ["ok_http"])
+
     async def test_list_skills(self) -> None:
         """Test listing skills from workspace.
 


### PR DESCRIPTION
## AgentScope Version

2.0.1

## Description

Fixes #1817.

`LocalWorkspace.initialize()` restored every entry from `.mcp` in one list comprehension. One invalid entry, such as a stateless stdio MCP, raised during `MCPClient.model_validate()` and aborted the whole workspace before skills or any valid MCPs could load.

This PR makes MCP restore behave like skill restore in the same method:

- validate `.mcp` entries independently and skip only the bad entry
- keep valid MCP entries available
- skip a stateful MCP if connecting it fails, instead of keeping the workspace dead
- add a regression test with one invalid stdio entry and one valid stateless HTTP entry

Docs are unchanged because this is a recovery-path bug fix.

Tested locally:

```shell
$env:PYTHONPATH=(Resolve-Path .\src).Path; python -m pytest tests\workspace_local_test.py -k "invalid_mcp_entries" -q
$env:PYTHONPATH=(Resolve-Path .\src).Path; python -m pytest tests\workspace_local_test.py -q
python -m py_compile src\agentscope\workspace\_local_workspace.py tests\workspace_local_test.py
python -m ruff check src\agentscope\workspace\_local_workspace.py tests\workspace_local_test.py
git diff --check
```

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [x]  Code is ready for review
