### PR TITLE
feat(storage): Add in-memory storage and message bus with unit tests for example running.

### DIFF
--- a/examples/agent_service/README.md
+++ b/examples/agent_service/README.md
@@ -40,6 +40,28 @@ sudo systemctl start redis-server
 docker run --rm -p 6379:6379 redis:7
 ```
 
+> **Tip: Run without Redis**
+>
+> If you want to try the example quickly without setting up Redis, you can use the in-memory storage and message bus instead. In `main.py`, replace `RedisStorage` and `RedisMessageBus` with `MemStorage` and `MemMessageBus`:
+>
+> ```python
+> # Before (requires Redis)
+> from agentscope.app.storage import RedisStorage
+> from agentscope.app.message_bus import RedisMessageBus
+>
+> storage = RedisStorage(host="localhost", port=6379)
+> message_bus = RedisMessageBus(host="localhost", port=6379)
+>
+> # After (no Redis required)
+> from agentscope.app.storage import MemStorage
+> from agentscope.app.message_bus import MemMessageBus
+>
+> storage = MemStorage()
+> message_bus = MemMessageBus()
+> ```
+>
+> Note: In-memory storage loses all data when the process exits and cannot coordinate across multiple processes. Use it for development and testing only.
+
 Start the agent service:
 
 ```bash

--- a/src/agentscope/app/message_bus/__init__.py
+++ b/src/agentscope/app/message_bus/__init__.py
@@ -2,9 +2,11 @@
 """The message bus module — live transport for cross-session messages."""
 
 from ._base import MessageBus
+from ._mem_message_bus import MemMessageBus
 from ._redis_message_bus import RedisMessageBus
 
 __all__ = [
     "MessageBus",
+    "MemMessageBus",
     "RedisMessageBus",
 ]

--- a/src/agentscope/app/message_bus/_mem_message_bus.py
+++ b/src/agentscope/app/message_bus/_mem_message_bus.py
@@ -68,13 +68,16 @@ class MemMessageBus(MessageBus):
     # ==================================================================
 
     async def aclose(self) -> None:
-        """Release resources — clear all stored data."""
-        self._queues.clear()
-        self._logs.clear()
-        self._log_counters.clear()
-        self._channels.clear()
-        self._locks.clear()
-        self._registries.clear()
+        """Release transport resources — a true no-op for the in-memory bus.
+
+        Mirrors :meth:`RedisMessageBus.aclose`, which only closes the
+        connection pool and leaves Redis-side data intact. There are no
+        connections to release here, so the in-memory state stays
+        attached to this instance and is reclaimed naturally when the
+        instance is garbage-collected. Callers that genuinely need to
+        wipe state should drop their reference to the bus and create a
+        new one.
+        """
 
     # ==================================================================
     # Mode A — drain queue
@@ -142,7 +145,9 @@ class MemMessageBus(MessageBus):
         self._log_counters[key] = entry_id + 1
         self._logs[key].append((entry_id, payload))
         if max_len is not None:
-            if len(self._logs[key]) > max_len:
+            if max_len <= 0:
+                self._logs[key] = []
+            elif len(self._logs[key]) > max_len:
                 self._logs[key] = self._logs[key][-max_len:]
         return str(entry_id)
 
@@ -245,6 +250,15 @@ class MemMessageBus(MessageBus):
         The ``ttl_secs`` parameter is accepted for interface parity but
         the lock has no expiry — it is released only when the context
         manager exits.
+
+        The :class:`asyncio.Lock` instance for each ``key`` is cached
+        permanently in :attr:`_locks` so that all coroutines waiting on
+        the same key share the same underlying primitive. Removing
+        entries here would race with pending waiters and let two
+        coroutines hold "the lock" simultaneously after the entry is
+        recreated. The dict is bounded by the set of distinct keys
+        (typically session ids), which is small enough to live for the
+        lifetime of the process.
         """
         if key not in self._locks:
             self._locks[key] = asyncio.Lock()
@@ -273,9 +287,6 @@ class MemMessageBus(MessageBus):
                     await hb_task
                 except asyncio.CancelledError:
                     pass
-        # Clean up lock dict entry if no one is waiting.
-        if not lock.locked():
-            _ = self._locks.pop(key, None)
 
     async def is_locked(self, key: str) -> bool:
         """Return whether ``key`` is currently locked."""
@@ -304,8 +315,11 @@ class MemMessageBus(MessageBus):
     async def registry_del(self, namespace: str, field: str) -> None:
         """Remove ``field`` from the registry at ``namespace``."""
         reg = self._registries.get(namespace)
-        if reg is not None:
-            _ = reg.pop(field, None)
+        if reg is None:
+            return
+        _ = reg.pop(field, None)
+        if not reg:
+            _ = self._registries.pop(namespace, None)
 
     async def registry_exists(self, namespace: str, field: str) -> bool:
         """Return whether ``field`` exists in the registry."""

--- a/src/agentscope/app/message_bus/_mem_message_bus.py
+++ b/src/agentscope/app/message_bus/_mem_message_bus.py
@@ -54,7 +54,7 @@ class MemMessageBus(MessageBus):
 
         # Mode D — transient broadcast: channel → set of subscriber queues
         self._channels: dict[
-            str, set[asyncio.Queue[dict]]
+            str, set[asyncio.Queue[dict]],
         ] = defaultdict(set)
 
         # Mode E — distributed locks: key → asyncio.Lock
@@ -141,8 +141,9 @@ class MemMessageBus(MessageBus):
         entry_id = self._log_counters[key]
         self._log_counters[key] = entry_id + 1
         self._logs[key].append((entry_id, payload))
-        if max_len is not None and len(self._logs[key]) > max_len:
-            self._logs[key] = self._logs[key][-max_len:]
+        if max_len is not None:
+            if len(self._logs[key]) > max_len:
+                self._logs[key] = self._logs[key][-max_len:]
         return str(entry_id)
 
     async def log_read(
@@ -252,7 +253,9 @@ class MemMessageBus(MessageBus):
         # _LOCK_HEARTBEAT_RATIO work the same way.
         async def _heartbeat() -> None:
             while True:
-                await asyncio.sleep(max(1.0, ttl_secs * self._LOCK_HEARTBEAT_RATIO))
+                await asyncio.sleep(
+                    max(1.0, ttl_secs * self._LOCK_HEARTBEAT_RATIO),
+                )
 
         async with lock:
             hb_task = asyncio.create_task(

--- a/src/agentscope/app/message_bus/_mem_message_bus.py
+++ b/src/agentscope/app/message_bus/_mem_message_bus.py
@@ -1,0 +1,321 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=too-many-public-methods
+"""An in-memory message bus backed by Python data structures.
+
+Suitable for development, testing, and single-process deployments.  All
+state resides in process memory — restarting the process loses all data
+and the bus cannot coordinate across process boundaries.
+"""
+import asyncio
+import uuid
+from collections import defaultdict
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import Callable
+
+from ._base import MessageBus
+
+
+class MemMessageBus(MessageBus):
+    """An in-memory message bus implementation.
+
+    Mapping of bus modes to in-memory primitives:
+
+    - **Mode A (drain queue)** uses :class:`asyncio.Queue` per key.
+      ``queue_push`` puts into the queue; ``queue_drain`` pumps up to
+      ``max_count`` items with a short non-blocking poll.  ``queue_delete``
+      drops the queue.
+    - **Mode C (replay log)** uses an ordered :class:`list` per key.
+      Each entry gets a monotonic integer id.  ``log_read`` slices from
+      ``since``; ``log_append`` pushes to the end; ``log_trim`` prunes
+      old entries or drops the whole log.
+    - **Mode D (transient broadcast)** uses per-channel subscriber
+      :class:`asyncio.Queue` instances.  ``publish`` pushes to all
+      subscribed queues; ``subscribe`` yields from a personal queue.
+    - **Mode E (distributed lock)** uses per-key :class:`asyncio.Lock`.
+      Single-process only — no cross-process coordination.
+    - **Mode F (registry map)** uses nested :class:`dict` per namespace.
+
+    Usage::
+
+        async with MemMessageBus() as bus:
+            await bus.publish("chan", {"msg": "hello"})
+    """
+
+    def __init__(self) -> None:
+        """Initialise the in-memory bus with empty data structures."""
+        # Mode A — drain queues: key → asyncio.Queue
+        self._queues: dict[str, asyncio.Queue[tuple[str, dict]]] = {}
+
+        # Mode C — replay logs: key → list of (int_id, payload)
+        self._logs: dict[str, list[tuple[int, dict]]] = defaultdict(list)
+        # Per-log monotonic id counter
+        self._log_counters: dict[str, int] = defaultdict(int)
+
+        # Mode D — transient broadcast: channel → set of subscriber queues
+        self._channels: dict[
+            str, set[asyncio.Queue[dict]]
+        ] = defaultdict(set)
+
+        # Mode E — distributed locks: key → asyncio.Lock
+        self._locks: dict[str, asyncio.Lock] = {}
+
+        # Mode F — registry maps: namespace → dict of field→value
+        self._registries: dict[str, dict[str, str]] = defaultdict(dict)
+
+    # ==================================================================
+    # Lifecycle
+    # ==================================================================
+
+    async def aclose(self) -> None:
+        """Release resources — clear all stored data."""
+        self._queues.clear()
+        self._logs.clear()
+        self._log_counters.clear()
+        self._channels.clear()
+        self._locks.clear()
+        self._registries.clear()
+
+    # ==================================================================
+    # Mode A — drain queue
+    # ==================================================================
+
+    async def queue_push(
+        self,
+        key: str,
+        payload: dict,
+        *,
+        ttl_secs: int | None = None,
+    ) -> str:
+        """Append ``payload`` to the drain queue at ``key``.
+
+        ``ttl_secs`` is accepted for interface parity but ignored —
+        in-memory queues have no expiry.
+        """
+        _ = ttl_secs
+        entry_id = uuid.uuid4().hex
+        if key not in self._queues:
+            self._queues[key] = asyncio.Queue()
+        await self._queues[key].put((entry_id, payload))
+        return entry_id
+
+    async def queue_drain(
+        self,
+        key: str,
+        max_count: int = 100,
+    ) -> list[tuple[str, dict]]:
+        """Drain up to ``max_count`` entries from the queue at ``key``."""
+        queue = self._queues.get(key)
+        if queue is None:
+            return []
+        results: list[tuple[str, dict]] = []
+        for _ in range(max_count):
+            try:
+                entry_id, payload = queue.get_nowait()
+                results.append((entry_id, payload))
+            except asyncio.QueueEmpty:
+                break
+        return results
+
+    async def queue_delete(self, key: str) -> None:
+        """Delete the drain queue at ``key``."""
+        _ = self._queues.pop(key, None)
+
+    # ==================================================================
+    # Mode C — replay log
+    # ==================================================================
+
+    async def log_append(
+        self,
+        key: str,
+        payload: dict,
+        *,
+        ttl_secs: int | None = None,
+        max_len: int | None = None,
+    ) -> str:
+        """Append ``payload`` to the replay log at ``key``.
+
+        ``ttl_secs`` is accepted for interface parity but ignored.
+        """
+        _ = ttl_secs
+        entry_id = self._log_counters[key]
+        self._log_counters[key] = entry_id + 1
+        self._logs[key].append((entry_id, payload))
+        if max_len is not None and len(self._logs[key]) > max_len:
+            self._logs[key] = self._logs[key][-max_len:]
+        return str(entry_id)
+
+    async def log_read(
+        self,
+        key: str,
+        since: str | None = None,
+        max_count: int = 100,
+    ) -> list[tuple[str, dict]]:
+        """Read up to ``max_count`` entries newer than ``since``."""
+        entries = self._logs.get(key)
+        if entries is None:
+            return []
+        # Map string ids back to int for comparison
+        since_int = int(since) if since is not None else -1
+        results: list[tuple[str, dict]] = []
+        for entry_id, payload in entries:
+            if entry_id <= since_int:
+                continue
+            results.append((str(entry_id), payload))
+            if len(results) >= max_count:
+                break
+        return results
+
+    async def log_trim(
+        self,
+        key: str,
+        before_id: str | None = None,
+    ) -> None:
+        """Trim the replay log at ``key``."""
+        if before_id is None:
+            _ = self._logs.pop(key, None)
+            _ = self._log_counters.pop(key, None)
+            return
+        before_int = int(before_id)
+        entries = self._logs.get(key)
+        if entries is None:
+            return
+        self._logs[key] = [
+            (eid, p) for eid, p in entries if eid >= before_int
+        ]
+
+    # ==================================================================
+    # Mode D — transient broadcast
+    # ==================================================================
+
+    async def publish(
+        self,
+        key: str,
+        payload: dict,
+    ) -> None:
+        """Publish ``payload`` on the broadcast channel ``key``."""
+        subscribers = self._channels.get(key)
+        if subscribers is None:
+            return
+        # Snapshot subscribers to avoid mutation-during-iteration issues
+        for q in list(subscribers):
+            await q.put(payload)
+
+    async def subscribe(
+        self,
+        key: str,
+        *,
+        on_ready: Callable[[], None] | None = None,
+    ) -> AsyncGenerator[dict, None]:
+        """Yield broadcast payloads on ``key`` until the generator closes."""
+        q: asyncio.Queue[dict] = asyncio.Queue()
+        self._channels[key].add(q)
+        try:
+            if on_ready is not None:
+                on_ready()
+            while True:
+                payload = await q.get()
+                yield payload
+        finally:
+            self._channels[key].discard(q)
+            if not self._channels[key]:
+                _ = self._channels.pop(key, None)
+
+    # ==================================================================
+    # Mode E — distributed lock
+    # ==================================================================
+
+    # Heartbeat interval as fraction of TTL (renews every ttl/2).
+    _LOCK_HEARTBEAT_RATIO: float = 0.5
+
+    @asynccontextmanager
+    async def acquire_lock(
+        self,
+        key: str,
+        *,
+        ttl_secs: int = 600,
+    ) -> AsyncGenerator[None, None]:
+        """Acquire an in-process mutex on ``key``.
+
+        Single-process only: uses :class:`asyncio.Lock` internally.
+        The ``ttl_secs`` parameter is accepted for interface parity but
+        the lock has no expiry — it is released only when the context
+        manager exits.
+        """
+        if key not in self._locks:
+            self._locks[key] = asyncio.Lock()
+        lock = self._locks[key]
+
+        # Heartbeat task exists for interface parity — it does nothing
+        # because asyncio.Lock never expires.  We still spawn and cancel
+        # it so subclass or decorator-based tests that mock
+        # _LOCK_HEARTBEAT_RATIO work the same way.
+        async def _heartbeat() -> None:
+            while True:
+                await asyncio.sleep(max(1.0, ttl_secs * self._LOCK_HEARTBEAT_RATIO))
+
+        async with lock:
+            hb_task = asyncio.create_task(
+                _heartbeat(),
+                name=f"mem-lock-heartbeat:{key}",
+            )
+            try:
+                yield
+            finally:
+                _ = hb_task.cancel()
+                try:
+                    await hb_task
+                except asyncio.CancelledError:
+                    pass
+                # Clean up lock dict entry if no one is waiting.
+                if not lock.locked():
+                    _ = self._locks.pop(key, None)
+
+    async def is_locked(self, key: str) -> bool:
+        """Return whether ``key`` is currently locked."""
+        lock = self._locks.get(key)
+        return lock is not None and lock.locked()
+
+    # ==================================================================
+    # Mode F — registry map
+    # ==================================================================
+
+    async def registry_set(
+        self,
+        namespace: str,
+        field: str,
+        value: str,
+        *,
+        ttl_secs: int | None = None,
+    ) -> None:
+        """Set ``field`` to ``value`` in the registry at ``namespace``.
+
+        ``ttl_secs`` is accepted for interface parity but ignored.
+        """
+        _ = ttl_secs
+        self._registries[namespace][field] = value
+
+    async def registry_del(self, namespace: str, field: str) -> None:
+        """Remove ``field`` from the registry at ``namespace``."""
+        reg = self._registries.get(namespace)
+        if reg is not None:
+            _ = reg.pop(field, None)
+
+    async def registry_exists(self, namespace: str, field: str) -> bool:
+        """Return whether ``field`` exists in the registry."""
+        reg = self._registries.get(namespace)
+        return reg is not None and field in reg
+
+    async def registry_getall(
+        self,
+        namespace: str,
+    ) -> dict[str, str]:
+        """Return all field-value pairs in the registry."""
+        reg = self._registries.get(namespace)
+        if reg is None:
+            return {}
+        return dict(reg)
+
+    async def registry_drop(self, namespace: str) -> None:
+        """Delete the entire registry at ``namespace``."""
+        _ = self._registries.pop(namespace, None)

--- a/src/agentscope/app/message_bus/_mem_message_bus.py
+++ b/src/agentscope/app/message_bus/_mem_message_bus.py
@@ -198,7 +198,8 @@ class MemMessageBus(MessageBus):
         subscribers = self._channels.get(key)
         if subscribers is None:
             return
-        # Snapshot subscribers to avoid mutation-during-iteration issues
+        # Snapshot subscribers to avoid mutation-during-iteration issues.
+        # Queues are unbounded by default, so put() completes immediately.
         for q in list(subscribers):
             await q.put(payload)
 
@@ -218,9 +219,11 @@ class MemMessageBus(MessageBus):
                 payload = await q.get()
                 yield payload
         finally:
-            self._channels[key].discard(q)
-            if not self._channels[key]:
-                _ = self._channels.pop(key, None)
+            subscribers = self._channels.get(key)
+            if subscribers is not None:
+                subscribers.discard(q)
+                if not subscribers:
+                    _ = self._channels.pop(key, None)
 
     # ==================================================================
     # Mode E — distributed lock
@@ -270,9 +273,9 @@ class MemMessageBus(MessageBus):
                     await hb_task
                 except asyncio.CancelledError:
                     pass
-                # Clean up lock dict entry if no one is waiting.
-                if not lock.locked():
-                    _ = self._locks.pop(key, None)
+        # Clean up lock dict entry if no one is waiting.
+        if not lock.locked():
+            _ = self._locks.pop(key, None)
 
     async def is_locked(self, key: str) -> bool:
         """Return whether ``key`` is currently locked."""

--- a/src/agentscope/app/storage/__init__.py
+++ b/src/agentscope/app/storage/__init__.py
@@ -2,6 +2,7 @@
 """The storage module in agentscope."""
 
 from ._base import StorageBase
+from ._mem_storage import MemStorage
 from ._redis_storage import RedisStorage
 from ._model import (
     AgentData,
@@ -23,6 +24,7 @@ from ._model import (
 
 __all__ = [
     "StorageBase",
+    "MemStorage",
     "RedisStorage",
     # The ORM models
     "AgentData",

--- a/src/agentscope/app/storage/_mem_storage.py
+++ b/src/agentscope/app/storage/_mem_storage.py
@@ -800,10 +800,11 @@ class MemStorage(StorageBase):
         """
         key = self._message_key(user_id, session_id)
         msgs = self._messages[user_id][key]
-        if msgs and msgs[-1].id == msg.id:
-            msgs[-1] = msg
+        msg_copy = msg.model_copy(deep=True)
+        if msgs and msgs[-1].id == msg_copy.id:
+            msgs[-1] = msg_copy
         else:
-            msgs.append(msg)
+            msgs.append(msg_copy)
 
     async def get_message(
         self,
@@ -982,10 +983,12 @@ class MemStorage(StorageBase):
         if team is None:
             kind = self._entity_kind("team")
             index = self._index_name("team")
-            if team_id in self._records[user_id][kind]:
+            # Defensive cleanup: remove orphan index entries
+            deleted_record = team_id in self._records[user_id][kind]
+            if deleted_record:
                 del self._records[user_id][kind][team_id]
             self._indexes[user_id][index].discard(team_id)
-            return False
+            return deleted_record
 
         # Cascade: delete each worker agent (which cascades its session)
         for member_id in team.data.member_ids:

--- a/src/agentscope/app/storage/_mem_storage.py
+++ b/src/agentscope/app/storage/_mem_storage.py
@@ -34,9 +34,9 @@ class MemStorage(StorageBase):
 
     Record objects are isolated via JSON round-trip
     (``model_dump_json`` / ``model_validate_json``) on both read and write,
-    matching the semantics of :class:`RedisStorage`.  Messages are stored as
-    live :class:`Msg` objects for efficiency — callers must not mutate
-    returned message objects.
+    matching the semantics of :class:`RedisStorage`.  Messages use
+    ``Msg.model_copy(deep=True)`` on both write and read for the same
+    isolation guarantee.
 
     Usage::
 
@@ -78,10 +78,14 @@ class MemStorage(StorageBase):
     # ==================================================================
 
     async def aclose(self) -> None:
-        """Release resources — no-op for the in-memory backend."""
-        self._records.clear()
-        self._indexes.clear()
-        self._messages.clear()
+        """Release resources — a true no-op for the in-memory backend.
+
+        Unlike :class:`RedisStorage`, there are no connections or pools to
+        close. The in-memory state stays attached to this instance and is
+        released naturally when the instance is garbage-collected, matching
+        the Redis semantics where data outlives ``aclose()`` (Redis keeps
+        the data; only the connection is closed).
+        """
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -110,6 +114,66 @@ class MemStorage(StorageBase):
             "team": "team_ids",
         }
         return _MAP[entity]
+
+    def _get_record_raw(
+        self,
+        user_id: str,
+        kind: str,
+        entity_id: str,
+    ) -> str | None:
+        """Read a record without triggering ``defaultdict`` auto-creation.
+
+        Plain ``self._records[user_id][kind].get(entity_id)`` would create
+        empty ``user_id`` and ``kind`` nodes for unknown users — leaking
+        memory and producing ghost entries that confuse later iteration.
+        """
+        kind_dict = self._records.get(user_id, {}).get(kind)
+        if kind_dict is None:
+            return None
+        return kind_dict.get(entity_id)
+
+    def _get_index_set(self, user_id: str, index_name: str) -> set[str]:
+        """Read an index set without triggering ``defaultdict`` auto-creation.
+
+        Returns an empty set for unknown ``(user_id, index_name)`` pairs
+        without writing anything to ``self._indexes``.
+        """
+        return self._indexes.get(user_id, {}).get(index_name, set())
+
+    def _discard_from_index(
+        self,
+        user_id: str,
+        index_name: str,
+        entity_id: str,
+    ) -> None:
+        """Remove ``entity_id`` from an index set and reclaim empty containers.
+
+        Plain ``self._indexes[user_id][index_name].discard(entity_id)`` would
+        auto-create both nodes via ``defaultdict`` when the user is unknown,
+        and would leave behind an empty ``set`` after the last ``discard``.
+        This helper avoids both leaks by reading via ``.get()`` and dropping
+        empty sets / empty user dicts.
+        """
+        user_indexes = self._indexes.get(user_id)
+        if user_indexes is None:
+            return
+        index_set = user_indexes.get(index_name)
+        if index_set is None:
+            return
+        index_set.discard(entity_id)
+        if not index_set:
+            del user_indexes[index_name]
+            if not user_indexes:
+                del self._indexes[user_id]
+
+    def _drop_index_key(self, user_id: str, index_name: str) -> None:
+        """Drop an entire index key and reclaim the user dict if empty."""
+        user_indexes = self._indexes.get(user_id)
+        if user_indexes is None:
+            return
+        user_indexes.pop(index_name, None)
+        if not user_indexes:
+            del self._indexes[user_id]
 
     def _session_index_key(self, _user_id: str, agent_id: str) -> str:
         """Composite key for per-(user, agent) session indexes."""
@@ -206,9 +270,11 @@ class MemStorage(StorageBase):
         kind = self._entity_kind("credential")
         index = self._index_name("credential")
 
-        if credential_data.id and credential_data.id in self._records[
-            user_id
-        ][kind]:
+        if credential_data.id and self._get_record_raw(
+            user_id,
+            kind,
+            credential_data.id,
+        ):
             record = CredentialRecord.model_validate_json(
                 self._records[user_id][kind][credential_data.id],
             )
@@ -242,8 +308,8 @@ class MemStorage(StorageBase):
         kind = self._entity_kind("credential")
         index = self._index_name("credential")
         records: list[CredentialRecord] = []
-        for cred_id in self._indexes[user_id][index]:
-            raw = self._records[user_id][kind].get(cred_id)
+        for cred_id in self._get_index_set(user_id, index):
+            raw = self._get_record_raw(user_id, kind, cred_id)
             if raw:
                 records.append(CredentialRecord.model_validate_json(raw))
         return records
@@ -263,7 +329,7 @@ class MemStorage(StorageBase):
             `CredentialRecord | None`: The record, or ``None`` if not found.
         """
         kind = self._entity_kind("credential")
-        raw = self._records[user_id][kind].get(credential_id)
+        raw = self._get_record_raw(user_id, kind, credential_id)
         if not raw:
             return None
         return CredentialRecord.model_validate_json(raw)
@@ -285,11 +351,10 @@ class MemStorage(StorageBase):
         """
         kind = self._entity_kind("credential")
         index = self._index_name("credential")
-        record_kind = self._records[user_id][kind]
-        if credential_id not in record_kind:
+        if self._get_record_raw(user_id, kind, credential_id) is None:
             return False
-        del record_kind[credential_id]
-        self._indexes[user_id][index].discard(credential_id)
+        del self._records[user_id][kind][credential_id]
+        self._discard_from_index(user_id, index, credential_id)
         return True
 
     # ==================================================================
@@ -342,8 +407,8 @@ class MemStorage(StorageBase):
         kind = self._entity_kind("agent")
         index = self._index_name("agent")
         records: list[AgentRecord] = []
-        for agent_id in self._indexes[user_id][index]:
-            raw = self._records[user_id][kind].get(agent_id)
+        for agent_id in self._get_index_set(user_id, index):
+            raw = self._get_record_raw(user_id, kind, agent_id)
             if raw:
                 record = AgentRecord.model_validate_json(raw)
                 if record.source == "user":
@@ -365,7 +430,7 @@ class MemStorage(StorageBase):
             `AgentRecord | None`: The record, or ``None`` if not found.
         """
         kind = self._entity_kind("agent")
-        raw = self._records[user_id][kind].get(agent_id)
+        raw = self._get_record_raw(user_id, kind, agent_id)
         if not raw:
             return None
         return AgentRecord.model_validate_json(raw)
@@ -403,7 +468,7 @@ class MemStorage(StorageBase):
         """
         kind = self._entity_kind("agent")
         index = self._index_name("agent")
-        if agent_id not in self._records[user_id][kind]:
+        if self._get_record_raw(user_id, kind, agent_id) is None:
             return False
 
         # Cascade: sessions
@@ -429,7 +494,7 @@ class MemStorage(StorageBase):
                 _ = await self.upsert_team(user_id, team)
 
         del self._records[user_id][kind][agent_id]
-        self._indexes[user_id][index].discard(agent_id)
+        self._discard_from_index(user_id, index, agent_id)
         return True
 
     # ==================================================================
@@ -469,15 +534,18 @@ class MemStorage(StorageBase):
         index = self._index_name("session")
         session_idx_key = self._session_index_key(user_id, agent_id)
 
-        if session_id and session_id in self._records[user_id][kind]:
-            raw = self._records[user_id][kind][session_id]
-            record = SessionRecord.model_validate_json(raw)
-            record.config = config
-            if state is not None:
-                record.state = state
-            record.updated_at = datetime.now()
-            self._records[user_id][kind][session_id] = record.model_dump_json()
-            return record
+        if session_id:
+            raw = self._get_record_raw(user_id, kind, session_id)
+            if raw:
+                record = SessionRecord.model_validate_json(raw)
+                record.config = config
+                if state is not None:
+                    record.state = state
+                record.updated_at = datetime.now()
+                self._records[user_id][kind][session_id] = (
+                    record.model_dump_json()
+                )
+                return record
 
         new_id_kwargs: dict[str, Any] = (
             {"id": session_id} if session_id else {}
@@ -516,7 +584,7 @@ class MemStorage(StorageBase):
             KeyError: If the session does not exist.
         """
         kind = self._entity_kind("session")
-        raw = self._records[user_id][kind].get(session_id)
+        raw = self._get_record_raw(user_id, kind, session_id)
         if raw is None:
             raise KeyError(f"Session {session_id!r} not found.")
         record = SessionRecord.model_validate_json(raw)
@@ -542,8 +610,8 @@ class MemStorage(StorageBase):
         kind = self._entity_kind("session")
         session_idx_key = self._session_index_key(user_id, agent_id)
         records: list[SessionRecord] = []
-        for session_id in self._indexes[user_id][session_idx_key]:
-            raw = self._records[user_id][kind].get(session_id)
+        for session_id in self._get_index_set(user_id, session_idx_key):
+            raw = self._get_record_raw(user_id, kind, session_id)
             if raw:
                 records.append(SessionRecord.model_validate_json(raw))
         records.sort(key=lambda r: r.created_at, reverse=True)
@@ -566,7 +634,7 @@ class MemStorage(StorageBase):
             `SessionRecord | None`: The record, or ``None`` if not found.
         """
         kind = self._entity_kind("session")
-        raw = self._records[user_id][kind].get(session_id)
+        raw = self._get_record_raw(user_id, kind, session_id)
         if not raw:
             return None
         return SessionRecord.model_validate_json(raw)
@@ -599,7 +667,7 @@ class MemStorage(StorageBase):
         session_idx_key = self._session_index_key(user_id, agent_id)
         msg_key = self._message_key(user_id, session_id)
 
-        raw = self._records[user_id][kind].get(session_id)
+        raw = self._get_record_raw(user_id, kind, session_id)
         if raw is None:
             return False
 
@@ -612,14 +680,15 @@ class MemStorage(StorageBase):
                 _ = await self.delete_team(user_id, record.team_id)
 
         del self._records[user_id][kind][session_id]
-        self._indexes[user_id][index].discard(session_id)
-        self._indexes[user_id][session_idx_key].discard(session_id)
-        _ = self._messages[user_id].pop(msg_key, None)
+        self._discard_from_index(user_id, index, session_id)
+        self._discard_from_index(user_id, session_idx_key, session_id)
+        if user_id in self._messages:
+            self._messages[user_id].pop(msg_key, None)
 
         if record.source_schedule_id:
             sched_key_base = self._schedule_session_index_key(user_id)
             sched_key = f"{sched_key_base}:{record.source_schedule_id}"
-            self._indexes[user_id][sched_key].discard(session_id)
+            self._discard_from_index(user_id, sched_key, session_id)
 
         return True
 
@@ -642,8 +711,8 @@ class MemStorage(StorageBase):
         sched_key_base = self._schedule_session_index_key(user_id)
         sched_key = f"{sched_key_base}:{schedule_id}"
         records: list[SessionRecord] = []
-        for session_id in self._indexes[user_id][sched_key]:
-            raw = self._records[user_id][kind].get(session_id)
+        for session_id in self._get_index_set(user_id, sched_key):
+            raw = self._get_record_raw(user_id, kind, session_id)
             if raw:
                 records.append(SessionRecord.model_validate_json(raw))
         records.sort(key=lambda r: r.created_at, reverse=True)
@@ -693,7 +762,7 @@ class MemStorage(StorageBase):
             `ScheduleRecord | None`: The record, or ``None`` if not found.
         """
         kind = self._entity_kind("schedule")
-        raw = self._records[user_id][kind].get(schedule_id)
+        raw = self._get_record_raw(user_id, kind, schedule_id)
         if not raw:
             return None
         return ScheduleRecord.model_validate_json(raw)
@@ -710,8 +779,8 @@ class MemStorage(StorageBase):
         kind = self._entity_kind("schedule")
         index = self._index_name("schedule")
         records: list[ScheduleRecord] = []
-        for schedule_id in self._indexes[user_id][index]:
-            raw = self._records[user_id][kind].get(schedule_id)
+        for schedule_id in self._get_index_set(user_id, index):
+            raw = self._get_record_raw(user_id, kind, schedule_id)
             if raw:
                 records.append(ScheduleRecord.model_validate_json(raw))
         return records
@@ -731,7 +800,7 @@ class MemStorage(StorageBase):
         index = self._index_name("schedule")
         global_index = "schedule_global_ids"
 
-        raw = self._records[user_id][kind].get(schedule_id)
+        raw = self._get_record_raw(user_id, kind, schedule_id)
         if raw is None:
             return False
 
@@ -749,11 +818,13 @@ class MemStorage(StorageBase):
         # Clean up the schedule-session index key
         sched_key_base = self._schedule_session_index_key(user_id)
         sched_key = f"{sched_key_base}:{schedule_id}"
-        _ = self._indexes[user_id].pop(sched_key, None)
+        self._drop_index_key(user_id, sched_key)
 
         del self._records[user_id][kind][schedule_id]
-        self._indexes[user_id][index].discard(schedule_id)
-        self._indexes["__global__"][global_index].discard(
+        self._discard_from_index(user_id, index, schedule_id)
+        self._discard_from_index(
+            "__global__",
+            global_index,
             f"{user_id}:{schedule_id}",
         )
         return True
@@ -770,9 +841,9 @@ class MemStorage(StorageBase):
         global_index = "schedule_global_ids"
         kind = self._entity_kind("schedule")
         records: list[ScheduleRecord] = []
-        for entry in self._indexes["__global__"][global_index]:
+        for entry in self._get_index_set("__global__", global_index):
             user_id, schedule_id = entry.split(":", 1)
-            raw = self._records[user_id][kind].get(schedule_id)
+            raw = self._get_record_raw(user_id, kind, schedule_id)
             if raw:
                 records.append(ScheduleRecord.model_validate_json(raw))
         return records
@@ -814,6 +885,8 @@ class MemStorage(StorageBase):
     ) -> Msg | None:
         """Fetch a single message by id from the session's message list.
 
+        Returns a deep copy so callers cannot mutate the stored object.
+
         Args:
             user_id (`str`): The owner user id.
             session_id (`str`): The session id.
@@ -823,9 +896,10 @@ class MemStorage(StorageBase):
             `Msg | None`: The message, or ``None`` if not found.
         """
         key = self._message_key(user_id, session_id)
-        for msg in reversed(self._messages[user_id][key]):
+        msgs = self._messages.get(user_id, {}).get(key, [])
+        for msg in reversed(msgs):
             if msg.id == message_id:
-                return msg
+                return msg.model_copy(deep=True)
         return None
 
     async def list_messages(
@@ -837,6 +911,8 @@ class MemStorage(StorageBase):
     ) -> list[Msg]:
         """Return messages for a session with pagination.
 
+        Returns deep copies so callers cannot mutate the stored objects.
+
         Args:
             user_id (`str`): The owner user id.
             session_id (`str`): The session id.
@@ -847,8 +923,8 @@ class MemStorage(StorageBase):
             `list[Msg]`: Messages in chronological order.
         """
         key = self._message_key(user_id, session_id)
-        msgs = self._messages[user_id][key]
-        return msgs[offset : offset + limit]
+        msgs = self._messages.get(user_id, {}).get(key, [])
+        return [m.model_copy(deep=True) for m in msgs[offset : offset + limit]]
 
     # ==================================================================
     # Team persistence
@@ -900,7 +976,7 @@ class MemStorage(StorageBase):
                 The record, or ``None`` if no record exists.
         """
         kind = self._entity_kind("team")
-        raw = self._records[user_id][kind].get(team_id)
+        raw = self._get_record_raw(user_id, kind, team_id)
         if not raw:
             return None
         return TeamRecord.model_validate_json(raw)
@@ -919,8 +995,8 @@ class MemStorage(StorageBase):
         kind = self._entity_kind("team")
         index = self._index_name("team")
         records: list[TeamRecord] = []
-        for team_id in self._indexes[user_id][index]:
-            raw = self._records[user_id][kind].get(team_id)
+        for team_id in self._get_index_set(user_id, index):
+            raw = self._get_record_raw(user_id, kind, team_id)
             if raw:
                 records.append(TeamRecord.model_validate_json(raw))
         return records
@@ -947,7 +1023,7 @@ class MemStorage(StorageBase):
                 team.
         """
         kind = self._entity_kind("session")
-        raw = self._records[user_id][kind].get(session_id)
+        raw = self._get_record_raw(user_id, kind, session_id)
         if raw is None:
             return
         record = SessionRecord.model_validate_json(raw)
@@ -983,11 +1059,12 @@ class MemStorage(StorageBase):
         if team is None:
             kind = self._entity_kind("team")
             index = self._index_name("team")
-            # Defensive cleanup: remove orphan index entries
-            deleted_record = team_id in self._records[user_id][kind]
+            deleted_record = (
+                self._get_record_raw(user_id, kind, team_id) is not None
+            )
             if deleted_record:
                 del self._records[user_id][kind][team_id]
-            self._indexes[user_id][index].discard(team_id)
+            self._discard_from_index(user_id, index, team_id)
             return deleted_record
 
         # Cascade: delete each worker agent (which cascades its session)
@@ -1001,5 +1078,5 @@ class MemStorage(StorageBase):
         index = self._index_name("team")
         existed = team_id in self._records[user_id][kind]
         _ = self._records[user_id][kind].pop(team_id, None)
-        self._indexes[user_id][index].discard(team_id)
+        self._discard_from_index(user_id, index, team_id)
         return existed

--- a/src/agentscope/app/storage/_mem_storage.py
+++ b/src/agentscope/app/storage/_mem_storage.py
@@ -1,0 +1,1002 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=too-many-public-methods
+"""An in-memory storage implementation backed by Python dicts and lists.
+
+Suitable for development, testing, and single-process deployments.  All data
+resides in process memory — restarting the process loses all persisted state.
+"""
+from collections import defaultdict
+from datetime import datetime
+from typing import Any
+
+from ._base import StorageBase
+from ._model import (
+    AgentRecord,
+    CredentialRecord,
+    ScheduleRecord,
+    SessionConfig,
+    SessionRecord,
+    SessionSource,
+    TeamRecord,
+)
+from ._utils import _dump_with_secrets
+from ...credential import CredentialBase
+from ...message import Msg
+from ...state import AgentState
+
+
+class MemStorage(StorageBase):
+    """An in-memory storage implementation.
+
+    All data is stored in nested :class:`dict` and :class:`list` structures
+    keyed by ``user_id`` → entity type → entity id.  Indexes (sets of ids)
+    are stored alongside the records.
+
+    Record objects are isolated via JSON round-trip
+    (``model_dump_json`` / ``model_validate_json``) on both read and write,
+    matching the semantics of :class:`RedisStorage`.  Messages are stored as
+    live :class:`Msg` objects for efficiency — callers must not mutate
+    returned message objects.
+
+    Usage::
+
+        async with MemStorage() as storage:
+            await storage.upsert_credential(user_id, cred_data)
+            records = await storage.list_credentials(user_id)
+
+    .. note::
+        This backend is **not** suitable for multi-process deployments
+        because the data lives in a single Python process.  Use
+        :class:`RedisStorage` for production service setups.
+    """
+
+    def __init__(self) -> None:
+        """Initialise the in-memory store with empty data structures."""
+        # ── Record storage ──────────────────────────────────────────
+        # Structure: _records[user_id][entity_kind][entity_id] = json_str
+        # Backed by nested defaultdicts for auto-vivification.
+        self._records: defaultdict[
+            str, defaultdict[str, dict[str, str]]
+        ] = defaultdict(lambda: defaultdict(dict))
+
+        # ── Index storage ───────────────────────────────────────────
+        # Structure: _indexes[user_id][index_name] = set of ids
+        # Backed by nested defaultdicts for auto-vivification.
+        self._indexes: defaultdict[
+            str, defaultdict[str, set[str]]
+        ] = defaultdict(lambda: defaultdict(set))
+
+        # ── Message storage ─────────────────────────────────────────
+        # Structure: _messages[user_id][session_key] = list[Msg]
+        # Backed by nested defaultdicts for auto-vivification.
+        self._messages: defaultdict[
+            str, defaultdict[str, list[Msg]]
+        ] = defaultdict(lambda: defaultdict(list))
+
+    # ==================================================================
+    # Infrastructure helpers
+    # ==================================================================
+
+    async def aclose(self) -> None:
+        """Release resources — no-op for the in-memory backend."""
+        self._records.clear()
+        self._indexes.clear()
+        self._messages.clear()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _entity_kind(entity: str) -> str:
+        """Map entity name to the key used inside ``_records``."""
+        _MAP = {
+            "credential": "credentials",
+            "agent": "agents",
+            "session": "sessions",
+            "schedule": "schedules",
+            "team": "teams",
+        }
+        return _MAP[entity]
+
+    @staticmethod
+    def _index_name(entity: str) -> str:
+        """Map entity name to the key used inside ``_indexes``."""
+        _MAP = {
+            "credential": "credential_ids",
+            "agent": "agent_ids",
+            "session": "session_ids",
+            "schedule": "schedule_ids",
+            "team": "team_ids",
+        }
+        return _MAP[entity]
+
+    def _session_index_key(self, _user_id: str, agent_id: str) -> str:
+        """Composite key for per-(user, agent) session indexes."""
+        return f"session_ids:{agent_id}"
+
+    @staticmethod
+    def _schedule_session_index_key(user_id: str) -> str:
+        """Composite key for per-(user, schedule) session indexes.
+
+        ``user_id`` is accepted for signature parity with the Redis
+        backend but is not embedded in the key — MemStorage only needs
+        the composite ``schedule_id`` portion.
+        """
+        _ = user_id
+        return "schedule_session_ids"
+
+    @staticmethod
+    def _message_key(user_id: str, session_id: str) -> str:
+        """Normalise the composite key used for session message lists.
+
+        ``user_id`` is accepted for signature parity with the Redis
+        backend but is not embedded in the key — MemStorage only needs
+        the ``session_id`` portion.
+        """
+        _ = user_id
+        return f"messages:{session_id}"
+
+    async def _generate_credential_name(
+        self,
+        user_id: str,
+        credential_data: CredentialBase,
+    ) -> str:
+        """Auto-generate a display name for a credential based on its type.
+
+        Produces names like "OpenAI", "OpenAI (2)", "OpenAI (3)", etc.
+        """
+        cred_type = getattr(credential_data, "type", "")
+        base_name = (
+            cred_type.removesuffix("_credential").replace("_", " ").title()
+        )
+        if not base_name:
+            base_name = "Credential"
+
+        existing = await self.list_credentials(user_id)
+        same_type_names = [
+            c.data.get("name", "")
+            for c in existing
+            if c.data.get("type") == cred_type and c.id != credential_data.id
+        ]
+
+        if base_name not in same_type_names:
+            return base_name
+
+        idx = 2
+        while f"{base_name} ({idx})" in same_type_names:
+            idx += 1
+        return f"{base_name} ({idx})"
+
+    # ==================================================================
+    # Credential CRUD
+    # ==================================================================
+
+    async def upsert_credential(
+        self,
+        user_id: str,
+        credential_data: CredentialBase,
+    ) -> str:
+        """Create or update a credential record for the given user.
+
+        If ``credential_data.id`` is set and the record already exists, the
+        existing record's ``data`` field is updated in place (preserving
+        ``created_at``). If the id is set but no record exists, a new record
+        is created with that id.  If ``credential_data.id`` is ``None``, a
+        new record with a generated id is always created.
+
+        Args:
+            user_id (`str`):
+                The owner user id.
+            credential_data (`CredentialBase`):
+                Input data containing an optional ``id`` and the credential
+                data.
+
+        Returns:
+            `str`:
+                The id of the created or updated credential record.
+        """
+        if not credential_data.name:
+            credential_data.name = await self._generate_credential_name(
+                user_id,
+                credential_data,
+            )
+
+        data_dump = _dump_with_secrets(credential_data)
+        kind = self._entity_kind("credential")
+        index = self._index_name("credential")
+
+        if credential_data.id and credential_data.id in self._records[
+            user_id
+        ][kind]:
+            record = CredentialRecord.model_validate_json(
+                self._records[user_id][kind][credential_data.id],
+            )
+            record.data = data_dump
+            record.updated_at = datetime.now()
+        elif credential_data.id:
+            record = CredentialRecord(
+                id=credential_data.id,
+                user_id=user_id,
+                data=data_dump,
+            )
+        else:
+            record = CredentialRecord(
+                user_id=user_id,
+                data=data_dump,
+            )
+
+        self._records[user_id][kind][record.id] = record.model_dump_json()
+        self._indexes[user_id][index].add(record.id)
+        return record.id
+
+    async def list_credentials(self, user_id: str) -> list[CredentialRecord]:
+        """Return all credential records belonging to the given user.
+
+        Args:
+            user_id (`str`): The owner user id.
+
+        Returns:
+            `list[CredentialRecord]`: All credential records for the user.
+        """
+        kind = self._entity_kind("credential")
+        index = self._index_name("credential")
+        records: list[CredentialRecord] = []
+        for cred_id in self._indexes[user_id][index]:
+            raw = self._records[user_id][kind].get(cred_id)
+            if raw:
+                records.append(CredentialRecord.model_validate_json(raw))
+        return records
+
+    async def get_credential(
+        self,
+        user_id: str,
+        credential_id: str,
+    ) -> CredentialRecord | None:
+        """Fetch a single credential record by id.
+
+        Args:
+            user_id (`str`): The owner user id.
+            credential_id (`str`): The credential id.
+
+        Returns:
+            `CredentialRecord | None`: The record, or ``None`` if not found.
+        """
+        kind = self._entity_kind("credential")
+        raw = self._records[user_id][kind].get(credential_id)
+        if not raw:
+            return None
+        return CredentialRecord.model_validate_json(raw)
+
+    async def delete_credential(
+        self,
+        user_id: str,
+        credential_id: str,
+    ) -> bool:
+        """Delete a credential record and remove it from the user's index.
+
+        Args:
+            user_id (`str`): The owner user id.
+            credential_id (`str`): The id of the credential to delete.
+
+        Returns:
+            `bool`: ``True`` if the record existed and was deleted,
+            ``False`` if it did not exist.
+        """
+        kind = self._entity_kind("credential")
+        index = self._index_name("credential")
+        record_kind = self._records[user_id][kind]
+        if credential_id not in record_kind:
+            return False
+        del record_kind[credential_id]
+        self._indexes[user_id][index].discard(credential_id)
+        return True
+
+    # ==================================================================
+    # Agent CRUD
+    # ==================================================================
+
+    async def upsert_agent(
+        self,
+        user_id: str,
+        agent_record: AgentRecord,
+    ) -> str:
+        """Persist an agent record and register it in the user's agent index.
+
+        The caller is responsible for constructing the full ``AgentRecord``
+        (including its ``id``). If a record with the same id already exists
+        it will be overwritten.
+
+        Args:
+            user_id (`str`):
+                The owner user id.
+            agent_record (`AgentRecord`):
+                The fully-populated agent record to store.
+
+        Returns:
+            `str`:
+                The id of the stored agent record.
+        """
+        kind = self._entity_kind("agent")
+        index = self._index_name("agent")
+        self._records[user_id][kind][agent_record.id] = (
+            agent_record.model_dump_json()
+        )
+        self._indexes[user_id][index].add(agent_record.id)
+        return agent_record.id
+
+    async def list_agents(self, user_id: str) -> list[AgentRecord]:
+        """Return user-facing agent records (``source='user'``).
+
+        Filters out team-spawned workers (``source='team'``) — those are
+        scoped to a team and only addressable via team detail / direct id
+        lookup.
+
+        Args:
+            user_id (`str`): The owner user id.
+
+        Returns:
+            `list[AgentRecord]`:
+                All ``source='user'`` agent records for the user.
+        """
+        kind = self._entity_kind("agent")
+        index = self._index_name("agent")
+        records: list[AgentRecord] = []
+        for agent_id in self._indexes[user_id][index]:
+            raw = self._records[user_id][kind].get(agent_id)
+            if raw:
+                record = AgentRecord.model_validate_json(raw)
+                if record.source == "user":
+                    records.append(record)
+        return records
+
+    async def get_agent(
+        self,
+        user_id: str,
+        agent_id: str,
+    ) -> AgentRecord | None:
+        """Fetch a single agent record by id.
+
+        Args:
+            user_id (`str`): The owner user id.
+            agent_id (`str`): The agent id.
+
+        Returns:
+            `AgentRecord | None`: The record, or ``None`` if not found.
+        """
+        kind = self._entity_kind("agent")
+        raw = self._records[user_id][kind].get(agent_id)
+        if not raw:
+            return None
+        return AgentRecord.model_validate_json(raw)
+
+    async def delete_agent(self, user_id: str, agent_id: str) -> bool:
+        """Delete an agent record and cascade-delete its sessions,
+        schedules, and any team back-references.
+
+        Cascade order:
+
+        1. **Sessions** — every session belonging to this agent is
+           deleted via :meth:`delete_session` (which itself cascades
+           message log, schedule-session index, and — if a session leads
+           a team — the team).
+        2. **Schedules** — every schedule whose ``data.agent_id`` matches
+           is deleted via :meth:`delete_schedule`.
+        3. **Team back-references (defensive)** — if the agent is a team
+           worker (``source='team'``) but the caller chose to delete it
+           directly instead of going through :meth:`delete_team`, scan
+           the user's teams and remove the agent id from every
+           :attr:`TeamData.member_ids` list it appears in.
+        4. **Agent record + index** — finally delete the agent key and
+           remove from the per-user agent index.
+
+        Args:
+            user_id (`str`):
+                The owner user id.
+            agent_id (`str`):
+                The id of the agent to delete.
+
+        Returns:
+            `bool`:
+                ``True`` if the agent record existed and was deleted,
+                ``False`` if it did not exist.
+        """
+        kind = self._entity_kind("agent")
+        index = self._index_name("agent")
+        if agent_id not in self._records[user_id][kind]:
+            return False
+
+        # Cascade: sessions
+        sessions = await self.list_sessions(user_id, agent_id)
+        for session in sessions:
+            _ = await self.delete_session(user_id, agent_id, session.id)
+
+        # Cascade: schedules owned by this agent
+        schedules = await self.list_schedules(user_id)
+        for schedule in schedules:
+            if schedule.agent_id == agent_id:
+                _ = await self.delete_schedule(user_id, schedule.id)
+
+        # Defensive: scrub agent_id from any team's member_ids list.
+        teams = await self.list_teams(user_id)
+        for team in teams:
+            if agent_id in team.data.member_ids:
+                team.data.member_ids = [
+                    mid
+                    for mid in team.data.member_ids
+                    if mid != agent_id
+                ]
+                _ = await self.upsert_team(user_id, team)
+
+        del self._records[user_id][kind][agent_id]
+        self._indexes[user_id][index].discard(agent_id)
+        return True
+
+    # ==================================================================
+    # Session CRUD
+    # ==================================================================
+
+    async def upsert_session(
+        self,
+        user_id: str,
+        agent_id: str,
+        config: SessionConfig,
+        state: AgentState | None = None,
+        session_id: str | None = None,
+        source: SessionSource = SessionSource.USER,
+        source_schedule_id: str | None = None,
+    ) -> SessionRecord:
+        """Create or update a session for a (user, agent) pair.
+
+        When *session_id* is provided the existing session is updated.
+        When *session_id* is ``None`` a new session is always created.
+
+        Args:
+            user_id (`str`): The owner user id.
+            agent_id (`str`): The agent id.
+            config (`SessionConfig`): Immutable session configuration.
+            state (`AgentState | None`, optional): Runtime state to persist.
+            session_id (`str | None`, optional): If provided, update the
+                existing session with this id.
+            source (`SessionSource`, optional): Creation source.
+            source_schedule_id (`str | None`, optional): Schedule that
+                created this session.
+
+        Returns:
+            `SessionRecord`: The created or updated record.
+        """
+        kind = self._entity_kind("session")
+        index = self._index_name("session")
+        session_idx_key = self._session_index_key(user_id, agent_id)
+
+        if session_id and session_id in self._records[user_id][kind]:
+            raw = self._records[user_id][kind][session_id]
+            record = SessionRecord.model_validate_json(raw)
+            record.config = config
+            if state is not None:
+                record.state = state
+            record.updated_at = datetime.now()
+            self._records[user_id][kind][session_id] = record.model_dump_json()
+            return record
+
+        new_id_kwargs: dict[str, Any] = (
+            {"id": session_id} if session_id else {}
+        )
+        record = SessionRecord(
+            user_id=user_id,
+            agent_id=agent_id,
+            config=config,
+            source=source,
+            source_schedule_id=source_schedule_id,
+            state=state if state is not None else AgentState(),
+            **new_id_kwargs,
+        )
+        self._records[user_id][kind][record.id] = record.model_dump_json()
+        self._indexes[user_id][index].add(record.id)
+        self._indexes[user_id][session_idx_key].add(record.id)
+
+        if source_schedule_id:
+            sched_key = self._schedule_session_index_key(user_id)
+            self._indexes[user_id][f"{sched_key}:{source_schedule_id}"].add(
+                record.id,
+            )
+
+        return record
+
+    async def update_session_state(
+        self,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+        state: AgentState,
+    ) -> None:
+        """Update only the mutable state of an existing session.
+
+        Raises:
+            KeyError: If the session does not exist.
+        """
+        kind = self._entity_kind("session")
+        raw = self._records[user_id][kind].get(session_id)
+        if raw is None:
+            raise KeyError(f"Session {session_id!r} not found.")
+        record = SessionRecord.model_validate_json(raw)
+        record.state = state
+        record.updated_at = datetime.now()
+        self._records[user_id][kind][session_id] = record.model_dump_json()
+
+    async def list_sessions(
+        self,
+        user_id: str,
+        agent_id: str,
+    ) -> list[SessionRecord]:
+        """Return all session records for a given (user, agent) pair.
+
+        Args:
+            user_id (`str`): The owner user id.
+            agent_id (`str`): The agent id whose sessions to list.
+
+        Returns:
+            `list[SessionRecord]`: All session records for the (user, agent)
+            pair, ordered by creation time (newest first).
+        """
+        kind = self._entity_kind("session")
+        session_idx_key = self._session_index_key(user_id, agent_id)
+        records: list[SessionRecord] = []
+        for session_id in self._indexes[user_id][session_idx_key]:
+            raw = self._records[user_id][kind].get(session_id)
+            if raw:
+                records.append(SessionRecord.model_validate_json(raw))
+        records.sort(key=lambda r: r.created_at, reverse=True)
+        return records
+
+    async def get_session(
+        self,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> SessionRecord | None:
+        """Fetch a single session record by id.
+
+        Args:
+            user_id (`str`): The owner user id.
+            agent_id (`str`): The agent id.
+            session_id (`str`): The session id.
+
+        Returns:
+            `SessionRecord | None`: The record, or ``None`` if not found.
+        """
+        kind = self._entity_kind("session")
+        raw = self._records[user_id][kind].get(session_id)
+        if not raw:
+            return None
+        return SessionRecord.model_validate_json(raw)
+
+    async def delete_session(
+        self,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> bool:
+        """Delete a session record and cascade clean-up.
+
+        Cascades:
+
+        - Existing: per-session message log, schedule-session index entry.
+        - If this session is the leader of a team, call
+          :meth:`delete_team` first.
+
+        Args:
+            user_id (`str`): The owner user id.
+            agent_id (`str`): The id of the agent that owns the session.
+            session_id (`str`): The id of the session to delete.
+
+        Returns:
+            `bool`: ``True`` if the session existed and was deleted,
+            ``False`` if no record was found.
+        """
+        kind = self._entity_kind("session")
+        index = self._index_name("session")
+        session_idx_key = self._session_index_key(user_id, agent_id)
+        msg_key = self._message_key(user_id, session_id)
+
+        raw = self._records[user_id][kind].get(session_id)
+        if raw is None:
+            return False
+
+        record = SessionRecord.model_validate_json(raw)
+
+        # Cascade: if this session leads a team, dissolve it first.
+        if record.team_id:
+            team = await self.get_team(user_id, record.team_id)
+            if team is not None and team.session_id == session_id:
+                _ = await self.delete_team(user_id, record.team_id)
+
+        del self._records[user_id][kind][session_id]
+        self._indexes[user_id][index].discard(session_id)
+        self._indexes[user_id][session_idx_key].discard(session_id)
+        _ = self._messages[user_id].pop(msg_key, None)
+
+        if record.source_schedule_id:
+            sched_key_base = self._schedule_session_index_key(user_id)
+            sched_key = f"{sched_key_base}:{record.source_schedule_id}"
+            self._indexes[user_id][sched_key].discard(session_id)
+
+        return True
+
+    async def list_sessions_by_schedule(
+        self,
+        user_id: str,
+        schedule_id: str,
+    ) -> list[SessionRecord]:
+        """Return all sessions created by a given schedule.
+
+        Args:
+            user_id (`str`): The owner user id.
+            schedule_id (`str`): The schedule id.
+
+        Returns:
+            `list[SessionRecord]`: Sessions triggered by this schedule,
+            ordered by creation time (newest first).
+        """
+        kind = self._entity_kind("session")
+        sched_key_base = self._schedule_session_index_key(user_id)
+        sched_key = f"{sched_key_base}:{schedule_id}"
+        records: list[SessionRecord] = []
+        for session_id in self._indexes[user_id][sched_key]:
+            raw = self._records[user_id][kind].get(session_id)
+            if raw:
+                records.append(SessionRecord.model_validate_json(raw))
+        records.sort(key=lambda r: r.created_at, reverse=True)
+        return records
+
+    # ==================================================================
+    # Schedule CRUD
+    # ==================================================================
+
+    async def upsert_schedule(
+        self,
+        user_id: str,
+        record: ScheduleRecord,
+    ) -> str:
+        """Persist a cron task record and register it in the user and global
+        indexes.
+
+        Args:
+            user_id (`str`): The owner user id.
+            record (`ScheduleRecord`): The fully-populated record to store.
+
+        Returns:
+            `str`: The id of the stored record.
+        """
+        kind = self._entity_kind("schedule")
+        index = self._index_name("schedule")
+        global_index = "schedule_global_ids"
+        self._records[user_id][kind][record.id] = record.model_dump_json()
+        self._indexes[user_id][index].add(record.id)
+        self._indexes["__global__"][global_index].add(
+            f"{user_id}:{record.id}",
+        )
+        return record.id
+
+    async def get_schedule(
+        self,
+        user_id: str,
+        schedule_id: str,
+    ) -> ScheduleRecord | None:
+        """Fetch a single cron task record by id.
+
+        Args:
+            user_id (`str`): The owner user id.
+            schedule_id (`str`): The task id.
+
+        Returns:
+            `ScheduleRecord | None`: The record, or ``None`` if not found.
+        """
+        kind = self._entity_kind("schedule")
+        raw = self._records[user_id][kind].get(schedule_id)
+        if not raw:
+            return None
+        return ScheduleRecord.model_validate_json(raw)
+
+    async def list_schedules(self, user_id: str) -> list[ScheduleRecord]:
+        """Return all cron task records belonging to the given user.
+
+        Args:
+            user_id (`str`): The owner user id.
+
+        Returns:
+            `list[ScheduleRecord]`: All cron task records for the user.
+        """
+        kind = self._entity_kind("schedule")
+        index = self._index_name("schedule")
+        records: list[ScheduleRecord] = []
+        for schedule_id in self._indexes[user_id][index]:
+            raw = self._records[user_id][kind].get(schedule_id)
+            if raw:
+                records.append(ScheduleRecord.model_validate_json(raw))
+        return records
+
+    async def delete_schedule(self, user_id: str, schedule_id: str) -> bool:
+        """Delete a cron task record, cascade-delete its execution sessions,
+        and remove it from the user and global indexes.
+
+        Args:
+            user_id (`str`): The owner user id.
+            schedule_id (`str`): The id of the task to delete.
+
+        Returns:
+            `bool`: ``True`` if deleted, ``False`` if not found.
+        """
+        kind = self._entity_kind("schedule")
+        index = self._index_name("schedule")
+        global_index = "schedule_global_ids"
+
+        raw = self._records[user_id][kind].get(schedule_id)
+        if raw is None:
+            return False
+
+        record = ScheduleRecord.model_validate_json(raw)
+
+        # Cascade: delete all sessions created by this schedule
+        sessions = await self.list_sessions_by_schedule(user_id, schedule_id)
+        for session in sessions:
+            _ = await self.delete_session(
+                user_id,
+                record.agent_id,
+                session.id,
+            )
+
+        # Clean up the schedule-session index key
+        sched_key_base = self._schedule_session_index_key(user_id)
+        sched_key = f"{sched_key_base}:{schedule_id}"
+        _ = self._indexes[user_id].pop(sched_key, None)
+
+        del self._records[user_id][kind][schedule_id]
+        self._indexes[user_id][index].discard(schedule_id)
+        self._indexes["__global__"][global_index].discard(
+            f"{user_id}:{schedule_id}",
+        )
+        return True
+
+    async def list_all_schedules(self) -> list[ScheduleRecord]:
+        """Return every schedule record across all users.
+
+        Used on startup to restore the in-memory scheduler from persisted
+        state.
+
+        Returns:
+            `list[ScheduleRecord]`: All schedule records in the store.
+        """
+        global_index = "schedule_global_ids"
+        kind = self._entity_kind("schedule")
+        records: list[ScheduleRecord] = []
+        for entry in self._indexes["__global__"][global_index]:
+            user_id, schedule_id = entry.split(":", 1)
+            raw = self._records[user_id][kind].get(schedule_id)
+            if raw:
+                records.append(ScheduleRecord.model_validate_json(raw))
+        return records
+
+    # ==================================================================
+    # Message persistence
+    # ==================================================================
+
+    async def upsert_message(
+        self,
+        user_id: str,
+        session_id: str,
+        msg: Msg,
+    ) -> None:
+        """Persist a message to the session's message list.
+
+        If the last message in the list has the same ``id`` as *msg*, it is
+        replaced (merge/overwrite for the same reply_id across continuation
+        calls). Otherwise, *msg* is appended as a new entry.
+
+        Args:
+            user_id (`str`): The owner user id.
+            session_id (`str`): The session id.
+            msg (`Msg`): The message to persist.
+        """
+        key = self._message_key(user_id, session_id)
+        msgs = self._messages[user_id][key]
+        if msgs and msgs[-1].id == msg.id:
+            msgs[-1] = msg
+        else:
+            msgs.append(msg)
+
+    async def get_message(
+        self,
+        user_id: str,
+        session_id: str,
+        message_id: str,
+    ) -> Msg | None:
+        """Fetch a single message by id from the session's message list.
+
+        Args:
+            user_id (`str`): The owner user id.
+            session_id (`str`): The session id.
+            message_id (`str`): The message id to look up.
+
+        Returns:
+            `Msg | None`: The message, or ``None`` if not found.
+        """
+        key = self._message_key(user_id, session_id)
+        for msg in reversed(self._messages[user_id][key]):
+            if msg.id == message_id:
+                return msg
+        return None
+
+    async def list_messages(
+        self,
+        user_id: str,
+        session_id: str,
+        offset: int = 0,
+        limit: int = 50,
+    ) -> list[Msg]:
+        """Return messages for a session with pagination.
+
+        Args:
+            user_id (`str`): The owner user id.
+            session_id (`str`): The session id.
+            offset (`int`): Starting index (0-based). Defaults to 0.
+            limit (`int`): Maximum number of messages to return.
+
+        Returns:
+            `list[Msg]`: Messages in chronological order.
+        """
+        key = self._message_key(user_id, session_id)
+        msgs = self._messages[user_id][key]
+        return msgs[offset : offset + limit]
+
+    # ==================================================================
+    # Team persistence
+    # ==================================================================
+
+    async def upsert_team(
+        self,
+        user_id: str,
+        record: TeamRecord,
+    ) -> TeamRecord:
+        """Persist a team record and register it in the user's team index.
+
+        Args:
+            user_id (`str`):
+                The owner user id. Used to scope both the record key and
+                the per-user team index.
+            record (`TeamRecord`):
+                The team record to persist. Its ``id`` is used as the
+                primary key; an existing record with the same id is
+                overwritten. ``updated_at`` is refreshed to
+                ``datetime.now()`` before writing.
+
+        Returns:
+            `TeamRecord`:
+                The stored record (with refreshed ``updated_at``).
+        """
+        record.updated_at = datetime.now()
+        kind = self._entity_kind("team")
+        index = self._index_name("team")
+        self._records[user_id][kind][record.id] = record.model_dump_json()
+        self._indexes[user_id][index].add(record.id)
+        return record
+
+    async def get_team(
+        self,
+        user_id: str,
+        team_id: str,
+    ) -> TeamRecord | None:
+        """Fetch a single team record by id.
+
+        Args:
+            user_id (`str`):
+                The owner user id.
+            team_id (`str`):
+                The team id to look up.
+
+        Returns:
+            `TeamRecord | None`:
+                The record, or ``None`` if no record exists.
+        """
+        kind = self._entity_kind("team")
+        raw = self._records[user_id][kind].get(team_id)
+        if not raw:
+            return None
+        return TeamRecord.model_validate_json(raw)
+
+    async def list_teams(self, user_id: str) -> list[TeamRecord]:
+        """Return all team records belonging to the given user.
+
+        Args:
+            user_id (`str`):
+                The owner user id whose teams to list.
+
+        Returns:
+            `list[TeamRecord]`:
+                All team records for the user, in arbitrary order.
+        """
+        kind = self._entity_kind("team")
+        index = self._index_name("team")
+        records: list[TeamRecord] = []
+        for team_id in self._indexes[user_id][index]:
+            raw = self._records[user_id][kind].get(team_id)
+            if raw:
+                records.append(TeamRecord.model_validate_json(raw))
+        return records
+
+    async def set_session_team_id(
+        self,
+        user_id: str,
+        session_id: str,
+        team_id: str | None,
+    ) -> None:
+        """Set or clear ``team_id`` on an existing session record.
+
+        Bypasses :meth:`upsert_session` because that method does not
+        allow writing ``team_id``. Idempotent: a no-op if the session
+        does not exist or already holds the given value.
+
+        Args:
+            user_id (`str`):
+                The owner user id.
+            session_id (`str`):
+                The session whose ``team_id`` should be updated.
+            team_id (`str | None`):
+                The new value. ``None`` detaches the session from any
+                team.
+        """
+        kind = self._entity_kind("session")
+        raw = self._records[user_id][kind].get(session_id)
+        if raw is None:
+            return
+        record = SessionRecord.model_validate_json(raw)
+        if record.team_id == team_id:
+            return
+        record.team_id = team_id
+        record.updated_at = datetime.now()
+        self._records[user_id][kind][session_id] = record.model_dump_json()
+
+    async def delete_team(self, user_id: str, team_id: str) -> bool:
+        """Delete a team record and cascade-delete all of its workers.
+
+        Cascade order:
+
+        1. For each ``member_id`` in :attr:`TeamData.member_ids`, call
+           :meth:`delete_agent` (which cascades that worker's session).
+        2. Clear ``team_id`` on the leader session.
+        3. Delete the :class:`TeamRecord` key and the per-user team
+           index entry.
+
+        Args:
+            user_id (`str`):
+                The owner user id.
+            team_id (`str`):
+                The id of the team to delete.
+
+        Returns:
+            `bool`:
+                ``True`` if the team record existed and was deleted,
+                ``False`` if no record was found.
+        """
+        team = await self.get_team(user_id, team_id)
+        if team is None:
+            kind = self._entity_kind("team")
+            index = self._index_name("team")
+            if team_id in self._records[user_id][kind]:
+                del self._records[user_id][kind][team_id]
+            self._indexes[user_id][index].discard(team_id)
+            return False
+
+        # Cascade: delete each worker agent (which cascades its session)
+        for member_id in team.data.member_ids:
+            _ = await self.delete_agent(user_id, member_id)
+
+        # Clear team_id on the leader session (idempotent)
+        await self.set_session_team_id(user_id, team.session_id, None)
+
+        kind = self._entity_kind("team")
+        index = self._index_name("team")
+        existed = team_id in self._records[user_id][kind]
+        _ = self._records[user_id][kind].pop(team_id, None)
+        self._indexes[user_id][index].discard(team_id)
+        return existed

--- a/src/agentscope/app/storage/_mem_storage.py
+++ b/src/agentscope/app/storage/_mem_storage.py
@@ -56,21 +56,21 @@ class MemStorage(StorageBase):
         # Structure: _records[user_id][entity_kind][entity_id] = json_str
         # Backed by nested defaultdicts for auto-vivification.
         self._records: defaultdict[
-            str, defaultdict[str, dict[str, str]]
+            str, defaultdict[str, dict[str, str]],
         ] = defaultdict(lambda: defaultdict(dict))
 
         # ── Index storage ───────────────────────────────────────────
         # Structure: _indexes[user_id][index_name] = set of ids
         # Backed by nested defaultdicts for auto-vivification.
         self._indexes: defaultdict[
-            str, defaultdict[str, set[str]]
+            str, defaultdict[str, set[str]],
         ] = defaultdict(lambda: defaultdict(set))
 
         # ── Message storage ─────────────────────────────────────────
         # Structure: _messages[user_id][session_key] = list[Msg]
         # Backed by nested defaultdicts for auto-vivification.
         self._messages: defaultdict[
-            str, defaultdict[str, list[Msg]]
+            str, defaultdict[str, list[Msg]],
         ] = defaultdict(lambda: defaultdict(list))
 
     # ==================================================================

--- a/tests/message_bus_mem_test.py
+++ b/tests/message_bus_mem_test.py
@@ -1,0 +1,464 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Unit tests for MemMessageBus."""
+
+import asyncio
+from unittest.async_case import IsolatedAsyncioTestCase
+
+from agentscope.app.message_bus._mem_message_bus import MemMessageBus
+
+
+class TestLifecycle(IsolatedAsyncioTestCase):
+    """Tests for bus lifecycle: create, context manager, close."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.bus = MemMessageBus()
+
+    async def test_context_manager(self) -> None:
+        """Bus can be used as an async context manager."""
+        async with MemMessageBus() as bus:
+            self.assertIsInstance(bus, MemMessageBus)
+            # push something to verify it's alive
+            await bus.queue_push("k", {"v": 1})
+
+    async def test_aclose_clears_all_state(self) -> None:
+        """aclose clears all internal data structures."""
+        await self.bus.queue_push("q", {"x": 1})
+        await self.bus.log_append("l", {"y": 2})
+        await self.bus.registry_set("ns", "f", "val")
+        await self.bus.aclose()
+        self.assertEqual(self.bus._queues, {})
+        self.assertEqual(self.bus._logs, {})
+        self.assertEqual(self.bus._log_counters, {})
+        self.assertEqual(self.bus._channels, {})
+        self.assertEqual(self.bus._locks, {})
+        self.assertEqual(self.bus._registries, {})
+
+
+class TestDrainQueue(IsolatedAsyncioTestCase):
+    """Tests for Mode A — drain queue operations."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.bus = MemMessageBus()
+
+    async def test_push_returns_entry_id(self) -> None:
+        """queue_push returns a string entry id."""
+        eid = await self.bus.queue_push("key-a", {"msg": "hello"})
+        self.assertIsInstance(eid, str)
+        self.assertTrue(len(eid) > 0)
+
+    async def test_drain_returns_pushed_entry(self) -> None:
+        """queue_drain returns the entry previously pushed."""
+        await self.bus.queue_push("key-b", {"msg": "hello"})
+        entries = await self.bus.queue_drain("key-b")
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0][1], {"msg": "hello"})
+
+    async def test_drain_removes_entries(self) -> None:
+        """After drain, the same entry cannot be read again."""
+        await self.bus.queue_push("key-c", {"msg": "once"})
+        _ = await self.bus.queue_drain("key-c")
+        entries = await self.bus.queue_drain("key-c")
+        self.assertEqual(entries, [])
+
+    async def test_drain_empty_queue_returns_empty(self) -> None:
+        """queue_drain on a non-existent key returns an empty list."""
+        entries = await self.bus.queue_drain("no-such-key")
+        self.assertEqual(entries, [])
+
+    async def test_drain_respects_max_count(self) -> None:
+        """queue_drain returns at most max_count entries."""
+        for i in range(5):
+            await self.bus.queue_push("key-d", {"i": i})
+        entries = await self.bus.queue_drain("key-d", max_count=3)
+        self.assertEqual(len(entries), 3)
+
+    async def test_drain_fifo_order(self) -> None:
+        """queue_drain returns entries in FIFO order."""
+        await self.bus.queue_push("key-e", {"seq": 1})
+        await self.bus.queue_push("key-e", {"seq": 2})
+        await self.bus.queue_push("key-e", {"seq": 3})
+        entries = await self.bus.queue_drain("key-e")
+        self.assertEqual(
+            [e[1]["seq"] for e in entries],
+            [1, 2, 3],
+        )
+
+    async def test_queue_delete_removes_key(self) -> None:
+        """queue_delete removes the queue entirely."""
+        await self.bus.queue_push("key-f", {"x": 1})
+        await self.bus.queue_delete("key-f")
+        entries = await self.bus.queue_drain("key-f")
+        self.assertEqual(entries, [])
+
+    async def test_ttl_is_ignored(self) -> None:
+        """ttl_secs is accepted but has no effect on in-memory queues."""
+        eid = await self.bus.queue_push("key-g", {"x": 1}, ttl_secs=60)
+        self.assertIsInstance(eid, str)
+        # No expiry in memory — entry still present after "time passes"
+        await asyncio.sleep(0.01)
+        entries = await self.bus.queue_drain("key-g")
+        self.assertEqual(len(entries), 1)
+
+
+class TestReplayLog(IsolatedAsyncioTestCase):
+    """Tests for Mode C — replay log operations."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.bus = MemMessageBus()
+
+    async def test_log_append_returns_entry_id(self) -> None:
+        """log_append returns a monotonic integer as string."""
+        eid = await self.bus.log_append("log-a", {"msg": "hello"})
+        self.assertEqual(eid, "0")
+
+    async def test_log_append_ids_are_monotonic(self) -> None:
+        """Each log_append increments the entry id."""
+        eid1 = await self.bus.log_append("log-b", {"n": 1})
+        eid2 = await self.bus.log_append("log-b", {"n": 2})
+        eid3 = await self.bus.log_append("log-b", {"n": 3})
+        self.assertEqual(eid1, "0")
+        self.assertEqual(eid2, "1")
+        self.assertEqual(eid3, "2")
+
+    async def test_log_read_returns_all_entries(self) -> None:
+        """log_read without since returns all entries."""
+        await self.bus.log_append("log-c", {"n": 1})
+        await self.bus.log_append("log-c", {"n": 2})
+        entries = await self.bus.log_read("log-c")
+        self.assertEqual(len(entries), 2)
+        self.assertEqual(entries[0][1], {"n": 1})
+        self.assertEqual(entries[1][1], {"n": 2})
+
+    async def test_log_read_empty_log_returns_empty(self) -> None:
+        """log_read on a non-existent key returns an empty list."""
+        entries = await self.bus.log_read("no-such-log")
+        self.assertEqual(entries, [])
+
+    async def test_log_read_since_filters_older(self) -> None:
+        """log_read with since returns only newer entries."""
+        await self.bus.log_append("log-d", {"n": 1})
+        await self.bus.log_append("log-d", {"n": 2})
+        await self.bus.log_append("log-d", {"n": 3})
+        entries = await self.bus.log_read("log-d", since="0")
+        self.assertEqual(len(entries), 2)
+        self.assertEqual([e[1]["n"] for e in entries], [2, 3])
+
+    async def test_log_read_respects_max_count(self) -> None:
+        """log_read returns at most max_count entries."""
+        for i in range(5):
+            await self.bus.log_append("log-e", {"i": i})
+        entries = await self.bus.log_read("log-e", max_count=3)
+        self.assertEqual(len(entries), 3)
+
+    async def test_log_trim_before_id_removes_older(self) -> None:
+        """log_trim with before_id prunes older entries."""
+        await self.bus.log_append("log-f", {"n": 1})
+        await self.bus.log_append("log-f", {"n": 2})
+        await self.bus.log_append("log-f", {"n": 3})
+        await self.bus.log_trim("log-f", before_id="1")
+        entries = await self.bus.log_read("log-f")
+        self.assertEqual(len(entries), 2)
+        self.assertEqual([e[1]["n"] for e in entries], [2, 3])
+
+    async def test_log_trim_none_drops_entire_log(self) -> None:
+        """log_trim with before_id=None drops the entire log."""
+        await self.bus.log_append("log-g", {"n": 1})
+        await self.bus.log_trim("log-g", before_id=None)
+        entries = await self.bus.log_read("log-g")
+        self.assertEqual(entries, [])
+
+    async def test_log_trim_nonexistent_key_noop(self) -> None:
+        """log_trim on non-existent key does not raise."""
+        await self.bus.log_trim("no-such-log", before_id="0")
+
+    async def test_max_len_caps_log_size(self) -> None:
+        """max_len removes oldest entries when exceeded."""
+        for i in range(5):
+            await self.bus.log_append("log-h", {"i": i}, max_len=3)
+        entries = await self.bus.log_read("log-h")
+        self.assertEqual(len(entries), 3)
+        # Only the 3 most recent entries survive
+        self.assertEqual([e[1]["i"] for e in entries], [2, 3, 4])
+
+    async def test_log_read_is_non_destructive(self) -> None:
+        """Reading the replay log does not remove entries."""
+        await self.bus.log_append("log-i", {"n": 1})
+        _ = await self.bus.log_read("log-i")
+        entries = await self.bus.log_read("log-i")
+        self.assertEqual(len(entries), 1)
+
+    async def test_ttl_is_ignored(self) -> None:
+        """ttl_secs is accepted but has no effect on in-memory logs."""
+        eid = await self.bus.log_append("log-j", {"x": 1}, ttl_secs=60)
+        self.assertIsInstance(eid, str)
+        await asyncio.sleep(0.01)
+        entries = await self.bus.log_read("log-j")
+        self.assertEqual(len(entries), 1)
+
+
+class TestBroadcast(IsolatedAsyncioTestCase):
+    """Tests for Mode D — transient broadcast."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.bus = MemMessageBus()
+
+    async def test_subscribe_receives_published(self) -> None:
+        """A subscriber receives published payloads."""
+        received: list[dict] = []
+        ready = asyncio.Event()
+
+        async def _collect() -> None:
+            async for payload in self.bus.subscribe("chan-a", on_ready=ready.set):
+                received.append(payload)
+                if len(received) >= 2:
+                    break
+
+        task = asyncio.create_task(_collect())
+        await ready.wait()
+        await self.bus.publish("chan-a", {"msg": "hello"})
+        await self.bus.publish("chan-a", {"msg": "world"})
+        await task
+        self.assertEqual(len(received), 2)
+        self.assertEqual(received[0], {"msg": "hello"})
+        self.assertEqual(received[1], {"msg": "world"})
+
+    async def test_publish_no_subscribers_noop(self) -> None:
+        """publish to a channel with no subscribers does not raise."""
+        await self.bus.publish("empty-chan", {"msg": "nobody"})
+        # Should not raise or block
+
+    async def test_unsubscribe_on_generator_close(self) -> None:
+        """When a subscriber generator closes, previously published
+        messages are received."""
+        received: list[dict] = []
+        ready = asyncio.Event()
+
+        async def _consume() -> None:
+            async for payload in self.bus.subscribe("chan-b", on_ready=ready.set):
+                received.append(payload)
+                break
+
+        task = asyncio.create_task(_consume())
+        await ready.wait()
+        await self.bus.publish("chan-b", {"msg": "release"})
+        await task
+        self.assertEqual(received, [{"msg": "release"}])
+
+    async def test_on_ready_callback(self) -> None:
+        """on_ready is called after subscription is established and
+        messages are received."""
+        ready_called = False
+        received: list[dict] = []
+
+        def _on_ready() -> None:
+            nonlocal ready_called
+            ready_called = True
+
+        async def _drain() -> None:
+            async for payload in self.bus.subscribe("chan-c", on_ready=_on_ready):
+                received.append(payload)
+                break
+
+        task = asyncio.create_task(_drain())
+        await asyncio.sleep(0.01)
+        self.assertTrue(ready_called)
+        await self.bus.publish("chan-c", {"msg": "done"})
+        await task
+        self.assertEqual(received, [{"msg": "done"}])
+
+    async def test_multiple_subscribers_same_channel(self) -> None:
+        """Multiple subscribers on the same channel all receive payloads."""
+        received_a: list[dict] = []
+        received_b: list[dict] = []
+        ready_a = asyncio.Event()
+        ready_b = asyncio.Event()
+
+        async def _collect_a() -> None:
+            async for payload in self.bus.subscribe("chan-d", on_ready=ready_a.set):
+                received_a.append(payload)
+                if len(received_a) >= 1:
+                    break
+
+        async def _collect_b() -> None:
+            async for payload in self.bus.subscribe("chan-d", on_ready=ready_b.set):
+                received_b.append(payload)
+                if len(received_b) >= 1:
+                    break
+
+        ta = asyncio.create_task(_collect_a())
+        tb = asyncio.create_task(_collect_b())
+        await ready_a.wait()
+        await ready_b.wait()
+        await self.bus.publish("chan-d", {"msg": "fanout"})
+        await asyncio.gather(ta, tb)
+        self.assertEqual(received_a, [{"msg": "fanout"}])
+        self.assertEqual(received_b, [{"msg": "fanout"}])
+
+    async def test_late_subscriber_misses_earlier(self) -> None:
+        """Only connected subscribers receive; late-joiners miss earlier
+        publishes (transient broadcast)."""
+        received: list[dict] = []
+        ready = asyncio.Event()
+
+        await self.bus.publish("chan-e", {"msg": "before"})
+
+        async def _collect() -> None:
+            async for payload in self.bus.subscribe("chan-e", on_ready=ready.set):
+                received.append(payload)
+                break
+
+        task = asyncio.create_task(_collect())
+        await ready.wait()
+        await self.bus.publish("chan-e", {"msg": "after"})
+        await task
+        self.assertEqual(received, [{"msg": "after"}])
+
+
+class TestLock(IsolatedAsyncioTestCase):
+    """Tests for Mode E — distributed lock (in-process mutex)."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.bus = MemMessageBus()
+
+    async def test_acquire_lock_yields(self) -> None:
+        """acquire_lock context manager yields control."""
+        async with self.bus.acquire_lock("lk-a") as _:
+            self.assertIsNone(_)
+
+    async def test_is_locked_returns_true_while_held(self) -> None:
+        """is_locked returns True while a lock is held."""
+        check_result = False
+
+        async def _holder() -> None:
+            nonlocal check_result
+            async with self.bus.acquire_lock("lk-b"):
+                check_result = await self.bus.is_locked("lk-b")
+
+        await _holder()
+        self.assertTrue(check_result)
+
+    async def test_is_locked_returns_false_when_not_held(self) -> None:
+        """is_locked returns False when no one holds the lock."""
+        result = await self.bus.is_locked("lk-c")
+        self.assertFalse(result)
+        async with self.bus.acquire_lock("lk-c"):
+            pass
+        result_after = await self.bus.is_locked("lk-c")
+        self.assertFalse(result_after)
+
+    async def test_lock_is_mutually_exclusive(self) -> None:
+        """Only one coroutine can hold the lock at a time."""
+        order: list[str] = []
+
+        async def _hold(name: str) -> None:
+            async with self.bus.acquire_lock("lk-d"):
+                order.append(f"{name}-enter")
+                await asyncio.sleep(0.05)
+                order.append(f"{name}-exit")
+
+        t1 = asyncio.create_task(_hold("a"))
+        await asyncio.sleep(0.01)
+        t2 = asyncio.create_task(_hold("b"))
+        await asyncio.gather(t1, t2)
+        # a enters, a exits, b enters, b exits (sequential)
+        self.assertEqual(
+            order,
+            ["a-enter", "a-exit", "b-enter", "b-exit"],
+        )
+
+    async def test_lock_cleans_up_after_release(self) -> None:
+        """After release with no waiters, the lock key is removed from _locks."""
+        async with self.bus.acquire_lock("lk-e"):
+            self.assertIn("lk-e", self.bus._locks)
+        self.assertNotIn("lk-e", self.bus._locks)
+        self.assertFalse(await self.bus.is_locked("lk-e"))
+
+    async def test_ttl_parameter_accepted(self) -> None:
+        """ttl_secs parameter is accepted (interface parity)."""
+        async with self.bus.acquire_lock("lk-f", ttl_secs=30):
+            self.assertTrue(await self.bus.is_locked("lk-f"))
+
+
+class TestRegistry(IsolatedAsyncioTestCase):
+    """Tests for Mode F — registry map operations."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.bus = MemMessageBus()
+
+    async def test_set_and_exists(self) -> None:
+        """registry_set writes a field; registry_exists confirms it."""
+        await self.bus.registry_set("ns-a", "key1", "val1")
+        self.assertTrue(await self.bus.registry_exists("ns-a", "key1"))
+        self.assertFalse(await self.bus.registry_exists("ns-a", "no-such"))
+
+    async def test_exists_nonexistent_namespace(self) -> None:
+        """registry_exists on unknown namespace returns False."""
+        result = await self.bus.registry_exists("no-such-ns", "f")
+        self.assertFalse(result)
+
+    async def test_getall_returns_all_fields(self) -> None:
+        """registry_getall returns all field-value pairs."""
+        await self.bus.registry_set("ns-b", "a", "1")
+        await self.bus.registry_set("ns-b", "b", "2")
+        all_fields = await self.bus.registry_getall("ns-b")
+        self.assertEqual(all_fields, {"a": "1", "b": "2"})
+
+    async def test_getall_empty_namespace_returns_empty(self) -> None:
+        """registry_getall on non-existent namespace returns {}."""
+        result = await self.bus.registry_getall("no-such-ns")
+        self.assertEqual(result, {})
+
+    async def test_del_removes_field(self) -> None:
+        """registry_del removes a field."""
+        await self.bus.registry_set("ns-c", "key1", "val1")
+        await self.bus.registry_del("ns-c", "key1")
+        self.assertFalse(await self.bus.registry_exists("ns-c", "key1"))
+
+    async def test_del_nonexistent_noop(self) -> None:
+        """registry_del on non-existent field/namespace does not raise."""
+        await self.bus.registry_del("no-such-ns", "f")
+
+    async def test_drop_deletes_entire_namespace(self) -> None:
+        """registry_drop removes all fields in a namespace."""
+        await self.bus.registry_set("ns-d", "a", "1")
+        await self.bus.registry_set("ns-d", "b", "2")
+        await self.bus.registry_drop("ns-d")
+        self.assertFalse(await self.bus.registry_exists("ns-d", "a"))
+        self.assertFalse(await self.bus.registry_exists("ns-d", "b"))
+        self.assertEqual(await self.bus.registry_getall("ns-d"), {})
+
+    async def test_drop_nonexistent_noop(self) -> None:
+        """registry_drop on non-existent namespace does not raise."""
+        await self.bus.registry_drop("no-such-ns")
+
+    async def test_overwrite_value(self) -> None:
+        """Setting the same field again overwrites the value."""
+        await self.bus.registry_set("ns-e", "key1", "first")
+        await self.bus.registry_set("ns-e", "key1", "second")
+        all_fields = await self.bus.registry_getall("ns-e")
+        self.assertEqual(all_fields, {"key1": "second"})
+
+    async def test_namespace_isolation(self) -> None:
+        """Different namespaces do not interfere."""
+        await self.bus.registry_set("ns-x", "f", "v1")
+        await self.bus.registry_set("ns-y", "f", "v2")
+        self.assertEqual(
+            await self.bus.registry_getall("ns-x"),
+            {"f": "v1"},
+        )
+        self.assertEqual(
+            await self.bus.registry_getall("ns-y"),
+            {"f": "v2"},
+        )
+
+    async def test_ttl_is_ignored(self) -> None:
+        """ttl_secs parameter is accepted but has no effect."""
+        await self.bus.registry_set("ns-f", "k", "v", ttl_secs=60)
+        self.assertTrue(await self.bus.registry_exists("ns-f", "k"))

--- a/tests/message_bus_mem_test.py
+++ b/tests/message_bus_mem_test.py
@@ -22,18 +22,22 @@ class TestLifecycle(IsolatedAsyncioTestCase):
             # push something to verify it's alive
             await bus.queue_push("k", {"v": 1})
 
-    async def test_aclose_clears_all_state(self) -> None:
-        """aclose clears all internal data structures."""
+    async def test_aclose_preserves_data(self) -> None:
+        """aclose is a no-op — data survives until GC, mirroring Redis."""
         await self.bus.queue_push("q", {"x": 1})
         await self.bus.log_append("l", {"y": 2})
         await self.bus.registry_set("ns", "f", "val")
+
         await self.bus.aclose()
-        self.assertEqual(self.bus._queues, {})
-        self.assertEqual(self.bus._logs, {})
-        self.assertEqual(self.bus._log_counters, {})
-        self.assertEqual(self.bus._channels, {})
-        self.assertEqual(self.bus._locks, {})
-        self.assertEqual(self.bus._registries, {})
+
+        drained = await self.bus.queue_drain("q")
+        self.assertEqual([payload for _eid, payload in drained], [{"x": 1}])
+        log = await self.bus.log_read("l")
+        self.assertEqual([payload for _eid, payload in log], [{"y": 2}])
+        self.assertEqual(
+            await self.bus.registry_getall("ns"),
+            {"f": "val"},
+        )
 
 
 class TestDrainQueue(IsolatedAsyncioTestCase):
@@ -372,11 +376,16 @@ class TestLock(IsolatedAsyncioTestCase):
             ["a-enter", "a-exit", "b-enter", "b-exit"],
         )
 
-    async def test_lock_cleans_up_after_release(self) -> None:
-        """After release with no waiters, the lock key is removed from _locks."""
+    async def test_lock_persists_after_release(self) -> None:
+        """The lock object stays in _locks after release.
+
+        Removing it would race with pending waiters and let a fresh
+        :class:`asyncio.Lock` be created for a key that another
+        coroutine is still waiting on, breaking mutual exclusion.
+        """
         async with self.bus.acquire_lock("lk-e"):
             self.assertIn("lk-e", self.bus._locks)
-        self.assertNotIn("lk-e", self.bus._locks)
+        self.assertIn("lk-e", self.bus._locks)
         self.assertFalse(await self.bus.is_locked("lk-e"))
 
     async def test_ttl_parameter_accepted(self) -> None:
@@ -462,3 +471,115 @@ class TestRegistry(IsolatedAsyncioTestCase):
         """ttl_secs parameter is accepted but has no effect."""
         await self.bus.registry_set("ns-f", "k", "v", ttl_secs=60)
         self.assertTrue(await self.bus.registry_exists("ns-f", "k"))
+
+
+class TestLockMutualExclusionUnderRace(IsolatedAsyncioTestCase):
+    """Regression: acquire_lock must hold mutual exclusion under contention."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.bus = MemMessageBus()
+
+    async def test_three_way_contention_no_overlap(self) -> None:
+        """A/B/C contending for the same key never overlap.
+
+        The previous implementation popped the asyncio.Lock from
+        ``_locks`` after the holder released, racing with pending
+        waiters: a third coroutine arriving in that window would create
+        a fresh Lock object while the original waiter was about to
+        acquire the old one, producing two simultaneous holders.
+        """
+        in_critical: list[str] = []
+        overlaps: list[list[str]] = []
+
+        async def worker(
+            name: str,
+            hold: float,
+            start_delay: float,
+        ) -> None:
+            await asyncio.sleep(start_delay)
+            async with self.bus.acquire_lock("shared"):
+                in_critical.append(name)
+                if len(in_critical) > 1:
+                    overlaps.append(list(in_critical))
+                await asyncio.sleep(hold)
+                in_critical.remove(name)
+
+        for _ in range(20):
+            in_critical.clear()
+            await asyncio.gather(
+                worker("A", hold=0.005, start_delay=0.0),
+                worker("B", hold=0.010, start_delay=0.001),
+                worker("C", hold=0.010, start_delay=0.006),
+            )
+
+        self.assertEqual(overlaps, [])
+
+
+class TestLogAppendMaxLenBoundary(IsolatedAsyncioTestCase):
+    """Regression: log_append max_len boundary handling."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.bus = MemMessageBus()
+
+    async def test_max_len_zero_trims_to_empty(self) -> None:
+        """max_len=0 must keep zero entries, not the whole list."""
+        await self.bus.log_append("k", {"v": 1}, max_len=0)
+        await self.bus.log_append("k", {"v": 2}, max_len=0)
+        await self.bus.log_append("k", {"v": 3}, max_len=0)
+        entries = await self.bus.log_read("k")
+        self.assertEqual(entries, [])
+
+    async def test_max_len_negative_trims_to_empty(self) -> None:
+        """Negative max_len behaves like zero — slice [-(-1):] gave junk before."""
+        await self.bus.log_append("k", {"v": 1}, max_len=-1)
+        entries = await self.bus.log_read("k")
+        self.assertEqual(entries, [])
+
+    async def test_max_len_one_keeps_only_latest(self) -> None:
+        """max_len=1 keeps only the most recently appended entry."""
+        await self.bus.log_append("k", {"v": 1}, max_len=1)
+        await self.bus.log_append("k", {"v": 2}, max_len=1)
+        await self.bus.log_append("k", {"v": 3}, max_len=1)
+        entries = await self.bus.log_read("k")
+        self.assertEqual([payload for _eid, payload in entries], [{"v": 3}])
+
+
+class TestRegistryNamespaceCleanup(IsolatedAsyncioTestCase):
+    """Regression: registry_del reclaims empty namespace dicts."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.bus = MemMessageBus()
+
+    async def test_delete_last_field_drops_namespace(self) -> None:
+        """Removing the last field reclaims the empty namespace dict."""
+        await self.bus.registry_set("ns", "f", "v")
+        self.assertIn("ns", self.bus._registries)
+        await self.bus.registry_del("ns", "f")
+        self.assertNotIn("ns", self.bus._registries)
+
+    async def test_partial_delete_keeps_namespace(self) -> None:
+        """Removing one of two fields keeps the namespace populated."""
+        await self.bus.registry_set("ns", "f1", "v1")
+        await self.bus.registry_set("ns", "f2", "v2")
+        await self.bus.registry_del("ns", "f1")
+        self.assertEqual(
+            self.bus._registries["ns"],
+            {"f2": "v2"},
+        )
+
+    async def test_delete_unknown_namespace_no_ghost(self) -> None:
+        """registry_del on a namespace that never existed creates no ghost."""
+        await self.bus.registry_del("never-set", "f")
+        self.assertNotIn("never-set", self.bus._registries)
+
+    async def test_delete_unknown_field_keeps_namespace(self) -> None:
+        """Deleting a missing field from a populated namespace is a no-op."""
+        await self.bus.registry_set("ns", "real", "v")
+        await self.bus.registry_del("ns", "missing")
+        self.assertEqual(
+            self.bus._registries["ns"],
+            {"real": "v"},
+        )

--- a/tests/storage_mem_test.py
+++ b/tests/storage_mem_test.py
@@ -1,0 +1,678 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Unit tests for MemStorage."""
+
+from unittest.async_case import IsolatedAsyncioTestCase
+
+from agentscope.app.storage import (
+    MemStorage,
+    AgentRecord,
+    SessionConfig,
+    ChatModelConfig,
+    ScheduleRecord,
+    ScheduleData,
+    SessionSource,
+    TeamData,
+    TeamRecord,
+)
+from agentscope.app.storage import AgentData
+from agentscope.credential import OllamaCredential
+from agentscope.agent import ContextConfig, ReActConfig
+from agentscope.message import UserMsg, AssistantMsg, TextBlock
+from agentscope.state import AgentState
+
+
+def make_storage() -> MemStorage:
+    """Create a MemStorage instance."""
+    return MemStorage()
+
+
+def make_agent_record(user_id: str) -> AgentRecord:
+    """Create a test AgentRecord with all-default sub-configs."""
+    return AgentRecord(
+        user_id=user_id,
+        data=AgentData(
+            id="agent-data-id",
+            name="test-agent",
+            system_prompt="You are a helpful assistant.",
+            context_config=ContextConfig(),
+            react_config=ReActConfig(),
+        ),
+    )
+
+
+def make_session_config(workspace_id: str = "ws-1") -> SessionConfig:
+    """Create a test SessionConfig with a chat model config."""
+    return SessionConfig(
+        workspace_id=workspace_id,
+        chat_model_config=ChatModelConfig(
+            type="openai",
+            credential_id="cred-1",
+            model="gpt-4",
+            parameters={},
+        ),
+    )
+
+
+def make_schedule_record(user_id: str, agent_id: str) -> ScheduleRecord:
+    """Create a test ScheduleRecord."""
+    return ScheduleRecord(
+        user_id=user_id,
+        agent_id=agent_id,
+        data=ScheduleData(
+            name="test-schedule",
+            cron_expression="0 9 * * *",
+            started_at="2026-01-01T00:00:00",
+            chat_model_config=ChatModelConfig(
+                type="openai",
+                credential_id="cred-1",
+                model="gpt-4",
+                parameters={},
+            ),
+        ),
+    )
+
+
+def make_team_record(
+    user_id: str,
+    session_id: str = "leader-session-1",
+    name: str = "test-team",
+    member_ids: list[str] | None = None,
+) -> TeamRecord:
+    """Create a test TeamRecord."""
+    return TeamRecord(
+        user_id=user_id,
+        session_id=session_id,
+        data=TeamData(
+            name=name,
+            member_ids=member_ids if member_ids is not None else [],
+        ),
+    )
+
+
+class TestCredential(IsolatedAsyncioTestCase):
+    """Tests for credential CRUD."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.storage = make_storage()
+        self.user_id = "user-1"
+
+    async def test_create(self) -> None:
+        """Create a credential and verify it is retrievable via list."""
+        cred_id = await self.storage.upsert_credential(
+            self.user_id,
+            OllamaCredential(host="http://localhost:11434"),
+        )
+        records = await self.storage.list_credentials(self.user_id)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].id, cred_id)
+        self.assertEqual(records[0].data.get("type"), "ollama_credential")
+        self.assertEqual(
+            records[0].data.get("host"),
+            "http://localhost:11434",
+        )
+
+    async def test_list_empty(self) -> None:
+        """Verify list returns empty when no records exist."""
+        records = await self.storage.list_credentials(self.user_id)
+        self.assertEqual(records, [])
+
+    async def test_update_in_place(self) -> None:
+        """Update a credential and verify data changed without adding
+        a new record."""
+        cred_id = await self.storage.upsert_credential(
+            self.user_id,
+            OllamaCredential(host="http://old-host:11434"),
+        )
+        await self.storage.upsert_credential(
+            self.user_id,
+            OllamaCredential(id=cred_id, host="http://new-host:11434"),
+        )
+        records = await self.storage.list_credentials(self.user_id)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].data.get("host"), "http://new-host:11434")
+
+    async def test_delete(self) -> None:
+        """Delete a credential and verify it is gone."""
+        cred_id = await self.storage.upsert_credential(
+            self.user_id,
+            OllamaCredential(host="http://localhost:11434"),
+        )
+        result = await self.storage.delete_credential(self.user_id, cred_id)
+        self.assertTrue(result)
+        records = await self.storage.list_credentials(self.user_id)
+        self.assertEqual(records, [])
+
+    async def test_delete_nonexistent(self) -> None:
+        """Verify delete returns False for non-existent record."""
+        result = await self.storage.delete_credential(
+            self.user_id,
+            "no-such-id",
+        )
+        self.assertFalse(result)
+
+    async def test_user_isolation(self) -> None:
+        """Verify different users cannot see each other's records."""
+        await self.storage.upsert_credential(
+            "user-A",
+            OllamaCredential(host="http://localhost:11434"),
+        )
+        records = await self.storage.list_credentials("user-B")
+        self.assertEqual(records, [])
+
+
+class TestAgent(IsolatedAsyncioTestCase):
+    """Tests for agent CRUD."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.storage = make_storage()
+        self.user_id = "user-1"
+
+    async def test_create(self) -> None:
+        """Create an agent and verify it is retrievable via list."""
+        record = make_agent_record(self.user_id)
+        agent_id = await self.storage.upsert_agent(self.user_id, record)
+        records = await self.storage.list_agents(self.user_id)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].id, agent_id)
+        self.assertEqual(records[0].data.name, "test-agent")
+
+    async def test_list_empty(self) -> None:
+        """Verify list returns empty when no records exist."""
+        records = await self.storage.list_agents(self.user_id)
+        self.assertEqual(records, [])
+
+    async def test_delete(self) -> None:
+        """Delete an agent and verify it is gone."""
+        record = make_agent_record(self.user_id)
+        await self.storage.upsert_agent(self.user_id, record)
+        result = await self.storage.delete_agent(self.user_id, record.id)
+        self.assertTrue(result)
+        records = await self.storage.list_agents(self.user_id)
+        self.assertEqual(records, [])
+
+    async def test_delete_nonexistent(self) -> None:
+        """Verify delete returns False for non-existent record."""
+        result = await self.storage.delete_agent(self.user_id, "no-such-id")
+        self.assertFalse(result)
+
+    async def test_user_isolation(self) -> None:
+        """Verify different users cannot see each other's records."""
+        await self.storage.upsert_agent("user-A", make_agent_record("user-A"))
+        records = await self.storage.list_agents("user-B")
+        self.assertEqual(records, [])
+
+
+class TestSession(IsolatedAsyncioTestCase):
+    """Tests for session CRUD."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.storage = make_storage()
+        self.user_id = "user-1"
+        self.agent_id = "agent-1"
+        self.workspace_id = "ws-1"
+
+    async def test_create(self) -> None:
+        """Create a session and verify it is retrievable via list."""
+        await self.storage.upsert_session(
+            self.user_id,
+            self.agent_id,
+            make_session_config(self.workspace_id),
+        )
+        records = await self.storage.list_sessions(self.user_id, self.agent_id)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].config.workspace_id, self.workspace_id)
+        self.assertEqual(records[0].agent_id, self.agent_id)
+
+    async def test_list_empty(self) -> None:
+        """Verify list returns empty when no records exist."""
+        records = await self.storage.list_sessions(self.user_id, self.agent_id)
+        self.assertEqual(records, [])
+
+    async def test_delete(self) -> None:
+        """Delete a session and verify it is gone."""
+        await self.storage.upsert_session(
+            self.user_id,
+            self.agent_id,
+            make_session_config(self.workspace_id),
+        )
+        records = await self.storage.list_sessions(self.user_id, self.agent_id)
+        result = await self.storage.delete_session(
+            self.user_id,
+            self.agent_id,
+            records[0].id,
+        )
+        self.assertTrue(result)
+        remaining = await self.storage.list_sessions(
+            self.user_id,
+            self.agent_id,
+        )
+        self.assertEqual(remaining, [])
+
+    async def test_delete_nonexistent(self) -> None:
+        """Verify delete returns False for non-existent record."""
+        result = await self.storage.delete_session(
+            self.user_id,
+            self.agent_id,
+            "no-such-id",
+        )
+        self.assertFalse(result)
+
+    async def test_agent_isolation(self) -> None:
+        """Verify different agents cannot see each other's sessions."""
+        await self.storage.upsert_session(
+            self.user_id,
+            "agent-A",
+            make_session_config(self.workspace_id),
+        )
+        records = await self.storage.list_sessions(self.user_id, "agent-B")
+        self.assertEqual(records, [])
+
+
+class TestMessage(IsolatedAsyncioTestCase):
+    """Tests for message persistence."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.storage = make_storage()
+        self.user_id = "user-1"
+        self.session_id = "session-1"
+
+    async def test_upsert_appends_new_message(self) -> None:
+        """Upserting a new message appends it to the session list."""
+        msg = UserMsg(name="alice", content="hello")
+        await self.storage.upsert_message(self.user_id, self.session_id, msg)
+        messages = await self.storage.list_messages(
+            self.user_id,
+            self.session_id,
+        )
+        self.assertListEqual(
+            [m.model_dump() for m in messages],
+            [msg.model_dump()],
+        )
+
+    async def test_upsert_replaces_last_message_with_same_id(self) -> None:
+        """Upserting a message whose id matches the last entry replaces it
+        in-place (streaming overwrite), rather than creating a duplicate."""
+        msg = AssistantMsg(name="bot", content="v1")
+        await self.storage.upsert_message(self.user_id, self.session_id, msg)
+
+        updated = msg.model_copy(
+            update={"content": [TextBlock(text="v2")]},
+        )
+        await self.storage.upsert_message(
+            self.user_id,
+            self.session_id,
+            updated,
+        )
+
+        messages = await self.storage.list_messages(
+            self.user_id,
+            self.session_id,
+        )
+        self.assertListEqual(
+            [m.model_dump() for m in messages],
+            [updated.model_dump()],
+            "Duplicate must not be created; existing entry must be replaced.",
+        )
+
+    async def test_upsert_appends_when_id_differs_from_last(self) -> None:
+        """Upserting a message with a different id than the last always
+        appends, even if an earlier message shares the same id."""
+        msg1 = UserMsg(name="alice", content="first")
+        msg2 = UserMsg(name="alice", content="second")
+        await self.storage.upsert_message(self.user_id, self.session_id, msg1)
+        await self.storage.upsert_message(self.user_id, self.session_id, msg2)
+        messages = await self.storage.list_messages(
+            self.user_id,
+            self.session_id,
+        )
+        self.assertListEqual(
+            [m.model_dump() for m in messages],
+            [msg1.model_dump(), msg2.model_dump()],
+        )
+
+    async def test_get_message_returns_correct_message(self) -> None:
+        """get_message fetches the message matching the given id."""
+        msg1 = UserMsg(name="alice", content="first")
+        msg2 = UserMsg(name="alice", content="second")
+        await self.storage.upsert_message(self.user_id, self.session_id, msg1)
+        await self.storage.upsert_message(self.user_id, self.session_id, msg2)
+
+        fetched = await self.storage.get_message(
+            self.user_id,
+            self.session_id,
+            msg1.id,
+        )
+        self.assertIsNotNone(fetched)
+        self.assertDictEqual(fetched.model_dump(), msg1.model_dump())
+
+    async def test_get_message_nonexistent_returns_none(self) -> None:
+        """get_message returns None when the message id does not exist."""
+        result = await self.storage.get_message(
+            self.user_id,
+            self.session_id,
+            "no-such-id",
+        )
+        self.assertIsNone(result)
+
+    async def test_list_messages_empty_session(self) -> None:
+        """list_messages returns an empty list for a session with no
+        messages."""
+        messages = await self.storage.list_messages(
+            self.user_id,
+            self.session_id,
+        )
+        self.assertListEqual(messages, [])
+
+    async def test_list_messages_pagination(self) -> None:
+        """list_messages respects offset and limit parameters."""
+        msgs = [UserMsg(name="alice", content=f"msg-{i}") for i in range(5)]
+        for m in msgs:
+            await self.storage.upsert_message(
+                self.user_id,
+                self.session_id,
+                m,
+            )
+
+        page = await self.storage.list_messages(
+            self.user_id,
+            self.session_id,
+            offset=1,
+            limit=3,
+        )
+        self.assertListEqual(
+            [m.model_dump() for m in page],
+            [m.model_dump() for m in msgs[1:4]],
+        )
+
+    async def test_session_isolation(self) -> None:
+        """Messages belonging to different sessions do not interfere."""
+        await self.storage.upsert_message(
+            self.user_id,
+            "session-A",
+            UserMsg(name="alice", content="in A"),
+        )
+        messages = await self.storage.list_messages(
+            self.user_id,
+            "session-B",
+        )
+        self.assertListEqual(messages, [])
+
+    async def test_message_isolation_via_model_copy(self) -> None:
+        """Modifying the original message after upsert does not affect
+        the stored copy."""
+        msg = UserMsg(name="alice", content="original")
+        await self.storage.upsert_message(self.user_id, self.session_id, msg)
+
+        msg.content = [TextBlock(text="modified")]
+
+        stored = await self.storage.get_message(
+            self.user_id,
+            self.session_id,
+            msg.id,
+        )
+        self.assertIsNotNone(stored)
+        self.assertEqual(stored.content[0].text, "original")
+
+
+class TestSchedule(IsolatedAsyncioTestCase):
+    """Tests for schedule CRUD."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.storage = make_storage()
+        self.user_id = "user-1"
+        self.agent_id = "agent-1"
+
+    async def test_create(self) -> None:
+        """Create a schedule and verify it is retrievable via list."""
+        record = make_schedule_record(self.user_id, self.agent_id)
+        schedule_id = await self.storage.upsert_schedule(self.user_id, record)
+        records = await self.storage.list_schedules(self.user_id)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].id, schedule_id)
+
+    async def test_list_empty(self) -> None:
+        """Verify list returns empty when no records exist."""
+        records = await self.storage.list_schedules(self.user_id)
+        self.assertEqual(records, [])
+
+    async def test_delete(self) -> None:
+        """Delete a schedule and verify it is gone."""
+        record = make_schedule_record(self.user_id, self.agent_id)
+        await self.storage.upsert_schedule(self.user_id, record)
+        result = await self.storage.delete_schedule(self.user_id, record.id)
+        self.assertTrue(result)
+        records = await self.storage.list_schedules(self.user_id)
+        self.assertEqual(records, [])
+
+    async def test_delete_nonexistent(self) -> None:
+        """Verify delete returns False for non-existent record."""
+        result = await self.storage.delete_schedule(self.user_id, "no-such-id")
+        self.assertFalse(result)
+
+
+class TestTeam(IsolatedAsyncioTestCase):
+    """Tests for team CRUD."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.storage = make_storage()
+        self.user_id = "user-1"
+
+    async def test_create(self) -> None:
+        """Create a team and verify it is retrievable via list."""
+        record = make_team_record(self.user_id)
+        stored = await self.storage.upsert_team(self.user_id, record)
+        records = await self.storage.list_teams(self.user_id)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].id, stored.id)
+        self.assertEqual(records[0].session_id, "leader-session-1")
+        self.assertEqual(records[0].data.name, "test-team")
+        self.assertEqual(records[0].data.member_ids, [])
+
+    async def test_list_empty(self) -> None:
+        """Verify list returns empty when no teams exist."""
+        records = await self.storage.list_teams(self.user_id)
+        self.assertEqual(records, [])
+
+    async def test_get_returns_record(self) -> None:
+        """get_team returns the persisted record by id."""
+        record = make_team_record(
+            self.user_id,
+            member_ids=["worker-a", "worker-b"],
+        )
+        await self.storage.upsert_team(self.user_id, record)
+        loaded = await self.storage.get_team(self.user_id, record.id)
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded.id, record.id)
+        self.assertEqual(loaded.data.member_ids, ["worker-a", "worker-b"])
+
+    async def test_get_nonexistent_returns_none(self) -> None:
+        """get_team returns None when the id does not exist."""
+        loaded = await self.storage.get_team(self.user_id, "no-such-id")
+        self.assertIsNone(loaded)
+
+    async def test_delete(self) -> None:
+        """Delete a team and verify it is gone."""
+        record = make_team_record(self.user_id)
+        await self.storage.upsert_team(self.user_id, record)
+
+        result = await self.storage.delete_team(self.user_id, record.id)
+        self.assertTrue(result)
+
+        loaded = await self.storage.get_team(self.user_id, record.id)
+        self.assertIsNone(loaded)
+        self.assertEqual(await self.storage.list_teams(self.user_id), [])
+
+    async def test_delete_nonexistent(self) -> None:
+        """delete_team returns False for an unknown id."""
+        result = await self.storage.delete_team(self.user_id, "no-such-id")
+        self.assertFalse(result)
+
+    async def test_user_isolation(self) -> None:
+        """Teams from one user are invisible to another."""
+        await self.storage.upsert_team(
+            "user-A",
+            make_team_record("user-A"),
+        )
+        records = await self.storage.list_teams("user-B")
+        self.assertEqual(records, [])
+
+
+class TestCascade(IsolatedAsyncioTestCase):
+    """Tests for cascade deletion behavior."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.storage = make_storage()
+        self.user_id = "user-1"
+        self.agent_id = "agent-1"
+
+    async def test_delete_agent_cascades_sessions(self) -> None:
+        """Deleting an agent cascades to its sessions."""
+        record = make_agent_record(self.user_id)
+        await self.storage.upsert_agent(self.user_id, record)
+        await self.storage.upsert_session(
+            self.user_id,
+            record.id,
+            make_session_config(),
+        )
+
+        await self.storage.delete_agent(self.user_id, record.id)
+
+        sessions = await self.storage.list_sessions(self.user_id, record.id)
+        self.assertEqual(sessions, [])
+
+    async def test_delete_schedule_cascades_sessions(self) -> None:
+        """Deleting a schedule cascades to its execution sessions."""
+        schedule = make_schedule_record(self.user_id, self.agent_id)
+        await self.storage.upsert_schedule(self.user_id, schedule)
+
+        await self.storage.upsert_session(
+            self.user_id,
+            self.agent_id,
+            make_session_config(),
+            source=SessionSource.SCHEDULE,
+            source_schedule_id=schedule.id,
+        )
+
+        await self.storage.delete_schedule(self.user_id, schedule.id)
+
+        sessions = await self.storage.list_sessions_by_schedule(
+            self.user_id,
+            schedule.id,
+        )
+        self.assertEqual(sessions, [])
+
+    async def test_delete_team_cascades_workers(self) -> None:
+        """Deleting a team cascades to its worker agents."""
+        leader_record = make_agent_record(self.user_id)
+        await self.storage.upsert_agent(self.user_id, leader_record)
+
+        leader_session = await self.storage.upsert_session(
+            self.user_id,
+            leader_record.id,
+            make_session_config(),
+        )
+
+        worker_a = AgentRecord(
+            id="worker-a",
+            user_id=self.user_id,
+            source="team",
+            data=AgentData(
+                id="data-a",
+                name="worker-a",
+                system_prompt="worker",
+                context_config=ContextConfig(),
+                react_config=ReActConfig(),
+            ),
+        )
+        await self.storage.upsert_agent(self.user_id, worker_a)
+
+        team = make_team_record(
+            self.user_id,
+            session_id=leader_session.id,
+            member_ids=[worker_a.id],
+        )
+        await self.storage.upsert_team(self.user_id, team)
+
+        await self.storage.delete_team(self.user_id, team.id)
+
+        self.assertIsNone(
+            await self.storage.get_team(self.user_id, team.id),
+        )
+        self.assertIsNone(
+            await self.storage.get_agent(self.user_id, worker_a.id),
+        )
+
+
+class TestSetSessionTeamId(IsolatedAsyncioTestCase):
+    """Tests for set_session_team_id."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.storage = make_storage()
+        self.user_id = "user-1"
+        self.agent_id = "agent-1"
+
+    async def test_set_team_id(self) -> None:
+        """set_session_team_id sets the team_id on a session."""
+        session = await self.storage.upsert_session(
+            self.user_id,
+            self.agent_id,
+            make_session_config(),
+        )
+
+        await self.storage.set_session_team_id(
+            self.user_id,
+            session.id,
+            "team-1",
+        )
+
+        loaded = await self.storage.get_session(
+            self.user_id,
+            self.agent_id,
+            session.id,
+        )
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded.team_id, "team-1")
+
+    async def test_clear_team_id(self) -> None:
+        """set_session_team_id with None clears the team_id."""
+        session = await self.storage.upsert_session(
+            self.user_id,
+            self.agent_id,
+            make_session_config(),
+        )
+        await self.storage.set_session_team_id(
+            self.user_id,
+            session.id,
+            "team-1",
+        )
+
+        await self.storage.set_session_team_id(
+            self.user_id,
+            session.id,
+            None,
+        )
+
+        loaded = await self.storage.get_session(
+            self.user_id,
+            self.agent_id,
+            session.id,
+        )
+        self.assertIsNotNone(loaded)
+        self.assertIsNone(loaded.team_id)
+
+    async def test_set_team_id_nonexistent_session_noop(self) -> None:
+        """set_session_team_id on a non-existent session is a no-op."""
+        await self.storage.set_session_team_id(
+            self.user_id,
+            "no-such-session",
+            "team-1",
+        )

--- a/tests/storage_mem_test.py
+++ b/tests/storage_mem_test.py
@@ -676,3 +676,405 @@ class TestSetSessionTeamId(IsolatedAsyncioTestCase):
             "no-such-session",
             "team-1",
         )
+
+
+class TestReadIsolation(IsolatedAsyncioTestCase):
+    """Regression tests for read-side isolation guarantees."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.storage = make_storage()
+        self.user_id = "user-1"
+        self.session_id = "session-1"
+
+    async def test_get_message_returns_deep_copy(self) -> None:
+        """Mutating a Msg returned by get_message must not affect storage."""
+        msg = UserMsg(name="alice", content="original")
+        await self.storage.upsert_message(self.user_id, self.session_id, msg)
+
+        first_read = await self.storage.get_message(
+            self.user_id,
+            self.session_id,
+            msg.id,
+        )
+        self.assertIsNotNone(first_read)
+        first_read.content = [TextBlock(text="hijacked")]
+
+        second_read = await self.storage.get_message(
+            self.user_id,
+            self.session_id,
+            msg.id,
+        )
+        self.assertIsNotNone(second_read)
+        self.assertEqual(second_read.content[0].text, "original")
+
+    async def test_list_messages_returns_deep_copies(self) -> None:
+        """Mutating items returned by list_messages must not affect storage."""
+        original = UserMsg(name="alice", content="original")
+        await self.storage.upsert_message(
+            self.user_id,
+            self.session_id,
+            original,
+        )
+
+        first = await self.storage.list_messages(
+            self.user_id,
+            self.session_id,
+        )
+        first[0].content = [TextBlock(text="hijacked")]
+
+        second = await self.storage.list_messages(
+            self.user_id,
+            self.session_id,
+        )
+        self.assertEqual(second[0].content[0].text, "original")
+
+
+class TestNoGhostUserOnRead(IsolatedAsyncioTestCase):
+    """Regression tests: read paths must not auto-create user nodes."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.storage = make_storage()
+        self.unknown_user = "never-seen-this-user"
+
+    def assert_no_ghost_user(self) -> None:
+        """Assert no internal state was created for an unknown user."""
+        self.assertNotIn(self.unknown_user, self.storage._records)
+        self.assertNotIn(self.unknown_user, self.storage._indexes)
+        self.assertNotIn(self.unknown_user, self.storage._messages)
+
+    async def test_get_credential_unknown_user(self) -> None:
+        """get_credential for an unknown user must not create a user node."""
+        result = await self.storage.get_credential(
+            self.unknown_user,
+            "any-id",
+        )
+        self.assertIsNone(result)
+        self.assert_no_ghost_user()
+
+    async def test_list_credentials_unknown_user(self) -> None:
+        """list_credentials for an unknown user must not create a user node."""
+        result = await self.storage.list_credentials(self.unknown_user)
+        self.assertEqual(result, [])
+        self.assert_no_ghost_user()
+
+    async def test_delete_credential_unknown_user(self) -> None:
+        """delete_credential for an unknown user must not create a user node."""
+        result = await self.storage.delete_credential(
+            self.unknown_user,
+            "any-id",
+        )
+        self.assertFalse(result)
+        self.assert_no_ghost_user()
+
+    async def test_get_agent_unknown_user(self) -> None:
+        """get_agent for an unknown user must not create a user node."""
+        result = await self.storage.get_agent(self.unknown_user, "any-id")
+        self.assertIsNone(result)
+        self.assert_no_ghost_user()
+
+    async def test_list_agents_unknown_user(self) -> None:
+        """list_agents for an unknown user must not create a user node."""
+        result = await self.storage.list_agents(self.unknown_user)
+        self.assertEqual(result, [])
+        self.assert_no_ghost_user()
+
+    async def test_delete_agent_unknown_user(self) -> None:
+        """delete_agent for an unknown user must not create a user node."""
+        result = await self.storage.delete_agent(self.unknown_user, "any-id")
+        self.assertFalse(result)
+        self.assert_no_ghost_user()
+
+    async def test_get_session_unknown_user(self) -> None:
+        """get_session for an unknown user must not create a user node."""
+        result = await self.storage.get_session(
+            self.unknown_user,
+            "any-agent",
+            "any-id",
+        )
+        self.assertIsNone(result)
+        self.assert_no_ghost_user()
+
+    async def test_list_sessions_unknown_user(self) -> None:
+        """list_sessions for an unknown user must not create a user node."""
+        result = await self.storage.list_sessions(
+            self.unknown_user,
+            "any-agent",
+        )
+        self.assertEqual(result, [])
+        self.assert_no_ghost_user()
+
+    async def test_delete_session_unknown_user(self) -> None:
+        """delete_session for an unknown user must not create a user node."""
+        result = await self.storage.delete_session(
+            self.unknown_user,
+            "any-agent",
+            "any-id",
+        )
+        self.assertFalse(result)
+        self.assert_no_ghost_user()
+
+    async def test_list_sessions_by_schedule_unknown_user(self) -> None:
+        """list_sessions_by_schedule for unknown user creates no user node."""
+        result = await self.storage.list_sessions_by_schedule(
+            self.unknown_user,
+            "any-schedule",
+        )
+        self.assertEqual(result, [])
+        self.assert_no_ghost_user()
+
+    async def test_get_schedule_unknown_user(self) -> None:
+        """get_schedule for an unknown user must not create a user node."""
+        result = await self.storage.get_schedule(
+            self.unknown_user,
+            "any-id",
+        )
+        self.assertIsNone(result)
+        self.assert_no_ghost_user()
+
+    async def test_list_schedules_unknown_user(self) -> None:
+        """list_schedules for an unknown user must not create a user node."""
+        result = await self.storage.list_schedules(self.unknown_user)
+        self.assertEqual(result, [])
+        self.assert_no_ghost_user()
+
+    async def test_delete_schedule_unknown_user(self) -> None:
+        """delete_schedule for an unknown user must not create a user node."""
+        result = await self.storage.delete_schedule(
+            self.unknown_user,
+            "any-id",
+        )
+        self.assertFalse(result)
+        self.assert_no_ghost_user()
+
+    async def test_get_team_unknown_user(self) -> None:
+        """get_team for an unknown user must not create a user node."""
+        result = await self.storage.get_team(self.unknown_user, "any-id")
+        self.assertIsNone(result)
+        self.assert_no_ghost_user()
+
+    async def test_list_teams_unknown_user(self) -> None:
+        """list_teams for an unknown user must not create a user node."""
+        result = await self.storage.list_teams(self.unknown_user)
+        self.assertEqual(result, [])
+        self.assert_no_ghost_user()
+
+    async def test_delete_team_unknown_user(self) -> None:
+        """delete_team for an unknown user must not create a user node."""
+        result = await self.storage.delete_team(self.unknown_user, "any-id")
+        self.assertFalse(result)
+        self.assert_no_ghost_user()
+
+    async def test_set_session_team_id_unknown_user(self) -> None:
+        """set_session_team_id for an unknown user must not create a node."""
+        await self.storage.set_session_team_id(
+            self.unknown_user,
+            "any-session",
+            "team-1",
+        )
+        self.assert_no_ghost_user()
+
+    async def test_get_message_unknown_user(self) -> None:
+        """get_message for an unknown user must not create a user node."""
+        result = await self.storage.get_message(
+            self.unknown_user,
+            "any-session",
+            "any-msg",
+        )
+        self.assertIsNone(result)
+        self.assert_no_ghost_user()
+
+    async def test_list_messages_unknown_user(self) -> None:
+        """list_messages for an unknown user must not create a user node."""
+        result = await self.storage.list_messages(
+            self.unknown_user,
+            "any-session",
+        )
+        self.assertEqual(result, [])
+        self.assert_no_ghost_user()
+
+    async def test_update_session_state_unknown_user_raises(self) -> None:
+        """update_session_state on unknown user raises and creates no node."""
+        with self.assertRaises(KeyError):
+            await self.storage.update_session_state(
+                self.unknown_user,
+                "any-agent",
+                "any-session",
+                AgentState(),
+            )
+        self.assert_no_ghost_user()
+
+
+class TestDeleteSessionMessagesIsolation(IsolatedAsyncioTestCase):
+    """Regression: delete_session must not create a _messages ghost node."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.storage = make_storage()
+        self.user_id = "user-1"
+        self.agent_id = "agent-1"
+
+    async def test_delete_session_without_messages_no_ghost(self) -> None:
+        """A session that never received messages leaves _messages clean."""
+        record = await self.storage.upsert_session(
+            self.user_id,
+            self.agent_id,
+            make_session_config(),
+        )
+        self.assertNotIn(self.user_id, self.storage._messages)
+
+        deleted = await self.storage.delete_session(
+            self.user_id,
+            self.agent_id,
+            record.id,
+        )
+        self.assertTrue(deleted)
+        self.assertNotIn(self.user_id, self.storage._messages)
+
+    async def test_delete_session_with_messages_clears_entry(self) -> None:
+        """A session that did receive messages has its entry removed."""
+        record = await self.storage.upsert_session(
+            self.user_id,
+            self.agent_id,
+            make_session_config(),
+        )
+        msg = UserMsg(name="alice", content="hi")
+        await self.storage.upsert_message(self.user_id, record.id, msg)
+        self.assertIn(self.user_id, self.storage._messages)
+
+        deleted = await self.storage.delete_session(
+            self.user_id,
+            self.agent_id,
+            record.id,
+        )
+        self.assertTrue(deleted)
+        msg_key = self.storage._message_key(self.user_id, record.id)
+        self.assertNotIn(msg_key, self.storage._messages[self.user_id])
+
+
+class TestAcloseDoesNotWipeData(IsolatedAsyncioTestCase):
+    """Regression: aclose() must preserve in-memory data (Redis-aligned)."""
+
+    async def test_aclose_keeps_records(self) -> None:
+        """Calling aclose() does not erase records — they live until GC."""
+        storage = make_storage()
+        user_id = "user-1"
+        cred_id = await storage.upsert_credential(
+            user_id,
+            OllamaCredential(name="ollama-1"),
+        )
+
+        await storage.aclose()
+
+        record = await storage.get_credential(user_id, cred_id)
+        self.assertIsNotNone(record)
+
+    async def test_async_with_keeps_records_after_exit(self) -> None:
+        """Data survives ``async with`` exit (mirrors RedisStorage)."""
+        storage = make_storage()
+        user_id = "user-1"
+        async with storage:
+            cred_id = await storage.upsert_credential(
+                user_id,
+                OllamaCredential(name="ollama-1"),
+            )
+
+        record = await storage.get_credential(user_id, cred_id)
+        self.assertIsNotNone(record)
+
+
+class TestIndexCleanupOnDiscard(IsolatedAsyncioTestCase):
+    """Regression: discard must clean up empty index sets and user dicts."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up test fixtures."""
+        self.storage = make_storage()
+        self.user_id = "user-1"
+
+    async def test_delete_credential_drops_empty_index_set(self) -> None:
+        """After deleting the only credential, its index set is removed."""
+        cred_id = await self.storage.upsert_credential(
+            self.user_id,
+            OllamaCredential(name="ollama-1"),
+        )
+        index_name = self.storage._index_name("credential")
+        self.assertIn(index_name, self.storage._indexes[self.user_id])
+
+        deleted = await self.storage.delete_credential(self.user_id, cred_id)
+        self.assertTrue(deleted)
+        self.assertNotIn(self.user_id, self.storage._indexes)
+
+    async def test_delete_agent_drops_empty_index_set(self) -> None:
+        """After deleting the only agent, its index set is removed."""
+        agent = make_agent_record(self.user_id)
+        await self.storage.upsert_agent(self.user_id, agent)
+        deleted = await self.storage.delete_agent(self.user_id, agent.id)
+        self.assertTrue(deleted)
+        self.assertNotIn(self.user_id, self.storage._indexes)
+
+    async def test_delete_session_drops_empty_session_index(self) -> None:
+        """After deleting the only session, both session indexes are gone."""
+        agent_id = "agent-1"
+        record = await self.storage.upsert_session(
+            self.user_id,
+            agent_id,
+            make_session_config(),
+        )
+        session_idx_key = self.storage._session_index_key(
+            self.user_id,
+            agent_id,
+        )
+        index_name = self.storage._index_name("session")
+        self.assertIn(session_idx_key, self.storage._indexes[self.user_id])
+        self.assertIn(index_name, self.storage._indexes[self.user_id])
+
+        deleted = await self.storage.delete_session(
+            self.user_id,
+            agent_id,
+            record.id,
+        )
+        self.assertTrue(deleted)
+        self.assertNotIn(self.user_id, self.storage._indexes)
+
+    async def test_delete_team_drops_empty_index_set(self) -> None:
+        """After deleting the only team, its index set is removed."""
+        team = make_team_record(self.user_id)
+        await self.storage.upsert_team(self.user_id, team)
+        deleted = await self.storage.delete_team(self.user_id, team.id)
+        self.assertTrue(deleted)
+        self.assertNotIn(self.user_id, self.storage._indexes)
+
+    async def test_delete_schedule_drops_empty_indexes(self) -> None:
+        """delete_schedule reclaims user index dict and global index entry."""
+        record = make_schedule_record(self.user_id, "agent-1")
+        await self.storage.upsert_schedule(self.user_id, record)
+
+        deleted = await self.storage.delete_schedule(self.user_id, record.id)
+        self.assertTrue(deleted)
+        self.assertNotIn(self.user_id, self.storage._indexes)
+        self.assertEqual(
+            self.storage._indexes.get("__global__", {}).get(
+                "schedule_global_ids",
+                set(),
+            ),
+            set(),
+        )
+
+    async def test_partial_delete_keeps_index_set(self) -> None:
+        """Deleting one of two records keeps the index set populated."""
+        cred_id_1 = await self.storage.upsert_credential(
+            self.user_id,
+            OllamaCredential(name="ollama-1"),
+        )
+        await self.storage.upsert_credential(
+            self.user_id,
+            OllamaCredential(name="ollama-2"),
+        )
+
+        await self.storage.delete_credential(self.user_id, cred_id_1)
+        index_name = self.storage._index_name("credential")
+        self.assertEqual(
+            len(self.storage._indexes[self.user_id][index_name]),
+            1,
+        )


### PR DESCRIPTION
## AgentScope Version

2.0.1 (branch: main)

## Description

According to [discussion before](https://github.com/agentscope-ai/agentscope/discussions/1862), this MR provide an in-memory MemStorage and MemMessageBus in order to make example easier to launch.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [x]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [x]  Code is ready for review

## Ques
Besides the current discussion, do I need to open an additional issue?