### PR TITLE
feat(rag): add Valkey vector store for RAG pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,9 @@ milvuslite = [
     "pymilvus[milvus-lite]>=2.4.0",
     "milvus-lite>=3.0; sys_platform == 'win32'",
 ]
+valkey = [
+    "valkey-glide>=2.4.0,<3.0.0",
+]
 
 # ------------ S3-compatible blob store ------------
 s3 = [

--- a/src/agentscope/rag/__init__.py
+++ b/src/agentscope/rag/__init__.py
@@ -10,6 +10,7 @@ from ._parser import ImageParser, ParserBase, PDFParser, PPTParser, TextParser
 from ._vdb import (
     DocumentSummary,
     MilvusLiteStore,
+    ValkeyStore,
     VectorStoreBase,
     VectorRecord,
     VectorSearchResult,
@@ -29,6 +30,7 @@ __all__ = [
     "PPTParser",
     "TextParser",
     "Section",
+    "ValkeyStore",
     "VectorStoreBase",
     "VectorRecord",
     "VectorSearchResult",

--- a/src/agentscope/rag/_vdb/__init__.py
+++ b/src/agentscope/rag/_vdb/__init__.py
@@ -9,10 +9,12 @@ from ._vector_store import (
 )
 from ._milvus_lite import MilvusLiteStore
 from ._qdrant import QdrantStore
+from ._valkey import ValkeyStore
 
 __all__ = [
     "DocumentSummary",
     "MilvusLiteStore",
+    "ValkeyStore",
     "VectorStoreBase",
     "VectorRecord",
     "VectorSearchResult",

--- a/src/agentscope/rag/_vdb/_valkey.py
+++ b/src/agentscope/rag/_vdb/_valkey.py
@@ -1,0 +1,832 @@
+# -*- coding: utf-8 -*-
+"""Valkey implementation of the vector store backend.
+
+Built on the ``valkey-glide`` async client, using the Valkey Search module
+with HNSW indexing for vector similarity search.
+
+The same class supports both standalone and cluster deployments through
+the constructor arguments:
+
+- ``host="localhost", port=6379`` — single-node standalone
+- ``cluster_mode=True`` — Valkey cluster with auto-discovery
+
+.. note:: Requires a Valkey server compiled with the Search module
+    (``valkey-bundle`` or a custom build with ``valkeysearch``).
+
+.. note:: The ``valkey-glide`` package is required. Install it with
+    ``pip install "valkey-glide>=2.4.0,<3.0.0"``.
+"""
+
+import asyncio
+import json
+import uuid
+from typing import Any, Literal, Self
+
+from ._vector_store import (
+    DocumentSummary,
+    VectorRecord,
+    VectorSearchResult,
+    VectorStoreBase,
+)
+from .._document import Chunk
+
+# Valkey Search distance metric mapping
+_DISTANCE_METRICS: dict[str, str] = {
+    "COSINE": "COSINE",
+    "L2": "L2",
+    "IP": "IP",
+}
+
+# Default HNSW parameters
+_DEFAULT_HNSW_M = 16
+_DEFAULT_HNSW_EF_CONSTRUCTION = 200
+_DEFAULT_HNSW_EF_RUNTIME = 10
+
+
+class ValkeyStore(VectorStoreBase):
+    """Vector store backend backed by `Valkey <https://valkey.io>`_ Search.
+
+    Each knowledge base maps to one Valkey Search index (collection).
+    Every record is stored as a hash with fields for the vector,
+    document ID, and the serialized :class:`~agentscope.rag.Chunk`.
+
+    The index uses HNSW for approximate nearest-neighbor search with
+    configurable distance metrics (Cosine, L2, IP).
+
+    .. note:: The ``valkey-glide`` package is required. Install it
+        with ``pip install "valkey-glide>=2.4.0,<3.0.0"``.
+
+    .. code-block:: python
+
+        store = ValkeyStore(host="localhost", port=6379)
+
+        async with store:
+            await store.create_collection("kb-1", dimensions=768)
+
+    """
+
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 6379,
+        cluster_mode: bool = False,
+        use_tls: bool = False,
+        credentials: tuple[str, str] | None = None,
+        client_name: str = "agentscope_rag_store_client",
+        distance: Literal["COSINE", "L2", "IP"] = "COSINE",
+        hnsw_m: int = _DEFAULT_HNSW_M,
+        hnsw_ef_construction: int = _DEFAULT_HNSW_EF_CONSTRUCTION,
+        hnsw_ef_runtime: int = _DEFAULT_HNSW_EF_RUNTIME,
+        batch_size: int = 100,
+        prefix_separator: str = ":",
+    ) -> None:
+        """Initialize the Valkey vector store.
+
+        Args:
+            host (`str`, defaults to ``"localhost"``):
+                The Valkey server hostname.
+            port (`int`, defaults to ``6379``):
+                The Valkey server port.
+            cluster_mode (`bool`, defaults to ``False``):
+                Whether to connect in cluster mode.
+            use_tls (`bool`, defaults to ``False``):
+                Whether to use TLS for the connection.
+            credentials (`tuple[str, str] | None`, optional):
+                A ``(username, password)`` pair for authentication,
+                or ``None`` for unauthenticated connections.
+            client_name (`str`, defaults to \
+             ``"agentscope_rag_store_client"``):
+                The client name set via ``CLIENT SETNAME``, visible in
+                ``CLIENT LIST`` and monitoring tools.
+            distance (`Literal["COSINE", "L2", "IP"]`, defaults to \
+             ``"COSINE"``):
+                The distance metric used when creating indexes.
+            hnsw_m (`int`, defaults to ``16``):
+                HNSW ``M`` parameter — max outgoing edges per node.
+            hnsw_ef_construction (`int`, defaults to ``200``):
+                HNSW ``EF_CONSTRUCTION`` — size of the dynamic
+                candidate list during index construction.
+            hnsw_ef_runtime (`int`, defaults to ``10``):
+                HNSW ``EF_RUNTIME`` — size of the dynamic candidate
+                list during search.
+            batch_size (`int`, defaults to ``100``):
+                Batch size for paginated operations (delete, list).
+            prefix_separator (`str`, defaults to ``":"``):
+                Separator between the collection prefix and record ID
+                in hash keys.
+        """
+        self._host = host
+        self._port = port
+        self._cluster_mode = cluster_mode
+        self._use_tls = use_tls
+        self._credentials = credentials
+        self._client_name = client_name
+        self._distance = distance
+        self._hnsw_m = hnsw_m
+        self._hnsw_ef_construction = hnsw_ef_construction
+        self._hnsw_ef_runtime = hnsw_ef_runtime
+        self._batch_size = batch_size
+        self._prefix_separator = prefix_separator
+        self._client: Any = None
+        self._index_locks: dict[str, asyncio.Lock] = {}
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> Self:
+        """Enter the async context — open the Valkey connection."""
+        self._client = await self._create_client()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        """Exit the async context — close the underlying client."""
+        if self._client is not None:
+            await self._client.close()
+            self._client = None
+
+    def get_client(self) -> Any:
+        """Return the cached Valkey client, raising if not connected.
+
+        Returns:
+            The Valkey Glide client instance.
+
+        Raises:
+            RuntimeError: If called outside an async context manager.
+        """
+        if self._client is None:
+            raise RuntimeError(
+                "ValkeyStore must be used as an async context manager. "
+                "Use `async with ValkeyStore(...) as store:`",
+            )
+        return self._client
+
+    async def _create_client(self) -> Any:
+        """Create and return a new Valkey Glide client."""
+        from glide import (
+            GlideClient,
+            GlideClientConfiguration,
+            GlideClusterClient,
+            GlideClusterClientConfiguration,
+            NodeAddress,
+            ServerCredentials,
+        )
+
+        address = NodeAddress(self._host, self._port)
+        server_credentials = None
+        if self._credentials is not None:
+            server_credentials = ServerCredentials(
+                password=self._credentials[1],
+                username=self._credentials[0],
+            )
+
+        if self._cluster_mode:
+            config = GlideClusterClientConfiguration(
+                addresses=[address],
+                use_tls=self._use_tls,
+                credentials=server_credentials,
+                client_name=self._client_name,
+            )
+            return await GlideClusterClient.create(config)
+
+        config = GlideClientConfiguration(
+            addresses=[address],
+            use_tls=self._use_tls,
+            credentials=server_credentials,
+            client_name=self._client_name,
+        )
+        return await GlideClient.create(config)
+
+    # ------------------------------------------------------------------
+    # Collection management
+    # ------------------------------------------------------------------
+
+    async def create_collection(
+        self,
+        name: str,
+        dimensions: int,
+    ) -> None:
+        """Create a new Valkey Search index for a collection.
+
+        No-op if the index already exists. Uses double-check locking
+        to ensure concurrent calls don't race to create the same index.
+
+        Args:
+            name (`str`):
+                The collection name. Typically, the knowledge base ID.
+            dimensions (`int`):
+                The fixed vector dimensionality for this collection.
+        """
+        # Fast path: check without lock
+        if await self.has_collection(name):
+            return
+
+        lock = self._get_index_lock(name)
+        async with lock:
+            # Double-check under lock
+            if await self.has_collection(name):
+                return
+            await self._create_index(name, dimensions)
+
+    async def delete_collection(self, name: str) -> None:
+        """Delete a collection index and all its data.
+
+        First drops the Valkey Search index, then scans and deletes
+        all hash keys with the collection prefix.  The ``DD`` flag is
+        not used because not all Valkey Search versions support it.
+
+        Args:
+            name (`str`):
+                The collection name to delete.
+        """
+        from glide import RequestError
+
+        client = self.get_client()
+
+        # Drop the index (data hashes are preserved)
+        try:
+            await client.custom_command(["FT.DROPINDEX", name])
+        except RequestError:
+            # Index does not exist — continue to clean up hashes
+            pass
+
+        # Scan and delete all hashes with the collection prefix
+        prefix = self._key_prefix(name)
+        cursor = b"0"
+        while True:
+            result = await client.custom_command(
+                ["SCAN", cursor, "MATCH", f"{prefix}*", "COUNT", "100"],
+            )
+            cursor = result[0]
+            keys = result[1]
+            if keys:
+                for key in keys:
+                    await client.custom_command(["DEL", key])
+            if cursor == b"0" or cursor == "0":
+                break
+
+        self._index_locks.pop(name, None)
+
+    async def has_collection(self, name: str) -> bool:
+        """Check whether a collection index exists.
+
+        Args:
+            name (`str`):
+                The collection name to check.
+
+        Returns:
+            `bool`: ``True`` if the index exists.
+        """
+        from glide import RequestError
+
+        client = self.get_client()
+        try:
+            await client.custom_command(["FT.INFO", name])
+            return True
+        except RequestError:
+            return False
+
+    # ------------------------------------------------------------------
+    # Data operations
+    # ------------------------------------------------------------------
+
+    async def insert(
+        self,
+        collection: str,
+        records: list[VectorRecord],
+    ) -> None:
+        """Insert records into a collection.
+
+        Each record is stored as a Valkey hash with fields for the
+        vector embedding, document ID, serialized chunk, and metadata.
+        The hash key uses the format ``{collection}:{uuid}``.
+
+        Args:
+            collection (`str`):
+                The target collection name.
+            records (`list[VectorRecord]`):
+                The records to insert (each carrying a
+                :class:`Chunk` and its embedding vector).
+        """
+        if not records:
+            return
+
+        client = self.get_client()
+        prefix = self._key_prefix(collection)
+
+        for record in records:
+            key = f"{prefix}{uuid.uuid4().hex}"
+            chunk_json = json.dumps(
+                record.chunk.model_dump(mode="json"),
+                ensure_ascii=False,
+            )
+            metadata_json = json.dumps(
+                record.chunk.metadata,
+                ensure_ascii=False,
+            )
+            vector_bytes = self._encode_vector(record.vector)
+
+            await client.hset(
+                key,
+                {
+                    "vector": vector_bytes,
+                    "document_id": record.document_id,
+                    "chunk": chunk_json,
+                    "metadata": metadata_json,
+                    "source": record.chunk.source,
+                },
+            )
+
+    async def delete(
+        self,
+        collection: str,
+        document_id: str,
+    ) -> None:
+        """Delete all records belonging to one source document.
+
+        Uses a Valkey Search query filtered by ``document_id`` tag to
+        find matching keys, then deletes them in batches.
+
+        Args:
+            collection (`str`):
+                The target collection name.
+            document_id (`str`):
+                The source document ID whose records should be
+                removed.
+        """
+        client = self.get_client()
+        escaped_id = self._escape_tag_value(document_id)
+        query = f"@document_id:{{{escaped_id}}}"
+
+        while True:
+            result = await client.custom_command(
+                [
+                    "FT.SEARCH",
+                    collection,
+                    query,
+                    "NOCONTENT",
+                    "LIMIT",
+                    "0",
+                    str(self._batch_size),
+                ],
+            )
+            keys = self._parse_nocontent_keys(result)
+            if not keys:
+                break
+            for key in keys:
+                await client.custom_command(["DEL", key])
+            if len(keys) < self._batch_size:
+                break
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        collection: str,
+        query_vector: list[float],
+        top_k: int = 5,
+        metadata_filter: dict[str, Any] | None = None,
+    ) -> list[VectorSearchResult]:
+        """Find the most similar records to a query vector.
+
+        Uses Valkey Search KNN query with optional pre-filtering via
+        metadata tag fields.
+
+        Args:
+            collection (`str`):
+                The collection to search.
+            query_vector (`list[float]`):
+                The query embedding vector.
+            top_k (`int`, defaults to ``5``):
+                Maximum number of results to return.
+            metadata_filter (`dict[str, Any] | None`, optional):
+                If provided, restrict the search to records whose
+                indexed tag fields match every ``key == value`` pair.
+                Typically used with ``document_id`` for cross-tenant
+                scoping.
+
+        Returns:
+            `list[VectorSearchResult]`:
+                Results ordered by descending similarity score.
+        """
+        client = self.get_client()
+        vector_bytes = self._encode_vector(query_vector)
+
+        pre_filter = self._build_metadata_filter(metadata_filter)
+        query = f"{pre_filter}=>[KNN {top_k} @vector $BLOB]"
+
+        result = await client.custom_command(
+            [
+                "FT.SEARCH",
+                collection,
+                query,
+                "PARAMS",
+                "2",
+                "BLOB",
+                vector_bytes,
+                "RETURN",
+                "4",
+                "__vector_score",
+                "document_id",
+                "chunk",
+                "source",
+                "LIMIT",
+                "0",
+                str(top_k),
+                "DIALECT",
+                "2",
+            ],
+        )
+
+        return self._parse_search_results(result)
+
+    # ------------------------------------------------------------------
+    # Document listing
+    # ------------------------------------------------------------------
+
+    async def list_documents(
+        self,
+        collection: str,
+        metadata_filter: dict[str, Any] | None = None,
+    ) -> list[DocumentSummary]:
+        """List all distinct source documents indexed in a collection.
+
+        Scans hash keys with the collection prefix and aggregates by
+        ``document_id``. The first chunk encountered for each document
+        supplies the ``source`` filename and the document-level
+        ``metadata``.
+
+        When ``metadata_filter`` is provided, uses an FT.SEARCH query
+        with tag filters.  Otherwise, uses SCAN on the key prefix for
+        a full listing (since Valkey Search does not support ``*`` as
+        a match-all query).
+
+        Args:
+            collection (`str`):
+                The target collection name.
+            metadata_filter (`dict[str, Any] | None`, optional):
+                If provided, restrict aggregation to records whose
+                indexed tag fields match every ``key == value`` pair.
+
+        Returns:
+            `list[DocumentSummary]`:
+                One summary per distinct ``document_id``.
+        """
+        if metadata_filter:
+            return await self._list_documents_filtered(
+                collection,
+                metadata_filter,
+            )
+        return await self._list_documents_scan(collection)
+
+    async def _list_documents_scan(
+        self,
+        collection: str,
+    ) -> list[DocumentSummary]:
+        """List documents by scanning all hash keys with the prefix."""
+        client = self.get_client()
+        prefix = self._key_prefix(collection)
+        summaries: dict[str, DocumentSummary] = {}
+
+        cursor = b"0"
+        while True:
+            result = await client.custom_command(
+                [
+                    "SCAN",
+                    cursor,
+                    "MATCH",
+                    f"{prefix}*",
+                    "COUNT",
+                    str(self._batch_size),
+                ],
+            )
+            cursor = result[0]
+            keys = result[1]
+
+            for key in keys:
+                fields = await client.hgetall(key)
+                if not fields:
+                    continue
+                doc_id = self._decode_field(fields.get(b"document_id", b""))
+                summary = summaries.get(doc_id)
+                if summary is None:
+                    chunk_raw = self._decode_field(
+                        fields.get(b"chunk", b"{}"),
+                    )
+                    chunk_payload = json.loads(chunk_raw)
+                    source = self._decode_field(
+                        fields.get(b"source", b""),
+                    )
+                    summaries[doc_id] = DocumentSummary(
+                        document_id=doc_id,
+                        source=source,
+                        chunk_count=1,
+                        metadata=dict(chunk_payload.get("metadata", {})),
+                    )
+                else:
+                    summary.chunk_count += 1
+
+            if cursor == b"0" or cursor == "0":
+                break
+
+        return list(summaries.values())
+
+    async def _list_documents_filtered(
+        self,
+        collection: str,
+        metadata_filter: dict[str, Any],
+    ) -> list[DocumentSummary]:
+        """List documents using an FT.SEARCH tag filter."""
+        client = self.get_client()
+        pre_filter = self._build_metadata_filter(metadata_filter)
+        summaries: dict[str, DocumentSummary] = {}
+        offset = 0
+
+        while True:
+            result = await client.custom_command(
+                [
+                    "FT.SEARCH",
+                    collection,
+                    pre_filter,
+                    "RETURN",
+                    "3",
+                    "document_id",
+                    "chunk",
+                    "source",
+                    "LIMIT",
+                    str(offset),
+                    str(self._batch_size),
+                ],
+            )
+            records = self._parse_dict_results(result)
+            if not records:
+                break
+            for record in records:
+                doc_id = record.get("document_id", "")
+                summary = summaries.get(doc_id)
+                if summary is None:
+                    chunk_payload = json.loads(
+                        record.get("chunk", "{}"),
+                    )
+                    summaries[doc_id] = DocumentSummary(
+                        document_id=doc_id,
+                        source=record.get("source", ""),
+                        chunk_count=1,
+                        metadata=dict(chunk_payload.get("metadata", {})),
+                    )
+                else:
+                    summary.chunk_count += 1
+            if len(records) < self._batch_size:
+                break
+            offset += self._batch_size
+
+        return list(summaries.values())
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _key_prefix(self, collection: str) -> str:
+        """Return the hash key prefix for a collection."""
+        return f"{collection}{self._prefix_separator}"
+
+    def _get_index_lock(self, name: str) -> asyncio.Lock:
+        """Get or create an asyncio lock for index creation."""
+        if name not in self._index_locks:
+            self._index_locks[name] = asyncio.Lock()
+        return self._index_locks[name]
+
+    async def _create_index(self, name: str, dimensions: int) -> None:
+        """Create a Valkey Search index with HNSW vector indexing.
+
+        Only the ``vector``, ``document_id``, and ``source`` fields are
+        declared in the schema.  The ``chunk`` and ``metadata`` fields
+        are stored in each hash but intentionally left out of the index
+        — they are retrieved via ``RETURN`` in FT.SEARCH queries
+        without needing to be indexed.
+        """
+        client = self.get_client()
+        prefix = self._key_prefix(name)
+
+        await client.custom_command(
+            [
+                "FT.CREATE",
+                name,
+                "ON",
+                "HASH",
+                "PREFIX",
+                "1",
+                prefix,
+                "SCHEMA",
+                "vector",
+                "VECTOR",
+                "HNSW",
+                "10",
+                "TYPE",
+                "FLOAT32",
+                "DIM",
+                str(dimensions),
+                "DISTANCE_METRIC",
+                _DISTANCE_METRICS[self._distance],
+                "M",
+                str(self._hnsw_m),
+                "EF_CONSTRUCTION",
+                str(self._hnsw_ef_construction),
+                "document_id",
+                "TAG",
+                "SEPARATOR",
+                "|",
+                "source",
+                "TAG",
+                "SEPARATOR",
+                "|",
+            ],
+        )
+
+    @staticmethod
+    def _encode_vector(vector: list[float]) -> bytes:
+        """Encode a float vector to little-endian bytes for Valkey."""
+        import struct
+
+        return struct.pack(f"<{len(vector)}f", *vector)
+
+    @staticmethod
+    def _escape_tag_value(value: str) -> str:
+        """Escape special characters in a Valkey Search tag value.
+
+        Tag queries require certain characters to be escaped with a
+        backslash.
+        """
+        special_chars = r",.<>{}[]\"':;!@#$%^&*()-+=~/ "
+        escaped = []
+        for char in value:
+            if char in special_chars:
+                escaped.append(f"\\{char}")
+            else:
+                escaped.append(char)
+        return "".join(escaped)
+
+    @staticmethod
+    def _build_metadata_filter(
+        metadata_filter: dict[str, Any] | None,
+    ) -> str:
+        """Build a Valkey Search pre-filter from metadata key-value pairs.
+
+        Supports filtering on indexed TAG fields (``document_id``,
+        ``source``).  Returns ``*`` (match all) when no filter is
+        provided.
+
+        Args:
+            metadata_filter (`dict[str, Any] | None`):
+                The flat filter, or ``None`` for no filter.
+
+        Returns:
+            `str`: A Valkey Search query expression.
+        """
+        if not metadata_filter:
+            return "*"
+
+        conditions = []
+        for key, value in metadata_filter.items():
+            escaped_value = ValkeyStore._escape_tag_value(str(value))
+            conditions.append(f"@{key}:{{{escaped_value}}}")
+
+        return " ".join(conditions) if conditions else "*"
+
+    @staticmethod
+    def _parse_nocontent_keys(result: Any) -> list[str]:
+        """Extract key names from an FT.SEARCH NOCONTENT result.
+
+        Valkey Search returns NOCONTENT results as:
+        ``[total_count, {key1: {}, key2: {}, ...}]``
+        or ``[total_count, key1, key2, ...]`` depending on version.
+        """
+        if result is None:
+            return []
+
+        if isinstance(result, list) and len(result) >= 1:
+            total = result[0]
+            if isinstance(total, bytes):
+                total = int(total)
+            if total == 0:
+                return []
+
+            if len(result) >= 2 and isinstance(result[1], dict):
+                # Dict-style response: [count, {key: {}, ...}]
+                return [
+                    k.decode("utf-8") if isinstance(k, bytes) else k
+                    for k in result[1].keys()
+                ]
+            # Legacy list-style: [count, key1, key2, ...]
+            keys = []
+            for item in result[1:]:
+                if isinstance(item, bytes):
+                    keys.append(item.decode("utf-8"))
+                elif isinstance(item, str):
+                    keys.append(item)
+            return keys
+
+        return []
+
+    @staticmethod
+    def _parse_dict_results(result: Any) -> list[dict[str, str]]:
+        """Parse FT.SEARCH result in Valkey dict format.
+
+        Valkey Search returns results as:
+        ``[total, {key1: {field1: val1, ...}, key2: {...}}]``
+
+        Returns a list of field dicts (one per result), with all
+        keys and values decoded to str.
+        """
+        if result is None:
+            return []
+
+        if not isinstance(result, list) or len(result) < 2:
+            return []
+
+        total = result[0]
+        if isinstance(total, bytes):
+            total = int(total)
+        if total == 0:
+            return []
+
+        data = result[1]
+        if not isinstance(data, dict):
+            return []
+
+        records = []
+        for _key, fields in data.items():
+            if not isinstance(fields, dict):
+                continue
+            record: dict[str, str] = {}
+            for field_name, field_value in fields.items():
+                name = (
+                    field_name.decode("utf-8")
+                    if isinstance(field_name, bytes)
+                    else field_name
+                )
+                value = (
+                    field_value.decode("utf-8")
+                    if isinstance(field_value, bytes)
+                    else str(field_value)
+                )
+                record[name] = value
+            records.append(record)
+        return records
+
+    def _parse_search_results(
+        self,
+        result: Any,
+    ) -> list[VectorSearchResult]:
+        """Parse FT.SEARCH KNN results into VectorSearchResult objects.
+
+        Valkey Search returns KNN results sorted by ascending distance
+        with a ``__vector_score`` field.  We convert to a similarity
+        score (higher = more similar).
+        """
+        records = self._parse_dict_results(result)
+        results = []
+        for record in records:
+            raw_score = float(record.get("__vector_score", "0"))
+            score = self._to_similarity_score(raw_score)
+            chunk_json = record.get("chunk", "{}")
+            chunk = Chunk.model_validate(json.loads(chunk_json))
+            results.append(
+                VectorSearchResult(
+                    score=score,
+                    document_id=record.get("document_id", ""),
+                    chunk=chunk,
+                ),
+            )
+        return results
+
+    @staticmethod
+    def _decode_field(value: Any) -> str:
+        """Decode a bytes or str field value to str."""
+        if isinstance(value, bytes):
+            return value.decode("utf-8")
+        return str(value) if value is not None else ""
+
+    def _to_similarity_score(self, distance: float) -> float:
+        """Convert a Valkey Search distance to a similarity score.
+
+        For COSINE: Valkey returns ``1 - cosine_similarity``, so
+            similarity = ``1 - distance``.
+        For IP (inner product): Valkey returns ``1 - IP``, so
+            similarity = ``1 - distance``.
+        For L2: Valkey returns the squared L2 distance directly;
+            lower distance = more similar. We return the negative
+            so that higher = more similar, consistent with the
+            interface contract.
+        """
+        if self._distance in ("COSINE", "IP"):
+            return 1.0 - distance
+        # L2: return negative distance so higher = more similar
+        return -distance

--- a/tests/rag_vdb_valkey_test.py
+++ b/tests/rag_vdb_valkey_test.py
@@ -1,0 +1,445 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the ValkeyStore class.
+
+These tests mock the Valkey Glide client so no running Valkey server is
+required. They verify that ValkeyStore correctly translates the
+VectorStoreBase interface into the expected Valkey Search commands.
+"""
+
+import json
+import struct
+from contextlib import AsyncExitStack
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+from agentscope.message import TextBlock
+from agentscope.rag import (
+    Chunk,
+    ValkeyStore,
+    VectorRecord,
+)
+
+
+def _make_record(
+    text: str,
+    vector: list[float],
+    document_id: str,
+    chunk_index: int = 0,
+    total_chunks: int = 1,
+    metadata: dict | None = None,
+) -> VectorRecord:
+    """Build a VectorRecord for testing.
+
+    Args:
+        text (`str`):
+            The chunk text content.
+        vector (`list[float]`):
+            The embedding vector.
+        document_id (`str`):
+            The ID of the source document the record belongs to.
+        chunk_index (`int`, defaults to ``0``):
+            The chunk index within the document.
+        total_chunks (`int`, defaults to ``1``):
+            The total number of chunks in the document.
+        metadata (`dict | None`, optional):
+            Additional metadata for the chunk.
+
+    Returns:
+        `VectorRecord`:
+            The constructed record.
+    """
+    return VectorRecord(
+        vector=vector,
+        document_id=document_id,
+        chunk=Chunk(
+            content=TextBlock(text=text),
+            source=f"{document_id}.txt",
+            chunk_index=chunk_index,
+            total_chunks=total_chunks,
+            metadata=metadata or {},
+        ),
+    )
+
+
+def _encode_vector(vector: list[float]) -> bytes:
+    """Encode a float vector to little-endian bytes."""
+    return struct.pack(f"<{len(vector)}f", *vector)
+
+
+class ValkeyStoreTest(IsolatedAsyncioTestCase):
+    """The test cases for the ValkeyStore class."""
+
+    async def asyncSetUp(self) -> None:
+        """Create a ValkeyStore with a mocked client before each test."""
+        self._exit_stack = AsyncExitStack()
+        self.mock_client = AsyncMock()
+
+        # Patch the client creation to return our mock
+        patcher = patch(
+            "agentscope.rag._vdb._valkey.ValkeyStore._create_client",
+            return_value=self.mock_client,
+        )
+        self._exit_stack.enter_context(patcher)
+
+        self.store = await self._exit_stack.enter_async_context(
+            ValkeyStore(host="localhost", port=6379),
+        )
+
+    async def asyncTearDown(self) -> None:
+        """Close the store after each test."""
+        await self._exit_stack.aclose()
+
+    async def test_create_collection_new_index(self) -> None:
+        """create_collection calls FT.CREATE when index does not exist."""
+        from glide import RequestError
+
+        # FT.INFO raises RequestError (index doesn't exist) twice
+        # (fast path + double-check under lock), then FT.CREATE succeeds
+        self.mock_client.custom_command = AsyncMock(
+            side_effect=[
+                RequestError("Unknown index name"),  # has_collection (fast)
+                RequestError("Unknown index name"),  # has_collection (lock)
+                b"OK",  # FT.CREATE
+            ],
+        )
+
+        await self.store.create_collection("kb-1", dimensions=3)
+
+        calls = self.mock_client.custom_command.call_args_list
+        self.assertEqual(calls[0][0][0][0], "FT.INFO")
+        self.assertEqual(calls[1][0][0][0], "FT.INFO")
+        self.assertEqual(calls[2][0][0][0], "FT.CREATE")
+
+        # Verify FT.CREATE has correct index name and dimensions
+        create_args = calls[2][0][0]
+        self.assertEqual(create_args[1], "kb-1")
+        self.assertIn("3", create_args)  # DIM value
+
+    async def test_create_collection_already_exists(self) -> None:
+        """create_collection is a no-op when index already exists."""
+        # FT.INFO succeeds — index exists
+        self.mock_client.custom_command = AsyncMock(
+            return_value=[b"index_name", b"kb-1"],
+        )
+
+        await self.store.create_collection("kb-1", dimensions=3)
+
+        # Only FT.INFO should be called (no FT.CREATE)
+        calls = self.mock_client.custom_command.call_args_list
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][0][0][0], "FT.INFO")
+
+    async def test_delete_collection(self) -> None:
+        """delete_collection drops the index and scans/deletes keys."""
+        # FT.DROPINDEX succeeds, then SCAN returns empty
+        self.mock_client.custom_command = AsyncMock(
+            side_effect=[
+                b"OK",  # FT.DROPINDEX
+                [b"0", []],  # SCAN returns no keys (cursor 0 = done)
+            ],
+        )
+
+        await self.store.delete_collection("kb-1")
+
+        calls = self.mock_client.custom_command.call_args_list
+        self.assertEqual(calls[0][0][0], ["FT.DROPINDEX", "kb-1"])
+        self.assertEqual(calls[1][0][0][0], "SCAN")
+
+    async def test_delete_collection_not_exists(self) -> None:
+        """delete_collection is a no-op when index doesn't exist."""
+        from glide import RequestError
+
+        self.mock_client.custom_command = AsyncMock(
+            side_effect=[
+                RequestError("Unknown index name"),  # FT.DROPINDEX fails
+                [b"0", []],  # SCAN returns no keys
+            ],
+        )
+
+        # Should not raise
+        await self.store.delete_collection("kb-1")
+
+    async def test_has_collection_true(self) -> None:
+        """has_collection returns True when FT.INFO succeeds."""
+        self.mock_client.custom_command = AsyncMock(
+            return_value=[b"index_name", b"kb-1"],
+        )
+
+        result = await self.store.has_collection("kb-1")
+        self.assertTrue(result)
+
+    async def test_has_collection_false(self) -> None:
+        """has_collection returns False when FT.INFO raises."""
+        from glide import RequestError
+
+        self.mock_client.custom_command = AsyncMock(
+            side_effect=RequestError("Unknown index name"),
+        )
+
+        result = await self.store.has_collection("kb-1")
+        self.assertFalse(result)
+
+    async def test_insert_stores_hash(self) -> None:
+        """insert calls hset with correct field structure."""
+        self.mock_client.hset = AsyncMock(return_value=5)
+
+        record = _make_record(
+            "Hello world!",
+            [1.0, 0.0, 0.0],
+            document_id="doc-1",
+        )
+        await self.store.insert("kb-1", [record])
+
+        self.mock_client.hset.assert_called_once()
+        call_args = self.mock_client.hset.call_args
+
+        # Key should start with collection prefix
+        key = call_args[0][0]
+        self.assertTrue(key.startswith("kb-1:"))
+
+        # Fields should contain expected data
+        fields = call_args[0][1]
+        self.assertEqual(fields["document_id"], "doc-1")
+        self.assertEqual(fields["source"], "doc-1.txt")
+        self.assertEqual(fields["vector"], _encode_vector([1.0, 0.0, 0.0]))
+
+        # Chunk should be valid JSON
+        chunk_data = json.loads(fields["chunk"])
+        self.assertEqual(chunk_data["content"]["text"], "Hello world!")
+        self.assertEqual(chunk_data["source"], "doc-1.txt")
+        self.assertEqual(chunk_data["chunk_index"], 0)
+
+    async def test_insert_empty_records(self) -> None:
+        """Inserting an empty record list is a no-op."""
+        await self.store.insert("kb-1", [])
+        self.mock_client.hset.assert_not_called()
+
+    async def test_delete_by_document_id(self) -> None:
+        """delete finds and removes all records for a document."""
+        # Mock FT.SEARCH NOCONTENT returning two keys (dict format),
+        # then DEL calls, then empty search
+        self.mock_client.custom_command = AsyncMock(
+            side_effect=[
+                # First search returns 2 results (NOCONTENT dict format)
+                [2, {b"kb-1:abc123": {}, b"kb-1:def456": {}}],
+                # DEL calls
+                1,
+                1,
+                # Second search returns 0 (no more)
+                [0, {}],
+            ],
+        )
+
+        await self.store.delete("kb-1", document_id="doc-1")
+
+        calls = self.mock_client.custom_command.call_args_list
+        # First call: FT.SEARCH with document_id filter
+        self.assertEqual(calls[0][0][0][0], "FT.SEARCH")
+        self.assertIn("@document_id", calls[0][0][0][2])
+        # DEL calls
+        self.assertEqual(calls[1][0][0], ["DEL", "kb-1:abc123"])
+        self.assertEqual(calls[2][0][0], ["DEL", "kb-1:def456"])
+
+    async def test_search_returns_results(self) -> None:
+        """search returns correctly parsed VectorSearchResult objects."""
+        chunk1 = json.dumps(
+            {
+                "content": {"type": "text", "text": "Hello world!", "id": "x"},
+                "source": "doc-1.txt",
+                "chunk_index": 0,
+                "total_chunks": 1,
+                "metadata": {},
+            },
+        )
+        chunk2 = json.dumps(
+            {
+                "content": {"type": "text", "text": "Goodbye!", "id": "y"},
+                "source": "doc-2.txt",
+                "chunk_index": 0,
+                "total_chunks": 1,
+                "metadata": {},
+            },
+        )
+
+        # Valkey dict-format response with __vector_score
+        search_response = [
+            2,
+            {
+                b"kb-1:abc": {
+                    b"__vector_score": b"0.0",
+                    b"document_id": b"doc-1",
+                    b"chunk": chunk1.encode(),
+                    b"source": b"doc-1.txt",
+                },
+                b"kb-1:def": {
+                    b"__vector_score": b"0.5",
+                    b"document_id": b"doc-2",
+                    b"chunk": chunk2.encode(),
+                    b"source": b"doc-2.txt",
+                },
+            },
+        ]
+
+        self.mock_client.custom_command = AsyncMock(
+            return_value=search_response,
+        )
+
+        results = await self.store.search(
+            "kb-1",
+            query_vector=[1.0, 0.0, 0.0],
+            top_k=2,
+        )
+
+        self.assertEqual(len(results), 2)
+        # First result: score 0.0 distance → 1.0 similarity (COSINE)
+        self.assertAlmostEqual(results[0].score, 1.0)
+        self.assertEqual(results[0].document_id, "doc-1")
+        self.assertEqual(results[0].chunk.content.text, "Hello world!")
+        # Second result: score 0.5 distance → 0.5 similarity
+        self.assertAlmostEqual(results[1].score, 0.5)
+        self.assertEqual(results[1].document_id, "doc-2")
+
+    async def test_search_with_metadata_filter(self) -> None:
+        """search passes metadata filter as a pre-filter expression."""
+        self.mock_client.custom_command = AsyncMock(
+            return_value=[0, {}],
+        )
+
+        await self.store.search(
+            "kb-1",
+            query_vector=[1.0, 0.0, 0.0],
+            top_k=5,
+            metadata_filter={"document_id": "doc-1"},
+        )
+
+        call_args = self.mock_client.custom_command.call_args[0][0]
+        # The query should contain the pre-filter
+        query = call_args[2]
+        self.assertIn("@document_id", query)
+        self.assertIn("doc\\-1", query)
+
+    async def test_search_empty_collection(self) -> None:
+        """search on empty collection returns empty list."""
+        self.mock_client.custom_command = AsyncMock(
+            return_value=[0, {}],
+        )
+
+        results = await self.store.search(
+            "kb-1",
+            query_vector=[1.0, 0.0, 0.0],
+            top_k=5,
+        )
+
+        self.assertEqual(results, [])
+
+    async def test_list_documents(self) -> None:
+        """list_documents aggregates records by document_id."""
+        chunk1 = json.dumps(
+            {
+                "content": {"type": "text", "text": "A", "id": "a"},
+                "source": "alpha.txt",
+                "chunk_index": 0,
+                "total_chunks": 2,
+                "metadata": {"media_type": "text/plain"},
+            },
+        )
+        chunk2 = json.dumps(
+            {
+                "content": {"type": "text", "text": "B", "id": "b"},
+                "source": "alpha.txt",
+                "chunk_index": 1,
+                "total_chunks": 2,
+                "metadata": {"media_type": "text/plain"},
+            },
+        )
+        chunk3 = json.dumps(
+            {
+                "content": {"type": "text", "text": "C", "id": "c"},
+                "source": "beta.md",
+                "chunk_index": 0,
+                "total_chunks": 1,
+                "metadata": {"media_type": "text/markdown"},
+            },
+        )
+
+        # SCAN returns 3 keys, then cursor 0 (done)
+        self.mock_client.custom_command = AsyncMock(
+            return_value=[b"0", [b"kb-1:a", b"kb-1:b", b"kb-1:c"]],
+        )
+
+        # hgetall returns field dicts for each key
+        self.mock_client.hgetall = AsyncMock(
+            side_effect=[
+                {
+                    b"document_id": b"doc-1",
+                    b"chunk": chunk1.encode(),
+                    b"source": b"alpha.txt",
+                },
+                {
+                    b"document_id": b"doc-1",
+                    b"chunk": chunk2.encode(),
+                    b"source": b"alpha.txt",
+                },
+                {
+                    b"document_id": b"doc-2",
+                    b"chunk": chunk3.encode(),
+                    b"source": b"beta.md",
+                },
+            ],
+        )
+
+        summaries = await self.store.list_documents("kb-1")
+        summaries_by_id = {s.document_id: s for s in summaries}
+
+        self.assertEqual(set(summaries_by_id), {"doc-1", "doc-2"})
+        self.assertEqual(summaries_by_id["doc-1"].chunk_count, 2)
+        self.assertEqual(summaries_by_id["doc-1"].source, "alpha.txt")
+        self.assertEqual(
+            summaries_by_id["doc-1"].metadata,
+            {"media_type": "text/plain"},
+        )
+        self.assertEqual(summaries_by_id["doc-2"].chunk_count, 1)
+        self.assertEqual(summaries_by_id["doc-2"].source, "beta.md")
+
+    async def test_context_manager_closes_client(self) -> None:
+        """Exiting the context manager closes the client."""
+        # The mock_client.close should be called on __aexit__
+        self.mock_client.close = AsyncMock()
+
+        await self.store.__aexit__(None, None, None)
+
+        self.mock_client.close.assert_called_once()
+
+    async def test_get_client_raises_outside_context(self) -> None:
+        """get_client raises RuntimeError when not in context."""
+        store = ValkeyStore(host="localhost", port=6379)
+
+        with self.assertRaises(RuntimeError):
+            store.get_client()
+
+    async def test_score_conversion_l2(self) -> None:
+        """L2 metric converts distance to negative for similarity."""
+        store = ValkeyStore(host="localhost", port=6379, distance="L2")
+        score = store._to_similarity_score(4.0)
+        self.assertAlmostEqual(score, -4.0)
+
+    async def test_score_conversion_cosine(self) -> None:
+        """COSINE metric converts distance to 1-distance."""
+        score = self.store._to_similarity_score(0.25)
+        self.assertAlmostEqual(score, 0.75)
+
+    async def test_escape_tag_value(self) -> None:
+        """Tag values with special characters are properly escaped."""
+        escaped = ValkeyStore._escape_tag_value("doc-1/file.txt")
+        self.assertEqual(escaped, r"doc\-1\/file\.txt")
+
+    async def test_encode_vector(self) -> None:
+        """Vectors are encoded as little-endian float32 bytes."""
+        vector = [1.0, 0.0, -1.0]
+        encoded = ValkeyStore._encode_vector(vector)
+        self.assertEqual(len(encoded), 12)  # 3 floats × 4 bytes
+        # Decode and verify
+        decoded = struct.unpack("<3f", encoded)
+        self.assertAlmostEqual(decoded[0], 1.0)
+        self.assertAlmostEqual(decoded[1], 0.0)
+        self.assertAlmostEqual(decoded[2], -1.0)

--- a/tests/valkey_store_integration_test.py
+++ b/tests/valkey_store_integration_test.py
@@ -1,0 +1,290 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for the ValkeyStore class.
+
+These tests require a running Valkey server with the Search module
+on localhost:6379. They are gated behind the environment variable
+``VALKEY_INTEGRATION_TEST=true``.
+
+Run with:
+    VALKEY_INTEGRATION_TEST=true uv run python -m pytest \
+        tests/valkey_store_integration_test.py -xvs
+"""
+
+import os
+import unittest
+from contextlib import AsyncExitStack
+from unittest.async_case import IsolatedAsyncioTestCase
+
+from agentscope.message import TextBlock
+from agentscope.rag import (
+    Chunk,
+    ValkeyStore,
+    VectorRecord,
+)
+
+SKIP_REASON = (
+    "Valkey integration tests require VALKEY_INTEGRATION_TEST=true "
+    "and a running Valkey server with the Search module on localhost:6379"
+)
+
+
+def _should_skip() -> bool:
+    return os.environ.get("VALKEY_INTEGRATION_TEST", "").lower() != "true"
+
+
+def _make_record(
+    text: str,
+    vector: list[float],
+    document_id: str,
+    chunk_index: int = 0,
+    total_chunks: int = 1,
+    metadata: dict | None = None,
+) -> VectorRecord:
+    """Build a VectorRecord for testing."""
+    return VectorRecord(
+        vector=vector,
+        document_id=document_id,
+        chunk=Chunk(
+            content=TextBlock(text=text),
+            source=f"{document_id}.txt",
+            chunk_index=chunk_index,
+            total_chunks=total_chunks,
+            metadata=metadata or {},
+        ),
+    )
+
+
+@unittest.skipIf(_should_skip(), SKIP_REASON)
+class ValkeyStoreIntegrationTest(IsolatedAsyncioTestCase):
+    """Integration tests for ValkeyStore against a real Valkey server."""
+
+    COLLECTION = "test_agentscope_integration"
+
+    async def asyncSetUp(self) -> None:
+        """Connect to Valkey and clean up any leftover test index."""
+        self._exit_stack = AsyncExitStack()
+        self.store = await self._exit_stack.enter_async_context(
+            ValkeyStore(
+                host=os.environ.get("VALKEY_HOST", "localhost"),
+                port=int(os.environ.get("VALKEY_PORT", "6379")),
+            ),
+        )
+        # Clean up from any previous failed run
+        await self.store.delete_collection(self.COLLECTION)
+
+    async def asyncTearDown(self) -> None:
+        """Drop the test collection and close the connection."""
+        try:
+            await self.store.delete_collection(self.COLLECTION)
+        except Exception:
+            pass
+        await self._exit_stack.aclose()
+
+    async def test_collection_lifecycle(self) -> None:
+        """Collections can be created, checked, and deleted."""
+        self.assertFalse(await self.store.has_collection(self.COLLECTION))
+
+        await self.store.create_collection(self.COLLECTION, dimensions=3)
+        self.assertTrue(await self.store.has_collection(self.COLLECTION))
+
+        # Creating an existing collection is a no-op
+        await self.store.create_collection(self.COLLECTION, dimensions=3)
+        self.assertTrue(await self.store.has_collection(self.COLLECTION))
+
+        await self.store.delete_collection(self.COLLECTION)
+        self.assertFalse(await self.store.has_collection(self.COLLECTION))
+
+    async def test_insert_and_search(self) -> None:
+        """Inserted records are searchable, ordered by similarity."""
+        await self.store.create_collection(self.COLLECTION, dimensions=3)
+
+        await self.store.insert(
+            self.COLLECTION,
+            [
+                _make_record(
+                    "Hello world!",
+                    [1.0, 0.0, 0.0],
+                    document_id="doc-1",
+                    chunk_index=0,
+                    total_chunks=2,
+                ),
+                _make_record(
+                    "Goodbye world!",
+                    [0.0, 1.0, 0.0],
+                    document_id="doc-1",
+                    chunk_index=1,
+                    total_chunks=2,
+                ),
+                _make_record(
+                    "Orthogonal",
+                    [0.0, 0.0, 1.0],
+                    document_id="doc-2",
+                ),
+            ],
+        )
+
+        # Search for vectors similar to [1, 0, 0]
+        results = await self.store.search(
+            self.COLLECTION,
+            query_vector=[1.0, 0.0, 0.0],
+            top_k=3,
+        )
+
+        self.assertEqual(len(results), 3)
+        # Most similar should be "Hello world!" (exact match)
+        self.assertEqual(results[0].chunk.content.text, "Hello world!")
+        self.assertAlmostEqual(results[0].score, 1.0, places=4)
+        self.assertEqual(results[0].document_id, "doc-1")
+
+    async def test_search_top_k(self) -> None:
+        """top_k limits the number of returned results."""
+        await self.store.create_collection(self.COLLECTION, dimensions=3)
+
+        await self.store.insert(
+            self.COLLECTION,
+            [
+                _make_record("A", [1.0, 0.0, 0.0], document_id="doc-1"),
+                _make_record("B", [0.9, 0.1, 0.0], document_id="doc-2"),
+                _make_record("C", [0.0, 0.0, 1.0], document_id="doc-3"),
+            ],
+        )
+
+        results = await self.store.search(
+            self.COLLECTION,
+            query_vector=[1.0, 0.0, 0.0],
+            top_k=1,
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].chunk.content.text, "A")
+
+    async def test_delete_by_document_id(self) -> None:
+        """delete removes all records of one document only."""
+        await self.store.create_collection(self.COLLECTION, dimensions=3)
+
+        await self.store.insert(
+            self.COLLECTION,
+            [
+                _make_record(
+                    "doc1-chunk0",
+                    [1.0, 0.0, 0.0],
+                    document_id="doc-1",
+                    chunk_index=0,
+                    total_chunks=2,
+                ),
+                _make_record(
+                    "doc1-chunk1",
+                    [0.9, 0.1, 0.0],
+                    document_id="doc-1",
+                    chunk_index=1,
+                    total_chunks=2,
+                ),
+                _make_record(
+                    "doc2-chunk0",
+                    [0.0, 1.0, 0.0],
+                    document_id="doc-2",
+                ),
+            ],
+        )
+
+        await self.store.delete(self.COLLECTION, document_id="doc-1")
+
+        results = await self.store.search(
+            self.COLLECTION,
+            query_vector=[1.0, 0.0, 0.0],
+            top_k=5,
+        )
+
+        # Only doc-2 should remain
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].document_id, "doc-2")
+        self.assertEqual(results[0].chunk.content.text, "doc2-chunk0")
+
+    async def test_insert_empty_records(self) -> None:
+        """Inserting an empty record list is a no-op."""
+        await self.store.create_collection(self.COLLECTION, dimensions=3)
+        await self.store.insert(self.COLLECTION, [])
+
+        results = await self.store.search(
+            self.COLLECTION,
+            query_vector=[1.0, 0.0, 0.0],
+        )
+        self.assertEqual(results, [])
+
+    async def test_list_documents(self) -> None:
+        """list_documents groups chunks by document_id."""
+        await self.store.create_collection(self.COLLECTION, dimensions=3)
+
+        await self.store.insert(
+            self.COLLECTION,
+            [
+                VectorRecord(
+                    vector=[1.0, 0.0, 0.0],
+                    document_id="doc-1",
+                    chunk=Chunk(
+                        content=TextBlock(text="A"),
+                        source="alpha.txt",
+                        chunk_index=0,
+                        total_chunks=2,
+                        metadata={"media_type": "text/plain"},
+                    ),
+                ),
+                VectorRecord(
+                    vector=[0.9, 0.1, 0.0],
+                    document_id="doc-1",
+                    chunk=Chunk(
+                        content=TextBlock(text="B"),
+                        source="alpha.txt",
+                        chunk_index=1,
+                        total_chunks=2,
+                        metadata={"media_type": "text/plain"},
+                    ),
+                ),
+                VectorRecord(
+                    vector=[0.0, 1.0, 0.0],
+                    document_id="doc-2",
+                    chunk=Chunk(
+                        content=TextBlock(text="C"),
+                        source="beta.md",
+                        chunk_index=0,
+                        total_chunks=1,
+                        metadata={"media_type": "text/markdown"},
+                    ),
+                ),
+            ],
+        )
+
+        summaries = await self.store.list_documents(self.COLLECTION)
+        summaries_by_id = {s.document_id: s for s in summaries}
+
+        self.assertEqual(set(summaries_by_id), {"doc-1", "doc-2"})
+        self.assertEqual(summaries_by_id["doc-1"].chunk_count, 2)
+        self.assertEqual(summaries_by_id["doc-1"].source, "alpha.txt")
+        self.assertEqual(
+            summaries_by_id["doc-1"].metadata,
+            {"media_type": "text/plain"},
+        )
+        self.assertEqual(summaries_by_id["doc-2"].chunk_count, 1)
+        self.assertEqual(summaries_by_id["doc-2"].source, "beta.md")
+
+    async def test_search_with_document_id_filter(self) -> None:
+        """search respects metadata_filter on document_id."""
+        await self.store.create_collection(self.COLLECTION, dimensions=3)
+
+        await self.store.insert(
+            self.COLLECTION,
+            [
+                _make_record("A", [1.0, 0.0, 0.0], document_id="doc-1"),
+                _make_record("B", [0.9, 0.1, 0.0], document_id="doc-2"),
+            ],
+        )
+
+        results = await self.store.search(
+            self.COLLECTION,
+            query_vector=[1.0, 0.0, 0.0],
+            top_k=5,
+            metadata_filter={"document_id": "doc-2"},
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].document_id, "doc-2")


### PR DESCRIPTION
## AgentScope Version

2.0

## Description

**Background:** AgentScope's existing vector store backends (QdrantStore, MilvusLiteStore) serve different deployment scenarios. However, there is no vector store implementation that leverages Valkey's Search module for semantic retrieval. Developers with existing Valkey infrastructure currently need a separate vector database for RAG pipelines.

**Purpose:** Add a `ValkeyStore` class that implements `VectorStoreBase`, enabling Valkey as a vector database backend for AgentScope's knowledge base and retrieval pipeline using HNSW indexing.

**Changes:**
- `src/agentscope/rag/_vdb/_valkey.py` — new `ValkeyStore(VectorStoreBase)` implementation
- `src/agentscope/rag/_vdb/__init__.py` — export `ValkeyStore`
- `src/agentscope/rag/__init__.py` — export `ValkeyStore` at top-level
- `pyproject.toml` — optional dependency `valkey-glide>=2.4.0,<3.0.0` in `[valkey]` group
- `tests/rag_vdb_valkey_test.py` — unit tests with mocks (no server required)
- `tests/valkey_store_integration_test.py` — integration tests gated behind `VALKEY_INTEGRATION_TEST=true`

**Features:**
- COSINE, L2, and IP distance metrics
- Configurable HNSW parameters (M, ef_construction, ef_runtime)
- Standalone and cluster mode via `valkey-glide` async client
- Tag-based filtering (`document_id`, `source`) for cross-tenant scoping
- Double-check locking for concurrent index creation safety
- `client_name="agentscope_rag_store_client"` for monitoring visibility
- Paginated batch delete with tag value escaping
- Compatible with Valkey Search 1.2+ (valkey-bundle 9.1+)

**How to test:**
```bash
# Unit tests (no Valkey required)
uv run python -m pytest tests/rag_vdb_valkey_test.py -xvs

# Integration tests (requires Valkey with Search module on localhost:6379)
VALKEY_INTEGRATION_TEST=true uv run python -m pytest tests/valkey_store_integration_test.py -xvs
```

Related issue: #1627

## Checklist

- [x] Code has been formatted with `pre-commit run --all-files` command
- [x] All tests are passing
- [x] Docstrings are in Google style
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review