### PR TITLE
fix(dashscope): correct qwen max 3.7 model id

### DIFF
--- a/src/agentscope/model/_dashscope/_models/qwen3.7-max.yaml
+++ b/src/agentscope/model/_dashscope/_models/qwen3.7-max.yaml
@@ -1,4 +1,4 @@
-name: qwen-max-3.7
+name: qwen3.7-max
 label: Qwen Max 3.7
 status: active
 

--- a/tests/model_dashscope_test.py
+++ b/tests/model_dashscope_test.py
@@ -27,18 +27,6 @@ from agentscope.tool import ToolChoice
 A = AnyString()
 
 
-class TestDashScopeListModels(unittest.TestCase):
-    """Tests for DashScope chat model cards."""
-
-    def test_qwen_max_37_uses_dashscope_model_id(self) -> None:
-        """Qwen Max 3.7 should use the DashScope-compatible model ID."""
-        cards = DashScopeChatModel.list_models()
-        names = {card.name for card in cards}
-
-        self.assertIn("qwen3.7-max", names)
-        self.assertNotIn("qwen-max-3.7", names)
-
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/model_dashscope_test.py
+++ b/tests/model_dashscope_test.py
@@ -27,6 +27,18 @@ from agentscope.tool import ToolChoice
 A = AnyString()
 
 
+class TestDashScopeListModels(unittest.TestCase):
+    """Tests for DashScope chat model cards."""
+
+    def test_qwen_max_37_uses_dashscope_model_id(self) -> None:
+        """Qwen Max 3.7 should use the DashScope-compatible model ID."""
+        cards = DashScopeChatModel.list_models()
+        names = {card.name for card in cards}
+
+        self.assertIn("qwen3.7-max", names)
+        self.assertNotIn("qwen-max-3.7", names)
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## AgentScope Version

2.0.1

## Description

DashScope's OpenAI-compatible model list exposes Qwen Max 3.7 as `qwen3.7-max`. The previous bundled model card used `qwen-max-3.7`, which causes DashScope API calls selected from `DashScopeChatModel.list_models()` to fail with `model_not_found`.

This PR updates the DashScope Qwen Max 3.7 model card to use the correct model ID, renames the bundled YAML file to match the model ID, and adds a regression test to ensure the invalid ID is no longer exposed.

Changes made:
- Rename `src/agentscope/model/_dashscope/_models/qwen-max-3.7.yaml` to `src/agentscope/model/_dashscope/_models/qwen3.7-max.yaml`.
- Change the model card `name` from `qwen-max-3.7` to `qwen3.7-max`.
- Add a regression test for `DashScopeChatModel.list_models()`.

Tested with:

```bash
.venv/bin/python -m pytest tests/model_dashscope_test.py -q