### PR TITLE
fix: prevent duplicate credential registration in CredentialFactory

### DIFF
--- a/src/agentscope/credential/_factory.py
+++ b/src/agentscope/credential/_factory.py
@@ -65,6 +65,8 @@ class CredentialFactory:
         Args:
             credential_cls: The subclass to register.
         """
+        if credential_cls in cls._classes:
+            return
         cls._classes.append(credential_cls)
         cls._adapter = None  # invalidate so it's rebuilt on next use
 


### PR DESCRIPTION
## AgentScope Version

2.0.4dev

## Description

`register_credential` was appending the same class on every call without checking for duplicates. When the app is started with `uvicorn --reload`, module-level code in the entry script runs more than once while the `CredentialFactory._classes` list (a class-level singleton) persists across reloads — causing custom credentials to appear multiple times in the UI. Added an early-return guard so that registering the same class twice is a no-op.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review