### PR TITLE
feat: support cwd in Bash tool

### DIFF
--- a/src/agentscope/tool/_builtin/_bash.py
+++ b/src/agentscope/tool/_builtin/_bash.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """The bash tool in agentscope."""
+
 import os
 from typing import AsyncGenerator, Any, List
 import re
@@ -132,10 +133,7 @@ easier to review tool calls and give permission.
             },
             "timeout": {
                 "type": "integer",
-                "description": (
-                    "Optional timeout in milliseconds "
-                    "(default: 120000, max: 600000)"
-                ),
+                "description": "Timeout in ms (default: 120000, max: 600000)",
                 "default": 120000,
                 "maximum": 600000,
                 "minimum": 0,
@@ -154,10 +152,13 @@ easier to review tool calls and give permission.
         self,
         dangerous_files: list[str] = DEFAULT_DANGEROUS_FILES,
         dangerous_directories: list[str] = DEFAULT_DANGEROUS_DIRECTORIES,
+        cwd: str | os.PathLike[str] | None = None,
     ) -> None:
         """Initialize the bash tool.
 
         Args:
+            cwd (`str | os.PathLike[str] | None`, optional):
+                The working directory used when executing bash commands.
             dangerous_files (`list[str]`, optional):
                 Sensitive files that require explicit user confirmation,
                 even in BYPASS mode. Matched by basename
@@ -177,6 +178,7 @@ easier to review tool calls and give permission.
 
         self.dangerous_files = list(dangerous_files)
         self.dangerous_directories = list(dangerous_directories)
+        self._cwd = os.fspath(cwd) if cwd is not None else None
 
     async def check_read_only(
         self,
@@ -275,8 +277,7 @@ easier to review tool calls and give permission.
                 behavior=PermissionBehavior.ASK,
                 message=f"Permission required: Command contains dangerous "
                 f"pattern: {dangerous_pattern}",
-                decision_reason="Safety check: dangerous command pattern "
-                "detected",
+                decision_reason="Safety check: dangerous pattern detected",
                 bypass_immune=True,
             )
 
@@ -342,9 +343,11 @@ easier to review tool calls and give permission.
                 "cp",
                 "sed",
             }
-            base_command = (
-                command.strip().split()[0] if command.strip() else ""
-            )
+            stripped_command = command.strip()
+            if stripped_command:
+                base_command = stripped_command.split()[0]
+            else:
+                base_command = ""
 
             if base_command in filesystem_commands:
                 # Collect every target path: file arguments AND output
@@ -682,11 +685,14 @@ easier to review tool calls and give permission.
 
         try:
             # Create subprocess
+            subprocess_kwargs = _subprocess_creation_kwargs()
+            if self._cwd is not None:
+                subprocess_kwargs["cwd"] = self._cwd
             process = await asyncio.create_subprocess_shell(
                 command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                **_subprocess_creation_kwargs(),
+                **subprocess_kwargs,
             )
 
             # Wait for completion with timeout

--- a/src/agentscope/tool/_builtin/_bash.py
+++ b/src/agentscope/tool/_builtin/_bash.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """The bash tool in agentscope."""
-
 import os
 from typing import AsyncGenerator, Any, List
 import re
@@ -133,7 +132,10 @@ easier to review tool calls and give permission.
             },
             "timeout": {
                 "type": "integer",
-                "description": "Timeout in ms (default: 120000, max: 600000)",
+                "description": (
+                    "Optional timeout in milliseconds "
+                    "(default: 120000, max: 600000)"
+                ),
                 "default": 120000,
                 "maximum": 600000,
                 "minimum": 0,
@@ -157,8 +159,6 @@ easier to review tool calls and give permission.
         """Initialize the bash tool.
 
         Args:
-            cwd (`str | os.PathLike[str] | None`, optional):
-                The working directory used when executing bash commands.
             dangerous_files (`list[str]`, optional):
                 Sensitive files that require explicit user confirmation,
                 even in BYPASS mode. Matched by basename
@@ -172,6 +172,8 @@ easier to review tool calls and give permission.
                 `DEFAULT_DANGEROUS_DIRECTORIES`. Pass a custom list to
                 fully replace the defaults, or `[]` to disable the
                 directory check.
+            cwd (`str | os.PathLike[str] | None`, optional):
+                The working directory used when executing bash commands.
         """
 
         self._bash_parser = BashCommandParser()
@@ -277,7 +279,8 @@ easier to review tool calls and give permission.
                 behavior=PermissionBehavior.ASK,
                 message=f"Permission required: Command contains dangerous "
                 f"pattern: {dangerous_pattern}",
-                decision_reason="Safety check: dangerous pattern detected",
+                decision_reason="Safety check: dangerous command pattern "
+                "detected",
                 bypass_immune=True,
             )
 
@@ -343,11 +346,9 @@ easier to review tool calls and give permission.
                 "cp",
                 "sed",
             }
-            stripped_command = command.strip()
-            if stripped_command:
-                base_command = stripped_command.split()[0]
-            else:
-                base_command = ""
+            base_command = (
+                command.strip().split()[0] if command.strip() else ""
+            )
 
             if base_command in filesystem_commands:
                 # Collect every target path: file arguments AND output

--- a/tests/builtin_bash_test.py
+++ b/tests/builtin_bash_test.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 """Bash tool test case."""
+
 import sys
 import unittest
 from unittest.async_case import IsolatedAsyncioTestCase
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from agentscope.tool import ToolChunk, Bash
 from agentscope.tool._builtin._bash import _subprocess_creation_kwargs
@@ -30,6 +31,28 @@ class BashSubprocessKwargsTest(unittest.TestCase):
                 _subprocess_creation_kwargs(),
                 {"creationflags": 0x08000000},
             )
+
+
+class BashCwdTest(IsolatedAsyncioTestCase):
+    """Test Bash working-directory wiring."""
+
+    async def test_cwd_is_passed_to_subprocess(self) -> None:
+        """The constructor-level cwd should be used for each command."""
+        process = MagicMock()
+        process.returncode = 0
+        process.communicate = AsyncMock(return_value=(b"ok\n", b""))
+
+        create_process = AsyncMock(return_value=process)
+        with patch(
+            "agentscope.tool._builtin._bash.asyncio.create_subprocess_shell",
+            create_process,
+        ):
+            chunks = []
+            async for chunk in Bash(cwd="workspace")(command="pwd"):
+                chunks.append(chunk)
+
+        self.assertEqual(create_process.call_args.kwargs["cwd"], "workspace")
+        self.assertEqual(chunks[0].state, "running")
 
 
 @unittest.skipIf(

--- a/tests/builtin_bash_test.py
+++ b/tests/builtin_bash_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Bash tool test case."""
-
 import sys
 import unittest
 from unittest.async_case import IsolatedAsyncioTestCase


### PR DESCRIPTION
Fixes #1792.

## Summary
- add a constructor-level `cwd` option to the built-in Bash tool
- pass the configured cwd through to `asyncio.create_subprocess_shell`
- add a mock-based regression test that runs on Windows without requiring a real shell

## To verify
- `PYTHONPATH=src python -m pytest tests/builtin_bash_test.py -q`
- `PYTHONPATH=src python -m ruff check src/agentscope/tool/_builtin/_bash.py tests/builtin_bash_test.py`
- `PYTHONPATH=src python -m ruff format --check src/agentscope/tool/_builtin/_bash.py tests/builtin_bash_test.py`
- `git diff --check`
