### PR TITLE
fix(agent): emit thinking end before answer text

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -2421,14 +2421,54 @@ class Agent:
             elif isinstance(block, DataBlock):
                 data_blocks.append(block)
 
-        # Handle the text blocks. We only auto-close the open text block
-        # when the current chunk has neither text NOR data — a chunk that
-        # carries only data (e.g. an omni-style audio PCM delta arriving
-        # between two text deltas) must keep the text stream alive so the
-        # frontend doesn't fragment one logical text stream into many
-        # separate bubbles. A chunk with tool calls (and no text/data)
-        # still closes text, which preserves text → tool → text render
-        # order via distinct text blocks.
+        # Pure data chunks (e.g. omni-style audio PCM deltas) keep the
+        # currently open text/thinking stream alive so the frontend doesn't
+        # fragment one logical stream into many separate bubbles.
+        data_only = bool(data_blocks) and not (
+            text_blocks or thinking_blocks or tool_call_blocks
+        )
+
+        # Close an open text stream before switching to another non-data
+        # modality. Tool-only chunks still close text, preserving text → tool
+        # → text render order via distinct text blocks.
+        if block_ids.get("text") and not text_blocks and not data_only:
+            yield TextBlockEndEvent(
+                reply_id=self.state.reply_id,
+                block_id=block_ids["text"],
+            )
+            block_ids["text"] = None
+
+        # Handle thinking before text so reasoning ends before answer text
+        # begins at the reasoning → answer boundary.
+        if thinking_blocks:
+            # Generate a new thinking block id and start event
+            if not block_ids.get("thinking"):
+                block_ids["thinking"] = _generate_id()
+                yield ThinkingBlockStartEvent(
+                    reply_id=self.state.reply_id,
+                    block_id=block_ids["thinking"],
+                )
+            # Generate the thinking delta event with the existing id
+            yield ThinkingBlockDeltaEvent(
+                reply_id=self.state.reply_id,
+                block_id=block_ids["thinking"],
+                delta="".join([_.thinking for _ in thinking_blocks]),
+            )
+            if text_blocks:
+                yield ThinkingBlockEndEvent(
+                    reply_id=self.state.reply_id,
+                    block_id=block_ids["thinking"],
+                )
+                block_ids["thinking"] = None
+
+        elif block_ids.get("thinking") and not data_only:
+            yield ThinkingBlockEndEvent(
+                reply_id=self.state.reply_id,
+                block_id=block_ids["thinking"],
+            )
+            block_ids["thinking"] = None
+
+        # Handle the text blocks after thinking transitions have been emitted.
         if text_blocks:
             # If the current chunk has text blocks but no text block id,
             # start with a start event
@@ -2444,37 +2484,6 @@ class Agent:
                 block_id=block_ids["text"],
                 delta="".join([_.text for _ in text_blocks]),
             )
-
-        elif block_ids.get("text") and not data_blocks:
-            yield TextBlockEndEvent(
-                reply_id=self.state.reply_id,
-                block_id=block_ids["text"],
-            )
-            block_ids["text"] = None
-
-        # Same reasoning as the text block above — keep the thinking
-        # stream open across data-only chunks.
-        if thinking_blocks:
-            # Generate a new thinking block id and start event
-            if not block_ids.get("thinking"):
-                block_ids["thinking"] = _generate_id()
-                yield ThinkingBlockStartEvent(
-                    reply_id=self.state.reply_id,
-                    block_id=block_ids["thinking"],
-                )
-            # Generate the thinking delta event with the existing id
-            yield ThinkingBlockDeltaEvent(
-                reply_id=self.state.reply_id,
-                block_id=block_ids["thinking"],
-                delta="".join([_.thinking for _ in thinking_blocks]),
-            )
-
-        elif block_ids.get("thinking") and not data_blocks:
-            yield ThinkingBlockEndEvent(
-                reply_id=self.state.reply_id,
-                block_id=block_ids["thinking"],
-            )
-            block_ids["thinking"] = None
 
         # Handle the tool calls that exist in the current chunk
         for tool_call in tool_call_blocks:

--- a/tests/agent_basic_test.py
+++ b/tests/agent_basic_test.py
@@ -17,7 +17,7 @@ from agentscope.permission import (
     PermissionBehavior,
     PermissionContext,
 )
-from agentscope.message import TextBlock, ToolCallBlock, UserMsg
+from agentscope.message import TextBlock, ThinkingBlock, ToolCallBlock, UserMsg
 
 
 class MockSequentialTool(ToolBase):
@@ -127,6 +127,21 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
             "role": "assistant",
             "usage": None,
         }
+
+    async def _collect_block_event_types(
+        self,
+        chunks: list[ChatResponse],
+    ) -> list[str]:
+        """Collect streamed block event types from the mock model."""
+        self.model.set_responses([chunks])
+        event_types: list[str] = []
+        async for event in self.agent.reply_stream(
+            UserMsg(name="user", content="Hi"),
+        ):
+            event_type = event.model_dump().get("type")
+            if isinstance(event_type, str) and "BLOCK" in event_type:
+                event_types.append(event_type)
+        return event_types
 
     async def test_default_configs_are_not_shared_between_agents(
         self,
@@ -365,6 +380,77 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
         ]
         context_dicts = [msg.model_dump() for msg in self.agent.state.context]
         self.assertListEqual(context_dicts, expected_context_after_reply)
+
+    async def test_streaming_thinking_closes_before_text_boundary(
+        self,
+    ) -> None:
+        """Thinking closes before answer text starts across chunks."""
+        event_types = await self._collect_block_event_types(
+            [
+                ChatResponse(
+                    content=[ThinkingBlock(thinking="reason")],
+                    is_last=False,
+                ),
+                ChatResponse(
+                    content=[TextBlock(text="Hello")],
+                    is_last=False,
+                ),
+                ChatResponse(
+                    content=[
+                        ThinkingBlock(thinking="reason"),
+                        TextBlock(text="Hello"),
+                    ],
+                    is_last=True,
+                ),
+            ],
+        )
+
+        self.assertListEqual(
+            event_types,
+            [
+                "THINKING_BLOCK_START",
+                "THINKING_BLOCK_DELTA",
+                "THINKING_BLOCK_END",
+                "TEXT_BLOCK_START",
+                "TEXT_BLOCK_DELTA",
+                "TEXT_BLOCK_END",
+            ],
+        )
+
+    async def test_streaming_thinking_precedes_text_in_same_chunk(
+        self,
+    ) -> None:
+        """Thinking is emitted before text when both arrive together."""
+        event_types = await self._collect_block_event_types(
+            [
+                ChatResponse(
+                    content=[
+                        ThinkingBlock(thinking="reason"),
+                        TextBlock(text="Hello"),
+                    ],
+                    is_last=False,
+                ),
+                ChatResponse(
+                    content=[
+                        ThinkingBlock(thinking="reason"),
+                        TextBlock(text="Hello"),
+                    ],
+                    is_last=True,
+                ),
+            ],
+        )
+
+        self.assertListEqual(
+            event_types,
+            [
+                "THINKING_BLOCK_START",
+                "THINKING_BLOCK_DELTA",
+                "THINKING_BLOCK_END",
+                "TEXT_BLOCK_START",
+                "TEXT_BLOCK_DELTA",
+                "TEXT_BLOCK_END",
+            ],
+        )
 
     async def test_non_streaming_reasoning(self) -> None:
         """Test the non-streaming model inference without tool calls generated,


### PR DESCRIPTION
## AgentScope Version

`2.0.3` from a local editable install.

## Description

Fixes #1885.

Streaming chat chunks were converted to events by handling text before thinking. At the reasoning-to-answer boundary, that could emit the first `TEXT_BLOCK_DELTA` before `THINKING_BLOCK_END`, which makes downstream renderers place the first answer token inside the thinking section.

This PR keeps data-only chunk behavior intact, emits thinking transitions before text transitions, and closes thinking before the answer text starts when thinking and text arrive in the same streamed chunk.

Validation run locally:

- `.venv/bin/python -m pytest tests/agent_basic_test.py`
- `.venv/bin/python -m pytest tests`
- `.venv/bin/pre-commit run --all-files`

## Checklist

- [x] An issue has been created for this PR: #1885
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style; this PR does not add public API docstrings
- [x] Related documentation has been updated or is not required for this internal bug fix
- [x] Code is ready for review
