### PR TITLE
feat(agent): add self-compaction feature with rubric-based compression

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -16,7 +16,12 @@ from typing import (
 
 import jsonschema
 
-from ._config import ContextConfig, ReActConfig, ModelConfig
+from ._config import (
+    ContextConfig,
+    ReActConfig,
+    ModelConfig,
+    SELF_COMPACT_DECISION_SCHEMA,
+)
 from ..state import AgentState
 from ._utils import _ToolCallBatch
 from .._logging import logger
@@ -309,6 +314,69 @@ class Agent:
 
             await execute_chain()
 
+    async def self_compact_context(
+        self,
+        context_config: ContextConfig | None = None,
+    ) -> None:
+        """Run optional rubric-gated self-compaction
+        below the hard threshold."""
+        cfg: ContextConfig = context_config or self.context_config
+        if not cfg.self_compact_enabled or not self.state.context:
+            return
+
+        kwargs = await self._prepare_model_input()
+        estimated_tokens = await self.model.count_tokens(**kwargs)
+
+        context_size = self.model.context_size
+        hard_threshold = cfg.trigger_ratio * context_size
+        early_threshold = cfg.self_compact_trigger_ratio * context_size
+        if (
+            estimated_tokens < early_threshold
+            or estimated_tokens >= hard_threshold
+        ):
+            return
+
+        try:
+            should_compact = await self._should_self_compact(
+                cfg,
+                kwargs["messages"],
+                estimated_tokens,
+            )
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.warning(
+                "[AGENT %s]: Self-compaction rubric failed, skipping "
+                "optional early compression: %s",
+                self.name,
+                e,
+            )
+            return
+
+        if not should_compact:
+            return
+
+        logger.info(
+            "[AGENT %s]: Self-compaction rubric requested compression "
+            "at token count %d below threshold %d.",
+            self.name,
+            int(estimated_tokens),
+            int(hard_threshold),
+        )
+
+        forced_cfg = cfg.model_copy(
+            update={
+                "trigger_ratio": estimated_tokens / context_size,
+            },
+        )
+        try:
+            await self.compress_context(context_config=forced_cfg)
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.warning(
+                "[AGENT %s]: Optional self-compaction failed below the "
+                "token threshold, keeping the original context: %s",
+                self.name,
+                e,
+            )
+
     async def _compress_context_impl(
         self,
         context_config: ContextConfig | None = None,
@@ -517,6 +585,81 @@ class Agent:
             self.name,
         )
 
+    async def _should_self_compact(
+        self,
+        context_config: ContextConfig,
+        messages: list[Msg],
+        estimated_tokens: int,
+    ) -> bool:
+        """Decide whether to compact context using the SELFCOMPACT rubric."""
+        cur_iter = self.state.cur_iter or 0
+        if cur_iter < context_config.self_compact_min_iters:
+            return False
+
+        probe_interval = context_config.self_compact_probe_interval
+        if probe_interval > 1 and cur_iter % probe_interval != 0:
+            return False
+
+        prompt = self._render_self_compact_rubric_prompt(
+            context_config,
+            estimated_tokens,
+        )
+        if not prompt:
+            return False
+
+        # SELFCOMPACT (https://arxiv.org/pdf/2606.23525) uses a lightweight
+        # model verdict to choose compaction timing, instead of relying only on
+        # a fixed token threshold.
+        rubric_messages = messages + [
+            UserMsg(
+                name="user",
+                content=prompt,
+            ),
+        ]
+        res = await self.model.generate_structured_output(
+            messages=rubric_messages,
+            structured_model=SELF_COMPACT_DECISION_SCHEMA,
+        )
+        decision = str(res.content.get("decision", "")).upper()
+        return decision == "COMPRESS"
+
+    def _render_self_compact_rubric_prompt(
+        self,
+        context_config: ContextConfig,
+        estimated_tokens: int,
+    ) -> str:
+        """Render the self-compaction prompt with current context usage."""
+        prompt = context_config.self_compact_rubric_prompt
+        if not prompt:
+            return ""
+
+        usage_percent = (
+            100 * estimated_tokens / self.model.context_size
+            if self.model.context_size
+            else 0
+        )
+        usage_text = f"{usage_percent:.1f}"
+        self_compact_trigger_percent = (
+            100 * context_config.self_compact_trigger_ratio
+        )
+        trigger_percent = 100 * context_config.trigger_ratio
+        return (
+            prompt.replace("{context_usage_percent}", usage_text)
+            .replace(
+                "{self_compact_trigger_percent}",
+                f"{self_compact_trigger_percent:.1f}",
+            )
+            .replace("{trigger_percent}", f"{trigger_percent:.1f}")
+            .replace("{context_usage_ratio}", f"{usage_percent / 100:.3f}")
+            .replace(
+                "{self_compact_trigger_ratio}",
+                f"{context_config.self_compact_trigger_ratio:.3f}",
+            )
+            .replace("{trigger_ratio}", f"{context_config.trigger_ratio:.3f}")
+            .replace("{estimated_tokens}", str(int(estimated_tokens)))
+            .replace("{context_size}", str(int(self.model.context_size)))
+        )
+
     # ======================================================================
     # Agent core methods, including _reply, _reasoning, _acting, etc.
     # ======================================================================
@@ -565,6 +708,9 @@ class Agent:
 
             async for item in execute_chain():
                 yield item
+
+        if self.context_config.self_compact_enabled:
+            await self.self_compact_context()
 
     async def _reply_impl(
         self,

--- a/src/agentscope/agent/_config.py
+++ b/src/agentscope/agent/_config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """The agent config classes."""
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from ..model import ChatModelBase
 
@@ -194,6 +194,19 @@ class ContextConfig(BaseModel):
         json_schema_extra={"format": "textarea"},
     )
     """Prompt used to ask the model whether context should be compacted."""
+
+    @model_validator(mode="after")
+    def _validate_self_compact_trigger_ratio(self) -> "ContextConfig":
+        """Ensure self-compaction runs before threshold compression."""
+        if (
+            self.self_compact_enabled
+            and self.self_compact_trigger_ratio >= self.trigger_ratio
+        ):
+            raise ValueError(
+                "self_compact_trigger_ratio must be smaller than "
+                "trigger_ratio.",
+            )
+        return self
 
 
 class ReActConfig(BaseModel):

--- a/src/agentscope/agent/_config.py
+++ b/src/agentscope/agent/_config.py
@@ -6,6 +6,41 @@ from pydantic import BaseModel, Field
 from ..model import ChatModelBase
 
 
+DEFAULT_SELF_COMPACT_RUBRIC_PROMPT = (
+    "<system-hint>You are deciding whether the current agent trajectory "
+    "should be compacted before the next reply. The current context usage is "
+    "{context_usage_percent}% of the model context window. Self-compaction is "
+    "being considered between {self_compact_trigger_percent}% and "
+    "{trigger_percent}%; at {trigger_percent}%, normal threshold compression "
+    "will be forced. Compress when the older conversation contains enough "
+    "completed work, tool results, or intermediate reasoning that a concise "
+    "continuation summary would preserve progress while reducing distraction "
+    "or context cost. Continue when recent details are still directly needed "
+    "verbatim, when there is too little history to summarize, or when "
+    "compaction would likely remove information needed for the next action. "
+    "Return COMPRESS or CONTINUE."
+    "</system-hint>"
+)
+
+
+SELF_COMPACT_DECISION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "decision": {
+            "type": "string",
+            "enum": ["COMPRESS", "CONTINUE"],
+            "description": "Whether to compact the current context.",
+        },
+        "reason": {
+            "type": "string",
+            "description": "A concise reason for the decision.",
+        },
+    },
+    "required": ["decision", "reason"],
+    "additionalProperties": False,
+}
+
+
 class SummarySchema(BaseModel):
     """The compressed memory model, used to generate summary of old memories"""
 
@@ -118,6 +153,47 @@ class ContextConfig(BaseModel):
         ),
     )
     """The tool result limit to avoid tool result bursting."""
+
+    self_compact_enabled: bool = Field(
+        default=False,
+        description=(
+            "Whether to enable model-driven self-compaction. When disabled, "
+            "AgentScope keeps the existing token-threshold compression "
+            "behavior."
+        ),
+    )
+    """Whether to enable model-driven self-compaction."""
+
+    self_compact_trigger_ratio: float = Field(default=0.5, gt=0, lt=0.9)
+    """When self-compaction is enabled, run the rubric only after this ratio
+    of the model context window is used and before ``trigger_ratio`` is
+    reached."""
+
+    self_compact_probe_interval: int = Field(
+        default=1,
+        ge=1,
+        description=(
+            "Run the self-compaction rubric every N completed reply "
+            "iterations when self-compaction is enabled."
+        ),
+    )
+    """How often to run the self-compaction rubric."""
+
+    self_compact_min_iters: int = Field(
+        default=1,
+        ge=0,
+        description=(
+            "Skip self-compaction rubric checks until the current reply has "
+            "reached this reasoning-acting iteration."
+        ),
+    )
+    """Minimum current reply iteration before probing self-compaction."""
+
+    self_compact_rubric_prompt: str = Field(
+        default=DEFAULT_SELF_COMPACT_RUBRIC_PROMPT,
+        json_schema_extra={"format": "textarea"},
+    )
+    """Prompt used to ask the model whether context should be compacted."""
 
 
 class ReActConfig(BaseModel):

--- a/tests/agent_basic_test.py
+++ b/tests/agent_basic_test.py
@@ -149,6 +149,7 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
 
         agent_1.model_config.max_retries = 3
         agent_1.context_config.tool_result_limit = 123
+        agent_1.context_config.self_compact_trigger_ratio = 0.6
         agent_1.react_config.max_iters = 2
 
         self.assertNotEqual(
@@ -158,6 +159,10 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
         self.assertNotEqual(
             agent_1.context_config.tool_result_limit,
             agent_2.context_config.tool_result_limit,
+        )
+        self.assertNotEqual(
+            agent_1.context_config.self_compact_trigger_ratio,
+            agent_2.context_config.self_compact_trigger_ratio,
         )
         self.assertNotEqual(
             agent_1.react_config.max_iters,

--- a/tests/compress_context_test.py
+++ b/tests/compress_context_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """A template test case."""
-# pylint: disable=protected-access
+# pylint: disable=protected-access,unused-argument
 import json
 import os
 import tempfile
@@ -10,7 +10,7 @@ from unittest.async_case import IsolatedAsyncioTestCase
 
 from utils import MockModel, AnyString
 
-from agentscope.model import StructuredResponse
+from agentscope.model import ChatResponse, StructuredResponse
 from agentscope.agent import Agent, ContextConfig
 from agentscope.state import AgentState
 from agentscope.message import (
@@ -738,6 +738,680 @@ class ContextCompressionTest(IsolatedAsyncioTestCase):
                 },
             ],
         )
+
+    async def test_self_compact_disabled_by_default(self) -> None:
+        """Self-compaction should not add rubric calls by default."""
+        model = MockModel(context_size=200)
+        agent = Agent(
+            name="Friday",
+            system_prompt="".join(["0" for _ in range(20 * 4)]),
+            model=model,
+            context_config=ContextConfig(
+                trigger_ratio=0.8,
+                reserve_ratio=0.1,
+            ),
+            state=AgentState(
+                session_id="123",
+                cur_iter=1,
+                context=[
+                    UserMsg(
+                        "User",
+                        "".join(["1" for _ in range(30 * 4)]),
+                        id="1",
+                    ),
+                    UserMsg(
+                        "User",
+                        "".join(["2" for _ in range(30 * 4)]),
+                        id="2",
+                    ),
+                ],
+            ),
+            toolkit=Toolkit(),
+        )
+
+        structured_calls = 0
+
+        async def mock_structured_output(
+            messages: list[Msg],
+            structured_model: Any,
+            **kwargs: Any,
+        ) -> StructuredResponse:
+            nonlocal structured_calls
+            structured_calls += 1
+            return StructuredResponse(
+                content={
+                    "decision": "COMPRESS",
+                    "reason": "Would compact if called.",
+                },
+            )
+
+        model.generate_structured_output = mock_structured_output
+
+        await agent.compress_context()
+
+        self.assertEqual(structured_calls, 0)
+        self.assertEqual(agent.state.summary, "")
+        self.assertEqual(len(agent.state.context), 2)
+
+    async def test_self_compact_skips_below_early_trigger_ratio(self) -> None:
+        """Self-compaction should not probe before its early trigger ratio."""
+        model = MockModel(context_size=200)
+        agent = Agent(
+            name="Friday",
+            system_prompt="".join(["0" for _ in range(20 * 4)]),
+            model=model,
+            context_config=ContextConfig(
+                trigger_ratio=0.8,
+                reserve_ratio=0.1,
+                self_compact_enabled=True,
+                self_compact_trigger_ratio=0.4,
+            ),
+            state=AgentState(
+                session_id="123",
+                cur_iter=1,
+                context=[
+                    UserMsg(
+                        "User",
+                        "".join(["1" for _ in range(30 * 4)]),
+                        id="1",
+                    ),
+                ],
+            ),
+            toolkit=Toolkit(),
+        )
+
+        structured_calls = 0
+
+        async def mock_structured_output(
+            messages: list[Msg],
+            structured_model: Any,
+            **kwargs: Any,
+        ) -> StructuredResponse:
+            nonlocal structured_calls
+            structured_calls += 1
+            return StructuredResponse(
+                content={
+                    "decision": "COMPRESS",
+                    "reason": "Would compact if called.",
+                },
+            )
+
+        model.generate_structured_output = mock_structured_output
+
+        await agent.compress_context()
+
+        self.assertEqual(structured_calls, 0)
+        self.assertEqual(agent.state.summary, "")
+        self.assertEqual(len(agent.state.context), 1)
+
+    async def test_self_compact_can_trigger_early_compression(self) -> None:
+        """Enabled self-compaction can compress before the token threshold."""
+        model = MockModel(context_size=200)
+        agent = Agent(
+            name="Friday",
+            system_prompt="".join(["0" for _ in range(20 * 4)]),
+            model=model,
+            context_config=ContextConfig(
+                trigger_ratio=0.8,
+                reserve_ratio=0.1,
+                self_compact_enabled=True,
+                self_compact_trigger_ratio=0.4,
+            ),
+            state=AgentState(
+                session_id="123",
+                cur_iter=1,
+                context=[
+                    UserMsg(
+                        "User",
+                        "".join(["1" for _ in range(30 * 4)]),
+                        id="1",
+                    ),
+                    UserMsg(
+                        "User",
+                        "".join(["2" for _ in range(30 * 4)]),
+                        id="2",
+                    ),
+                ],
+            ),
+            toolkit=Toolkit(),
+        )
+
+        structured_responses = [
+            StructuredResponse(
+                content={
+                    "decision": "COMPRESS",
+                    "reason": "The old trajectory can be summarized.",
+                },
+            ),
+            StructuredResponse(
+                content={
+                    "task_overview": "1",
+                    "current_state": "2",
+                    "important_discoveries": "3",
+                    "next_steps": "4",
+                    "context_to_preserve": "5",
+                },
+            ),
+        ]
+        structured_schemas = []
+        rubric_prompt = ""
+
+        async def mock_structured_output(
+            messages: list[Msg],
+            structured_model: Any,
+            **kwargs: Any,
+        ) -> StructuredResponse:
+            nonlocal rubric_prompt
+            structured_schemas.append(structured_model)
+            if len(structured_schemas) == 1:
+                rubric_prompt = messages[-1].get_text_content()
+            return structured_responses.pop(0)
+
+        model.generate_structured_output = mock_structured_output
+
+        await agent.self_compact_context()
+
+        self.assertEqual(len(structured_schemas), 2)
+        self.assertEqual(
+            structured_schemas[0]["properties"]["decision"]["enum"],
+            ["COMPRESS", "CONTINUE"],
+        )
+        self.assertIn("40.0% of the model context window", rubric_prompt)
+        self.assertIn(
+            "between 40.0% and 80.0%",
+            rubric_prompt,
+        )
+        self.assertIn(
+            "at 80.0%, normal threshold compression will be forced",
+            rubric_prompt,
+        )
+        self.assertEqual(
+            agent.state.summary,
+            """<system-info>Here is a summary of your previous work
+# Task Overview
+1
+
+# Current State
+2
+
+# Important Discoveries
+3
+
+# Next Steps
+4
+
+# Context to Preserve
+5</system-info>""",
+        )
+        self.assertListEqual(agent.state.context, [])
+
+    async def test_self_compact_continue_skips_early_compression(self) -> None:
+        """The rubric can decline compression below the token threshold."""
+        model = MockModel(context_size=200)
+        agent = Agent(
+            name="Friday",
+            system_prompt="".join(["0" for _ in range(20 * 4)]),
+            model=model,
+            context_config=ContextConfig(
+                trigger_ratio=0.8,
+                reserve_ratio=0.1,
+                self_compact_enabled=True,
+                self_compact_trigger_ratio=0.4,
+            ),
+            state=AgentState(
+                session_id="123",
+                cur_iter=1,
+                context=[
+                    UserMsg(
+                        "User",
+                        "".join(["1" for _ in range(30 * 4)]),
+                        id="1",
+                    ),
+                    UserMsg(
+                        "User",
+                        "".join(["2" for _ in range(30 * 4)]),
+                        id="2",
+                    ),
+                ],
+            ),
+            toolkit=Toolkit(),
+        )
+
+        structured_calls = 0
+
+        async def mock_structured_output(
+            messages: list[Msg],
+            structured_model: Any,
+            **kwargs: Any,
+        ) -> StructuredResponse:
+            nonlocal structured_calls
+            structured_calls += 1
+            return StructuredResponse(
+                content={
+                    "decision": "CONTINUE",
+                    "reason": "Recent details are still needed.",
+                },
+            )
+
+        model.generate_structured_output = mock_structured_output
+
+        await agent.self_compact_context()
+
+        self.assertEqual(structured_calls, 1)
+        self.assertEqual(agent.state.summary, "")
+        self.assertEqual(len(agent.state.context), 2)
+
+    async def test_self_compact_probe_interval(self) -> None:
+        """Self-compaction respects the configured probe interval."""
+        model = MockModel(context_size=200)
+        agent = Agent(
+            name="Friday",
+            system_prompt="".join(["0" for _ in range(20 * 4)]),
+            model=model,
+            context_config=ContextConfig(
+                trigger_ratio=0.8,
+                reserve_ratio=0.1,
+                self_compact_enabled=True,
+                self_compact_trigger_ratio=0.4,
+                self_compact_probe_interval=2,
+            ),
+            state=AgentState(
+                session_id="123",
+                cur_iter=1,
+                context=[
+                    UserMsg(
+                        "User",
+                        "".join(["1" for _ in range(30 * 4)]),
+                        id="1",
+                    ),
+                    UserMsg(
+                        "User",
+                        "".join(["2" for _ in range(30 * 4)]),
+                        id="2",
+                    ),
+                ],
+            ),
+            toolkit=Toolkit(),
+        )
+
+        structured_calls = 0
+
+        async def mock_structured_output(
+            messages: list[Msg],
+            structured_model: Any,
+            **kwargs: Any,
+        ) -> StructuredResponse:
+            nonlocal structured_calls
+            structured_calls += 1
+            return StructuredResponse(
+                content={
+                    "decision": "COMPRESS",
+                    "reason": "Would compact if probed.",
+                },
+            )
+
+        model.generate_structured_output = mock_structured_output
+
+        await agent.self_compact_context()
+
+        self.assertEqual(structured_calls, 0)
+        self.assertEqual(agent.state.summary, "")
+
+    async def test_self_compact_does_not_gate_threshold_compression(
+        self,
+    ) -> None:
+        """The hard trigger ratio should keep the original compression path."""
+        model = MockModel(context_size=200)
+        agent = Agent(
+            name="Friday",
+            system_prompt="".join(["0" for _ in range(20 * 4)]),
+            model=model,
+            context_config=ContextConfig(
+                trigger_ratio=0.8,
+                reserve_ratio=0.1,
+                self_compact_enabled=True,
+            ),
+            state=AgentState(
+                session_id="123",
+                cur_iter=1,
+                context=[
+                    UserMsg(
+                        "User",
+                        "".join(["1" for _ in range(50 * 4)]),
+                        id="1",
+                    ),
+                    UserMsg(
+                        "User",
+                        "".join(["2" for _ in range(50 * 4)]),
+                        id="2",
+                    ),
+                    UserMsg(
+                        "User",
+                        "".join(["3" for _ in range(50 * 4)]),
+                        id="3",
+                    ),
+                ],
+            ),
+            toolkit=Toolkit(),
+        )
+
+        structured_schemas = []
+
+        async def mock_structured_output(
+            messages: list[Msg],
+            structured_model: Any,
+            **kwargs: Any,
+        ) -> StructuredResponse:
+            structured_schemas.append(structured_model)
+            return StructuredResponse(
+                content={
+                    "task_overview": "1",
+                    "current_state": "2",
+                    "important_discoveries": "3",
+                    "next_steps": "4",
+                    "context_to_preserve": "5",
+                },
+            )
+
+        model.generate_structured_output = mock_structured_output
+
+        await agent.compress_context()
+
+        self.assertEqual(len(structured_schemas), 1)
+        self.assertIn("task_overview", structured_schemas[0]["properties"])
+        self.assertNotEqual(agent.state.summary, "")
+
+    async def test_self_compact_rubric_failure_skips_early_compression(
+        self,
+    ) -> None:
+        """Rubric failures should not interrupt below-threshold replies."""
+        model = MockModel(context_size=200)
+        agent = Agent(
+            name="Friday",
+            system_prompt="".join(["0" for _ in range(20 * 4)]),
+            model=model,
+            context_config=ContextConfig(
+                trigger_ratio=0.8,
+                reserve_ratio=0.1,
+                self_compact_enabled=True,
+                self_compact_trigger_ratio=0.4,
+            ),
+            state=AgentState(
+                session_id="123",
+                cur_iter=1,
+                context=[
+                    UserMsg(
+                        "User",
+                        "".join(["1" for _ in range(30 * 4)]),
+                        id="1",
+                    ),
+                    UserMsg(
+                        "User",
+                        "".join(["2" for _ in range(30 * 4)]),
+                        id="2",
+                    ),
+                ],
+            ),
+            toolkit=Toolkit(),
+        )
+
+        async def mock_structured_output(
+            messages: list[Msg],
+            structured_model: Any,
+            **kwargs: Any,
+        ) -> StructuredResponse:
+            raise RuntimeError("rubric unavailable")
+
+        model.generate_structured_output = mock_structured_output
+
+        await agent.self_compact_context()
+
+        self.assertEqual(agent.state.summary, "")
+        self.assertEqual(len(agent.state.context), 2)
+
+    async def test_self_compact_summary_failure_keeps_context(self) -> None:
+        """Optional early compression should fail open below the threshold."""
+        model = MockModel(context_size=200)
+        agent = Agent(
+            name="Friday",
+            system_prompt="".join(["0" for _ in range(20 * 4)]),
+            model=model,
+            context_config=ContextConfig(
+                trigger_ratio=0.8,
+                reserve_ratio=0.1,
+                self_compact_enabled=True,
+                self_compact_trigger_ratio=0.4,
+            ),
+            state=AgentState(
+                session_id="123",
+                cur_iter=1,
+                context=[
+                    UserMsg(
+                        "User",
+                        "".join(["1" for _ in range(30 * 4)]),
+                        id="1",
+                    ),
+                    UserMsg(
+                        "User",
+                        "".join(["2" for _ in range(30 * 4)]),
+                        id="2",
+                    ),
+                ],
+            ),
+            toolkit=Toolkit(),
+        )
+
+        structured_calls = 0
+
+        async def mock_structured_output(
+            messages: list[Msg],
+            structured_model: Any,
+            **kwargs: Any,
+        ) -> StructuredResponse:
+            nonlocal structured_calls
+            structured_calls += 1
+            if structured_calls == 1:
+                return StructuredResponse(
+                    content={
+                        "decision": "COMPRESS",
+                        "reason": "The old trajectory can be summarized.",
+                    },
+                )
+            raise RuntimeError("summary unavailable")
+
+        model.generate_structured_output = mock_structured_output
+
+        await agent.self_compact_context()
+
+        # One rubric call, then the existing compression implementation tries
+        # the summary call and its overflow fallback.
+        self.assertEqual(structured_calls, 3)
+        self.assertEqual(agent.state.summary, "")
+        self.assertEqual([_.id for _ in agent.state.context], ["1", "2"])
+
+    async def test_threshold_compression_still_runs_before_reasoning(
+        self,
+    ) -> None:
+        """The original threshold compression still runs before reasoning."""
+        model = MockModel(context_size=100, stream=False)
+        model.set_responses(
+            [
+                ChatResponse(
+                    content=[
+                        TextBlock(
+                            text="done",
+                        ),
+                    ],
+                    is_last=True,
+                    usage=None,
+                ),
+            ],
+        )
+        model.set_structured_response(
+            StructuredResponse(
+                content={
+                    "task_overview": "1",
+                    "current_state": "2",
+                    "important_discoveries": "3",
+                    "next_steps": "4",
+                    "context_to_preserve": "5",
+                },
+            ),
+        )
+        agent = Agent(
+            name="Friday",
+            system_prompt="".join(["0" for _ in range(20 * 4)]),
+            model=model,
+            context_config=ContextConfig(
+                trigger_ratio=0.8,
+                reserve_ratio=0.1,
+            ),
+            state=AgentState(
+                session_id="123",
+                context=[
+                    UserMsg(
+                        "User",
+                        "".join(["0" for _ in range(30 * 4)]),
+                    ),
+                    UserMsg(
+                        "User",
+                        "".join(["1" for _ in range(30 * 4)]),
+                    ),
+                ],
+            ),
+            toolkit=Toolkit(),
+        )
+
+        final_msg = await agent.reply(
+            UserMsg("User", "go"),
+        )
+
+        self.assertEqual(final_msg.get_text_content(), "done")
+        self.assertNotEqual(agent.state.summary, "")
+        self.assertEqual(agent.state.context[-1].get_text_content(), "done")
+
+    async def test_reply_runs_self_compaction_after_final_message(
+        self,
+    ) -> None:
+        """Optional self-compaction runs after the reply chain finishes."""
+        model = MockModel(context_size=200, stream=False)
+        model.set_responses(
+            [
+                ChatResponse(
+                    content=[
+                        TextBlock(
+                            text="".join(["2" for _ in range(50 * 4)]),
+                        ),
+                    ],
+                    is_last=True,
+                    usage=None,
+                ),
+            ],
+        )
+        structured_responses = [
+            StructuredResponse(
+                content={
+                    "decision": "COMPRESS",
+                    "reason": "The completed reply can be summarized.",
+                },
+            ),
+            StructuredResponse(
+                content={
+                    "task_overview": "1",
+                    "current_state": "2",
+                    "important_discoveries": "3",
+                    "next_steps": "4",
+                    "context_to_preserve": "5",
+                },
+            ),
+        ]
+        structured_schemas = []
+
+        async def mock_structured_output(
+            messages: list[Msg],
+            structured_model: Any,
+            **kwargs: Any,
+        ) -> StructuredResponse:
+            structured_schemas.append(structured_model)
+            return structured_responses.pop(0)
+
+        model.generate_structured_output = mock_structured_output
+        agent = Agent(
+            name="Friday",
+            system_prompt="".join(["0" for _ in range(20 * 4)]),
+            model=model,
+            context_config=ContextConfig(
+                trigger_ratio=0.8,
+                reserve_ratio=0.1,
+                self_compact_enabled=True,
+                self_compact_min_iters=0,
+            ),
+            toolkit=Toolkit(),
+        )
+
+        final_msg = await agent.reply(
+            UserMsg("User", "".join(["1" for _ in range(30 * 4)])),
+        )
+
+        self.assertEqual(final_msg.get_text_content(), "2" * 200)
+        self.assertEqual(len(structured_schemas), 2)
+        self.assertEqual(
+            structured_schemas[0]["properties"]["decision"]["enum"],
+            ["COMPRESS", "CONTINUE"],
+        )
+        self.assertNotEqual(agent.state.summary, "")
+
+    async def test_reply_does_not_run_threshold_compression_after_reply(
+        self,
+    ) -> None:
+        """Reply-end self-compaction must not force threshold compression."""
+        model = MockModel(context_size=200, stream=False)
+        model.set_responses(
+            [
+                ChatResponse(
+                    content=[
+                        TextBlock(
+                            text="".join(["2" for _ in range(150 * 4)]),
+                        ),
+                    ],
+                    is_last=True,
+                    usage=None,
+                ),
+            ],
+        )
+
+        structured_calls = 0
+
+        async def mock_structured_output(
+            messages: list[Msg],
+            structured_model: Any,
+            **kwargs: Any,
+        ) -> StructuredResponse:
+            nonlocal structured_calls
+            structured_calls += 1
+            raise AssertionError("threshold compression should wait")
+
+        model.generate_structured_output = mock_structured_output
+        agent = Agent(
+            name="Friday",
+            system_prompt="".join(["0" for _ in range(20 * 4)]),
+            model=model,
+            context_config=ContextConfig(
+                trigger_ratio=0.8,
+                reserve_ratio=0.1,
+                self_compact_enabled=True,
+                self_compact_min_iters=0,
+            ),
+            toolkit=Toolkit(),
+        )
+
+        final_msg = await agent.reply(
+            UserMsg("User", "".join(["1" for _ in range(30 * 4)])),
+        )
+
+        self.assertEqual(final_msg.get_text_content(), "2" * 600)
+        self.assertEqual(structured_calls, 0)
+        self.assertEqual(agent.state.summary, "")
 
     async def test_context_compression_clears_evicted_read_cache(self) -> None:
         """Read cache is cleared when its Read block is compressed out."""


### PR DESCRIPTION
- Import SELF_COMPACT_DECISION_SCHEMA from config module
- Add self_compact_context method to run optional rubric-gated compression
- Implement _should_self_compact method using SELFCOMPACT rubric logic
- Add _render_self_compact_rubric_prompt for context usage prompts
- Call self_compact_context after reply chain execution
- Add self_compact_enabled, trigger_ratio, probe_interval, min_iters
- Add self_compact_rubric_prompt field with default rubric template
- Update agent basic test to include self_compact_trigger_ratio check
- Add comprehensive tests for self-compaction behavior and failure cases
- Include ChatResponse import for compression tests
- Modify pylint disable flags in compression tests

## PR Title Format

Please ensure your PR title follows the Conventional Commits format:
- Format: `<type>(<scope>): <description>`
- Example: `feat(memory): add redis cache support`
- Allowed types: `feat`, `fix`, `docs`, `ci`, `refactor`, `test`, `chore`, `perf`, `style`, `build`, `revert`
- Description should start with a lowercase letter

## AgentScope Version

[The version of AgentScope you are working on, e.g. `import agentscope; print(agentscope.__version__)`]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review