### PR TITLE
fix(tool): reject negative grep pagination values

### DIFF
--- a/src/agentscope/tool/_builtin/_grep.py
+++ b/src/agentscope/tool/_builtin/_grep.py
@@ -138,12 +138,14 @@ class Grep(ToolBase):
                 "description": "Limit output to first N lines/entries. "
                 "Defaults to 250 when unspecified. "
                 "Pass 0 for unlimited.",
+                "minimum": 0,
             },
             "offset": {
                 "type": "integer",
                 "description": "Skip first N lines/entries before applying "
                 "head_limit. Defaults to 0.",
                 "default": 0,
+                "minimum": 0,
             },
         },
         "required": ["pattern"],
@@ -354,6 +356,24 @@ class Grep(ToolBase):
             **kwargs: Additional parameters (-A, -B, -C)
         """
         search_path = path or os.getcwd()
+
+        if head_limit is not None and head_limit < 0:
+            return ToolChunk(
+                content=[
+                    TextBlock(text="Error: head_limit must be non-negative."),
+                ],
+                state=ToolResultState.ERROR,
+                is_last=True,
+            )
+
+        if offset < 0:
+            return ToolChunk(
+                content=[
+                    TextBlock(text="Error: offset must be non-negative."),
+                ],
+                state=ToolResultState.ERROR,
+                is_last=True,
+            )
 
         args: list[str] = ["--hidden"]
 


### PR DESCRIPTION
## AgentScope Version

2.0.3

## Description

Fixes #1936.

### What Problem This Solves

This PR fixes a pagination validation bug in the builtin `Grep` tool.

`Grep` exposes `head_limit` and `offset` as pagination controls, but the previous schema did not reject negative values. These values are eventually used in Python list slicing, so negative values can trigger Python negative-index behavior instead of normal pagination semantics.

For example, `offset=-1` does not mean "skip no less than zero results". In Python slicing, it can address the result list from the end. When `head_limit=0` is used for unlimited output, `offset=-1` can return only the last result:

```python
from agentscope.tool import Grep

grep = Grep()
limited, applied_limit = grep._apply_head_limit(["a", "b", "c"], 0, -1)

print(limited)
# Before this fix: ["c"]
```

This is surprising for a pagination API because limits and offsets should be non-negative integers. A caller providing a negative offset should receive a validation error, not a result window computed from the end of the list.

The affected values reached the slicing step through the grep execution flow:

```python
limited, applied_limit = self._apply_head_limit(results, head_limit, offset)
```

Where `head_limit` and `offset` came from tool input.

### Change

Reject negative pagination values before they can affect result slicing:

- add schema-level `minimum: 0` constraints for `head_limit`
- add schema-level `minimum: 0` constraints for `offset`
- add runtime validation in `Grep.call(...)` so direct Python calls that bypass schema validation also reject negative values

After this change, invalid pagination input fails explicitly:

```text
head_limit < 0 -> Error: head_limit must be non-negative.
offset < 0     -> Error: offset must be non-negative.
```

This keeps valid grep behavior unchanged while preventing negative pagination values from being interpreted as Python negative slice indices.

### Evidence

The issue can be reproduced with the current slicing helper behavior:

```python
from agentscope.tool import Grep

grep = Grep()
limited, applied_limit = grep._apply_head_limit(["a", "b", "c"], 0, -1)

print(limited)
# Before this fix: ["c"]
```

The result comes from Python's negative-index slicing behavior, not from valid pagination semantics. After this fix, negative `head_limit` and `offset` are rejected before the search runs or result pagination is applied.

The local console evidence below shows the reproduction input, the old slicing result, the new runtime validation errors, and the focused validation output:

![Local console evidence](https://img.vectorpeak.cn/obsidian/2026/05-06/20260624151714957.png?imageSlim)

### Possible call chain / impact

The affected path is the builtin Grep tool execution path:

```text
src/agentscope/tool/_builtin/_grep.py
  -> Grep.call(...)
    -> search_path = path or os.getcwd()
    -> _run_ripgrep(...)
    -> _apply_head_limit(results, head_limit, offset)
```

Without validation, negative `head_limit` or `offset` values can reach the list-slicing pagination step. Python then interprets negative values as positions relative to the end of the list, which can expose a different result window than the caller requested.

This PR only changes validation for invalid negative pagination inputs. It does not change ripgrep invocation, pattern matching, glob/type filtering, result formatting, permission handling, or successful searches that use valid non-negative pagination values.

### Testing

- `.\.venv\Scripts\python.exe -m py_compile src/agentscope/tool/_builtin/_grep.py`
- `.\.venv\Scripts\python.exe -m pytest tests/builtin_grep_test.py -q`
- local console slicing reproduction for `offset=-1` with unlimited `head_limit=0`

```text
13 passed in 0.76s
```

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  An issue has been created for this PR
- [x]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [x]  Code is ready for review