### PR TITLE
fix(formatter): merge parallel tool_results into one user message in AnthropicChatFormatter

### DIFF
--- a/src/agentscope/formatter/_anthropic_formatter.py
+++ b/src/agentscope/formatter/_anthropic_formatter.py
@@ -151,7 +151,14 @@ class _AnthropicFormatterBase(FormatterBase, ABC):
                     )
 
                 elif isinstance(block, ToolResultBlock):
-                    if content_blocks:
+                    # Only flush when we have non-tool-result content
+                    # (i.e. the preceding assistant turn). Once
+                    # `has_tool_result` is True we are already accumulating
+                    # tool_results into the current user message, so we must
+                    # NOT flush on each additional ToolResultBlock — doing so
+                    # would split parallel results into separate user messages
+                    # which strict endpoints (e.g. DeepSeek) reject with 400.
+                    if content_blocks and not has_tool_result:
                         role = "user" if has_tool_result else msg.role
                         messages.append(
                             {"role": role, "content": content_blocks},

--- a/tests/formatter_anthropic_test.py
+++ b/tests/formatter_anthropic_test.py
@@ -666,11 +666,6 @@ class TestAnthropicFormatter(IsolatedAsyncioTestCase):
                                 {"type": "text", "text": "result_1"},
                             ],
                         },
-                    ],
-                },
-                {
-                    "role": "user",
-                    "content": [
                         {
                             "type": "tool_result",
                             "tool_use_id": "call_2",
@@ -824,6 +819,142 @@ class TestAnthropicFormatter(IsolatedAsyncioTestCase):
                                 "media_type": "image/png",
                                 "data": self.image_b64,
                             },
+                        },
+                    ],
+                },
+            ],
+            res,
+        )
+
+    async def test_chat_formatter_parallel_tool_results_merged(
+        self,
+    ) -> None:
+        """Parallel tool_results must be grouped into ONE user message.
+
+        Regression test for Issue #1892: AnthropicChatFormatter was flushing
+        content_blocks on every ToolResultBlock, which split N parallel results
+        into N separate user messages. Strict endpoints such as DeepSeek's
+        Anthropic-compatible API reject this with HTTP 400.
+        """
+        fmt = AnthropicChatFormatter()
+        msgs = [
+            UserMsg(
+                name="user",
+                content="Get weather for Beijing, Shanghai, and Guangzhou.",
+            ),
+            AssistantMsg(
+                name="assistant",
+                content=[
+                    TextBlock(text="Let me check all three cities."),
+                    ToolCallBlock(
+                        id="call_01",
+                        name="get_weather",
+                        input='{"city": "Beijing"}',
+                    ),
+                    ToolCallBlock(
+                        id="call_02",
+                        name="get_weather",
+                        input='{"city": "Shanghai"}',
+                    ),
+                    ToolCallBlock(
+                        id="call_03",
+                        name="get_weather",
+                        input='{"city": "Guangzhou"}',
+                    ),
+                ],
+            ),
+            AssistantMsg(
+                name="tool",
+                content=[
+                    ToolResultBlock(
+                        id="call_01",
+                        name="get_weather",
+                        output="Sunny, 28\u00b0C",
+                        state=ToolResultState.SUCCESS,
+                    ),
+                    ToolResultBlock(
+                        id="call_02",
+                        name="get_weather",
+                        output="Cloudy, 24\u00b0C",
+                        state=ToolResultState.SUCCESS,
+                    ),
+                    ToolResultBlock(
+                        id="call_03",
+                        name="get_weather",
+                        output="Rainy, 22\u00b0C",
+                        state=ToolResultState.SUCCESS,
+                    ),
+                ],
+            ),
+        ]
+        res = await fmt.format(msgs)
+
+        # Expected: 3 messages total
+        #   [0] user  -> original question
+        #   [1] assistant -> text + 3x tool_use
+        #   [2] user  -> ALL 3 tool_results in ONE message  (the fix)
+        self.assertListEqual(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Get weather for Beijing, Shanghai, "
+                            "and Guangzhou.",
+                        },
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Let me check all three cities.",
+                        },
+                        {
+                            "type": "tool_use",
+                            "id": "call_01",
+                            "name": "get_weather",
+                            "input": {"city": "Beijing"},
+                        },
+                        {
+                            "type": "tool_use",
+                            "id": "call_02",
+                            "name": "get_weather",
+                            "input": {"city": "Shanghai"},
+                        },
+                        {
+                            "type": "tool_use",
+                            "id": "call_03",
+                            "name": "get_weather",
+                            "input": {"city": "Guangzhou"},
+                        },
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_01",
+                            "content": [
+                                {"type": "text", "text": "Sunny, 28\u00b0C"},
+                            ],
+                        },
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_02",
+                            "content": [
+                                {"type": "text", "text": "Cloudy, 24\u00b0C"},
+                            ],
+                        },
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_03",
+                            "content": [
+                                {"type": "text", "text": "Rainy, 22\u00b0C"},
+                            ],
                         },
                     ],
                 },

--- a/tests/formatter_anthropic_test.py
+++ b/tests/formatter_anthropic_test.py
@@ -861,11 +861,6 @@ class TestAnthropicFormatter(IsolatedAsyncioTestCase):
                         name="get_weather",
                         input='{"city": "Guangzhou"}',
                     ),
-                ],
-            ),
-            AssistantMsg(
-                name="tool",
-                content=[
                     ToolResultBlock(
                         id="call_01",
                         name="get_weather",


### PR DESCRIPTION
## AgentScope Version

2.0.2

## Description

When the model returns multiple tool_use blocks in one turn, AnthropicChatFormatter was flushing content_blocks on every 
ToolResultBlock, splitting N parallel results into N separate  user messages. Strict Anthropic-compatible endpoints (e.g. DeepSeek) reject this with HTTP 400.

Fix: only flush the preceding assistant content on the *first* ToolResultBlock (`if content_blocks and not has_tool_result`), 
so all results accumulate into a single user message as the spec requires.

- Fix flush condition in `_anthropic_formatter.py`
- Update `test_chat_formatter_complex_multi_step` ground truth
- Add regression test `test_chat_formatter_parallel_tool_results_merged`

Fixes #1892

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review