### PR TITLE
fix(workspace): support e2b self-hosted gateway routing

### DIFF
--- a/src/agentscope/app/workspace_manager/_e2b_workspace_manager.py
+++ b/src/agentscope/app/workspace_manager/_e2b_workspace_manager.py
@@ -62,6 +62,8 @@ class E2BWorkspaceManager(WorkspaceManagerBase):
         *,
         template: str = DEFAULT_TEMPLATE,
         api_key: str = "",
+        api_url: str = "",
+        sandbox_url: str = "",
         domain: str = "",
         timeout_seconds: int = DEFAULT_TIMEOUT,
         gateway_port: int = DEFAULT_GATEWAY_PORT,
@@ -82,6 +84,12 @@ class E2BWorkspaceManager(WorkspaceManagerBase):
             api_key (`str`, defaults to `""`):
                 E2B API key. ``""`` falls back to the ``E2B_API_KEY``
                 env var on the SDK side.
+            api_url (`str`, defaults to `""`):
+                Optional E2B API URL. ``""`` falls back to the
+                ``E2B_API_URL`` env var on the SDK side.
+            sandbox_url (`str`, defaults to `""`):
+                Optional E2B sandbox proxy URL. ``""`` falls back to
+                the ``E2B_SANDBOX_URL`` env var on the SDK side.
             domain (`str`, defaults to `""`):
                 Optional custom E2B domain (self-hosted etc.).
             timeout_seconds (`int`, defaults to `DEFAULT_TIMEOUT`):
@@ -115,6 +123,8 @@ class E2BWorkspaceManager(WorkspaceManagerBase):
         """
         self._template = template
         self._api_key = api_key
+        self._api_url = api_url
+        self._sandbox_url = sandbox_url
         self._domain = domain
         self._timeout_seconds = timeout_seconds
         self._gateway_port = gateway_port
@@ -170,6 +180,8 @@ class E2BWorkspaceManager(WorkspaceManagerBase):
             workspace_id=workspace_id,
             template=self._template,
             api_key=self._api_key,
+            api_url=self._api_url,
+            sandbox_url=self._sandbox_url,
             domain=self._domain,
             timeout_seconds=self._timeout_seconds,
             gateway_port=self._gateway_port,

--- a/src/agentscope/workspace/_e2b/_e2b_workspace.py
+++ b/src/agentscope/workspace/_e2b/_e2b_workspace.py
@@ -23,8 +23,10 @@ Docker engine for the E2B SDK (``e2b.AsyncSandbox``):
   ``files.exists(GATEWAY_SCRIPT)`` probe so the cost is paid exactly
   once per sandbox lifetime.
 * **MCP gateway.** Identical to Docker: a FastAPI process inside the
-  sandbox, host-side talks to it over HTTPS via E2B's proxy
-  (``sandbox.get_host(port)`` + ``X-Access-Token`` header).
+  sandbox, host-side talks to it via E2B's proxy. Default E2B routing
+  uses ``sandbox.get_host(port)`` plus ``X-Access-Token``; self-hosted
+  ``E2B_SANDBOX_URL`` routing uses the shared proxy URL plus
+  ``E2b-Sandbox-Id`` / ``E2b-Sandbox-Port`` headers.
 * **Service-layer index.** The host stores only ``workspace_id``;
   the sandbox carries ``METADATA_WORKSPACE_ID_KEY = workspace_id`` in
   its E2B metadata. Manager code calls ``AsyncSandbox.list(query=...)``
@@ -153,6 +155,8 @@ class E2BWorkspace(WorkspaceBase):
         workspace_id: str | None = None,
         template: str = DEFAULT_TEMPLATE,
         api_key: str = "",
+        api_url: str = "",
+        sandbox_url: str = "",
         domain: str = "",
         timeout_seconds: int = DEFAULT_TIMEOUT,
         gateway_port: int = DEFAULT_GATEWAY_PORT,
@@ -180,6 +184,12 @@ class E2BWorkspace(WorkspaceBase):
             api_key (`str`, defaults to `""`):
                 E2B API key. ``""`` falls back to the ``E2B_API_KEY``
                 env var.
+            api_url (`str`, defaults to `""`):
+                Optional E2B API URL. ``""`` falls back to the
+                ``E2B_API_URL`` env var.
+            sandbox_url (`str`, defaults to `""`):
+                Optional E2B sandbox proxy URL. ``""`` falls back to
+                the ``E2B_SANDBOX_URL`` env var.
             domain (`str`, defaults to `""`):
                 Optional custom E2B domain (self-hosted etc.).
             timeout_seconds (`int`, defaults to `DEFAULT_TIMEOUT`):
@@ -214,6 +224,8 @@ class E2BWorkspace(WorkspaceBase):
         self.workdir = SANDBOX_WORKDIR
         self.template = template
         self.api_key = api_key
+        self.api_url = api_url
+        self.sandbox_url = sandbox_url
         self.domain = domain
         self.timeout_seconds = timeout_seconds
         self.gateway_port = gateway_port
@@ -304,9 +316,8 @@ class E2BWorkspace(WorkspaceBase):
         await self._write_gateway_config()
         await self._start_gateway_process()
 
-        host = self._sandbox.get_host(self.gateway_port)
         self._gateway = GatewayClient(
-            base_url=f"https://{host}",
+            base_url=self._gateway_base_url(),
             token=self._gateway_token,
             timeout=30.0,
             extra_headers=self._sandbox_proxy_headers(),
@@ -765,23 +776,55 @@ class E2BWorkspace(WorkspaceBase):
         return candidates[0]
 
     def _api_opts(self) -> dict[str, Any]:
-        """Common ``api_key`` / ``domain`` opts forwarded to E2B SDK calls."""
+        """Common connection opts forwarded to E2B SDK calls."""
         opts: dict[str, Any] = {}
         if self.api_key:
             opts["api_key"] = self.api_key
+        if self.api_url:
+            opts["api_url"] = self.api_url
+        if self.sandbox_url:
+            opts["sandbox_url"] = self.sandbox_url
         if self.domain:
             opts["domain"] = self.domain
         return opts
 
+    def _gateway_base_url(self) -> str:
+        """Host-visible URL for the AgentScope MCP gateway."""
+        if self._sandbox is None:
+            return ""
+        sandbox_url = self._sandbox_url()
+        if sandbox_url:
+            return sandbox_url.rstrip("/")
+        host = self._sandbox.get_host(self.gateway_port)
+        return f"https://{host}"
+
+    def _sandbox_url(self) -> str | None:
+        """Configured E2B sandbox proxy URL, if provided."""
+        if self.sandbox_url:
+            return self.sandbox_url
+        if self._sandbox is None:
+            return None
+        connection_config = getattr(self._sandbox, "connection_config", None)
+        if connection_config is None:
+            return None
+        return getattr(connection_config, "_sandbox_url", None)
+
     def _sandbox_proxy_headers(self) -> dict[str, str]:
         """Headers required by the E2B proxy to reach the gateway port.
 
-        E2B's edge proxy gates non-default ports behind the
-        ``X-Access-Token`` header tied to the sandbox. The token is
-        exposed on the sandbox object as ``traffic_access_token``.
+        Default E2B routing gates non-default ports behind the
+        ``X-Access-Token`` header tied to the sandbox. Self-hosted
+        sandbox URL routing uses the shared proxy endpoint and sends
+        the sandbox id / target port as routing headers.
         """
         if self._sandbox is None:
             return {}
+        sandbox_url = self._sandbox_url()
+        if sandbox_url:
+            return {
+                "E2b-Sandbox-Id": self._sandbox.sandbox_id,
+                "E2b-Sandbox-Port": str(self.gateway_port),
+            }
         token = getattr(self._sandbox, "traffic_access_token", None)
         if not token:
             return {}


### PR DESCRIPTION
## AgentScope Version

Current main branch.

## Description

This PR fixes `E2BWorkspace` compatibility with self-hosted E2B deployments.

`E2BWorkspace` starts an AgentScope MCP gateway inside the E2B sandbox. The gateway listens on the workspace gateway port, which defaults to `5600`, and all MCP services registered in the workspace are accessed through this gateway.

Before this change, the host-side `GatewayClient` always used E2B's default subdomain-based port routing:

```python
base_url = f"https://{sandbox.get_host(gateway_port)}"
````

with:

```http
X-Access-Token: <traffic_access_token>
```

This works for the default E2B cloud routing, but it does not work for self-hosted deployments where sandbox traffic is exposed through a shared client-proxy URL such as:

```text
http://<host-ip>:3002
http://localhost:3002
https://sandbox.<domain>
```

For these deployments, the client-proxy needs the target sandbox and port to be provided through routing headers:

```http
E2b-Sandbox-Id: <sandbox_id>
E2b-Sandbox-Port: <gateway_port>
```

This PR updates the E2B workspace routing logic to support that mode.

The updated behavior is:

- no `sandbox_url`: keep the existing default E2B cloud routing with `sandbox.get_host(gateway_port)` and `X-Access-Token`
- with `sandbox_url`: use the configured shared proxy URL and route the request with `E2b-Sandbox-Id` / `E2b-Sandbox-Port`

Changes include:

- Add `api_url` and `sandbox_url` parameters to `E2BWorkspace`
- Forward `api_url` and `sandbox_url` to E2B SDK calls
- Use `sandbox_url` as the host-side gateway base URL when configured
- Send `E2b-Sandbox-Id` and `E2b-Sandbox-Port` headers for self-hosted gateway routing
- Preserve the existing `sandbox.get_host(port)` + `X-Access-Token` behavior for default E2B cloud routing
- Add `api_url` and `sandbox_url` forwarding to `E2BWorkspaceManager`

Closes #1895

## Root Cause

`E2BWorkspace` starts an in-sandbox MCP gateway on `gateway_port`, which defaults to `5600`, and `_wait_for_gateway()` waits for it by probing:

```text
GET {base_url}/health
```

Before this change, `base_url` was always resolved through:

```python
base_url = f"https://{sandbox.get_host(gateway_port)}"
```

This assumes E2B subdomain-based port routing, where the target sandbox and port are encoded in the host name.

Self-hosted E2B deployments may expose sandbox traffic through a shared client-proxy URL instead. In that routing mode, the target sandbox and port must be sent through headers:

```http
E2b-Sandbox-Id: <sandbox_id>
E2b-Sandbox-Port: <gateway_port>
```

The gateway was already started successfully inside the sandbox:

```text
[gateway] connected 'server-everything'
[gateway] serving 1 MCPs on :5600
```

However, the previous host-side `GatewayClient` did not use the configured shared sandbox proxy URL or these routing headers, so the request was not routed to sandbox port `5600`. As a result, the host-side health check timed out even though the gateway was already running inside the sandbox.

## Test

### Pre-commit

```bash
pre-commit run --all-files
```

Result: passed after normalizing line endings in `src/agentscope/app/workspace_manager/_e2b_workspace_manager.py`.

### Compile check

```bash
python -m compileall -q src/agentscope/workspace/_e2b/_e2b_workspace.py src/agentscope/app/workspace_manager/_e2b_workspace_manager.py
```

Result: passed.

### Self-hosted E2B validation

Verified with a self-hosted E2B deployment using separate API and sandbox proxy endpoints:

```text
E2B_API_URL=http://<host-ip>:3000
E2B_SANDBOX_URL=http://<host-ip>:3002
```

Before the fix, initialization failed while waiting for the gateway health check:

```text
RuntimeError: gateway did not become healthy within 30.0s. Tail of /home/user/.agentscope/gateway.log:
[gateway] connected 'server-everything'
[gateway] serving 1 MCPs on :5600
```

After the fix, the workspace initialized successfully and the MCP gateway was reachable through header-based sandbox routing.

```text
[GatewayMCPClient(name='server-everything', is_stateful=True, mcp_config=StdioMCPConfig(type='stdio_mcp', command='npx', args=['@modelcontextprotocol/server-everything@latest'], env=None, cwd=None, encoding_error_handler='strict'), enable_tools=None, disable_tools=None, execution_timeout=None)]
```

## Checklist

- [X] An issue has been created for this PR
- [X] I have read the CONTRIBUTING.md
- [X] Docstrings are in Google style
- [ ] Related documentation has been updated, if needed
- [X] Code is ready for review