### PR TITLE
fix(agent): recover failed acting tool calls

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -49,7 +49,7 @@ from ..event import (
     DataBlockEndEvent,
     ExceedMaxItersEvent,
 )
-from ..exception import AgentOrientedException
+from ..exception import AgentOrientedException, DeveloperOrientedException
 from ..model import (
     ChatResponse,
     ChatUsage,
@@ -1493,95 +1493,132 @@ class Agent:
             # ================================================================
             # Step 4: Delegate raw execution to _acting (middleware hook point)
             # ================================================================
-            async for chunk in self._acting(tool_call):
-                # The ToolResponse is the last and completed tool result here
-                if isinstance(chunk, ToolResponse):
-                    tool_result_block = ToolResultBlock(
-                        id=tool_call.id,
-                        name=tool_call.name,
-                        output=[TextBlock(text=chunk.content)]
-                        if isinstance(chunk.content, str)
-                        else chunk.content,
-                        state=chunk.state,
-                        metadata=chunk.metadata,
-                    )
-
-                    # ========================================================
-                    # Step 5: Truncate the tool result if exceed
-                    # ========================================================
-                    (
-                        reserved_tool_result_block,
-                        offload_tool_result_block,
-                    ) = await self._split_tool_result_for_compression(
-                        tool_result_block,
-                    )
-
-                    # If offload result is not empty, attach reminder to the
-                    # reserved context
-                    if offload_tool_result_block is not None:
-                        reminder = (
-                            "\n<<<TRUNCATED>>>\n<system-reminder>The "
-                            "remaining content has been omitted for "
-                            "limited context.{offload_reminder}"
-                            "</system-reminder>"
+            try:
+                tool_chunks = self._acting(tool_call)
+                async for chunk in tool_chunks:
+                    # The ToolResponse is the last and completed tool result
+                    # here
+                    if isinstance(chunk, ToolResponse):
+                        tool_result_block = ToolResultBlock(
+                            id=tool_call.id,
+                            name=tool_call.name,
+                            output=[TextBlock(text=chunk.content)]
+                            if isinstance(chunk.content, str)
+                            else chunk.content,
+                            state=chunk.state,
+                            metadata=chunk.metadata,
                         )
 
-                        offload_reminder = ""
-                        if self.offloader:
-                            path = await self.offloader.offload_tool_result(
-                                self.state.session_id,
-                                offload_tool_result_block,
-                            )
-
-                            offload_reminder = (
-                                f" You can refer to the file in '{path}' "
-                                f"for the truncated content if needed."
-                            )
-
-                        reminder = reminder.format(
-                            offload_reminder=offload_reminder,
+                        # ====================================================
+                        # Step 5: Truncate the tool result if exceed
+                        # ====================================================
+                        (
+                            reserved_tool_result_block,
+                            offload_tool_result_block,
+                        ) = await self._split_tool_result_for_compression(
+                            tool_result_block,
                         )
 
-                        # Insert the reminder to the tool result output
-                        if isinstance(reserved_tool_result_block.output, str):
-                            reserved_tool_result_block.output += reminder
+                        # If offload result is not empty, attach reminder to the
+                        # reserved context
+                        if offload_tool_result_block is not None:
+                            reminder = (
+                                "\n<<<TRUNCATED>>>\n<system-reminder>The "
+                                "remaining content has been omitted for "
+                                "limited context.{offload_reminder}"
+                                "</system-reminder>"
+                            )
 
-                        elif len(
-                            reserved_tool_result_block.output,
-                        ) > 0 and isinstance(
-                            reserved_tool_result_block.output[-1],
-                            TextBlock,
+                            offload_reminder = ""
+                            if self.offloader:
+                                path = (
+                                    await self.offloader.offload_tool_result(
+                                        self.state.session_id,
+                                        offload_tool_result_block,
+                                    )
+                                )
+
+                                offload_reminder = (
+                                    f" You can refer to the file in '{path}' "
+                                    f"for the truncated content if needed."
+                                )
+
+                            reminder = reminder.format(
+                                offload_reminder=offload_reminder,
+                            )
+
+                            # Insert the reminder to the tool result output
+                            if isinstance(
+                                reserved_tool_result_block.output,
+                                str,
+                            ):
+                                reserved_tool_result_block.output += reminder
+
+                            elif len(
+                                reserved_tool_result_block.output,
+                            ) > 0 and isinstance(
+                                reserved_tool_result_block.output[-1],
+                                TextBlock,
+                            ):
+                                reserved_tool_result_block.output[
+                                    -1
+                                ].text += reminder
+
+                            else:
+                                reserved_tool_result_block.output += [
+                                    TextBlock(text=reminder),
+                                ]
+
+                        self._save_to_context([reserved_tool_result_block])
+                        # Ends the tool call lifecycle.
+                        self._update_tool_call_state(
+                            tool_call.id,
+                            ToolCallState.FINISHED,
+                        )
+                        # The ended event for the tool result
+                        yield ToolResultEndEvent(
+                            reply_id=self.state.reply_id,
+                            tool_call_id=tool_call.id,
+                            state=chunk.state,
+                            metadata=chunk.metadata,
+                        )
+
+                    else:
+                        # Intermediate ToolChunk — convert to streaming events
+                        async for evt in self._convert_tool_chunk_to_event(
+                            tool_call.id,
+                            chunk.content,
                         ):
-                            reserved_tool_result_block.output[
-                                -1
-                            ].text += reminder
-
-                        else:
-                            reserved_tool_result_block.output += [
-                                TextBlock(text=reminder),
-                            ]
-
-                    self._save_to_context([reserved_tool_result_block])
-                    # Ends the tool call lifecycle.
-                    self._update_tool_call_state(
-                        tool_call.id,
-                        ToolCallState.FINISHED,
-                    )
-                    # The ended event for the tool result
-                    yield ToolResultEndEvent(
-                        reply_id=self.state.reply_id,
-                        tool_call_id=tool_call.id,
-                        state=chunk.state,
-                        metadata=chunk.metadata,
-                    )
-
-                else:
-                    # Intermediate ToolChunk — convert to streaming events
-                    async for evt in self._convert_tool_chunk_to_event(
-                        tool_call.id,
-                        chunk.content,
-                    ):
-                        yield evt
+                            yield evt
+            except DeveloperOrientedException:
+                raise
+            except Exception as e:
+                error_msg = f"Tool call failed: {e}"
+                logger.exception(
+                    "Tool call %r failed during acting.",
+                    tool_call.name,
+                )
+                tool_result_block = ToolResultBlock(
+                    id=tool_call.id,
+                    name=tool_call.name,
+                    output=[TextBlock(text=error_msg)],
+                    state=ToolResultState.ERROR,
+                )
+                self._save_to_context([tool_result_block])
+                self._update_tool_call_state(
+                    tool_call.id,
+                    ToolCallState.FINISHED,
+                )
+                async for evt in self._convert_tool_chunk_to_event(
+                    tool_call.id,
+                    tool_result_block.output,
+                ):
+                    yield evt
+                yield ToolResultEndEvent(
+                    reply_id=self.state.reply_id,
+                    tool_call_id=tool_call.id,
+                    state=ToolResultState.ERROR,
+                )
 
             return
 

--- a/tests/agent_basic_test.py
+++ b/tests/agent_basic_test.py
@@ -6,6 +6,7 @@ from unittest.async_case import IsolatedAsyncioTestCase
 from utils import AnyString, MockModel
 
 from agentscope.agent import Agent
+from agentscope.middleware import MiddlewareBase
 from agentscope.model import ChatResponse
 from agentscope.tool import (
     ToolBase,
@@ -17,7 +18,14 @@ from agentscope.permission import (
     PermissionBehavior,
     PermissionContext,
 )
-from agentscope.message import TextBlock, ToolCallBlock, UserMsg
+from agentscope.message import (
+    TextBlock,
+    ToolCallBlock,
+    ToolCallState,
+    ToolResultBlock,
+    ToolResultState,
+    UserMsg,
+)
 
 
 class MockSequentialTool(ToolBase):
@@ -92,6 +100,20 @@ class MockConcurrentTool(ToolBase):
         return ToolChunk(
             content=[TextBlock(text=f"Concurrent result: {input}")],
         )
+
+
+class FailingActingMiddleware(MiddlewareBase):
+    """Middleware that simulates a runtime failure during tool execution."""
+
+    async def on_acting(
+        self,
+        agent: Agent,
+        input_kwargs: dict,
+        next_handler: Any,
+    ) -> Any:
+        """Raise before the underlying tool can return a result."""
+        raise RuntimeError("upstream MCP returned HTTP 401")
+        yield  # pylint: disable=unreachable
 
 
 class AgentBasicTest(IsolatedAsyncioTestCase):
@@ -823,6 +845,75 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
         context_dicts = [msg.model_dump() for msg in self.agent.state.context]
         expected_context = [{**msg_base, **_} for _ in expected_context]
         self.assertListEqual(context_dicts, expected_context)
+
+    async def test_acting_exception_becomes_tool_error_result(self) -> None:
+        """Runtime failures during acting should not crash the agent loop."""
+        self.agent.toolkit = Toolkit(tools=[MockSequentialTool()])
+        self.agent._acting_middlewares = [  # pylint: disable=protected-access
+            FailingActingMiddleware(),
+        ]
+        tool_call_id = "tool_call_failure"
+        self.model.set_responses(
+            [
+                [
+                    ChatResponse(
+                        content=[
+                            ToolCallBlock(
+                                id=tool_call_id,
+                                name="mock_sequential_tool",
+                                input='{"input": "test"}',
+                            ),
+                        ],
+                        is_last=True,
+                    ),
+                ],
+                [
+                    ChatResponse(
+                        content=[TextBlock(text="I will try another path.")],
+                        is_last=True,
+                    ),
+                ],
+            ],
+        )
+
+        events = []
+        async for event in self.agent.reply_stream(
+            UserMsg(name="user", content="Test"),
+        ):
+            events.append(event.model_dump(mode="json"))
+
+        self.assertIn(
+            {
+                **self._get_event_base(self.agent.state.reply_id),
+                "type": "TOOL_RESULT_TEXT_DELTA",
+                "tool_call_id": tool_call_id,
+                "delta": (
+                    "Tool call failed: upstream MCP returned HTTP 401"
+                ),
+            },
+            events,
+        )
+        self.assertIn(
+            {
+                **self._get_event_base(self.agent.state.reply_id),
+                "type": "TOOL_RESULT_END",
+                "tool_call_id": tool_call_id,
+                "state": "error",
+            },
+            events,
+        )
+
+        assistant_blocks = self.agent.state.context[1].content
+        self.assertEqual(
+            assistant_blocks[0].state,
+            ToolCallState.FINISHED,
+        )
+        self.assertIsInstance(assistant_blocks[1], ToolResultBlock)
+        self.assertEqual(assistant_blocks[1].state, ToolResultState.ERROR)
+        self.assertEqual(
+            assistant_blocks[1].output[0].text,
+            "Tool call failed: upstream MCP returned HTTP 401",
+        )
 
     async def test_streaming_concurrent_tool_calls(self) -> None:
         """Test the streaming model inference with tool calls generated.


### PR DESCRIPTION
## Summary
- catch runtime exceptions raised during the agent acting/tool execution phase
- persist an error ToolResultBlock and mark the tool call finished instead of crashing the ReAct loop
- keep DeveloperOrientedException behavior unchanged
- add a regression test that simulates an acting-layer MCP failure and verifies the agent continues

## Tests
- /tmp/agentscope-ripgrep-test/bin/python -m pytest tests/agent_basic_test.py

Fixes #1985