### PR TITLE
ci(webui): add format and build checks

### DIFF
--- a/.github/workflows/web-ui.yml
+++ b/.github/workflows/web-ui.yml
@@ -2,6 +2,8 @@ name: Web UI
 
 on:
   push:
+    branches:
+      - main
     paths:
       - ".github/workflows/web-ui.yml"
       - "examples/web_ui/**"
@@ -20,7 +22,7 @@ jobs:
       run:
         working-directory: examples/web_ui
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/web-ui.yml
+++ b/.github/workflows/web-ui.yml
@@ -1,0 +1,44 @@
+name: Web UI
+
+on:
+  push:
+    paths:
+      - ".github/workflows/web-ui.yml"
+      - "examples/web_ui/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/web-ui.yml"
+      - "examples/web_ui/**"
+
+jobs:
+  check:
+    if: github.event_name != 'pull_request' || false == contains(github.event.pull_request.title, 'WIP')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: examples/web_ui
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: examples/web_ui/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Check formatting
+        run: pnpm format:check
+
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
## Summary
- add a dedicated Web UI workflow for PR and push checks touching examples/web_ui
- install pnpm dependencies, run formatting validation, and build frontend/backend packages
- scope the workflow with path filters so unrelated Python-only changes do not run Web UI checks

Fixes #1798

## Notes
- The workflow uses pnpm install --no-frozen-lockfile because the current examples/web_ui lockfile on main is stale relative to frontend/package.json. A frozen install currently fails before the new checks can run.

## Testing
- corepack pnpm install --no-frozen-lockfile
- corepack pnpm exec prettier --check .
- corepack pnpm --filter frontend lint
- corepack pnpm --filter frontend build
- corepack pnpm --filter backend build
- .venv/bin/python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/web-ui.yml').read_text())"
- git diff --check