### PR TITLE
fix(webui): add a route-level error boundary with a friendly error page

### DIFF
--- a/examples/web_ui/frontend/src/App.tsx
+++ b/examples/web_ui/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from 'react';
 import { createBrowserRouter, Navigate, RouterProvider, useNavigate } from 'react-router-dom';
 import { Toaster } from 'sonner';
 
+import { RouteError } from '@/components/error/RouteError';
 import { AppLayout } from '@/components/layout/AppLayout';
 import { buildChatTour } from '@/components/tour/chatTourSteps';
 import { TourCard } from '@/components/tour/TourCard';
@@ -27,17 +28,27 @@ function SetupPageRoute() {
 const router = createBrowserRouter([
 	{
 		element: <AppLayout />,
+		errorElement: <RouteError />,
 		children: [
-			{ path: '/', element: <Navigate to="/chat" replace /> },
 			{
-				path: '/chat/:agentId?/:sessionId?/:memberId?',
-				element: <ChatPage />,
+				// Content-level boundary: a crash in a page replaces only
+				// the Outlet area, so AppLayout (the icon rail / nav) stays
+				// usable. The parent route keeps its own errorElement as a
+				// last-resort catch-all for AppLayout/AppSidebar crashes.
+				errorElement: <RouteError />,
+				children: [
+					{ path: '/', element: <Navigate to="/chat" replace /> },
+					{
+						path: '/chat/:agentId?/:sessionId?/:memberId?',
+						element: <ChatPage />,
+					},
+					{ path: '/schedule', element: <SchedulePage /> },
+					{ path: '/credential', element: <CredentialPage /> },
+				],
 			},
-			{ path: '/schedule', element: <SchedulePage /> },
-			{ path: '/credential', element: <CredentialPage /> },
 		],
 	},
-	{ path: '/setup', element: <SetupPageRoute /> },
+	{ path: '/setup', element: <SetupPageRoute />, errorElement: <RouteError /> },
 ]);
 
 function App() {

--- a/examples/web_ui/frontend/src/components/error/RouteError.tsx
+++ b/examples/web_ui/frontend/src/components/error/RouteError.tsx
@@ -1,0 +1,58 @@
+import { useEffect } from 'react';
+import { isRouteErrorResponse, useNavigate, useRouteError } from 'react-router-dom';
+
+import { Button } from '@/components/ui/button';
+import { useTranslation } from '@/i18n/useI18n';
+
+/**
+ * Reduce an unknown route error to a one-line, human-readable detail.
+ * Returns `null` when there is nothing meaningful to show (e.g. a
+ * nullish throw or a plain object), so the caller can hide the detail
+ * box instead of rendering "null" / "[object Object]".
+ */
+function formatErrorDetail(error: unknown): string | null {
+	if (isRouteErrorResponse(error)) return `${error.status} ${error.statusText}`;
+	if (error instanceof Error) return error.message || null;
+	if (typeof error === 'string') return error || null;
+	if (typeof error === 'number' || typeof error === 'boolean') return String(error);
+	return null;
+}
+
+/**
+ * Route-level error boundary. React Router renders this in place of the
+ * crashed route element instead of its bare developer overlay, so end
+ * users get a friendly, localized message plus recovery actions (retry /
+ * go home) rather than a raw stack trace. The full error (with stack) is
+ * still logged to the console for developers.
+ */
+export function RouteError() {
+	const error = useRouteError();
+	const navigate = useNavigate();
+	const { t } = useTranslation();
+
+	useEffect(() => {
+		console.error(error);
+	}, [error]);
+
+	const detail = formatErrorDetail(error);
+
+	return (
+		<div className="flex h-full w-full flex-col items-center justify-center gap-4 p-8 text-center">
+			<div role="alert" className="flex flex-col gap-1">
+				<h1 className="text-lg font-semibold">{t('common.error')}</h1>
+				<p className="text-muted-foreground text-sm">{t('error.description')}</p>
+			</div>
+			{detail && (
+				<pre className="text-muted-foreground bg-muted max-w-md overflow-auto rounded-md p-3 text-left text-xs whitespace-pre-wrap">
+					{detail}
+				</pre>
+			)}
+			<div className="flex gap-2">
+				<Button variant="outline" onClick={() => navigate(0)}>
+					{t('error.retry')}
+				</Button>
+				<Button onClick={() => navigate('/')}>{t('error.home')}</Button>
+			</div>
+		</div>
+	);
+}

--- a/examples/web_ui/frontend/src/i18n/locales/en.json
+++ b/examples/web_ui/frontend/src/i18n/locales/en.json
@@ -41,6 +41,11 @@
 		"deleteTitle": "Delete {{entity}} \"{{name}}\"?",
 		"deleteDescription": "This action cannot be undone."
 	},
+	"error": {
+		"description": "The page hit an unexpected error. You can retry or go back home.",
+		"retry": "Retry",
+		"home": "Back to home"
+	},
 	"tool": {
 		"moreLines": "... {{count}} more lines",
 		"read": {

--- a/examples/web_ui/frontend/src/i18n/locales/zh.json
+++ b/examples/web_ui/frontend/src/i18n/locales/zh.json
@@ -41,6 +41,11 @@
 		"deleteTitle": "删除{{entity}} \"{{name}}\"？",
 		"deleteDescription": "此操作无法撤销。"
 	},
+	"error": {
+		"description": "页面遇到意外错误。你可以重试或返回首页。",
+		"retry": "重试",
+		"home": "返回首页"
+	},
 	"tool": {
 		"moreLines": "... 还有 {{count}} 行",
 		"read": {


### PR DESCRIPTION
## AgentScope Version

`2.0.0` (built from source — `main`)

## Description

**Problem.** `createBrowserRouter` in `App.tsx` had no `errorElement`. Any render error in a route fell through to React Router's built-in developer overlay — a raw stack trace plus a *"provide your own ErrorBoundary / errorElement"* hint — shown directly to end users.

**Solution.** Add a `RouteError` component and wire it as `errorElement` so render failures show a recoverable, localized page instead of a stack trace.

- `components/error/RouteError.tsx` (new) — `useRouteError()` → localized title (reuses `common.error`) + a one-line error detail + **Retry** / **Back to home**. The detail box is hidden for nullish / non-`Error` throws; the full error is logged via `console.error` for developers; `role="alert"` is scoped to the text region (heading + description) only, not the interactive buttons.
- `App.tsx` — `errorElement` on a **pathless content child route**, so a page crash replaces only the `<Outlet>` and the `AppLayout` sidebar rail stays usable. The `AppLayout` route and `/setup` keep their own `errorElement` as last-resort catch-alls.
- `i18n/locales/{en,zh}.json` — `error.description` / `error.retry` / `error.home`.

**Validation.**

- `tsc -b`, `eslint`, `prettier --check` all pass.
- In-browser: temporarily throwing in a route component renders the friendly page **with the sidebar rail preserved** (only the Outlet area shows the error) instead of the React Router dev overlay. Screenshot below.

**Known limitations (intentional / out of scope for this PR):**

- There are no loaders/actions, so the detail shows `error.message` for render errors; a `RouteErrorResponse.data` body wouldn't be surfaced — easy to add if loaders are introduced later.
- A 404 (no-match) is caught by the root boundary, so it replaces the whole layout (rail included) rather than just the Outlet.
- The pre-`RouterProvider` setup screen (`App.tsx`, shown when `server_url` is unset) is outside the router, so crashes there aren't covered.
- Under React StrictMode the error is logged twice in dev (once in production).

Refs #1801, #1677

## Checklist

- [x] Frontend formatted & linted — `prettier --check` / `eslint` / `tsc -b` green.
- [x] No tests affected — the `web_ui` example ships no test suite; verified in-browser.
- [x] Docstrings — N/A (no Python).
- [x] i18n updated — en/zh both carry the new `error.*` keys.
- [x] Code is ready for review.

<img width="2560" height="1800" alt="route-error-rail-preserved" src="https://github.com/user-attachments/assets/e13bbf47-5ab5-4c68-8b80-a960c5e61b0a" />
