### PR TITLE
fix(middleware): use configured id factory for TTS audio blocks

### DIFF
--- a/src/agentscope/middleware/_tts_middleware.py
+++ b/src/agentscope/middleware/_tts_middleware.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """Middleware that turns reasoning text into speech and injects it as
 ``DATA_BLOCK_*`` events into the agent's event stream."""
-import uuid
 from typing import TYPE_CHECKING, AsyncGenerator, Callable
 
 from ._base import MiddlewareBase
+from .._utils._common import _generate_id
 from ..event import (
     DataBlockDeltaEvent,
     DataBlockEndEvent,
@@ -163,7 +163,7 @@ class TTSMiddleware(MiddlewareBase):
             return
 
         if audio_block_id is None:
-            audio_block_id = uuid.uuid4().hex
+            audio_block_id = _generate_id()
             audio_media_type = media_type
             yield DataBlockStartEvent(
                 reply_id=agent.state.reply_id,

--- a/tests/tts_middleware_test.py
+++ b/tests/tts_middleware_test.py
@@ -5,6 +5,7 @@ from typing import Any, AsyncGenerator
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock
 
+from agentscope import set_id_factory
 from agentscope.event import (
     DataBlockDeltaEvent,
     DataBlockEndEvent,
@@ -157,6 +158,43 @@ class TestTTSMiddlewareNonRealtime(IsolatedAsyncioTestCase):
             [_dump(e) for e in upstream_events],
         )
         tts.synthesize.assert_not_called()
+
+    async def test_audio_block_id_uses_configured_id_factory(self) -> None:
+        """TTS audio DATA_BLOCK events use the configured ID factory."""
+        import agentscope._utils._common as common
+
+        # pylint: disable=protected-access
+        saved_factory = common._id_factory
+        self.addCleanup(setattr, common, "_id_factory", saved_factory)
+        set_id_factory(lambda: "custom-audio-id")
+
+        tts = MagicMock(spec=TTSModelBase)
+        tts.realtime = False
+        tts.__aenter__ = AsyncMock(return_value=tts)
+        tts.__aexit__ = AsyncMock(return_value=None)
+        tts.synthesize = AsyncMock(
+            return_value=_make_tts_response("AAAA"),
+        )
+
+        middleware = TTSMiddleware(tts_model=tts)
+        agent = _make_agent_stub()
+
+        async def next_handler(**_kwargs: Any) -> AsyncGenerator:
+            yield TextBlockDeltaEvent(
+                reply_id="reply-1",
+                block_id="blk-1",
+                delta="hi",
+            )
+            yield TextBlockEndEvent(reply_id="reply-1", block_id="blk-1")
+
+        emitted = [
+            evt async for evt in middleware.on_reply(agent, {}, next_handler)
+        ]
+
+        self.assertEqual(
+            [evt.block_id for evt in emitted[2:]],
+            ["custom-audio-id"] * 3,
+        )
 
     async def test_streaming_output_multiple_chunks(self) -> None:
         """When synthesize() returns an async generator, each chunk produces


### PR DESCRIPTION
## AgentScope Version

2.0.3

## Description

`TTSMiddleware` generated audio `DATA_BLOCK_*` event `block_id`s with `uuid.uuid4().hex` directly. This bypassed the configurable ID factory set by `set_id_factory()`, while other entity/event IDs in AgentScope are generated through `_generate_id()`.

This PR updates `TTSMiddleware` to use `_generate_id()` when creating TTS audio block IDs, so `DataBlockStartEvent`, `DataBlockDeltaEvent`, and `DataBlockEndEvent` share a block ID produced by the configured factory.

Changes:
- replace direct `uuid.uuid4().hex` audio block ID generation with `_generate_id()`
- remove the now-unused `uuid` import
- add a regression test that drives `TTSMiddleware.on_reply()` and verifies TTS audio DATA_BLOCK events respect `set_id_factory()`

Testing:
- `uv run python -c "import agentscope; print(agentscope.__version__)"`
  - `2.0.3`
- `uv run --extra dev pytest tests/tts_middleware_test.py tests/id_factory_test.py -q`
  - `8 passed in 0.38s`

Additional check:
- `uv run pre-commit run --all-files` was attempted, but the pre-commit tool environment failed before completing:
  - `black` failed with `module 'ast' has no attribute 'Str'`
  - `pylint` failed with an astroid crash on Python 3.14: `TreeRebuilder` missing `visit_templatestr`
  - unrelated existing import-order reports appeared under `src/agentscope/credential/_gemini.py`

## Checklist

- [ ] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs) — not applicable; this is an internal bug fix with no documentation change
- [x] Code is ready for review