### PR TITLE
feat(agent-team): support template-scoped worker tools

### DIFF
--- a/src/agentscope/app/_service/_toolkit.py
+++ b/src/agentscope/app/_service/_toolkit.py
@@ -73,7 +73,8 @@ async def get_toolkit(
        that is its team's leader gets the full leader-side toolset
        (``TeamCreate / AgentCreate / TeamSay / TeamDelete``, plus
        ``AgentInvite`` when the user has at least one invitable agent).
-    6. Caller-supplied extras (``extra_factory``)
+    6. Template-scoped extras for matching created team workers
+    7. Caller-supplied extras (``extra_factory``)
 
     Plus the workspace's skills and MCPs, which become the toolkit's
     ``skills_or_loaders`` and ``mcps`` parameters.
@@ -229,6 +230,17 @@ time or interval"
                     **team_tool_kwargs,
                     invitable_pool=invitable_pool,
                 ),
+            )
+
+    if team_role == "worker" and agent_record.data.subagent_type:
+        template = (sub_agent_templates or {}).get(
+            agent_record.data.subagent_type,
+        )
+        if template is not None and template.extra_tools_factory is not None:
+            tools += await template.extra_tools_factory(
+                user_id,
+                agent_record.id,
+                session_record.id,
             )
 
     # Caller-supplied extras.

--- a/src/agentscope/app/_tool/_agent_create.py
+++ b/src/agentscope/app/_tool/_agent_create.py
@@ -463,6 +463,7 @@ optional):
                     react_config=template.react_config.model_copy(
                         deep=True,
                     ),
+                    subagent_type=template.type,
                 ),
             )
             await self._storage.upsert_agent(self._user_id, worker_agent)

--- a/src/agentscope/app/_types.py
+++ b/src/agentscope/app/_types.py
@@ -4,6 +4,7 @@ from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Protocol
 
 from pydantic import BaseModel, Field
+from pydantic.json_schema import SkipJsonSchema
 
 from ..agent import ContextConfig, ReActConfig
 from ..event import AgentEvent
@@ -94,8 +95,8 @@ class SubAgentTemplate(BaseModel):
     per-instance identifier the leader assigns to each worker (used for
     ``TeamSay(to=name)``).
 
-    All fields are pure data (no callables), so the template is fully
-    serializable for future config-driven startup.
+    ``extra_tools_factory`` is intentionally excluded from serialization;
+    all other fields are pure data for future config-driven startup.
     """
 
     type: str = Field(
@@ -185,5 +186,14 @@ class SubAgentTemplate(BaseModel):
         description=(
             "Pre-defined task context for the sub-agent, allowing "
             "the template to seed an initial workflow."
+        ),
+    )
+
+    extra_tools_factory: SkipJsonSchema[AgentToolFactory | None] = Field(
+        default=None,
+        exclude=True,
+        description=(
+            "Optional async factory for tools that should be attached "
+            "only to workers spawned from this template."
         ),
     )

--- a/src/agentscope/app/storage/_model/_agent.py
+++ b/src/agentscope/app/storage/_model/_agent.py
@@ -102,6 +102,15 @@ class AgentData(BaseModel):
         title="React Config",
     )
 
+    subagent_type: str | None = Field(
+        default=None,
+        description=(
+            "Template type used to spawn this team worker. ``None`` for "
+            "user-owned agents, invited agents, and legacy worker records."
+        ),
+        title="Sub-agent Type",
+    )
+
     invite_config: InviteConfig = Field(
         default_factory=InviteConfig,
         description="The invite config for the agent.",

--- a/tests/service_team_tools_test.py
+++ b/tests/service_team_tools_test.py
@@ -787,6 +787,7 @@ class TestAgentCreateTemplates(_TeamToolsTestBase):
             self.user_id,
             team.data.member_ids[0],
         )
+        self.assertEqual(worker_agent.data.subagent_type, "explorer")
         self.assertIn("an explorer in team", worker_agent.data.system_prompt)
         self.assertNotIn(
             "You communicate with the team leader",

--- a/tests/service_toolkit_test.py
+++ b/tests/service_toolkit_test.py
@@ -26,6 +26,7 @@ from agentscope.app._manager import (
     SchedulerManager,
 )
 from agentscope.app._service import ResourceAccessService, get_toolkit
+from agentscope.app._types import SubAgentTemplate
 from agentscope.app.access import DenyAllResourceAccessPolicy
 from agentscope.app.storage import (
     AgentData,
@@ -71,7 +72,12 @@ class _NullBus:
     nothing in :func:`get_toolkit` actually awaits it."""
 
 
-def _make_agent(*, source: str = "user", name: str = "A") -> AgentRecord:
+def _make_agent(
+    *,
+    source: str = "user",
+    name: str = "A",
+    subagent_type: str | None = None,
+) -> AgentRecord:
     """Build a minimal :class:`AgentRecord`."""
     return AgentRecord(
         user_id="u",
@@ -81,6 +87,7 @@ def _make_agent(*, source: str = "user", name: str = "A") -> AgentRecord:
             system_prompt=f"You are {name}.",
             context_config=ContextConfig(),
             react_config=ReActConfig(),
+            subagent_type=subagent_type,
         ),
     )
 
@@ -319,6 +326,141 @@ class TestGetToolkitWorkerVariant(IsolatedAsyncioTestCase):
             "AgentInvite",
         ):
             self.assertNotIn(missing, names)
+
+    async def test_worker_gets_matching_template_tools(self) -> None:
+        """A worker spawned from a template receives that template's
+        scoped extra tools."""
+
+        class _TemplateTool(_StubTool):
+            """Stub tool emitted by a sub-agent template."""
+
+            name: str = "template-tool"
+            description: str = "template scoped tool"
+
+        template_tool = _TemplateTool()
+
+        async def factory(
+            _user_id: str,
+            _agent_id: str,
+            _session_id: str,
+        ) -> list[ToolBase]:
+            """Return the template-scoped tool."""
+            return [template_tool]
+
+        agent = _make_agent(
+            source="team",
+            name="researcher-1",
+            subagent_type="researcher",
+        )
+        session = _make_session(
+            user_id="u",
+            agent_id=agent.id,
+            with_model=True,
+            team_id="t1",
+        )
+        team = TeamRecord(
+            user_id="u",
+            session_id="leader-sid",
+            data=TeamData(name="team", description="d"),
+        )
+        storage = _NoOpStorage(team_id_map={"t1": team})
+        toolkit = await get_toolkit(
+            storage=storage,  # type: ignore[arg-type]
+            workspace=_FakeWorkspace(),  # type: ignore[arg-type]
+            workspace_manager=FakeWorkspaceManager(),
+            scheduler_manager=SchedulerManager(
+                storage=_NoOpStorage(),  # type: ignore[arg-type]
+                message_bus=_NullBus(),  # type: ignore[arg-type]
+            ),
+            background_task_manager=BackgroundTaskManager(
+                message_bus=_NullBus(),  # type: ignore[arg-type]
+            ),
+            message_bus=_NullBus(),  # type: ignore[arg-type]
+            user_id="u",
+            agent_record=agent,
+            session_record=session,
+            extra_factory=None,
+            sub_agent_templates={
+                "researcher": SubAgentTemplate(
+                    type="researcher",
+                    description="Research worker.",
+                    system_prompt_template="Research.",
+                    extra_tools_factory=factory,
+                ),
+            },
+            middlewares=[],
+            resource_access_service=_make_access(storage),
+        )
+
+        names = set(_tool_names(toolkit))
+        self.assertIn("TeamSay", names)
+        self.assertIn("template-tool", names)
+
+    async def test_worker_without_matching_template_skips_template_tools(
+        self,
+    ) -> None:
+        """A worker does not receive tools from unrelated templates."""
+
+        class _TemplateTool(_StubTool):
+            """Stub tool emitted by a sub-agent template."""
+
+            name: str = "template-tool"
+            description: str = "template scoped tool"
+
+        async def factory(
+            _user_id: str,
+            _agent_id: str,
+            _session_id: str,
+        ) -> list[ToolBase]:
+            """Return the template-scoped tool."""
+            return [_TemplateTool()]
+
+        agent = _make_agent(
+            source="team",
+            name="coder-1",
+            subagent_type="coder",
+        )
+        session = _make_session(
+            user_id="u",
+            agent_id=agent.id,
+            with_model=True,
+            team_id="t1",
+        )
+        team = TeamRecord(
+            user_id="u",
+            session_id="leader-sid",
+            data=TeamData(name="team", description="d"),
+        )
+        storage = _NoOpStorage(team_id_map={"t1": team})
+        toolkit = await get_toolkit(
+            storage=storage,  # type: ignore[arg-type]
+            workspace=_FakeWorkspace(),  # type: ignore[arg-type]
+            workspace_manager=FakeWorkspaceManager(),
+            scheduler_manager=SchedulerManager(
+                storage=_NoOpStorage(),  # type: ignore[arg-type]
+                message_bus=_NullBus(),  # type: ignore[arg-type]
+            ),
+            background_task_manager=BackgroundTaskManager(
+                message_bus=_NullBus(),  # type: ignore[arg-type]
+            ),
+            message_bus=_NullBus(),  # type: ignore[arg-type]
+            user_id="u",
+            agent_record=agent,
+            session_record=session,
+            extra_factory=None,
+            sub_agent_templates={
+                "researcher": SubAgentTemplate(
+                    type="researcher",
+                    description="Research worker.",
+                    system_prompt_template="Research.",
+                    extra_tools_factory=factory,
+                ),
+            },
+            middlewares=[],
+            resource_access_service=_make_access(storage),
+        )
+
+        self.assertNotIn("template-tool", _tool_names(toolkit))
 
 
 class TestGetToolkitSchedulingGuard(IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary

Lets `SubAgentTemplate`-backed workers declare and receive their own
custom business tools, instead of being limited to the framework default
toolset. Issue #1947 reports that workers spawned from a template cannot
receive tools scoped to that template.

Changes:

- Persist `subagent_type` on `AgentData` so the service can recover which
  template, and therefore which tool factory, a worker belongs to.
- Add an optional, non-serializable `extra_tools_factory` to
  `SubAgentTemplate`.
- Recreate template-scoped tools when assembling a matching worker's
  toolkit, while preserving the existing defaults for legacy and invited
  workers.

Refs #1947.

## Tests

- A created worker persists its originating template type.
- A matching worker receives tools from its template factory.
- A worker without a matching template receives no unrelated tools.
- Existing team creation, invitation, routing, and toolkit tests remain
  green.

Local command for reviewer reproduction:

```bash
uv pip install -e ".[dev]"
pytest tests/service_team_tools_test.py tests/service_toolkit_test.py
```
