### PR TITLE
feat: allow custom id factory

### DIFF
--- a/src/agentscope/__init__.py
+++ b/src/agentscope/__init__.py
@@ -6,6 +6,7 @@ from ._logging import (
     logger,
     setup_logger,
 )
+from ._utils._common import set_id_factory
 from ._version import __version__
 
 # Raise each warning only once
@@ -15,5 +16,6 @@ warnings.filterwarnings("once", category=DeprecationWarning)
 __all__ = [
     "logger",
     "setup_logger",
+    "set_id_factory",
     "__version__",
 ]

--- a/src/agentscope/_utils/_common.py
+++ b/src/agentscope/_utils/_common.py
@@ -11,8 +11,6 @@ import uuid
 from datetime import datetime
 from typing import Any, Callable
 
-from json_repair import repair_json
-
 from .._logging import logger
 from ..exception import ToolJSONDecodeError
 
@@ -62,6 +60,8 @@ def _json_loads_with_repair(
             A dictionary parsed from the JSON string after repair attempts.
             Returns an empty dict if all repair attempts fail.
     """
+    from json_repair import repair_json
+
     try:
         # Loads directly
         res = json.loads(json_str)

--- a/src/agentscope/_utils/_common.py
+++ b/src/agentscope/_utils/_common.py
@@ -11,7 +11,6 @@ import uuid
 from datetime import datetime
 from typing import Any, Callable
 
-import requests
 from json_repair import repair_json
 
 from .._logging import logger
@@ -184,6 +183,8 @@ def _get_bytes_from_web_url(
         max_retries (`int`, defaults to `3`):
             The maximum number of retries.
     """
+    import requests
+
     for _ in range(max_retries):
         try:
             response = requests.get(url)

--- a/src/agentscope/_utils/_common.py
+++ b/src/agentscope/_utils/_common.py
@@ -18,6 +18,28 @@ from .._logging import logger
 from ..exception import ToolJSONDecodeError
 
 
+_id_factory_impl: Callable[[], str] = lambda: uuid.uuid4().hex
+
+
+def _id_factory() -> str:
+    """Generate a new AgentScope entity identifier."""
+    return _id_factory_impl()
+
+
+def set_id_factory(factory: Callable[[], str]) -> None:
+    """Set the global factory used for AgentScope entity identifiers.
+
+    Args:
+        factory (`Callable[[], str]`):
+            A no-argument callable returning a string identifier.
+    """
+    if not callable(factory):
+        raise TypeError("ID factory must be callable.")
+
+    global _id_factory_impl
+    _id_factory_impl = factory
+
+
 def _json_loads_with_repair(
     json_str: str,
     schema: dict | None = None,

--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -2,7 +2,6 @@
 """The unified agent class in AgentScope library."""
 import asyncio
 import inspect
-import uuid
 
 from asyncio import Queue
 from copy import deepcopy
@@ -21,7 +20,7 @@ from ._config import ContextConfig, ReActConfig, ModelConfig
 from ..state import AgentState
 from ._utils import _ToolCallBatch
 from .._logging import logger
-from .._utils._common import _json_loads_with_repair
+from .._utils._common import _id_factory, _json_loads_with_repair
 from ..event import (
     AgentEvent,
     ModelCallEndEvent,
@@ -579,7 +578,7 @@ class Agent:
         else:
             await self._handle_incoming_messages(msgs)
             # Update the context with the incoming message and state
-            self.state.reply_id = uuid.uuid4().hex
+            self.state.reply_id = _id_factory()
             self.state.cur_iter = 0
 
             yield ReplyStartEvent(
@@ -2434,7 +2433,7 @@ class Agent:
             # If the current chunk has text blocks but no text block id,
             # start with a start event
             if not block_ids.get("text"):
-                block_ids["text"] = uuid.uuid4().hex
+                block_ids["text"] = _id_factory()
                 yield TextBlockStartEvent(
                     reply_id=self.state.reply_id,
                     block_id=block_ids["text"],
@@ -2458,7 +2457,7 @@ class Agent:
         if thinking_blocks:
             # Generate a new thinking block id and start event
             if not block_ids.get("thinking"):
-                block_ids["thinking"] = uuid.uuid4().hex
+                block_ids["thinking"] = _id_factory()
                 yield ThinkingBlockStartEvent(
                     reply_id=self.state.reply_id,
                     block_id=block_ids["thinking"],

--- a/src/agentscope/app/_manager/_background_task_manager.py
+++ b/src/agentscope/app/_manager/_background_task_manager.py
@@ -7,9 +7,9 @@ from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import Any, Self, TYPE_CHECKING
 
-import shortuuid
 from pydantic import BaseModel, Field
 
+from agentscope._utils._common import _id_factory
 from agentscope.message import TextBlock, ToolResultState
 from agentscope.permission import (
     PermissionContext,
@@ -57,7 +57,7 @@ class BackgroundTask:
     tool_name: str
     """The name of the offloaded tool."""
 
-    id: str = field(default_factory=shortuuid.uuid)
+    id: str = field(default_factory=_id_factory)
     """The background task id."""
 
 

--- a/src/agentscope/app/_router/_session.py
+++ b/src/agentscope/app/_router/_session.py
@@ -2,12 +2,12 @@
 """Session router — create, list, update, delete, stream, and get messages."""
 import asyncio
 import json
-import uuid
 from typing import AsyncGenerator
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
 
+from ..._utils._common import _id_factory
 from ..deps import (
     get_current_user_id,
     get_message_bus,
@@ -237,7 +237,7 @@ async def create_session(
         user_id=user_id,
         agent_id=body.agent_id,
         config=SessionConfig(
-            workspace_id=body.workspace_id or uuid.uuid4().hex,
+            workspace_id=body.workspace_id or _id_factory(),
             chat_model_config=body.chat_model_config,
             fallback_chat_model_config=body.fallback_chat_model_config,
             tts_model_config=body.tts_model_config,

--- a/src/agentscope/app/storage/_model/_agent.py
+++ b/src/agentscope/app/storage/_model/_agent.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 """The agent storage class."""
-import uuid
 from typing import Literal
 
 from pydantic import Field, BaseModel
 
 from ._base import _RecordBase
+from ...._utils._common import _id_factory
 from ....agent import ContextConfig, ReActConfig
 
 
@@ -14,7 +14,7 @@ class AgentData(BaseModel):
 
     id: str = Field(
         description="Unique agent id",
-        default_factory=lambda: uuid.uuid4().hex,
+        default_factory=_id_factory,
     )
     """The agent id."""
 

--- a/src/agentscope/app/storage/_model/_base.py
+++ b/src/agentscope/app/storage/_model/_base.py
@@ -1,16 +1,17 @@
 # -*- coding: utf-8 -*-
 """The base attributes used in storage."""
-import uuid
 from datetime import datetime
 
 from pydantic import BaseModel, Field
+
+from ...._utils._common import _id_factory
 
 
 class _RecordBase(BaseModel):
     """The base class for all records."""
 
     id: str = Field(
-        default_factory=lambda: uuid.uuid4().hex,
+        default_factory=_id_factory,
         description="Unique identifier for the credential.",
     )
 

--- a/src/agentscope/app/storage/_model/_credential.py
+++ b/src/agentscope/app/storage/_model/_credential.py
@@ -1,17 +1,16 @@
 # -*- coding: utf-8 -*-
 """The credential record."""
-import uuid
-
 from pydantic import Field
 
 from ._base import _RecordBase
+from ...._utils._common import _id_factory
 
 
 class CredentialRecord(_RecordBase):
     """The credential model used for storing credentials."""
 
     user_id: str = Field(
-        default_factory=lambda: uuid.uuid4().hex,
+        default_factory=_id_factory,
     )
 
     data: dict

--- a/src/agentscope/credential/_base.py
+++ b/src/agentscope/credential/_base.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 """The credential base class."""
-import uuid
 from typing import TYPE_CHECKING, Type
 
 from pydantic import BaseModel, Field
+
+from .._utils._common import _id_factory
 
 if TYPE_CHECKING:
     from ..embedding import EmbeddingModelBase
@@ -16,7 +17,7 @@ class CredentialBase(BaseModel):
     """The credential base class."""
 
     id: str = Field(
-        default_factory=lambda: uuid.uuid4().hex,
+        default_factory=_id_factory,
         description="The credential id",
     )
 

--- a/src/agentscope/event/_event.py
+++ b/src/agentscope/event/_event.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 """Event types for agent execution."""
-import uuid
 from datetime import datetime
 from enum import StrEnum
 from typing import Any, Dict, Literal, List, TypeAlias
 
 from pydantic import BaseModel, Field, ConfigDict
 
+from .._utils._common import _id_factory
 from ..message import (
     DataBlock,
     TextBlock,
@@ -65,7 +65,7 @@ class EventBase(BaseModel):
 
     model_config = ConfigDict(use_enum_values=True)
 
-    id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    id: str = Field(default_factory=_id_factory)
     """Unique event identifier."""
     created_at: str = Field(default_factory=lambda: datetime.now().isoformat())
     """ISO 8601 timestamp of when the event was created."""
@@ -337,7 +337,7 @@ class ToolResultDataDeltaEvent(EventBase):
     """ID of the reply message this tool result belongs to."""
     tool_call_id: str
     """ID of the corresponding tool call."""
-    block_id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    block_id: str = Field(default_factory=_id_factory)
     """Unique identifier of the data block created by this event."""
     media_type: str
     """MIME type of the binary content."""

--- a/src/agentscope/formatter/_formatter_base.py
+++ b/src/agentscope/formatter/_formatter_base.py
@@ -7,9 +7,9 @@ from abc import abstractmethod
 from fnmatch import fnmatch
 from typing import Any, List, AsyncGenerator
 
-import shortuuid
 from pydantic import BaseModel, Field
 
+from .._utils._common import _id_factory
 from ..message import (
     Msg,
     DataBlock,
@@ -111,7 +111,7 @@ class FormatterBase(BaseModel):
 
                     # Create an identifier for such multimodal data for
                     # accurate reference (in terms of order, position, etc.)
-                    identifier = shortuuid.uuid()
+                    identifier = _id_factory()
 
                     textual_output.append(
                         f"<system-reminder>A(n) {main_type} file is returned "

--- a/src/agentscope/message/_base.py
+++ b/src/agentscope/message/_base.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """The message class in agentscope."""
 import base64
-import uuid
 from datetime import datetime
 from typing import Literal, List, overload, Sequence, Self, TYPE_CHECKING, Any
 
@@ -22,6 +21,7 @@ from ._block import (
     ContentBlockTypes,
 )
 from .._logging import logger
+from .._utils._common import _id_factory
 
 if TYPE_CHECKING:
     from ..event import AgentEvent
@@ -73,7 +73,7 @@ class Msg(BaseModel):
     """The message content as a list of content blocks."""
     role: Literal["user", "assistant", "system"]
     """The role of the sender."""
-    id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    id: str = Field(default_factory=_id_factory)
     """The message identifier."""
     metadata: dict = Field(default_factory=dict)
     """The metadata of the message"""
@@ -487,7 +487,7 @@ def UserMsg(
             ISO-format timestamp for when the message was finished. Defaults to
             the same value as ``created_at`` when not provided.
         id (`str | None`, optional):
-            A unique identifier for the message. A random UUID hex string is
+            A unique identifier for the message. A generated string is
             generated when not provided.
 
     Returns:
@@ -504,7 +504,7 @@ def UserMsg(
         metadata=metadata or {},
         created_at=created_at,
         finished_at=finished_at,
-        id=id or uuid.uuid4().hex,
+        id=id or _id_factory(),
     )
 
 
@@ -536,7 +536,7 @@ def AssistantMsg(
             ISO-format timestamp for when the message was finished. Not set by
             default for assistant messages.
         id (`str | None`, optional):
-            A unique identifier for the message. A random UUID hex string is
+            A unique identifier for the message. A generated string is
             generated when not provided.
         usage (`Usage | None`, optional):
             The token usage information of the message.
@@ -552,7 +552,7 @@ def AssistantMsg(
         metadata=metadata or {},
         created_at=created_at or datetime.now().isoformat(),
         finished_at=finished_at,
-        id=id or uuid.uuid4().hex,
+        id=id or _id_factory(),
         usage=usage,
     )
 
@@ -584,7 +584,7 @@ def SystemMsg(
             ISO-format timestamp for when the message was finished. Defaults to
             the same value as ``created_at`` when not provided.
         id (`str | None`, optional):
-            A unique identifier for the message. A random UUID hex string is
+            A unique identifier for the message. A generated string is
             generated when not provided.
 
     Returns:
@@ -601,5 +601,5 @@ def SystemMsg(
         metadata=metadata or {},
         created_at=created_at,
         finished_at=finished_at,
-        id=id or uuid.uuid4().hex,
+        id=id or _id_factory(),
     )

--- a/src/agentscope/message/_block.py
+++ b/src/agentscope/message/_block.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """The content blocks of messages."""
-import uuid
 from enum import StrEnum
 from typing import Literal, List, TypeAlias
 from pydantic import BaseModel, Field, AnyUrl, field_serializer, ConfigDict
 
+from .._utils._common import _id_factory
 from ..permission import PermissionRule
 
 
@@ -15,7 +15,7 @@ class TextBlock(BaseModel):
     """The type of the text block, which is always 'text'."""
     text: str
     """The text content of the block."""
-    id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    id: str = Field(default_factory=_id_factory)
     """The unique identifier of the block."""
 
 
@@ -33,7 +33,7 @@ class ThinkingBlock(BaseModel):
     """The type of the thinking block, which is always 'thinking'."""
     thinking: str
     """The thinking content of the block."""
-    id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    id: str = Field(default_factory=_id_factory)
     """The unique identifier of the block."""
 
 
@@ -69,7 +69,7 @@ class DataBlock(BaseModel):
 
     type: Literal["data"] = "data"
     """The type of the data block, which is always 'data'."""
-    id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    id: str = Field(default_factory=_id_factory)
     """The unique identifier of the block."""
     source: Base64Source | URLSource
     """The source of the data, which can be either a base64-encoded string or
@@ -93,7 +93,7 @@ class HintBlock(BaseModel):
     hint: str | list[TextBlock | DataBlock]
     """The hint content — plain text or a list of content blocks for
     multimodal data."""
-    id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    id: str = Field(default_factory=_id_factory)
     """The unique identifier of the block."""
     source: str | None = None
     """The sender or origin of this hint. For team messages this is the

--- a/src/agentscope/middleware/_tts_middleware.py
+++ b/src/agentscope/middleware/_tts_middleware.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """Middleware that turns reasoning text into speech and injects it as
 ``DATA_BLOCK_*`` events into the agent's event stream."""
-import uuid
 from typing import TYPE_CHECKING, AsyncGenerator, Callable
 
 from ._base import MiddlewareBase
+from .._utils._common import _id_factory
 from ..event import (
     DataBlockDeltaEvent,
     DataBlockEndEvent,
@@ -163,7 +163,7 @@ class TTSMiddleware(MiddlewareBase):
             return
 
         if audio_block_id is None:
-            audio_block_id = uuid.uuid4().hex
+            audio_block_id = _id_factory()
             audio_media_type = media_type
             yield DataBlockStartEvent(
                 reply_id=agent.state.reply_id,

--- a/src/agentscope/model/_dashscope/_model.py
+++ b/src/agentscope/model/_dashscope/_model.py
@@ -2,7 +2,6 @@
 """The DashScope chat model class (OpenAI-compatible implementation)."""
 import base64
 import io
-import uuid
 import warnings
 import wave
 from collections import OrderedDict
@@ -15,6 +14,7 @@ from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse, StructuredResponse
 from .._model_usage import ChatUsage
 from ..._utils._audio import _build_streaming_wav_header
+from ..._utils._common import _id_factory
 from ...credential import DashScopeCredential
 from ...formatter import FormatterBase, DashScopeChatFormatter
 from ...message import (
@@ -349,7 +349,7 @@ class DashScopeChatModel(ChatModelBase):
                         audio_chunk = getattr(delta_audio, "data", "") or ""
                     if audio_chunk:
                         if audio_block_id is None:
-                            audio_block_id = uuid.uuid4().hex
+                            audio_block_id = _id_factory()
                         pcm_bytes = base64.b64decode(audio_chunk)
                         acc_audio_data += pcm_bytes
                         if not audio_header_sent:

--- a/src/agentscope/model/_gemini/_model.py
+++ b/src/agentscope/model/_gemini/_model.py
@@ -3,7 +3,6 @@
 import base64
 import copy
 import json
-import uuid
 from datetime import datetime
 from typing import Literal, Any, AsyncGenerator, TYPE_CHECKING, List, Type
 
@@ -17,6 +16,7 @@ from ...formatter import FormatterBase, GeminiChatFormatter
 from ...message import Msg, ThinkingBlock, ToolCallBlock, TextBlock
 from ...tool import ToolChoice
 from ..._logging import logger
+from ..._utils._common import _id_factory
 
 if TYPE_CHECKING:
     from google.genai.types import GenerateContentResponse
@@ -314,7 +314,7 @@ class GeminiChatModel(ChatModelBase):
             # Capture response_id from the first chunk that carries it
             if response_id is None:
                 response_id = (
-                    getattr(chunk, "response_id", None) or uuid.uuid4().hex
+                    getattr(chunk, "response_id", None) or _id_factory()
                 )
 
             delta_content: list = []
@@ -385,7 +385,7 @@ class GeminiChatModel(ChatModelBase):
             )
 
         yield ChatResponse(
-            id=response_id or uuid.uuid4().hex,
+            id=response_id or _id_factory(),
             content=final_content,
             is_last=True,
             usage=usage,
@@ -443,7 +443,7 @@ class GeminiChatModel(ChatModelBase):
         usage = self._extract_usage(response.usage_metadata, start_datetime)
 
         return ChatResponse(
-            id=getattr(response, "response_id", None) or uuid.uuid4().hex,
+            id=getattr(response, "response_id", None) or _id_factory(),
             content=content_blocks,
             is_last=True,
             usage=usage,

--- a/src/agentscope/model/_model_response.py
+++ b/src/agentscope/model/_model_response.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 """The model response module."""
-import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Literal, Sequence
 
 from ._model_usage import ChatUsage
+from .._utils._common import _id_factory
 from .._utils._mixin import DictMixin
 from ..message import (
     TextBlock,
@@ -28,7 +28,7 @@ class ChatResponse(DictMixin):
     """Whether this response is the last response, if `Ture`, the content will
     be the complete response, otherwise the content is a partial response"""
 
-    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    id: str = field(default_factory=_id_factory)
     """The unique identifier."""
 
     created_at: str = field(default_factory=lambda: datetime.now().isoformat())
@@ -55,7 +55,7 @@ class StructuredResponse:
     content: dict
     """The structured output of the model."""
 
-    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    id: str = field(default_factory=_id_factory)
     """The unique identifier."""
 
     created_at: str = field(default_factory=lambda: datetime.now().isoformat())

--- a/src/agentscope/model/_ollama/_model.py
+++ b/src/agentscope/model/_ollama/_model.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """The Ollama chat model implementation."""
 import json
-import uuid
 from datetime import datetime
 from typing import Literal, Any, AsyncGenerator, TYPE_CHECKING, List, Type
 
@@ -15,6 +14,7 @@ from ...formatter import FormatterBase, OllamaChatFormatter
 from ...message import Msg, ThinkingBlock, ToolCallBlock, TextBlock
 from ...tool import ToolChoice
 from ..._logging import logger
+from ..._utils._common import _id_factory
 
 if TYPE_CHECKING:
     from ollama._types import ChatResponse as OllamaChatResponse
@@ -250,7 +250,7 @@ class OllamaChatModel(ChatModelBase):
         # All delta should have the same block identifier.
         # Ollama does not return a request id, so we generate one upfront
         # to keep it stable.
-        response_id = getattr(response, "id", None) or uuid.uuid4().hex
+        response_id = getattr(response, "id", None) or _id_factory()
         acc_text = TextBlock(text="")
         acc_thinking = ThinkingBlock(thinking="")
         acc_tool_calls: dict = {}
@@ -367,7 +367,7 @@ class OllamaChatModel(ChatModelBase):
             )
 
         return ChatResponse(
-            id=getattr(response, "id", None) or uuid.uuid4().hex,
+            id=getattr(response, "id", None) or _id_factory(),
             content=content_blocks,
             is_last=True,
             usage=usage,

--- a/src/agentscope/model/_openai_chat/_model.py
+++ b/src/agentscope/model/_openai_chat/_model.py
@@ -3,7 +3,6 @@
 import warnings
 import base64
 import io
-import uuid
 import wave
 from collections import OrderedDict
 from datetime import datetime
@@ -15,6 +14,7 @@ from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse, StructuredResponse
 from .._model_usage import ChatUsage
 from ..._utils._audio import _build_streaming_wav_header
+from ..._utils._common import _id_factory
 from ...credential import OpenAICredential
 from ...formatter import FormatterBase, OpenAIChatFormatter
 from ...message import (
@@ -385,7 +385,7 @@ class OpenAIChatModel(ChatModelBase):
                         )
                     if audio_chunk:
                         if audio_block_id is None:
-                            audio_block_id = uuid.uuid4().hex
+                            audio_block_id = _id_factory()
                         pcm_bytes = base64.b64decode(audio_chunk)
                         acc_audio_data += pcm_bytes
                         if not audio_header_sent:

--- a/src/agentscope/state/_state.py
+++ b/src/agentscope/state/_state.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 """The agent state class."""
-import uuid
-
 from pydantic import BaseModel, Field
 
 import aiofiles.os
 
 from ._task import Task
+from .._utils._common import _id_factory
 from ..message import TextBlock, DataBlock, Msg
 from ..permission import PermissionContext
 
@@ -140,7 +139,7 @@ class TaskContext(BaseModel):
 class AgentState(BaseModel):
     """The agent state that should be saved and loaded from storage."""
 
-    session_id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    session_id: str = Field(default_factory=_id_factory)
     """The session id of the agent. Normally, each session will maintain one
     independent agent state for each agent."""
 
@@ -149,7 +148,7 @@ class AgentState(BaseModel):
     context when feed into the LLM."""
     context: list[Msg] = Field(default_factory=list)
     """The uncompressed conversation context, that will be feed into the LLM"""
-    reply_id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    reply_id: str = Field(default_factory=_id_factory)
     """The id of the current reply, which is also used as the id of the
     final message of the reply."""
     cur_iter: int = 0

--- a/src/agentscope/state/_task.py
+++ b/src/agentscope/state/_task.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """The task class."""
-import uuid
 from datetime import datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
+
+from .._utils._common import _id_factory
 
 
 class Task(BaseModel):
@@ -25,7 +26,7 @@ class Task(BaseModel):
     state: Literal["pending", "in_progress", "completed"] = "pending"
     """The task state."""
 
-    id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    id: str = Field(default_factory=_id_factory)
     """The task identifier."""
 
     owner: str | None = None

--- a/src/agentscope/tool/_response.py
+++ b/src/agentscope/tool/_response.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 """The tool response class."""
-import uuid
 from typing import List, Literal, Self
 
 from pydantic import BaseModel, Field
 
-from ..message import DataBlock, TextBlock, Base64Source, ToolResultState
+from .._utils._common import _id_factory
+from ..message import DataBlock, TextBlock, Base64Source
+from ..message._block import ToolResultState
 
 
 class ToolChunk(BaseModel):
@@ -26,7 +27,7 @@ class ToolChunk(BaseModel):
     """The metadata to be accessed within the agent, so that we don't need to
     parse the tool result block."""
 
-    id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    id: str = Field(default_factory=_id_factory)
     """The identity of the tool response."""
 
 
@@ -49,7 +50,7 @@ class ToolResponse(BaseModel):
     """The metadata to be accessed within the agent, so that we don't need to
     parse the tool result block."""
 
-    id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    id: str = Field(default_factory=_id_factory)
     """The identity of the tool response."""
 
     def append_chunk(self, chunk: ToolChunk) -> Self:
@@ -100,7 +101,7 @@ class ToolResponse(BaseModel):
                     # For different block types with the same ID, we just
                     # append the new block with a new ID to avoid the conflict
                     new_chunk_block = chunk_block.model_copy(deep=True)
-                    new_chunk_block.id = uuid.uuid4().hex
+                    new_chunk_block.id = _id_factory()
                     self.content.append(new_chunk_block)
 
             else:

--- a/src/agentscope/workspace/_base.py
+++ b/src/agentscope/workspace/_base.py
@@ -23,10 +23,10 @@ Consumers:
 - **Developer** — manages lifecycle via ``initialize`` / ``close``.
 """
 
-import uuid
 from abc import abstractmethod
 from typing import Self
 
+from .._utils._common import _id_factory
 from ..mcp import MCPClient
 from ..message import Msg, ToolResultBlock
 from ..skill import Skill
@@ -60,7 +60,7 @@ class WorkspaceBase:
 
     def __init__(self, workspace_id: str | None) -> None:
         """Initialize the workspace base instance."""
-        self.workspace_id = workspace_id or uuid.uuid4().hex
+        self.workspace_id = workspace_id or _id_factory()
         self.is_alive = False
 
     # ── lifecycle (developer) ──────────────────────────────────────

--- a/tests/formatter_dashscope_test.py
+++ b/tests/formatter_dashscope_test.py
@@ -374,7 +374,7 @@ class TestDashScopeFormatter(IsolatedAsyncioTestCase):
         )
 
     @patch(
-        "agentscope.formatter._formatter_base.shortuuid.uuid",
+        "agentscope.formatter._formatter_base._id_factory",
         return_value=_FIXED_ID,
     )
     async def test_chat_formatter_url_image_in_tool_result(

--- a/tests/formatter_gemini_test.py
+++ b/tests/formatter_gemini_test.py
@@ -308,7 +308,7 @@ class TestGeminiFormatter(IsolatedAsyncioTestCase):
         )
 
     @patch(
-        "agentscope.formatter._formatter_base.shortuuid.uuid",
+        "agentscope.formatter._formatter_base._id_factory",
         return_value=_FIXED_ID,
     )
     async def test_chat_formatter_base64_image_in_tool_result(

--- a/tests/formatter_moonshot_test.py
+++ b/tests/formatter_moonshot_test.py
@@ -420,7 +420,7 @@ class TestMoonshotFormatter(IsolatedAsyncioTestCase):
         )
 
     @patch(
-        "agentscope.formatter._formatter_base.shortuuid.uuid",
+        "agentscope.formatter._formatter_base._id_factory",
         return_value=_FIXED_ID,
     )
     async def test_chat_formatter_url_image_in_tool_result(

--- a/tests/formatter_ollama_test.py
+++ b/tests/formatter_ollama_test.py
@@ -251,7 +251,7 @@ class TestOllamaFormatter(IsolatedAsyncioTestCase):
         )
 
     @patch(
-        "agentscope.formatter._formatter_base.shortuuid.uuid",
+        "agentscope.formatter._formatter_base._id_factory",
         return_value=_FIXED_ID,
     )
     async def test_chat_formatter_base64_image_in_tool_result(

--- a/tests/formatter_openai_chat_test.py
+++ b/tests/formatter_openai_chat_test.py
@@ -374,7 +374,7 @@ class TestOpenAIFormatter(IsolatedAsyncioTestCase):
         )
 
     @patch(
-        "agentscope.formatter._formatter_base.shortuuid.uuid",
+        "agentscope.formatter._formatter_base._id_factory",
         return_value=_FIXED_ID,
     )
     async def test_chat_formatter_url_image_in_tool_result(

--- a/tests/formatter_openai_response_test.py
+++ b/tests/formatter_openai_response_test.py
@@ -401,7 +401,7 @@ class TestOpenAIResponseFormatter(IsolatedAsyncioTestCase):
         )
 
     @patch(
-        "agentscope.formatter._formatter_base.shortuuid.uuid",
+        "agentscope.formatter._formatter_base._id_factory",
         return_value=_FIXED_ID,
     )
     async def test_chat_formatter_url_image_in_tool_result(

--- a/tests/id_factory_test.py
+++ b/tests/id_factory_test.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""Tests for custom AgentScope ID generation."""
+import uuid
+
+from agentscope import set_id_factory
+from agentscope._utils._common import _id_factory
+from agentscope.credential import CredentialBase
+from agentscope.event import ModelCallStartEvent
+from agentscope.message import AssistantMsg, TextBlock, UserMsg
+from agentscope.model import ChatModelBase, ChatResponse, ModelCard
+from agentscope.state import AgentState, Task
+from agentscope.tool import ToolResponse
+
+
+class _DummyCredential(CredentialBase):
+    """Concrete credential used only for ID generation tests."""
+
+    api_key: str = ""
+
+    @classmethod
+    def get_chat_model_class(cls) -> type[ChatModelBase]:
+        """Return a dummy model class for abstract method completeness."""
+        return ChatModelBase
+
+    @classmethod
+    def list_models(cls) -> list[ModelCard]:
+        """Return no model cards for this test credential."""
+        return []
+
+
+def _reset_id_factory() -> None:
+    """Restore the default random UUID hex factory."""
+    set_id_factory(lambda: uuid.uuid4().hex)
+
+
+def test_set_id_factory_updates_imported_factory_reference() -> None:
+    """The imported _id_factory wrapper should observe factory updates."""
+    try:
+        set_id_factory(lambda: "custom-id")
+
+        assert _id_factory() == "custom-id"
+        assert TextBlock(text="hello").id == "custom-id"
+        assert UserMsg("user", "hello").id == "custom-id"
+        assert AssistantMsg("assistant", "hello").id == "custom-id"
+        assert (
+            ModelCallStartEvent(
+                reply_id="reply",
+                model_name="model",
+            ).id
+            == "custom-id"
+        )
+        assert AgentState().session_id == "custom-id"
+        assert (
+            Task(
+                subject="subject",
+                description="description",
+                metadata={},
+            ).id
+            == "custom-id"
+        )
+        assert ToolResponse().id == "custom-id"
+        assert (
+            ChatResponse(
+                content=[],
+                is_last=True,
+            ).id
+            == "custom-id"
+        )
+        assert _DummyCredential().id == "custom-id"
+    finally:
+        _reset_id_factory()
+
+
+def test_set_id_factory_supports_incremental_ids() -> None:
+    """Factories can provide ordered identifiers such as UUID7 strings."""
+    counter = 0
+
+    def next_id() -> str:
+        nonlocal counter
+        counter += 1
+        return f"id-{counter}"
+
+    try:
+        set_id_factory(next_id)
+
+        assert TextBlock(text="first").id == "id-1"
+        assert TextBlock(text="second").id == "id-2"
+    finally:
+        _reset_id_factory()
+
+
+def test_set_id_factory_rejects_non_callable() -> None:
+    """The ID factory must be callable."""
+    try:
+        try:
+            set_id_factory("not-callable")  # type: ignore[arg-type]
+        except TypeError as exc:
+            assert "callable" in str(exc)
+        else:
+            raise AssertionError("set_id_factory accepted a non-callable")
+    finally:
+        _reset_id_factory()


### PR DESCRIPTION
## Summary
- add a public set_id_factory API for customizing AgentScope-generated entity IDs
- route message, block, event, state, task, tool response, model response, credential, storage, workspace, background task, formatter fallback, and audio block IDs through the shared factory
- keep security-sensitive gateway tokens and Redis lock tokens on raw UUID4
- add focused coverage for custom and incremental ID factories, and update formatter tests to mock the new factory

Closes #1782

## Verification
- pre-commit passed for all changed files
- targeted core tests passed: 27 passed
- provider and formatter tests passed: 107 passed
- tool, storage, workspace, and TTS tests passed: 119 passed
- full local tests run: 830 passed, 19 skipped, 10 failed due local environment/pre-existing behavior: MCP server tests could not bind localhost ports under sandbox, and message-bus registry tests returned byte mappings locally.