### PR TITLE
feat(tool):Support forwarding request metadata to MCP tools

### DIFF
--- a/src/agentscope/tool/__init__.py
+++ b/src/agentscope/tool/__init__.py
@@ -6,6 +6,7 @@ from ._response import ToolResponse, ToolChunk
 from ._toolkit import Toolkit
 from ._base import ToolBase, ParamsBase
 from ._adapters import MCPTool, FunctionTool
+from ._constants import MCP_CALL_META_KEY
 from ._builtin import (
     ResetTools,
     Bash,
@@ -36,6 +37,7 @@ __all__ = [
     "ToolChunk",
     "ToolResponse",
     "RegisteredTool",
+    "MCP_CALL_META_KEY",
     # Builtin tools
     "ResetTools",
     "Bash",

--- a/src/agentscope/tool/_adapters.py
+++ b/src/agentscope/tool/_adapters.py
@@ -291,6 +291,10 @@ class MCPTool(ToolBase):
             `ToolChunk`: The converted tool execution result.
         """
 
+        meta = kwargs.pop("_meta", None)
+        if meta is not None and not isinstance(meta, dict):
+            meta = None
+
         # Call the MCP tool
         if self._client_gen:
             # Stateless client: create temporary session
@@ -302,6 +306,7 @@ class MCPTool(ToolBase):
                         self._tool.name,
                         arguments=kwargs,
                         read_timeout_seconds=self._timeout,
+                        meta=meta,
                     )
         else:
             # Stateful client: use existing session
@@ -309,6 +314,7 @@ class MCPTool(ToolBase):
                 self._tool.name,
                 arguments=kwargs,
                 read_timeout_seconds=self._timeout,
+                meta=meta,
             )
 
         # Convert MCP result to AgentScope blocks

--- a/src/agentscope/tool/_constants.py
+++ b/src/agentscope/tool/_constants.py
@@ -108,3 +108,20 @@ DANGEROUS_NODE_TYPES = {
 #
 # Note: simple_expansion ($VAR) is handled separately with allowlist
 # for known-safe environment variables ($HOME, $PWD, etc.)
+
+MCP_CALL_META_KEY = "__tool_call_meta__"
+# Reserved key under `Msg.metadata` for per-request meta forwarded to MCP.
+#
+# Flow:
+# 1. Caller stores a dict at `UserMsg.metadata[MCP_CALL_META_KEY]`.
+# 2. `Toolkit.call_tool` walks `state.context` in reverse, picks the most
+#    recent user message, and injects that dict as `kwargs["_meta"]`
+#    (only when the target tool is an MCP tool).
+# 3. `MCPTool.__call__` pops `_meta` from kwargs and passes it as the
+#    `meta` kwarg of `session.call_tool(...)`.
+# 4. The MCP server reads it from `CallToolRequestParams.meta`, surfaced
+#    to tool handlers via `ctx.request_context.meta`.
+#
+# The dict stays out of LLM sight (the tool schema is unchanged) and
+# out of tool args (`_meta` is popped before `session.call_tool`
+# receives `arguments=kwargs`).

--- a/src/agentscope/tool/_toolkit.py
+++ b/src/agentscope/tool/_toolkit.py
@@ -18,6 +18,7 @@ from pydantic import (
     create_model,
 )
 
+from ._constants import MCP_CALL_META_KEY
 from ._builtin import ResetTools, SkillViewer
 from ._base import ToolBase
 from ._response import ToolResponse, ToolChunk
@@ -222,6 +223,13 @@ class Toolkit:
 
         return function_schemas
 
+    def _extract_mcp_call_meta(self, state: AgentState) -> dict | None:
+        """Return the MCP call meta dict from the most recent user message."""
+        for msg in reversed(state.context):
+            if msg.role == "user":
+                return msg.metadata.get(MCP_CALL_META_KEY)
+        return None
+
     async def call_tool(
         self,
         tool_call: ToolCallBlock,
@@ -305,6 +313,12 @@ class Toolkit:
                 and not tool_func.is_external_tool
             ):
                 kwargs["_agent_state"] = state
+
+            # MCP call meta injection, symmetric with `_agent_state` above
+            if tool_func.is_mcp and not tool_func.is_external_tool:
+                mcp_call_meta = self._extract_mcp_call_meta(state)
+                if mcp_call_meta is not None:
+                    kwargs["_meta"] = mcp_call_meta
 
             if inspect.iscoroutinefunction(tool_func.__call__):
                 res = await tool_func(**kwargs)


### PR DESCRIPTION
## AgentScope Version

2.0.1

## Description

This change adds support for passing per-request metadata from user messages to MCP tools.

A caller can attach a metadata dictionary to the user message context, and the framework will automatically forward it to the target MCP tool invocation. The metadata is delivered through the MCP request context, allowing tool handlers to access request-scoped information without exposing it to the LLM or modifying tool schemas.

Benefits
Supports request-scoped context propagation for MCP tools.
Keeps metadata hidden from the model and tool argument schema.
Requires no changes to existing tool definitions.
Provides a clean mechanism for passing tracing, authentication, routing, or other contextual information to MCP servers.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review