### PR TITLE
fix(agent): preserve middleware kwargs across next handlers

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -299,7 +299,10 @@ class Agent:
                     }
 
                     async def next_handler(**kwargs: Any) -> None:
-                        await execute_chain(index + 1, **kwargs)
+                        await execute_chain(
+                            index + 1,
+                            **{**input_kwargs, **kwargs},
+                        )
 
                     await mw.on_compress_context(
                         agent=self,
@@ -553,7 +556,10 @@ class Agent:
                     async def next_handler(
                         **kwargs: Any,
                     ) -> AsyncGenerator[AgentEvent | Msg, None]:
-                        async for item in execute_chain(index + 1, **kwargs):
+                        async for item in execute_chain(
+                            index + 1,
+                            **{**input_kwargs, **kwargs},
+                        ):
                             yield item
 
                     async for item in mw.on_reply(
@@ -766,7 +772,10 @@ class Agent:
                     input_kwargs = {"tool_choice": tool_choice}
 
                     async def next_handler(**kwargs: Any) -> AsyncGenerator:
-                        async for item in execute_chain(index + 1, **kwargs):
+                        async for item in execute_chain(
+                            index + 1,
+                            **{**input_kwargs, **kwargs},
+                        ):
                             yield item
 
                     async for item in mw.on_reasoning(
@@ -1609,7 +1618,10 @@ class Agent:
                     input_kwargs = {"tool_call": tool_call}
 
                     async def next_handler(**kwargs: Any) -> AsyncGenerator:
-                        async for item in execute_chain(index + 1, **kwargs):
+                        async for item in execute_chain(
+                            index + 1,
+                            **{**input_kwargs, **kwargs},
+                        ):
                             yield item
 
                     async for item in mw.on_acting(
@@ -2145,7 +2157,7 @@ class Agent:
                                     # pylint: disable=cell-var-from-loop
                                     return await execute_chain(
                                         index + 1,
-                                        **kwargs,
+                                        **{**input_kwargs, **kwargs},
                                     )
 
                                 return await mw.on_model_call(

--- a/tests/middleware_test.py
+++ b/tests/middleware_test.py
@@ -561,6 +561,81 @@ class TestMiddleware(IsolatedAsyncioTestCase):
             user_messages[-1].get_text_content(),
         )
 
+    async def test_on_reply_keeps_outer_input_when_inner_omits_kwargs(
+        self,
+    ) -> None:
+        """Argumentless next_handler() keeps outer reply input changes."""
+
+        class ModifyInputMiddleware(MiddlewareBase):
+            """Middleware that replaces the reply input."""
+
+            async def on_reply(
+                self,
+                agent: Agent,
+                input_kwargs: dict,
+                next_handler: Callable[..., AsyncGenerator],
+            ) -> AsyncGenerator:
+                inputs = input_kwargs["inputs"]
+                modified = UserMsg(
+                    name=inputs.name,
+                    content="MODIFIED by outer middleware",
+                )
+                async for item in next_handler(inputs=modified):
+                    yield item
+
+        class TransparentMiddleware(MiddlewareBase):
+            """Middleware that calls next_handler() without passing kwargs."""
+
+            async def on_reply(
+                self,
+                agent: Agent,
+                input_kwargs: dict,
+                next_handler: Callable[..., AsyncGenerator],
+            ) -> AsyncGenerator:
+                assert (
+                    "MODIFIED by outer middleware"
+                    in input_kwargs["inputs"].get_text_content()
+                )
+                async for item in next_handler():
+                    yield item
+
+        received_messages = []
+
+        class TrackingModel(MockModel):
+            """Model that tracks received messages."""
+
+            async def _call_api(
+                self,
+                *args: Any,
+                **kwargs: Any,
+            ) -> ChatResponse:
+                received_messages.extend(kwargs.get("messages", []))
+                return await super()._call_api(*args, **kwargs)
+
+        tracking_model = TrackingModel()
+        tracking_model.set_responses(
+            [ChatResponse(content=[TextBlock(text="response")], is_last=True)],
+        )
+
+        agent_instance = Agent(
+            name="test_agent",
+            system_prompt="test prompt",
+            model=tracking_model,
+            toolkit=self.toolkit,
+            middlewares=[
+                ModifyInputMiddleware(),
+                TransparentMiddleware(),
+            ],
+        )
+
+        await agent_instance.reply(UserMsg("user", "original message"))
+
+        user_messages = [m for m in received_messages if m.role == "user"]
+        self.assertIn(
+            "MODIFIED by outer middleware",
+            user_messages[-1].get_text_content(),
+        )
+
     async def test_on_reasoning_middleware_modify_input(self) -> None:
         """Test that on_reasoning middleware can modify tool_choice input."""
 
@@ -814,6 +889,166 @@ class TestMiddleware(IsolatedAsyncioTestCase):
             any(
                 "INJECTED SYSTEM MESSAGE" in m.get_text_content()
                 for m in system_messages
+            ),
+        )
+
+    async def test_on_model_call_keeps_outer_messages_when_inner_omits_kwargs(
+        self,
+    ) -> None:
+        """Transparent inner model-call middleware keeps outer messages."""
+
+        class ModifyMessagesMiddleware(MiddlewareBase):
+            """Middleware that changes the messages."""
+
+            async def on_model_call(
+                self,
+                agent: Agent,
+                input_kwargs: dict,
+                next_handler: Callable[..., Any],
+            ) -> Union[ChatResponse, AsyncGenerator[ChatResponse, None]]:
+                modified_messages = [
+                    SystemMsg(
+                        name="system",
+                        content="INJECTED SYSTEM MESSAGE",
+                    ),
+                ] + input_kwargs["messages"]
+                return await next_handler(messages=modified_messages)
+
+        class TransparentMiddleware(MiddlewareBase):
+            """Middleware that calls next_handler() without passing kwargs."""
+
+            async def on_model_call(
+                self,
+                agent: Agent,
+                input_kwargs: dict,
+                next_handler: Callable[..., Any],
+            ) -> Union[ChatResponse, AsyncGenerator[ChatResponse, None]]:
+                system_messages = [
+                    m for m in input_kwargs["messages"] if m.role == "system"
+                ]
+                assert any(
+                    "INJECTED SYSTEM MESSAGE" in m.get_text_content()
+                    for m in system_messages
+                )
+                return await next_handler()
+
+        received_messages = []
+
+        class TrackingModel(MockModel):
+            """Model that tracks received messages."""
+
+            async def _call_api(
+                self,
+                *args: Any,
+                **kwargs: Any,
+            ) -> ChatResponse:
+                received_messages.extend(kwargs.get("messages", []))
+                return await super()._call_api(*args, **kwargs)
+
+        tracking_model = TrackingModel()
+        tracking_model.set_responses(
+            [ChatResponse(content=[TextBlock(text="response")], is_last=True)],
+        )
+
+        agent_instance = Agent(
+            name="test_agent",
+            system_prompt="test prompt",
+            model=tracking_model,
+            toolkit=self.toolkit,
+            middlewares=[
+                ModifyMessagesMiddleware(),
+                TransparentMiddleware(),
+            ],
+        )
+
+        await agent_instance.reply(UserMsg("user", "test message"))
+
+        system_messages = [m for m in received_messages if m.role == "system"]
+        self.assertTrue(
+            any(
+                "INJECTED SYSTEM MESSAGE" in m.get_text_content()
+                for m in system_messages
+            ),
+        )
+
+    async def test_on_model_call_keeps_outer_messages_with_partial_kwargs(
+        self,
+    ) -> None:
+        """Partial next_handler kwargs keep outer model-call changes."""
+        injected_text = "INJECTED SYSTEM MESSAGE FROM OUTER MIDDLEWARE"
+        inner_saw_injected_message = False
+
+        class ModifyMessagesMiddleware(MiddlewareBase):
+            """Middleware that changes the messages."""
+
+            async def on_model_call(
+                self,
+                agent: Agent,
+                input_kwargs: dict,
+                next_handler: Callable[..., Any],
+            ) -> Union[ChatResponse, AsyncGenerator[ChatResponse, None]]:
+                modified_messages = [
+                    SystemMsg(
+                        name="system",
+                        content=injected_text,
+                    ),
+                ] + input_kwargs["messages"]
+                return await next_handler(messages=modified_messages)
+
+        class PartialForwardMiddleware(MiddlewareBase):
+            """Middleware that forwards only one of the current kwargs."""
+
+            async def on_model_call(
+                self,
+                agent: Agent,
+                input_kwargs: dict,
+                next_handler: Callable[..., Any],
+            ) -> Union[ChatResponse, AsyncGenerator[ChatResponse, None]]:
+                nonlocal inner_saw_injected_message
+                inner_saw_injected_message = any(
+                    injected_text in m.get_text_content()
+                    for m in input_kwargs["messages"]
+                )
+                return await next_handler(
+                    tool_choice=input_kwargs["tool_choice"],
+                )
+
+        received_messages = []
+
+        class TrackingModel(MockModel):
+            """Model that tracks received messages."""
+
+            async def _call_api(
+                self,
+                *args: Any,
+                **kwargs: Any,
+            ) -> ChatResponse:
+                received_messages.extend(kwargs.get("messages", []))
+                return await super()._call_api(*args, **kwargs)
+
+        tracking_model = TrackingModel()
+        tracking_model.set_responses(
+            [ChatResponse(content=[TextBlock(text="response")], is_last=True)],
+        )
+
+        agent_instance = Agent(
+            name="test_agent",
+            system_prompt="test prompt",
+            model=tracking_model,
+            toolkit=self.toolkit,
+            middlewares=[
+                ModifyMessagesMiddleware(),
+                PartialForwardMiddleware(),
+            ],
+        )
+
+        await agent_instance.reply(UserMsg("user", "test message"))
+
+        self.assertTrue(inner_saw_injected_message)
+        self.assertTrue(
+            any(
+                injected_text in m.get_text_content()
+                for m in received_messages
             ),
         )
 


### PR DESCRIPTION
## AgentScope Version

2.0.4dev

## Description

Fixes #1965.

This PR fixes agent middleware kwargs propagation in onion-style middleware chains.

When an outer middleware modifies `input_kwargs` and calls `next_handler(**input_kwargs)`,
a later middleware may call `next_handler()` or forward only a subset of kwargs.
Previously, omitted kwargs fell back to the original arguments captured when the
middleware chain was created, silently discarding upstream middleware modifications.

### Background

Agent middleware chains are expected to preserve the current request state as it
flows through nested middleware. However, the previous recursive `execute_chain`
implementation only forwarded explicitly provided kwargs to the next layer.

As a result, if an inner middleware omitted a kwarg, that value could reset to the
original chain input instead of inheriting the value already modified by an outer
middleware.

### Changes

- Preserve the current middleware input kwargs when `next_handler()` is called
  without kwargs.
- Merge partial `next_handler(...)` kwargs with the current middleware input kwargs,
  so omitted fields keep upstream middleware modifications.
- Apply the fix to agent middleware hooks including reply, reasoning, acting,
  model-call, and context-compression flows.
- Add focused regression tests for omitted and partially forwarded kwargs.

### Tests

- `.venv/bin/pytest tests/middleware_test.py -k "keeps_outer"` — 3 passed, 14 deselected

### Backward Compatibility

Existing middleware that passes all kwargs explicitly remains compatible.

This changes only the behavior of omitted kwargs inside agent middleware chains:
they now inherit the current middleware state instead of resetting to the original
chain input.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation has been updated, or is not required for this focused bug fix
- [x] Code is ready for review