### PR TITLE
fix(model): use flat estimate for multimodal data blocks

### DIFF
--- a/src/agentscope/model/_base.py
+++ b/src/agentscope/model/_base.py
@@ -24,13 +24,12 @@ from ..message import (
     ThinkingBlock,
     ToolResultBlock,
     DataBlock,
-    URLSource,
-    Base64Source,
     HintBlock,
 )
 from ..tool import ToolChoice
 
 _TOOL_CHOICE_LITERAL_MODES = {"auto", "none", "required"}
+_MULTIMODAL_DATA_BLOCK_TOKEN_ESTIMATE = 2000
 
 
 class ChatModelBase:
@@ -371,13 +370,10 @@ class ChatModelBase:
         if tools:
             acc_texts.append(json.dumps(tools, ensure_ascii=False))
 
-        # Add the multimodal tokens
-        for block in data_blocks:
-            if isinstance(block.source, URLSource):
-                # We don't download the content here to avoid blocking
-                acc_texts.append(str(block.source.url))
-            elif isinstance(block.source, Base64Source):
-                cnt += len(block.source.data) // 4
+        # Add the multimodal tokens. Binary payloads are not consumed by
+        # multimodal models as base64 text, and file URLs should not count as
+        # only a path string. Use a stable flat estimate for all DataBlocks.
+        cnt += len(data_blocks) * _MULTIMODAL_DATA_BLOCK_TOKEN_ESTIMATE
 
         # Count the text tokens
         acc_text = "".join(acc_texts)

--- a/tests/model_count_tokens_test.py
+++ b/tests/model_count_tokens_test.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+"""Tests for the fallback chat model token estimation."""
+from unittest.async_case import IsolatedAsyncioTestCase
+
+from utils import MockModel
+
+from agentscope.message import (
+    Base64Source,
+    DataBlock,
+    TextBlock,
+    URLSource,
+    UserMsg,
+)
+
+
+class ModelCountTokensTest(IsolatedAsyncioTestCase):
+    """Test the base chat model token estimation behavior."""
+
+    async def asyncSetUp(self) -> None:
+        """Set up a mock model that uses ChatModelBase.count_tokens."""
+        self.model = MockModel()
+
+    async def test_data_blocks_use_flat_multimodal_estimate(self) -> None:
+        """Large base64 payloads are not counted as prompt text."""
+        data = "a" * 400_000
+        tokens = await self.model.count_tokens(
+            [
+                UserMsg(
+                    name="user",
+                    content=[
+                        TextBlock(text="hi"),
+                        DataBlock(
+                            source=Base64Source(
+                                data=data,
+                                media_type="image/png",
+                            ),
+                        ),
+                    ],
+                ),
+            ],
+            None,
+        )
+
+        self.assertEqual(tokens, 2001)
+
+    async def test_base64_and_url_data_blocks_have_same_estimate(self) -> None:
+        """The same data block should not differ by source representation."""
+        base64_tokens = await self.model.count_tokens(
+            [
+                UserMsg(
+                    name="user",
+                    content=[
+                        DataBlock(
+                            source=Base64Source(
+                                data="a" * 400_000,
+                                media_type="image/png",
+                            ),
+                        ),
+                    ],
+                ),
+            ],
+            None,
+        )
+        # The file does not need to exist; token estimation must not read
+        # URLSource payloads.
+        url_tokens = await self.model.count_tokens(
+            [
+                UserMsg(
+                    name="user",
+                    content=[
+                        DataBlock(
+                            source=URLSource(
+                                url="file:///tmp/image.png",
+                                media_type="image/png",
+                            ),
+                        ),
+                    ],
+                ),
+            ],
+            None,
+        )
+
+        self.assertEqual(base64_tokens, 2000)
+        self.assertEqual(url_tokens, 2000)


### PR DESCRIPTION
## AgentScope Version

2.0.2

## Description

This PR fixes the fallback token estimation for multimodal `DataBlock` inputs in `ChatModelBase.count_tokens`.

Previously, base64 inputs were estimated from the raw base64 string length, while URL inputs were estimated from the URL text itself. This could produce very large overestimates for inline base64 image/audio inputs, and inconsistent estimates between equivalent `Base64Source` and `URLSource` payloads.

After checking how several agent projects (including Claude Code, Hermes, Pi) handle local multimodal token estimation, this PR uses a conservative flat estimate for each `DataBlock`. This follows the common fallback pattern of treating binary multimodal payloads as provider-side media inputs rather than prompt text. The selected value, `2000` tokens per `DataBlock`, is intentionally conservative, so it avoids underestimating context usage while preventing base64 payloads from dominating the estimate.

Changes made:

Updated multimodal `DataBlock` token estimation to use a conservative flat estimate, and added tests for base64 and file URL inputs.