### PR TITLE
feat(webui): clarify the credential sidebar with provider grouping

### DIFF
--- a/examples/web_ui/frontend/src/i18n/locales/en.json
+++ b/examples/web_ui/frontend/src/i18n/locales/en.json
@@ -168,7 +168,6 @@
 		"description": "Update the saved credential for this provider."
 	},
 	"credential": {
-		"addConfig": "Add configuration",
 		"noProviders": "No providers available",
 		"noConfigs": "No configurations",
 		"selectHint": "No credential selected",
@@ -178,6 +177,8 @@
 		"noModelsDescription": "This provider returned no models.",
 		"deleteEntity": "credential",
 		"subtitle": "Model API credential configuration",
+		"configured": "Configured",
+		"addProvider": "Add credential",
 		"reasoning": "Reasoning",
 		"maxContext": "Max. Context",
 		"maxOutput": "Max. Output",

--- a/examples/web_ui/frontend/src/i18n/locales/zh.json
+++ b/examples/web_ui/frontend/src/i18n/locales/zh.json
@@ -168,7 +168,6 @@
 		"description": "更新该提供商已保存的凭证。"
 	},
 	"credential": {
-		"addConfig": "添加配置",
 		"noProviders": "暂无可用提供商",
 		"noConfigs": "暂无配置",
 		"selectHint": "未选择凭证",
@@ -178,6 +177,8 @@
 		"noModelsDescription": "该提供商未返回任何模型。",
 		"deleteEntity": "凭证",
 		"subtitle": "模型 API 授权配置",
+		"configured": "已配置",
+		"addProvider": "添加凭证",
 		"reasoning": "推理模型",
 		"maxContext": "最大上下文",
 		"maxOutput": "最大输出",

--- a/examples/web_ui/frontend/src/pages/credential/index.tsx
+++ b/examples/web_ui/frontend/src/pages/credential/index.tsx
@@ -16,7 +16,6 @@ import {
 	Sidebar,
 	SidebarContent,
 	SidebarGroup,
-	SidebarGroupAction,
 	SidebarGroupContent,
 	SidebarGroupLabel,
 	SidebarHeader,
@@ -344,6 +343,11 @@ export const CredentialPage = () => {
 			};
 		});
 
+	// Split providers so the user's actual configuration leads, and the
+	// (mostly empty) "add a provider" entries don't drown it out.
+	const configuredGroups = groupedByType.filter((g) => g.records.length > 0);
+	const totalConfigured = configuredGroups.reduce((n, g) => n + g.records.length, 0);
+
 	const handleOpenCreate = useCallback((type?: string) => {
 		setCreateDefaultType(type);
 		setCreateOpen(true);
@@ -378,40 +382,68 @@ export const CredentialPage = () => {
 							</EmptyHeader>
 						</Empty>
 					) : (
-						groupedByType.map(({ type, title, records }) => (
-							<SidebarGroup key={type}>
-								<SidebarGroupLabel>{title}</SidebarGroupLabel>
-								<SidebarGroupAction
-									asChild
-									title={t('credential.addConfig')}
-									onClick={() => handleOpenCreate(type)}
-								>
-									<Button variant="ghost" size={'icon-sm'}>
-										<Plus />
-									</Button>
-								</SidebarGroupAction>
+						<>
+							{/* Configured credentials lead — this is what the user actually set up. */}
+							{configuredGroups.length > 0 && (
+								<SidebarGroup>
+									<SidebarGroupLabel>
+										{t('credential.configured')} ({totalConfigured})
+									</SidebarGroupLabel>
+									<SidebarGroupContent className="flex flex-col gap-y-4">
+										{configuredGroups.map(({ type, title, records }) => (
+											<div key={type}>
+												<div className="px-2 pb-1.5 text-xs font-semibold text-foreground/70">
+													{title}
+												</div>
+												<SidebarMenu className="pl-4">
+													{records.map((rec) => {
+														const name =
+															(rec.data.name as string | undefined) ??
+															rec.id;
+														return (
+															<SidebarMenuItem key={rec.id}>
+																<SidebarMenuButton
+																	isActive={selectedId === rec.id}
+																	onClick={() =>
+																		setSelectedId(rec.id)
+																	}
+																>
+																	<span className="min-w-0 flex-1 truncate">
+																		{name}
+																	</span>
+																</SidebarMenuButton>
+															</SidebarMenuItem>
+														);
+													})}
+												</SidebarMenu>
+											</div>
+										))}
+									</SidebarGroupContent>
+								</SidebarGroup>
+							)}
+
+							{/* Add credential — every provider is an entry point (including
+							    configured ones, to add more under the same provider). */}
+							<SidebarGroup>
+								<SidebarGroupLabel>{t('credential.addProvider')}</SidebarGroupLabel>
 								<SidebarGroupContent>
-									{records.length > 0 && (
-										<SidebarMenu>
-											{records.map((rec) => {
-												const name =
-													(rec.data.name as string | undefined) ?? rec.id;
-												return (
-													<SidebarMenuItem key={rec.id}>
-														<SidebarMenuButton
-															isActive={selectedId === rec.id}
-															onClick={() => setSelectedId(rec.id)}
-														>
-															<span className="truncate">{name}</span>
-														</SidebarMenuButton>
-													</SidebarMenuItem>
-												);
-											})}
-										</SidebarMenu>
-									)}
+									<SidebarMenu>
+										{groupedByType.map(({ type, title }) => (
+											<SidebarMenuItem key={type}>
+												<SidebarMenuButton
+													onClick={() => handleOpenCreate(type)}
+												>
+													<Plus />
+													<span className="min-w-0 flex-1 truncate">
+														{title}
+													</span>
+												</SidebarMenuButton>
+											</SidebarMenuItem>
+										))}
+									</SidebarMenu>
 								</SidebarGroupContent>
 							</SidebarGroup>
-						))
+						</>
 					)}
 				</SidebarContent>
 			</Sidebar>

--- a/src/agentscope/credential/_moonshot.py
+++ b/src/agentscope/credential/_moonshot.py
@@ -2,7 +2,7 @@
 """The Moonshot AI credential."""
 from typing import Literal, Type, TYPE_CHECKING
 
-from pydantic import Field, SecretStr
+from pydantic import ConfigDict, Field, SecretStr
 
 from ._base import CredentialBase
 
@@ -14,6 +14,10 @@ _MOONSHOT_BASE_URL = "https://api.moonshot.cn/v1"
 
 class MoonshotCredential(CredentialBase):
     """The Moonshot AI credential model."""
+
+    model_config = ConfigDict(
+        title="Moonshot API",
+    )
 
     type: Literal["moonshot_credential"] = "moonshot_credential"
     """The credential type."""


### PR DESCRIPTION
## AgentScope Version

2.0.0

## Description

Improves the credential page so the user's actual configuration leads, and a provider's multiple keys stay clearly grouped. Two related changes: a frontend IA rework plus a backend title fix that surfaced while building it.

### Frontend — group the credential sidebar by provider (`feat(webui)`)

The sidebar listed all provider _types_ flat (including the ~6 unconfigured ones), each as an identical gray label, so configured credentials had no visual prominence ("which providers did I actually set up?") and a provider with multiple keys had them scattered rather than grouped.

Now the sidebar has two sections:

- **Configured (N)** — credentials grouped **by provider**: each provider header leads its own indented keys, so multiple keys under one provider read clearly as a group.
- **Add credential** — every provider as an entry point (configured ones included, to add more keys under the same provider).

Hierarchy is built with spacing, indent, and weight (providers read as groups, credentials as their members) — no new colors or borders.

### Backend — fix the Moonshot credential schema title (`fix(credential)`)

`MoonshotCredential` was the only provider missing `model_config = ConfigDict(title=...)` that the other 7 set, so its schema `title` fell back to the class name `MoonshotCredential` — shown verbatim in the sidebar instead of `Moonshot API`. This was introduced in #1609 (the kimi → moonshot rename). Added the title to match the other providers; the frontend reads it via `schema.title`, so no frontend special-casing is needed.

### i18n

Added `credential.configured` / `credential.addProvider` (zh + en); removed the now-orphaned `credential.addConfig` (its only consumer was removed by this change). Surgical diff — no unrelated reformatting.

## How to test

- `tsc -b`, `eslint`, `prettier --check`, and `pre-commit` (mypy / black / flake8 / pylint / pyroma + check-json / trailing-whitespace) all pass on the changed files.
- Backend: `MoonshotCredential.model_json_schema()["title"]` now returns `"Moonshot API"`.
- Frontend (verified in the running Web UI): configuring multiple keys under one provider (e.g. 3 keys under OpenAI) groups them under the provider header in the **Configured** section; unconfigured providers collapse into **Add credential**. Screenshots below.

Refs #1677
Refs #1609

## Checklist

- [x] Code has been formatted (`pre-commit` mypy/black/flake8/pylint/pyroma + check-json/trailing-whitespace pass; `prettier --check` passes)
- [x] All tests are passing (no test suite for the example frontend; verified via type-check, lint, pre-commit, and browser inspection)
- [x] Docstrings are in Google style (N/A — i18n/TSX + config-only backend change)
- [x] Related documentation has been updated (N/A — bugfix + UI change)
- [x] Code is ready for review


<img width="2950" height="1532" alt="image" src="https://github.com/user-attachments/assets/58249581-7ca3-484a-8e51-8ed4a02b3f7c" />
