### PR TITLE
fix(agent): emit ThinkingBlockEnd before TextBlockStart on thinking→text transition

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -2421,6 +2421,31 @@ class Agent:
             elif isinstance(block, DataBlock):
                 data_blocks.append(block)
 
+        # Handle thinking blocks first so that ThinkingBlockEnd is
+        # emitted *before* TextBlockStart when thinking→text transitions
+        # happen (the old block should close before the new one opens).
+        if thinking_blocks:
+            # Generate a new thinking block id and start event
+            if not block_ids.get("thinking"):
+                block_ids["thinking"] = _generate_id()
+                yield ThinkingBlockStartEvent(
+                    reply_id=self.state.reply_id,
+                    block_id=block_ids["thinking"],
+                )
+            # Generate the thinking delta event with the existing id
+            yield ThinkingBlockDeltaEvent(
+                reply_id=self.state.reply_id,
+                block_id=block_ids["thinking"],
+                delta="".join([_.thinking for _ in thinking_blocks]),
+            )
+
+        elif block_ids.get("thinking") and not data_blocks:
+            yield ThinkingBlockEndEvent(
+                reply_id=self.state.reply_id,
+                block_id=block_ids["thinking"],
+            )
+            block_ids["thinking"] = None
+
         # Handle the text blocks. We only auto-close the open text block
         # when the current chunk has neither text NOR data — a chunk that
         # carries only data (e.g. an omni-style audio PCM delta arriving
@@ -2451,30 +2476,6 @@ class Agent:
                 block_id=block_ids["text"],
             )
             block_ids["text"] = None
-
-        # Same reasoning as the text block above — keep the thinking
-        # stream open across data-only chunks.
-        if thinking_blocks:
-            # Generate a new thinking block id and start event
-            if not block_ids.get("thinking"):
-                block_ids["thinking"] = _generate_id()
-                yield ThinkingBlockStartEvent(
-                    reply_id=self.state.reply_id,
-                    block_id=block_ids["thinking"],
-                )
-            # Generate the thinking delta event with the existing id
-            yield ThinkingBlockDeltaEvent(
-                reply_id=self.state.reply_id,
-                block_id=block_ids["thinking"],
-                delta="".join([_.thinking for _ in thinking_blocks]),
-            )
-
-        elif block_ids.get("thinking") and not data_blocks:
-            yield ThinkingBlockEndEvent(
-                reply_id=self.state.reply_id,
-                block_id=block_ids["thinking"],
-            )
-            block_ids["thinking"] = None
 
         # Handle the tool calls that exist in the current chunk
         for tool_call in tool_call_blocks:


### PR DESCRIPTION
## Problem

When the SSE stream transitions from thinking to text output, `_convert_chunk_to_events()` emitted events in the wrong order:

```
TextBlockStart → TextBlockDelta → ThinkingBlockEnd  (interleaved)
```

This is because text blocks were processed before thinking blocks. When the transition chunk arrives (has text, no thinking), text events were yielded first, then the thinking close was detected.

## Fix

Move thinking block handling **before** text block handling in `_convert_chunk_to_events()`, so the old block closes before the new one opens:

```
ThinkingBlockEnd → TextBlockStart → TextBlockDelta  (correct)
```

No logic changes — only the ordering of two independent code blocks is swapped.

## How it was found

Discovered via mitmproxy traffic analysis of DashScope (qwen-plus with `enable_thinking=True`).

The SSE stream separates thinking and text into **different chunks** with a hard boundary — there is no overlap. The last thinking chunk carries a non-empty `reasoning_content` with an empty `content`; the very next chunk switches to non-empty `content` with `reasoning_content` absent entirely:

```
# Last thinking chunk
data: {"choices":[{"delta":{"content":"","reasoning_content":"介绍的问题。"},...}],...}

# First text chunk  ← reasoning_content field is gone
data: {"choices":[{"delta":{"content":"你好！我是Friday，"},...}],...}
```

The interleaving was purely in AgentScope's event conversion layer, not in the protocol itself.

## Reproduction

```python
from agentscope.agent import Agent
from agentscope.credential import DashScopeCredential
from agentscope.model import DashScopeChatModel
from agentscope.message import UserMsg
import asyncio

async def main() -> None:
    agent = Agent(
        name="Friday",
        system_prompt="You're a helpful assistant named Friday.",
        model=DashScopeChatModel(
            credential=DashScopeCredential(api_key='<YOUR_DASHSCOPE_API_KEY>'),
            model="qwen-plus",
            parameters=DashScopeChatModel.Parameters(thinking_enable=True),
        ),
    )
    async for evt in agent.reply_stream(UserMsg("Tony", "你好，你是谁？")):
        print(evt)

asyncio.run(main())
```

## Before / After

**Before (main) — wrong order at the transition:**

```
...
type=THINKING_BLOCK_DELTA  delta='plain text with a friendly tone.\n'
type=TEXT_BLOCK_START                          ← text opens BEFORE thinking closes
type=TEXT_BLOCK_DELTA      delta='你好！我是Friday'
type=THINKING_BLOCK_END                        ← thinking closes AFTER text started
type=TEXT_BLOCK_DELTA      delta='，你的智能助手。有什么'
type=TEXT_BLOCK_DELTA      delta='我可以帮助你的吗？😊'
type=TEXT_BLOCK_END
```

**After (this PR) — correct order:**

```
...
type=THINKING_BLOCK_DELTA  delta='Ready to respond.\n'
type=THINKING_BLOCK_END                        ← thinking closes first
type=TEXT_BLOCK_START                          ← then text opens
type=TEXT_BLOCK_DELTA      delta='你好！我是Friday'
type=TEXT_BLOCK_DELTA      delta='，你的智能助手。有什么'
type=TEXT_BLOCK_DELTA      delta='我可以帮助你的吗？😊'
type=TEXT_BLOCK_END
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
