### PR TITLE
fix(tools): pin ripgrep to avoid rust bootstrap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,9 @@ workspace = [
 ]
 # ------------ Tools ------------
 tools = [
-    "ripgrep",
+    # 15.x can require a Rust bootstrap in restricted Linux
+    # environments, which breaks installation behind some mirrors.
+    "ripgrep==14.1.0",
 ]
 # ------------ RAG ------------
 rag = [


### PR DESCRIPTION
## Summary
- pin the optional tools extra to ripgrep==14.1.0
- avoid ripgrep 15.x source builds that try to bootstrap Rust in restricted Linux or mirrored package environments

## Verification
- UV_CACHE_DIR=/tmp/uv-cache uv venv /tmp/agentscope-ripgrep-test
- UV_CACHE_DIR=/tmp/uv-cache uv pip install --python /tmp/agentscope-ripgrep-test/bin/python -e ".[tools]"

Fixes #1759