### PR TITLE
fix(agent): guard against empty or interrupted streaming responses

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -842,13 +842,14 @@ class Agent:
                 reply_id=self.state.reply_id,
                 block_id=data_block_id,
             )
-        
+
         # Guard against empty or interrupted streaming responses.
         if completed_response is None:
             raise RuntimeError(
-                "Model returned an empty streaming response: no is_last=True "
-                "chunk was received.  The model call may have been interrupted "
-                "mid-stream (network dropout, timeout, or model bug).",
+                "Model returned an empty streaming response: no is_last=True"
+                " chunk was received.  The model call may have been "
+                "interrupted mid-stream (network dropout, timeout, or model "
+                "bug).",
             )
 
         # Send the model call ended event with usage if available

--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -842,6 +842,14 @@ class Agent:
                 reply_id=self.state.reply_id,
                 block_id=data_block_id,
             )
+        
+        # Guard against empty or interrupted streaming responses.
+        if completed_response is None:
+            raise RuntimeError(
+                "Model returned an empty streaming response: no is_last=True "
+                "chunk was received.  The model call may have been interrupted "
+                "mid-stream (network dropout, timeout, or model bug).",
+            )
 
         # Send the model call ended event with usage if available
         yield ModelCallEndEvent(


### PR DESCRIPTION
## PR Title Format

fix(agent): guard against empty or interrupted streaming responses

## AgentScope Version

AgentScope Version: 2.0.1

## Description

This PR fixes a bug in `Agent._reasoning_impl()` where `completed_response` remains `None` when a streaming model response yields zero chunks, or when the stream is cut off before any chunk with `is_last=True` arrives.
The code then dereferences `.usage` and `.content` on `None`, causing:
AttributeError: 'NoneType' object has no attribute 'usage'

Fixes #1860

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  An issue has been created for this PR
- [x]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x]  Docstrings are in Google style
- []  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [x]  Code is ready for review