### PR TITLE
fix(tool): merge base64 tool response chunks by bytes

### DIFF
--- a/src/agentscope/tool/_response.py
+++ b/src/agentscope/tool/_response.py
@@ -1,11 +1,28 @@
 # -*- coding: utf-8 -*-
 """The tool response class."""
+import base64
+import binascii
 from typing import List, Literal, Self
 
 from pydantic import BaseModel, Field
 
 from .._utils._common import _generate_id
 from ..message import DataBlock, TextBlock, Base64Source, ToolResultState
+
+
+def _merge_base64_chunks(existing: str, incoming: str) -> str:
+    """Merge independently encoded base64 chunks without corrupting padding."""
+    try:
+        merged = base64.b64decode(
+            existing,
+            validate=True,
+        ) + base64.b64decode(incoming, validate=True)
+    except (binascii.Error, ValueError):
+        # Keep compatibility with callers/tests that used placeholder strings
+        # instead of valid base64 payloads.
+        return existing + incoming
+
+    return base64.b64encode(merged).decode("ascii")
 
 
 class ToolChunk(BaseModel):
@@ -80,8 +97,11 @@ class ToolResponse(BaseModel):
                         target_block.source,
                         Base64Source,
                     ) and isinstance(chunk_block.source, Base64Source):
-                        # Accumulate the base64 data
-                        target_block.source.data += chunk_block.source.data
+                        # Accumulate independently encoded base64 chunks.
+                        target_block.source.data = _merge_base64_chunks(
+                            target_block.source.data,
+                            chunk_block.source.data,
+                        )
                         # Update the newest media type and name if provided
                         target_block.name = (
                             chunk_block.name or target_block.name

--- a/tests/toolkit_test.py
+++ b/tests/toolkit_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=unused-argument
 """Toolkit test case."""
+import base64
 import json
 from typing import Any, AsyncGenerator, Generator
 from unittest import TestCase
@@ -417,6 +418,47 @@ class ToolkitTest(IsolatedAsyncioTestCase):
                 "metadata": {},
                 "id": "test_2",
             },
+        )
+
+    async def test_tool_response_merges_base64_chunks_by_bytes(self) -> None:
+        """Base64 chunks with padding should merge as bytes, not strings."""
+        response = ToolResponse()
+        first = base64.b64encode(b"hello").decode("ascii")
+        second = base64.b64encode(b"world").decode("ascii")
+
+        response.append_chunk(
+            ToolChunk(
+                content=[
+                    DataBlock(
+                        id="image",
+                        source=Base64Source(
+                            data=first,
+                            media_type="image/png",
+                        ),
+                    ),
+                ],
+            ),
+        )
+        response.append_chunk(
+            ToolChunk(
+                content=[
+                    DataBlock(
+                        id="image",
+                        source=Base64Source(
+                            data=second,
+                            media_type="image/png",
+                        ),
+                    ),
+                ],
+            ),
+        )
+
+        self.assertEqual(len(response.content), 1)
+        merged = response.content[0]
+        self.assertIsInstance(merged, DataBlock)
+        self.assertEqual(
+            base64.b64decode(merged.source.data),
+            b"helloworld",
         )
 
 


### PR DESCRIPTION
## AgentScope Version

`2.0.3`

## Description

Fixes #1900.

### Background

`ToolResponse.append_chunk` merges `DataBlock` instances with the same block id when accumulating streamed tool output. When those blocks use `Base64Source`, the previous implementation concatenated the base64 strings directly.

That corrupts binary payloads when each streamed chunk is independently base64-encoded and contains padding. For example, merging `base64(b"hello")` and `base64(b"world")` as strings produces `aGVsbG8=d29ybGQ=`, which decodes only to `b"hello"` instead of `b"helloworld"`.

### Changes

- Decode valid base64 chunks into bytes before merging them.
- Re-encode the merged bytes as a single valid base64 payload.
- Keep the previous string-concatenation behavior as a compatibility fallback for non-base64 placeholder strings.
- Add a regression test covering padded base64 chunks.

### How to Test

```bash
pytest tests/toolkit_test.py -q
pytest tests/event_to_message_test.py -q

Observed locally:
tests/toolkit_test.py: 16 passed
tests/event_to_message_test.py: 3 passed


## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  An issue has been created for this PR
- [x]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [x]  Code is ready for review