### PR TITLE
fix(agent): avoid shared default configs

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -144,15 +144,9 @@ class Agent:
         self.model = model
         self.state = state or AgentState()
 
-        self.model_config = (
-            model_config if model_config is not None else ModelConfig()
-        )
-        self.context_config = (
-            context_config if context_config is not None else ContextConfig()
-        )
-        self.react_config = (
-            react_config if react_config is not None else ReActConfig()
-        )
+        self.model_config = model_config or ModelConfig()
+        self.context_config = context_config or ContextConfig()
+        self.react_config = react_config or ReActConfig()
 
         # The permission engine
         self._engine = PermissionEngine(self.state.permission_context)

--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -103,9 +103,9 @@ class Agent:
         state: AgentState | None = None,
         offloader: Offloader | None = None,
         # The agent configurations
-        model_config: ModelConfig = ModelConfig(),
-        context_config: ContextConfig = ContextConfig(),
-        react_config: ReActConfig = ReActConfig(),
+        model_config: ModelConfig | None = None,
+        context_config: ContextConfig | None = None,
+        react_config: ReActConfig | None = None,
     ) -> None:
         """Initialize the agent class in AgentScope.
 
@@ -144,9 +144,15 @@ class Agent:
         self.model = model
         self.state = state or AgentState()
 
-        self.model_config = model_config
-        self.context_config = context_config
-        self.react_config = react_config
+        self.model_config = (
+            model_config if model_config is not None else ModelConfig()
+        )
+        self.context_config = (
+            context_config if context_config is not None else ContextConfig()
+        )
+        self.react_config = (
+            react_config if react_config is not None else ReActConfig()
+        )
 
         # The permission engine
         self._engine = PermissionEngine(self.state.permission_context)

--- a/tests/agent_basic_test.py
+++ b/tests/agent_basic_test.py
@@ -128,6 +128,42 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
             "usage": None,
         }
 
+    async def test_default_configs_are_not_shared_between_agents(
+        self,
+    ) -> None:
+        """Agents created with defaults own independent config objects."""
+        agent_1 = Agent(
+            name="agent-1",
+            system_prompt="You are agent 1.",
+            model=MockModel(),
+        )
+        agent_2 = Agent(
+            name="agent-2",
+            system_prompt="You are agent 2.",
+            model=MockModel(),
+        )
+
+        self.assertIsNot(agent_1.model_config, agent_2.model_config)
+        self.assertIsNot(agent_1.context_config, agent_2.context_config)
+        self.assertIsNot(agent_1.react_config, agent_2.react_config)
+
+        agent_1.model_config.max_retries = 3
+        agent_1.context_config.tool_result_limit = 123
+        agent_1.react_config.max_iters = 2
+
+        self.assertNotEqual(
+            agent_1.model_config.max_retries,
+            agent_2.model_config.max_retries,
+        )
+        self.assertNotEqual(
+            agent_1.context_config.tool_result_limit,
+            agent_2.context_config.tool_result_limit,
+        )
+        self.assertNotEqual(
+            agent_1.react_config.max_iters,
+            agent_2.react_config.max_iters,
+        )
+
     async def test_streaming_reasoning(self) -> None:
         """Test the streaming model inference without tool calls generated,
         only text in model response.


### PR DESCRIPTION
## Summary
- replace mutable Agent config defaults with None sentinels
- instantiate fresh ModelConfig, ContextConfig, and ReActConfig per Agent when omitted
- add a regression test proving default-created agents do not share config instances or mutations

Fixes #1904.

## Tests
- .venv/bin/python -m pytest tests/agent_basic_test.py -q
- .venv/bin/pre-commit run --files src/agentscope/agent/_agent.py tests/agent_basic_test.py