### PR TITLE
feat(agent): support user-defined instructions when compressing memory

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -70,6 +70,7 @@ from ..message import (
     ToolCallState,
     ToolResultState,
     Usage,
+    HintBlock,
 )
 from ..tool import (
     Toolkit,
@@ -258,6 +259,7 @@ class Agent:
     async def compress_context(
         self,
         context_config: ContextConfig | None = None,
+        instructions: HintBlock | None = None,
     ) -> None:
         """Compress the agent's context if the token count exceeds the
         threshold.
@@ -267,23 +269,34 @@ class Agent:
                 If provided, compress the context with the given context
                 config. Otherwise, use the default context config in the
                 agent.
+            instructions (`HintBlock | None`, optional):
+                Optional hints or instructions injected into the compression
+                prompt to guide the summarization behavior.
         """
         if not self._compress_context_middlewares:
-            await self._compress_context_impl(context_config=context_config)
+            await self._compress_context_impl(
+                context_config=context_config,
+                instructions=instructions,
+            )
         else:
 
             async def execute_chain(
                 index: int = 0,
                 context_config: ContextConfig | None = context_config,
+                instructions: HintBlock | None = instructions,
             ) -> None:
                 """Execute the compress_context middleware chain."""
                 if index >= len(self._compress_context_middlewares):
                     await self._compress_context_impl(
                         context_config=context_config,
+                        instructions=instructions,
                     )
                 else:
                     mw = self._compress_context_middlewares[index]
-                    input_kwargs = {"context_config": context_config}
+                    input_kwargs = {
+                        "context_config": context_config,
+                        "instructions": instructions,
+                    }
 
                     async def next_handler(**kwargs: Any) -> None:
                         await execute_chain(index + 1, **kwargs)
@@ -299,6 +312,7 @@ class Agent:
     async def _compress_context_impl(
         self,
         context_config: ContextConfig | None = None,
+        instructions: HintBlock | None = None,
     ) -> None:
         """Compress the agent's context if the token count exceeds the
         threshold.
@@ -308,6 +322,9 @@ class Agent:
                 If provided, compress the context with the given context
                 config. Otherwise, use the default context config in the
                 agent.
+            instructions (`HintBlock | None`, optional):
+                Optional hints or instructions injected into the compression
+                prompt to guide the summarization behavior.
         """
         cfg: ContextConfig = context_config or self.context_config
 
@@ -382,9 +399,19 @@ class Agent:
         if self.state.summary:
             msgs_system.append(UserMsg("user", self.state.summary))
 
+        instruction_msgs: list[Msg] = []
+        if instructions is not None:
+            instruction_msgs.append(
+                UserMsg(
+                    name=instructions.source or "user",
+                    content=instructions.hint,
+                ),
+            )
+
         messages = (
             msgs_system
             + msgs_to_compress
+            + instruction_msgs
             + [
                 UserMsg(name="user", content=cfg.compression_prompt),
             ]

--- a/src/agentscope/middleware/_base.py
+++ b/src/agentscope/middleware/_base.py
@@ -199,6 +199,7 @@ class MiddlewareBase:  # pylint: disable=unused-argument
             input_kwargs (`dict`):
                 Dictionary containing:
                 - context_config: ContextConfig | None
+                - instructions: HintBlock | None
             next_handler (`Callable[..., Awaitable[None]]`):
                 Callable that executes the next middleware or
                 original method

--- a/tests/compress_context_test.py
+++ b/tests/compress_context_test.py
@@ -4,6 +4,7 @@
 import json
 import os
 import tempfile
+from typing import Any
 
 from unittest.async_case import IsolatedAsyncioTestCase
 
@@ -12,8 +13,39 @@ from utils import MockModel, AnyString
 from agentscope.model import StructuredResponse
 from agentscope.agent import Agent, ContextConfig
 from agentscope.state import AgentState
-from agentscope.message import UserMsg, AssistantMsg, TextBlock, ToolCallBlock
+from agentscope.message import (
+    UserMsg,
+    AssistantMsg,
+    TextBlock,
+    ToolCallBlock,
+    HintBlock,
+)
 from agentscope.tool import Toolkit
+
+
+class RecordingMockModel(MockModel):
+    """A MockModel that records structured-output calls."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the recording mock model."""
+        super().__init__(*args, **kwargs)
+        self.recorded_calls: list[tuple[list[Any], dict[str, Any]]] = []
+
+    async def _call_api_with_structured_output(
+        self,
+        model_name: str,
+        messages: list[Any],
+        structured_model: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Record the call and delegate to the parent mock."""
+        self.recorded_calls.append((messages, structured_model))
+        return await super()._call_api_with_structured_output(
+            model_name,
+            messages,
+            structured_model,
+            **kwargs,
+        )
 
 
 class ContextCompressionTest(IsolatedAsyncioTestCase):
@@ -870,6 +902,73 @@ class ContextCompressionTest(IsolatedAsyncioTestCase):
             self.assertIsNone(
                 await agent.state.tool_context.get_cache(file_path),
             )
+
+    async def test_compress_context_with_instructions(self) -> None:
+        """Test that user-defined instructions are injected into the
+        compression prompt."""
+        model = RecordingMockModel(context_size=100)
+        agent = Agent(
+            name="Friday",
+            system_prompt="".join(["0" for _ in range(20 * 4)]),
+            model=model,
+            context_config=ContextConfig(
+                trigger_ratio=0.7,
+                reserve_ratio=0.4,
+            ),
+            state=AgentState(
+                session_id="123",
+                context=[
+                    UserMsg(
+                        "User",
+                        "".join(["1" for _ in range(30 * 4)]),
+                        id="1",
+                    ),
+                    AssistantMsg(
+                        "Friday",
+                        "".join(["2" for _ in range(10 * 4)]),
+                        id="2",
+                    ),
+                    UserMsg(
+                        "User",
+                        "".join(["3" for _ in range(10 * 4)]),
+                        id="3",
+                    ),
+                ],
+            ),
+            toolkit=Toolkit(),
+        )
+
+        model.set_structured_response(
+            StructuredResponse(
+                content={
+                    "task_overview": "1",
+                    "current_state": "2",
+                    "important_discoveries": "3",
+                    "next_steps": "4",
+                    "context_to_preserve": "5",
+                },
+            ),
+        )
+
+        instructions = HintBlock(
+            hint="Focus on the user's intent, not the assistant's filler.",
+            source="system",
+        )
+
+        await agent.compress_context(instructions=instructions)
+
+        self.assertEqual(len(model.recorded_calls), 1)
+        messages, _ = model.recorded_calls[0]
+
+        # The instruction should appear as a user message right before the
+        # compression prompt.
+        self.assertTrue(
+            any(
+                msg.role == "user"
+                and msg.content[0].text == instructions.hint
+                for msg in messages
+            ),
+        )
 
     async def asyncTearDown(self) -> None:
         """The async teardown method."""


### PR DESCRIPTION
Add an instructions: HintBlock argument to Agent.compress_context. The hint is converted to a user message and injected right before the compression prompt, allowing callers to guide the summarization behavior.

- Pass instructions through the compress_context middleware chain.
- Update on_compress_context docstring to document the new kwarg.
- Add RecordingMockModel and a unit test verifying the hint is included in the messages sent to the model.

Closes #1924

## PR Title Format

Please ensure your PR title follows the Conventional Commits format:
- Format: `<type>(<scope>): <description>`
- Example: `feat(memory): add redis cache support`
- Allowed types: `feat`, `fix`, `docs`, `ci`, `refactor`, `test`, `chore`, `perf`, `style`, `build`, `revert`
- Description should start with a lowercase letter

## AgentScope Version

[The version of AgentScope you are working on, e.g. `import agentscope; print(agentscope.__version__)`]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review