### PR TITLE
fix(agent): raise clear error when streaming response yields no completed chunk

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -848,6 +848,18 @@ class Agent:
             ):
                 yield evt
 
+        # The streaming response may yield no chunk, or be cut off before a
+        # chunk with ``is_last=True`` arrives, leaving ``completed_response``
+        # as ``None``. Raise a clear error here instead of letting the later
+        # ``completed_response.usage``/``.content`` accesses fail with an
+        # opaque ``AttributeError: 'NoneType' object has no attribute ...``.
+        if completed_response is None:
+            raise RuntimeError(
+                "Failed to get a completed response from the model: the "
+                "streaming response ended without a final chunk "
+                "(`is_last=True`) or yielded no chunks.",
+            )
+
         # Send the ended events for the remaining active blocks
         if block_ids["text"] is not None:
             yield TextBlockEndEvent(

--- a/tests/agent_basic_test.py
+++ b/tests/agent_basic_test.py
@@ -128,6 +128,19 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
             "usage": None,
         }
 
+    async def test_reasoning_raises_clear_error_on_empty_stream(self) -> None:
+        """A streaming response that yields no final chunk should raise a
+        clear ``RuntimeError`` instead of an opaque ``AttributeError`` from
+        dereferencing ``None`` (see issue #1860)."""
+        # A streaming response that yields zero chunks leaves
+        # ``completed_response`` as ``None`` in ``_reasoning_impl``.
+        self.model.set_responses([[]])
+
+        with self.assertRaises(RuntimeError) as ctx:
+            await self.agent.reply(UserMsg(name="user", content="Hi"))
+
+        self.assertIn("completed response", str(ctx.exception).lower())
+
     async def test_default_configs_are_not_shared_between_agents(
         self,
     ) -> None:


### PR DESCRIPTION
## Description

In `Agent._reasoning_impl()`, `completed_response` stays `None` when a streaming model response yields **zero chunks**, or is **cut off before a chunk with `is_last=True`** arrives. The code then dereferences `completed_response.usage` and `.content`, crashing the entire agent session with an opaque error:

```
AttributeError: 'NoneType' object has no attribute 'usage'
```

## Fix

Add an explicit `None` guard right after the response is collected and raise a clear `RuntimeError`. This mirrors the existing handling in `ChatModelBase` (`src/agentscope/model/_base.py`), which already does the same check for the same situation — so this brings `Agent` in line with the project's own convention.

```python
if completed_response is None:
    raise RuntimeError(
        "Failed to get a completed response from the model: the "
        "streaming response ended without a final chunk "
        "(`is_last=True`) or yielded no chunks.",
    )
```

## Tests

Added a regression test `test_reasoning_raises_clear_error_on_empty_stream` to `tests/agent_basic_test.py` that drives an empty streaming response through the agent and asserts a clear `RuntimeError` is raised (previously: `AttributeError`).

Verified locally:
- `agent_basic_test.py` — **7 passed** (6 existing + 1 new).
- `black --line-length=79` — clean.
- `flake8 --extend-ignore=E203` — clean.

Closes #1860