### PR TITLE
feat(service): expose background tasks via REST endpoints

### DIFF
--- a/src/agentscope/app/_app.py
+++ b/src/agentscope/app/_app.py
@@ -6,6 +6,7 @@ from ._lifespan import lifespan
 from .workspace_manager import WorkspaceManagerBase
 from ._router import (
     agent_router,
+    background_task_router,
     chat_router,
     credential_router,
     model_router,
@@ -164,6 +165,7 @@ def create_app(
     # Built-in routers
     for router in (
         agent_router,
+        background_task_router,
         chat_router,
         credential_router,
         schedule_router,

--- a/src/agentscope/app/_manager/__init__.py
+++ b/src/agentscope/app/_manager/__init__.py
@@ -6,12 +6,13 @@ from ._scheduler import SchedulerManager
 from ._wakeup_dispatcher import WakeupDispatcher
 from ._cancel_dispatcher import CancelDispatcher
 from ._chat_run_registry import ChatRunRegistry
-from ._background_task_manager import BackgroundTaskManager
+from ._background_task_manager import BackgroundTaskManager, TaskStatus
 
 __all__ = [
     "BackgroundTaskManager",
     "CancelDispatcher",
     "ChatRunRegistry",
     "SchedulerManager",
+    "TaskStatus",
     "WakeupDispatcher",
 ]

--- a/src/agentscope/app/_manager/_background_task_manager.py
+++ b/src/agentscope/app/_manager/_background_task_manager.py
@@ -5,6 +5,7 @@ import json
 import time
 from collections import OrderedDict
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any, Self, TYPE_CHECKING
 
 import shortuuid
@@ -21,6 +22,19 @@ from agentscope._logging import logger
 
 if TYPE_CHECKING:
     from ..message_bus import MessageBus
+
+
+class TaskStatus(str, Enum):
+    """Status of a background task throughout its lifecycle."""
+
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+_MAX_RETAINED_TASKS = 50
+# Maximum number of terminal-state tasks to keep for frontend polling.
 
 
 @dataclass
@@ -40,6 +54,19 @@ class BackgroundTask:
             The name of the tool that was offloaded.
         id (`str`):
             Auto-generated unique task identifier.
+        summary (`str`):
+            A short human-readable summary of the tool invocation
+            for frontend display (at most 128 characters).
+        started_at (`float`):
+            Unix epoch (UTC) when the task was registered.
+        completed_at (`float | None`):
+            Unix epoch (UTC) when the task reached a terminal state,
+            or ``None`` while still running.
+        status (`TaskStatus`):
+            Current lifecycle status of the task.
+        error_summary (`str | None`):
+            Brief description of the failure reason when
+            ``status == FAILED``.
     """
 
     asyncio_task: asyncio.Task
@@ -59,6 +86,21 @@ class BackgroundTask:
 
     id: str = field(default_factory=shortuuid.uuid)
     """The background task id."""
+
+    summary: str = ""
+    """Short human-readable summary for frontend display."""
+
+    started_at: float = field(default_factory=time.time)
+    """Unix epoch (UTC) when the task was registered."""
+
+    completed_at: float | None = None
+    """Unix epoch (UTC) when the task finished, or None if running."""
+
+    status: TaskStatus = TaskStatus.RUNNING
+    """Current lifecycle status."""
+
+    error_summary: str | None = None
+    """Brief failure description (populated only for FAILED tasks)."""
 
 
 class _ToolStopParams(BaseModel):
@@ -249,12 +291,15 @@ class BackgroundTaskManager:
         agent_id: str,
         user_id: str,
         tool_name: str = "",
+        *,
+        summary: str = "",
     ) -> str:
         """Register an already-running asyncio task.
 
         Writes to both the local handle cache and the global Redis
-        registry. The task auto-removes from both when it finishes
-        (via ``add_done_callback``).
+        registry. On completion, updates the task status (rather than
+        removing immediately) so frontends can observe terminal states
+        via polling.
 
         Args:
             asyncio_task (`asyncio.Task`):
@@ -267,6 +312,9 @@ class BackgroundTaskManager:
                 The user id of the originating request.
             tool_name (`str`, optional):
                 The name of the offloaded tool.
+            summary (`str`, optional):
+                Short human-readable summary of the tool invocation
+                for frontend display.
 
         Returns:
             `str`:
@@ -278,6 +326,7 @@ class BackgroundTaskManager:
             agent_id=agent_id,
             user_id=user_id,
             tool_name=tool_name,
+            summary=summary,
         )
         task_id = bg_task.id
         self.tasks[task_id] = bg_task
@@ -287,7 +336,7 @@ class BackgroundTaskManager:
             {
                 "tool_name": tool_name,
                 "agent_id": agent_id,
-                "started_at": time.time(),
+                "started_at": bg_task.started_at,
             },
         )
         await self._message_bus.bg_task_register(
@@ -306,11 +355,20 @@ class BackgroundTaskManager:
         )
 
         def _on_done(_t: asyncio.Task) -> None:
-            self.tasks.pop(task_id, None)
-            # Schedule async Redis cleanup (fire-and-forget). Wrap in a
-            # coroutine that logs failures so the bus error (e.g. Redis
-            # connection drop) does not surface as
-            # ``Task exception was never retrieved``.
+            bg = self.tasks.get(task_id)
+            if bg is None:
+                return
+
+            bg.completed_at = time.time()
+            if _t.cancelled():
+                bg.status = TaskStatus.CANCELLED
+            elif _t.exception() is not None:
+                bg.status = TaskStatus.FAILED
+                bg.error_summary = str(_t.exception())[:512]
+            else:
+                bg.status = TaskStatus.COMPLETED
+
+            # Unregister from the global Redis registry.
             try:
                 asyncio.ensure_future(
                     self._safe_bg_task_unregister(session_id, task_id),
@@ -318,6 +376,8 @@ class BackgroundTaskManager:
             except RuntimeError:
                 # Event loop already closed during shutdown.
                 pass
+
+            self._evict_completed()
 
         asyncio_task.add_done_callback(_on_done)
         return task_id
@@ -348,6 +408,80 @@ class BackgroundTaskManager:
                 session_id,
                 str(e),
             )
+
+    def _evict_completed(self) -> None:
+        """Remove the oldest terminal-state tasks when capacity is exceeded.
+
+        Keeps at most :data:`_MAX_RETAINED_TASKS` completed/failed/cancelled
+        tasks in the local registry so memory usage stays bounded while
+        still giving frontends a window to observe terminal states.
+        """
+        completed = [
+            tid
+            for tid, t in self.tasks.items()
+            if t.status != TaskStatus.RUNNING
+        ]
+        while len(completed) > _MAX_RETAINED_TASKS:
+            oldest = completed.pop(0)
+            self.tasks.pop(oldest, None)
+
+    # ------------------------------------------------------------------
+    # Task querying (for REST endpoints)
+    # ------------------------------------------------------------------
+
+    def list_tasks(
+        self,
+        *,
+        user_id: str,
+        session_id: str | None = None,
+    ) -> list[BackgroundTask]:
+        """List tasks visible to a given user.
+
+        Returns both running and recently-completed tasks that are
+        still within the retention window.
+
+        Args:
+            user_id (`str`):
+                Only return tasks belonging to this user.
+            session_id (`str | None`, optional):
+                If provided, further filter by session.
+
+        Returns:
+            `list[BackgroundTask]`:
+                Matching tasks ordered by registration time.
+        """
+        return [
+            t
+            for t in self.tasks.values()
+            if t.user_id == user_id
+            and (session_id is None or t.session_id == session_id)
+        ]
+
+    def get_task(
+        self,
+        task_id: str,
+        *,
+        user_id: str,
+    ) -> BackgroundTask | None:
+        """Get a single task by id, scoped to the requesting user.
+
+        Returns ``None`` when the task does not exist or belongs to a
+        different user (no information leakage about task existence).
+
+        Args:
+            task_id (`str`):
+                The task identifier.
+            user_id (`str`):
+                The requesting user's id.
+
+        Returns:
+            `BackgroundTask | None`:
+                The task if found and owned by *user_id*, else ``None``.
+        """
+        t = self.tasks.get(task_id)
+        if t is None or t.user_id != user_id:
+            return None
+        return t
 
     # ------------------------------------------------------------------
     # Tool listing

--- a/src/agentscope/app/_router/__init__.py
+++ b/src/agentscope/app/_router/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """App routers."""
 from ._agent import agent_router
+from ._background_task import background_task_router
 from ._chat import chat_router
 from ._credential import credential_router
 from ._schedule import schedule_router
@@ -11,6 +12,7 @@ from ._workspace import workspace_router
 
 __all__ = [
     "agent_router",
+    "background_task_router",
     "model_router",
     "tts_model_router",
     "chat_router",

--- a/src/agentscope/app/_router/_background_task.py
+++ b/src/agentscope/app/_router/_background_task.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""Background-task router — read-only endpoints for task observability."""
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from ..deps import get_background_task_manager, get_current_user_id
+from .._manager import BackgroundTaskManager
+from ._schema import (
+    BackgroundTaskInfo,
+    ListBackgroundTasksResponse,
+    to_info,
+)
+
+background_task_router = APIRouter(
+    prefix="/background-tasks",
+    tags=["background-tasks"],
+    responses={404: {"description": "Not found"}},
+)
+
+
+@background_task_router.get(
+    "",
+    response_model=ListBackgroundTasksResponse,
+    summary="List background tasks for the current user",
+)
+async def list_background_tasks(
+    session_id: str
+    | None = Query(
+        default=None,
+        description="Optional session filter.",
+    ),
+    user_id: str = Depends(get_current_user_id),
+    bg_manager: BackgroundTaskManager = Depends(
+        get_background_task_manager,
+    ),
+) -> ListBackgroundTasksResponse:
+    """List all background tasks (running and recently-completed) visible
+    to the authenticated user.
+
+    Args:
+        session_id (`str | None`, optional):
+            If provided, only return tasks belonging to this session.
+        user_id (`str`):
+            The authenticated user id (from ``X-User-ID`` header).
+        bg_manager (`BackgroundTaskManager`):
+            The application-wide background task manager.
+
+    Returns:
+        `ListBackgroundTasksResponse`:
+            Tasks and their total count.
+    """
+    tasks = bg_manager.list_tasks(
+        user_id=user_id,
+        session_id=session_id,
+    )
+    infos = [to_info(t) for t in tasks]
+    return ListBackgroundTasksResponse(tasks=infos, total=len(infos))
+
+
+@background_task_router.get(
+    "/{task_id}",
+    response_model=BackgroundTaskInfo,
+    summary="Get a single background task by id",
+)
+async def get_background_task(
+    task_id: str,
+    user_id: str = Depends(get_current_user_id),
+    bg_manager: BackgroundTaskManager = Depends(
+        get_background_task_manager,
+    ),
+) -> BackgroundTaskInfo:
+    """Retrieve details of a single background task.
+
+    Returns 404 when the task does not exist or belongs to a different
+    user (no information leakage about task existence).
+
+    Args:
+        task_id (`str`):
+            The unique task identifier.
+        user_id (`str`):
+            The authenticated user id (from ``X-User-ID`` header).
+        bg_manager (`BackgroundTaskManager`):
+            The application-wide background task manager.
+
+    Returns:
+        `BackgroundTaskInfo`:
+            The task details.
+
+    Raises:
+        `HTTPException`:
+            404 if the task is not found or not owned by the user.
+    """
+    task = bg_manager.get_task(task_id, user_id=user_id)
+    if task is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Background task '{task_id}' not found.",
+        )
+    return to_info(task)

--- a/src/agentscope/app/_router/_schema/__init__.py
+++ b/src/agentscope/app/_router/_schema/__init__.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 """Schema models for the agent service."""
 
+from ._background_task import (
+    BackgroundTaskInfo,
+    ListBackgroundTasksResponse,
+    to_info,
+)
 from ._chat import ChatRequest, ChatTriggerResponse
 from ._model import ListModelsResponse, ListModelsRequest
 from ._tts_model import ListTTSModelsResponse, ListTTSModelsRequest
@@ -44,6 +49,10 @@ __all__ = [
     "CreateAgentResponse",
     "UpdateAgentRequest",
     "ListSchedulesResponse",
+    # Background Task
+    "BackgroundTaskInfo",
+    "ListBackgroundTasksResponse",
+    "to_info",
     # Chat
     "ChatRequest",
     "ChatTriggerResponse",

--- a/src/agentscope/app/_router/_schema/_background_task.py
+++ b/src/agentscope/app/_router/_schema/_background_task.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""Request / response schemas for the background-task router."""
+from datetime import datetime, timezone
+
+from pydantic import BaseModel, Field
+
+from ..._manager._background_task_manager import (
+    BackgroundTask,
+    TaskStatus,
+)
+
+
+class BackgroundTaskInfo(BaseModel):
+    """Summary of a single background task for API responses."""
+
+    task_id: str = Field(description="Unique task identifier.")
+    session_id: str = Field(description="Session that owns this task.")
+    agent_id: str = Field(description="Agent that triggered this task.")
+    tool_name: str = Field(description="Name of the offloaded tool.")
+    summary: str = Field(
+        description="Short human-readable summary of the tool invocation.",
+    )
+    status: TaskStatus = Field(description="Current lifecycle status.")
+    started_at: datetime = Field(
+        description="UTC timestamp when the task was registered.",
+    )
+    completed_at: datetime | None = Field(
+        default=None,
+        description="UTC timestamp when the task reached a terminal "
+        "state, or null while still running.",
+    )
+    error_summary: str | None = Field(
+        default=None,
+        description="Brief failure description (only for failed tasks).",
+    )
+
+
+class ListBackgroundTasksResponse(BaseModel):
+    """Response body for listing background tasks."""
+
+    tasks: list[BackgroundTaskInfo] = Field(
+        description="Background tasks for the requested scope.",
+    )
+    total: int = Field(description="Total number of tasks returned.")
+
+
+def to_info(task: BackgroundTask) -> BackgroundTaskInfo:
+    """Convert an internal :class:`BackgroundTask` to an API-facing schema.
+
+    Args:
+        task (`BackgroundTask`):
+            The internal background task dataclass instance.
+
+    Returns:
+        `BackgroundTaskInfo`:
+            The serializable API response model.
+    """
+    return BackgroundTaskInfo(
+        task_id=task.id,
+        session_id=task.session_id,
+        agent_id=task.agent_id,
+        tool_name=task.tool_name,
+        summary=task.summary,
+        status=task.status,
+        started_at=datetime.fromtimestamp(
+            task.started_at,
+            tz=timezone.utc,
+        ),
+        completed_at=(
+            datetime.fromtimestamp(task.completed_at, tz=timezone.utc)
+            if task.completed_at is not None
+            else None
+        ),
+        error_summary=task.error_summary,
+    )

--- a/src/agentscope/app/middleware/_tool_offload_middleware.py
+++ b/src/agentscope/app/middleware/_tool_offload_middleware.py
@@ -22,7 +22,7 @@ bus/wakeup infrastructure, which works correctly across processes.
 import asyncio
 import json
 from copy import deepcopy
-from typing import AsyncGenerator, Callable
+from typing import Any, AsyncGenerator, Callable
 
 from .._manager import BackgroundTaskManager
 from ...middleware import MiddlewareBase
@@ -40,6 +40,62 @@ from ..._logging import logger
 
 # Sentinel object used to signal end-of-stream in the drain queue.
 _QUEUE_SENTINEL = object()
+
+_SUMMARY_MAX_LEN = 128
+
+
+def _make_summary(tool_name: str, raw_input: str | None) -> str:
+    """Generate a short human-readable summary for frontend display.
+
+    The result is guaranteed to be at most :data:`_SUMMARY_MAX_LEN`
+    characters. For dict-shaped JSON inputs, multiple key=value pairs
+    are included up to the length budget.
+
+    Args:
+        tool_name (`str`):
+            The tool name (always included as prefix).
+        raw_input (`str | None`):
+            The raw JSON-encoded tool input string.
+
+    Returns:
+        `str`:
+            A concise summary such as ``Bash(command=ls -la, ...)``.
+    """
+    if not raw_input:
+        return tool_name[:_SUMMARY_MAX_LEN]
+
+    try:
+        parsed: Any = json.loads(raw_input)
+    except (json.JSONDecodeError, TypeError):
+        snippet = raw_input[:64]
+        suffix = "..." if len(raw_input) > 64 else ""
+        result = f"{tool_name}({snippet}{suffix})"
+        return result[:_SUMMARY_MAX_LEN]
+
+    if not isinstance(parsed, dict) or not parsed:
+        return tool_name[:_SUMMARY_MAX_LEN]
+
+    prefix = f"{tool_name}("
+    suffix = ")"
+    budget = _SUMMARY_MAX_LEN - len(prefix) - len(suffix)
+    if budget <= 0:
+        return tool_name[:_SUMMARY_MAX_LEN]
+
+    parts: list[str] = []
+    used = 0
+    for key, val in parsed.items():
+        val_str = str(val)
+        if len(val_str) > 40:
+            val_str = val_str[:37] + "..."
+        part = f"{key}={val_str}"
+        separator_len = 2 if parts else 0
+        if used + len(part) + separator_len > budget:
+            parts.append("...")
+            break
+        parts.append(part)
+        used += len(part) + separator_len
+
+    return (prefix + ", ".join(parts) + suffix)[:_SUMMARY_MAX_LEN]
 
 
 class ToolOffloadMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
@@ -361,6 +417,7 @@ class ToolOffloadMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
             agent_id=self._agent_id,
             user_id=self._user_id,
             tool_name=tool_name,
+            summary=_make_summary(tool_name, tool_call.input),
         )
 
         logger.info(

--- a/tests/background_task_endpoint_test.py
+++ b/tests/background_task_endpoint_test.py
@@ -1,0 +1,338 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Unit tests for the background task endpoint feature.
+
+Tests cover:
+- TaskStatus lifecycle transitions in BackgroundTaskManager
+- Capacity-based eviction of terminal-state tasks
+- _make_summary helper in ToolOffloadMiddleware
+- Background task REST endpoints (list + detail)
+"""
+import asyncio
+import json
+import time
+from unittest.async_case import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock
+
+from agentscope.app._manager import BackgroundTaskManager, TaskStatus
+from agentscope.app._manager._background_task_manager import (
+    _MAX_RETAINED_TASKS,
+)
+from agentscope.app.message_bus import MessageBus
+from agentscope.app.middleware._tool_offload_middleware import (
+    _make_summary,
+)
+
+
+class TestTaskStatusLifecycle(IsolatedAsyncioTestCase):
+    """Test status transitions in BackgroundTaskManager._on_done."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up a manager with a mock message bus."""
+        self.bus = MagicMock(spec=MessageBus)
+        self.bus.bg_task_register = AsyncMock()
+        self.bus.bg_task_unregister = AsyncMock()
+        self.mgr = BackgroundTaskManager(message_bus=self.bus)
+
+    async def test_completed_status_on_normal_finish(self) -> None:
+        """A task that completes normally transitions to COMPLETED."""
+
+        async def _work() -> str:
+            return "done"
+
+        task = asyncio.create_task(_work())
+        task_id = await self.mgr.register_task(
+            asyncio_task=task,
+            session_id="s1",
+            agent_id="a1",
+            user_id="u1",
+            tool_name="test_tool",
+            summary="test_tool()",
+        )
+        await asyncio.sleep(0.05)
+
+        bg = self.mgr.tasks[task_id]
+        self.assertEqual(bg.status, TaskStatus.COMPLETED)
+        self.assertIsNotNone(bg.completed_at)
+        self.assertIsNone(bg.error_summary)
+
+    async def test_failed_status_on_exception(self) -> None:
+        """A task that raises transitions to FAILED with error_summary."""
+
+        async def _work() -> None:
+            raise ValueError("something broke")
+
+        task = asyncio.create_task(_work())
+        task_id = await self.mgr.register_task(
+            asyncio_task=task,
+            session_id="s1",
+            agent_id="a1",
+            user_id="u1",
+            tool_name="broken_tool",
+        )
+        await asyncio.sleep(0.05)
+
+        bg = self.mgr.tasks[task_id]
+        self.assertEqual(bg.status, TaskStatus.FAILED)
+        self.assertIn("something broke", bg.error_summary or "")
+        self.assertIsNotNone(bg.completed_at)
+
+    async def test_cancelled_status_on_cancel(self) -> None:
+        """A cancelled task transitions to CANCELLED."""
+
+        async def _work() -> None:
+            await asyncio.sleep(100)
+
+        task = asyncio.create_task(_work())
+        task_id = await self.mgr.register_task(
+            asyncio_task=task,
+            session_id="s1",
+            agent_id="a1",
+            user_id="u1",
+            tool_name="long_tool",
+        )
+        task.cancel()
+        await asyncio.sleep(0.05)
+
+        bg = self.mgr.tasks[task_id]
+        self.assertEqual(bg.status, TaskStatus.CANCELLED)
+        self.assertIsNotNone(bg.completed_at)
+
+    async def test_summary_and_started_at_are_recorded(self) -> None:
+        """Registered tasks store summary and started_at."""
+
+        async def _work() -> None:
+            await asyncio.sleep(100)
+
+        before = time.time()
+        task = asyncio.create_task(_work())
+        task_id = await self.mgr.register_task(
+            asyncio_task=task,
+            session_id="s1",
+            agent_id="a1",
+            user_id="u1",
+            tool_name="my_tool",
+            summary="my_tool(x=1)",
+        )
+        after = time.time()
+
+        bg = self.mgr.tasks[task_id]
+        self.assertEqual(bg.summary, "my_tool(x=1)")
+        self.assertGreaterEqual(bg.started_at, before)
+        self.assertLessEqual(bg.started_at, after)
+
+        task.cancel()
+        await asyncio.sleep(0.05)
+
+
+class TestEviction(IsolatedAsyncioTestCase):
+    """Test capacity-based eviction of terminal-state tasks."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up a manager with a mock message bus."""
+        self.bus = MagicMock(spec=MessageBus)
+        self.bus.bg_task_register = AsyncMock()
+        self.bus.bg_task_unregister = AsyncMock()
+        self.mgr = BackgroundTaskManager(message_bus=self.bus)
+
+    async def test_eviction_removes_oldest_completed(self) -> None:
+        """When completed tasks exceed _MAX_RETAINED_TASKS, oldest are
+        removed."""
+        tasks = []
+        for i in range(_MAX_RETAINED_TASKS + 5):
+
+            async def _work(idx: int = i) -> int:
+                return idx
+
+            t = asyncio.create_task(_work())
+            await self.mgr.register_task(
+                asyncio_task=t,
+                session_id="s",
+                agent_id="a",
+                user_id="u",
+                tool_name=f"tool_{i}",
+            )
+            tasks.append(t)
+
+        # Wait for all to complete
+        await asyncio.sleep(0.1)
+
+        completed = [
+            t
+            for t in self.mgr.tasks.values()
+            if t.status != TaskStatus.RUNNING
+        ]
+        self.assertLessEqual(len(completed), _MAX_RETAINED_TASKS)
+
+
+class TestListAndGetTasks(IsolatedAsyncioTestCase):
+    """Test list_tasks and get_task query methods."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up a manager with a mock message bus."""
+        self.bus = MagicMock(spec=MessageBus)
+        self.bus.bg_task_register = AsyncMock()
+        self.bus.bg_task_unregister = AsyncMock()
+        self.mgr = BackgroundTaskManager(message_bus=self.bus)
+
+    async def test_list_tasks_filters_by_user(self) -> None:
+        """list_tasks only returns tasks owned by the specified user."""
+
+        async def _work() -> None:
+            await asyncio.sleep(100)
+
+        t1 = asyncio.create_task(_work())
+        t2 = asyncio.create_task(_work())
+        await self.mgr.register_task(
+            asyncio_task=t1,
+            session_id="s1",
+            agent_id="a1",
+            user_id="alice",
+            tool_name="tool_a",
+        )
+        await self.mgr.register_task(
+            asyncio_task=t2,
+            session_id="s2",
+            agent_id="a2",
+            user_id="bob",
+            tool_name="tool_b",
+        )
+
+        alice_tasks = self.mgr.list_tasks(user_id="alice")
+        self.assertEqual(len(alice_tasks), 1)
+        self.assertEqual(alice_tasks[0].user_id, "alice")
+
+        bob_tasks = self.mgr.list_tasks(user_id="bob")
+        self.assertEqual(len(bob_tasks), 1)
+        self.assertEqual(bob_tasks[0].user_id, "bob")
+
+        t1.cancel()
+        t2.cancel()
+        await asyncio.sleep(0.05)
+
+    async def test_list_tasks_filters_by_session(self) -> None:
+        """list_tasks with session_id filter narrows results."""
+
+        async def _work() -> None:
+            await asyncio.sleep(100)
+
+        t1 = asyncio.create_task(_work())
+        t2 = asyncio.create_task(_work())
+        await self.mgr.register_task(
+            asyncio_task=t1,
+            session_id="s1",
+            agent_id="a1",
+            user_id="alice",
+            tool_name="tool_a",
+        )
+        await self.mgr.register_task(
+            asyncio_task=t2,
+            session_id="s2",
+            agent_id="a2",
+            user_id="alice",
+            tool_name="tool_b",
+        )
+
+        filtered = self.mgr.list_tasks(
+            user_id="alice",
+            session_id="s1",
+        )
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0].session_id, "s1")
+
+        t1.cancel()
+        t2.cancel()
+        await asyncio.sleep(0.05)
+
+    async def test_get_task_returns_none_for_other_user(self) -> None:
+        """get_task returns None when user_id doesn't match."""
+
+        async def _work() -> None:
+            await asyncio.sleep(100)
+
+        t = asyncio.create_task(_work())
+        task_id = await self.mgr.register_task(
+            asyncio_task=t,
+            session_id="s1",
+            agent_id="a1",
+            user_id="alice",
+            tool_name="tool_a",
+        )
+
+        self.assertIsNotNone(
+            self.mgr.get_task(task_id, user_id="alice"),
+        )
+        self.assertIsNone(
+            self.mgr.get_task(task_id, user_id="bob"),
+        )
+
+        t.cancel()
+        await asyncio.sleep(0.05)
+
+    async def test_get_task_returns_none_for_missing_id(self) -> None:
+        """get_task returns None for a non-existent task_id."""
+        self.assertIsNone(
+            self.mgr.get_task("nonexistent", user_id="anyone"),
+        )
+
+
+class TestMakeSummary(IsolatedAsyncioTestCase):
+    """Test the _make_summary helper function."""
+
+    async def test_empty_input_returns_tool_name(self) -> None:
+        """Empty or None input returns just the tool name."""
+        self.assertEqual(_make_summary("Bash", None), "Bash")
+        self.assertEqual(_make_summary("Bash", ""), "Bash")
+
+    async def test_dict_input_includes_key_values(self) -> None:
+        """JSON dict input produces key=value summary."""
+        raw = json.dumps({"command": "ls -la", "timeout": 30})
+        result = _make_summary("Bash", raw)
+        self.assertIn("Bash(", result)
+        self.assertIn("command=ls -la", result)
+        self.assertIn("timeout=30", result)
+        self.assertTrue(result.endswith(")"))
+
+    async def test_respects_max_length(self) -> None:
+        """Summary never exceeds _SUMMARY_MAX_LEN characters."""
+        raw = json.dumps({"key": "x" * 200, "other": "y" * 200})
+        result = _make_summary("VeryLongToolName", raw)
+        self.assertLessEqual(len(result), 128)
+
+    async def test_non_json_input_is_truncated(self) -> None:
+        """Non-JSON input is included as-is with truncation."""
+        raw = "a" * 100
+        result = _make_summary("Tool", raw)
+        self.assertIn("Tool(", result)
+        self.assertIn("...", result)
+        self.assertLessEqual(len(result), 128)
+
+    async def test_non_json_short_input_no_ellipsis(self) -> None:
+        """Short non-JSON input doesn't get a misleading ellipsis."""
+        result = _make_summary("Tool", "hi")
+        self.assertEqual(result, "Tool(hi)")
+
+    async def test_empty_dict_returns_tool_name(self) -> None:
+        """Empty JSON dict returns just the tool name."""
+        result = _make_summary("Tool", "{}")
+        self.assertEqual(result, "Tool")
+
+    async def test_non_dict_json_returns_tool_name(self) -> None:
+        """JSON that's not a dict returns just the tool name."""
+        result = _make_summary("Tool", "[1, 2, 3]")
+        self.assertEqual(result, "Tool")
+
+    async def test_long_values_are_truncated(self) -> None:
+        """Individual values longer than 40 chars are truncated."""
+        raw = json.dumps({"file": "/" + "a" * 100})
+        result = _make_summary("Read", raw)
+        self.assertIn("...", result)
+        self.assertLessEqual(len(result), 128)
+
+    async def test_multiple_keys_included_within_budget(self) -> None:
+        """Multiple short key-values are all included."""
+        raw = json.dumps({"a": "1", "b": "2", "c": "3"})
+        result = _make_summary("T", raw)
+        self.assertIn("a=1", result)
+        self.assertIn("b=2", result)
+        self.assertIn("c=3", result)


### PR DESCRIPTION
## AgentScope Version

2.0.1

## Description

**Background**

`ToolOffloadMiddleware` offloads tool calls that exceed the timeout to background `asyncio` tasks. However, there was no REST endpoint for the frontend to observe the status of these background tasks, leaving users unaware of ongoing or recently-completed executions (issue #1720).

**Changes**

- **`BackgroundTask` dataclass** — added five fields: `summary` (≤128-char human-readable invocation summary), `started_at` (Unix epoch), `completed_at`, `status` (`TaskStatus` enum: `running` / `completed` / `failed` / `cancelled`), and `error_summary`.
- **`TaskStatus` enum** — new `str` enum tracking the full task lifecycle.
- **`_on_done` callback** — rewritten from "remove on completion" to "update status + capacity-based eviction". Terminal-state tasks are retained (up to `_MAX_RETAINED_TASKS = 50`) so frontends can observe outcomes via polling.
- **`BackgroundTaskManager`** — added `list_tasks(user_id, session_id?)` and `get_task(task_id, user_id)` query methods; `register_task` gains a `summary` keyword argument (backward-compatible default `""`).
- **`ToolOffloadMiddleware`** — added `_make_summary` helper that generates a concise summary from the tool name and JSON input, passed to `register_task` at offload time.
- **New `_router/_background_task.py`** — two read-only endpoints, both user-isolated via `Depends(get_current_user_id)`:
  - `GET /background-tasks` — list all tasks for the current user (optional `?session_id=` filter)
  - `GET /background-tasks/{task_id}` — single task detail; returns 404 for missing or cross-user access
- **New `_router/_schema/_background_task.py`** — `BackgroundTaskInfo` and `ListBackgroundTasksResponse` Pydantic models; `to_info` conversion helper.
- No `DELETE` endpoint is provided — task cancellation remains exclusively via the `ToolStop` agent tool, consistent with the architectural decision in PR #1776.
- `ToolStop`, `CancelDispatcher`, `MessageBus`, and Redis metadata schema are **unchanged**.

**How to test**

1. Start the AgentScope service and trigger a tool call that exceeds `timeout_secs` (e.g. a `Bash` tool running `sleep 30`).
2. Poll `GET /background-tasks` with the `X-User-ID` header — the task should appear with `status: "running"`.
3. Wait for completion; re-poll — `status` transitions to `"completed"` and `completed_at` is populated.
4. Use a different `X-User-ID` to access the same `task_id` — should return `404`.
5. Run the unit test suite: `pytest tests/background_task_endpoint_test.py tests/tool_offload_middleware_test.py -v`

## Checklist

- [x] An issue has been created for this PR (closes #1720)
- [ ] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [x] Code is ready for review
