### PR TITLE
docs(agent): fix copy-paste and mismatched docstrings in agent, state and tool modules

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -121,23 +121,23 @@ class Agent:
             toolkit (`Toolkit | None`, optional):
                 The toolkit used for registering tools, MCPs and skills as the
                 sole source.
-            middlewares (`list[MiddlewareBase] | None`):
+            middlewares (`list[MiddlewareBase] | None`, optional):
                 Middlewares applied to the agent to modify its behavior
                 without altering its source code. Supported hook points
                 include: reply, reasoning, acting, model call, and system
                 prompt retrieval.
-            state (`AgentState`):
+            state (`AgentState | None`, optional):
                 The agent state. A new state will be created if not provided.
             offloader (`Offloader | None`, optional):
                 The context offloader. If provided, the compressed context and
                 tool result will be offloaded.
-            model_config (`ModelConfig`):
+            model_config (`ModelConfig | None`, optional):
                 The additional chat model configuration including fallback
                 model and retries.
-            context_config (`CompressionConfig`):
+            context_config (`ContextConfig | None`, optional):
                 The context config for context compression and tool result
                 compression.
-            react_config (`ReActConfig`):
+            react_config (`ReActConfig | None`, optional):
                 The config for the reasoning-acting loop.
         """
         self.name = name
@@ -1327,7 +1327,7 @@ class Agent:
         """Execute a single tool call and forward every event into *queue*.
 
         Args:
-            tool_call (`ToolBlockCall`):
+            tool_call (`ToolCallBlock`):
                 The tool call to execute.
             queue (`Queue`):
                 The shared async queue that collects events from all
@@ -1694,7 +1694,7 @@ class Agent:
             message (`str`):
                 The error message to be returned for the tool call.
             state (`ToolResultState`):
-                The state of the tool result, which can be "error", "denied",
+                The state of the tool result, such as "error" or "denied".
 
         Yields:
             `ToolResultStartEvent \

--- a/src/agentscope/agent/_config.py
+++ b/src/agentscope/agent/_config.py
@@ -44,8 +44,8 @@ class SummarySchema(BaseModel):
             "Any promises made to the user"
         ),
     )
-    """Whether to execute multiple tool calls in parallel within one
-    reasoning step."""
+    """The important context to preserve across compression, e.g. user
+    preferences, domain-specific details and promises made to the user."""
 
 
 class ContextConfig(BaseModel):
@@ -101,7 +101,7 @@ class ContextConfig(BaseModel):
     )
     """The string template to present the compressed summary to the agent,
     which will be formatted with the fields from the
-    `compression_summary_model`."""
+    `summary_schema`."""
 
     summary_schema: dict = Field(
         default_factory=SummarySchema.model_json_schema,

--- a/src/agentscope/state/_state.py
+++ b/src/agentscope/state/_state.py
@@ -154,9 +154,9 @@ class AgentState(BaseModel):
 
     summary: str | list[TextBlock | DataBlock] = ""
     """The compressed summary of the context, which will be prepended to the
-    context when feed into the LLM."""
+    context when fed into the LLM."""
     context: list[Msg] = Field(default_factory=list)
-    """The uncompressed conversation context, that will be feed into the LLM"""
+    """The uncompressed conversation context, which will be fed into the LLM"""
     reply_id: str = Field(default_factory=_generate_id)
     """The id of the current reply, which is also used as the id of the
     final message of the reply."""

--- a/src/agentscope/tool/_response.py
+++ b/src/agentscope/tool/_response.py
@@ -44,7 +44,7 @@ class ToolChunk(BaseModel):
     parse the tool result block."""
 
     id: str = Field(default_factory=_generate_id)
-    """The identity of the tool response."""
+    """The identity of the tool chunk."""
 
 
 class ToolResponse(BaseModel):


### PR DESCRIPTION
## Summary

Documentation-only fixes for several incorrect or copy-pasted docstrings in the `agent`, `state`, and `tool` modules. No behavior change.

**`src/agentscope/agent/_config.py`**
- `SummarySchema.context_to_preserve` carried a leftover attribute docstring about "executing multiple tool calls in parallel", which is unrelated to the field; it now describes the field itself.
- The `ContextConfig` summary-template docstring referenced a non-existent `compression_summary_model`; the template fields actually come from `summary_schema`.

**`src/agentscope/agent/_agent.py`**
- `Agent.__init__` documented `context_config` as a non-existent `CompressionConfig` (actual type: `ContextConfig`), and several params (`middlewares`, `state`, `model_config`, `context_config`, `react_config`) were missing the `| None` / `optional` markers that match the actual signature defaults.
- `_into_queue` documented `tool_call` as `ToolBlockCall` instead of `ToolCallBlock`.
- `_handle_error_tool_call` had a truncated sentence for the `state` param.

**`src/agentscope/state/_state.py`**
- Grammar: "when feed into the LLM" → "when fed into the LLM" (×2) in `AgentState` field docstrings.

**`src/agentscope/tool/_response.py`**
- `ToolChunk.id` docstring said "The identity of the tool response" (copied from `ToolResponse`); it now says "tool chunk".

## Notes

- Docstring/comment changes only — no runtime behavior, public API, or breaking changes.
- `pre-commit` and `pytest tests` pass locally.
- No companion docs PR needed (inline docstrings only).
