### PR TITLE
fix(model): handle Gemini function calls without an id

### DIFF
--- a/src/agentscope/model/_gemini/_model.py
+++ b/src/agentscope/model/_gemini/_model.py
@@ -347,7 +347,7 @@ class GeminiChatModel(ChatModelBase):
                                 part.thought_signature,
                             ).decode("utf-8")
                         else:
-                            call_id = part.function_call.id
+                            call_id = part.function_call.id or uuid.uuid4().hex
                         input_str = json.dumps(
                             keyword_args,
                             ensure_ascii=False,
@@ -431,7 +431,7 @@ class GeminiChatModel(ChatModelBase):
                             part.thought_signature,
                         ).decode("utf-8")
                     else:
-                        call_id = part.function_call.id
+                        call_id = part.function_call.id or uuid.uuid4().hex
                     content_blocks.append(
                         ToolCallBlock(
                             id=call_id,

--- a/tests/model_gemini_test.py
+++ b/tests/model_gemini_test.py
@@ -171,6 +171,46 @@ class TestGeminiNonStream(IsolatedAsyncioTestCase):
         )
 
     @patch("google.genai.Client")
+    async def test_tool_call_response_without_id(
+        self,
+        mock_client_cls: MagicMock,
+    ) -> None:
+        """A function call with no id gets a generated id, not a crash."""
+        parts = [
+            _make_part(
+                function_call={
+                    "name": "get_weather",
+                    "args": {"city": "Tokyo"},
+                    "id": None,
+                },
+            ),
+        ]
+        mock_client_cls.return_value.aio.models.generate_content = AsyncMock(
+            return_value=_mock_completion(parts),
+        )
+
+        result = await self.model([])
+
+        self.assertEqual(
+            (result.is_last, result.content),
+            (
+                True,
+                [
+                    ToolCallBlock.model_construct(
+                        id=A,
+                        name="get_weather",
+                        input=json.dumps(
+                            {"city": "Tokyo"},
+                            ensure_ascii=False,
+                        ),
+                    ),
+                ],
+            ),
+        )
+        self.assertIsInstance(result.content[0].id, str)
+        self.assertTrue(result.content[0].id)
+
+    @patch("google.genai.Client")
     async def test_thinking_response(
         self,
         mock_client_cls: MagicMock,
@@ -306,6 +346,53 @@ class TestGeminiStream(IsolatedAsyncioTestCase):
             [
                 (False, [tool_block]),
                 (True, [tool_block]),
+            ],
+        )
+
+    @patch("google.genai.Client")
+    async def test_stream_tool_calls_without_id(
+        self,
+        mock_client_cls: MagicMock,
+    ) -> None:
+        """Two id-less function calls in one chunk get distinct ids."""
+        chunks = [
+            _make_stream_chunk(
+                [
+                    _make_part(
+                        function_call={
+                            "name": "search",
+                            "args": {"q": "a"},
+                            "id": None,
+                        },
+                    ),
+                    _make_part(
+                        function_call={
+                            "name": "search",
+                            "args": {"q": "b"},
+                            "id": None,
+                        },
+                    ),
+                ],
+            ),
+        ]
+        mock_client_cls.return_value.aio.models.generate_content_stream = (
+            AsyncMock(return_value=_MockAsyncStream(chunks))
+        )
+
+        gen = await self.model([])
+        responses = [r async for r in gen]
+
+        final = responses[-1]
+        self.assertTrue(final.is_last)
+        self.assertEqual(len(final.content), 2)
+        ids = [block.id for block in final.content]
+        self.assertTrue(all(isinstance(i, str) and i for i in ids))
+        self.assertNotEqual(ids[0], ids[1])
+        self.assertEqual(
+            [block.input for block in final.content],
+            [
+                json.dumps({"q": "a"}, ensure_ascii=False),
+                json.dumps({"q": "b"}, ensure_ascii=False),
             ],
         )
 


### PR DESCRIPTION
## AgentScope Version

2.0.2 (current `main`)

## Description

Gemini does not always return an `id` on a function call. On the non-thinking
models there is no `thought_signature` to fall back on either, so the parser
ends up passing `id=None` into `ToolCallBlock`, whose `id` is a required `str`.
That raises:

```
pydantic_core.ValidationError: 1 validation error for ToolCallBlock
id
  Input should be a valid string [type=string_type, input_value=None]
```

which kills the whole tool-calling turn. It hits both code paths:

- `_parse_stream_response` (`src/agentscope/model/_gemini/_model.py:350`)
- `_parse_completion_response` (`src/agentscope/model/_gemini/_model.py:434`)

Fix is to mint a fallback id when neither the function call id nor a thought
signature is present:

```python
call_id = part.function_call.id or uuid.uuid4().hex
```

`uuid` is already imported, and the accumulated text/thinking blocks already
generate their ids the same way. The formatter round-trips `block.id` as both
`function_call.id` and `function_response.id`
(`src/agentscope/formatter/_gemini_formatter.py:200,224`), so a synthetic id
stays consistent across the tool-call / tool-result pair.

## How I tested

Added two tests to `tests/model_gemini_test.py`:

- non-streaming: an id-less function call now returns a `ToolCallBlock` with a
  generated id instead of crashing
- streaming: two parallel id-less calls in one chunk get distinct ids
  (previously they both crashed, and would have collided on the `None`
  accumulator key)

Both fail on current `main` with the ValidationError above and pass with the
fix. Full file stays green:

```
python -m pytest tests/model_gemini_test.py -q
14 passed
```

`black --line-length=79` and `flake8` are clean on both files.

## Checklist

- [x] I have read the CONTRIBUTING.md
- [x] Docstrings are in Google style
- [x] Code is ready for review

Used Claude Code to assist; I reviewed the diff and ran the tests myself.
