### PR TITLE
feat(tool): add builtin skill markdown reader

### DIFF
--- a/src/agentscope/skill/_local_loader.py
+++ b/src/agentscope/skill/_local_loader.py
@@ -25,7 +25,7 @@ class LocalSkillLoader(SkillLoaderBase):
                 Whether to scan subdirectories. Defaults to False (only
                 scan current directory).
         """
-        self.directory = os.path.abspath(directory)
+        self.directory = os.path.abspath(os.path.expanduser(directory))
         self.scan_subdir = scan_subdir
         self._cache: dict[str, Skill] = {}
 

--- a/src/agentscope/tool/_builtin/__init__.py
+++ b/src/agentscope/tool/_builtin/__init__.py
@@ -8,11 +8,12 @@ from ._glob import Glob
 from ._grep import Grep
 from ._meta import ResetTools
 from ._read import Read
-from ._skill import SkillViewer
+from ._skill import SkillMarkdownReader, SkillViewer
 from ._write import Write
 
 __all__ = [
     "ResetTools",
+    "SkillMarkdownReader",
     "SkillViewer",
     "Bash",
     "Edit",

--- a/src/agentscope/tool/_builtin/_skill.py
+++ b/src/agentscope/tool/_builtin/_skill.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
-"""The builtin skill viewer tool."""
-from typing import Any, Callable, Awaitable, List
+"""The builtin skill tools."""
+import asyncio
+import os
+from typing import Any, Awaitable, Callable, List
 
 from ...exception import DeveloperOrientedException
 from ...permission import (
@@ -125,3 +127,135 @@ class SkillViewer(ToolBase):
             )
 
         return ToolChunk(content=[TextBlock(text=target_skill.markdown)])
+
+
+class SkillMarkdownReader(ToolBase):
+    """The builtin SKILL.md reader tool."""
+
+    name: str = "read_skill_md"
+    """The name of the skill markdown reader tool to the agent."""
+
+    description = "Read the SKILL.md file for a registered skill."
+    """The tool description of the skill markdown reader tool."""
+
+    input_schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "skill": {
+                "type": "string",
+                "description": (
+                    "The exact name of the skill whose SKILL.md should "
+                    "be read."
+                ),
+            },
+        },
+        "required": ["skill"],
+    }
+    """The input schema of the skill markdown reader tool."""
+
+    is_concurrency_safe: bool = True
+    """The skill markdown reader is concurrency safe."""
+
+    is_external_tool: bool = False
+    """The skill markdown reader is not an external tool."""
+
+    is_state_injected: bool = True
+    """The skill markdown reader requires state injection to access skills."""
+
+    is_read_only: bool = True
+    """The skill markdown reader is read-only."""
+
+    is_mcp: bool = False
+    """The skill markdown reader is not an MCP tool."""
+
+    mcp_name: str | None = None
+    """The skill markdown reader does not belong to any MCP server."""
+
+    def __init__(
+        self,
+        get_skills_method: Callable[..., Awaitable[dict[str, Skill]]],
+        middlewares: List[ToolMiddlewareBase] | None = None,
+    ) -> None:
+        """Initialize the skill markdown reader.
+
+        Args:
+            get_skills_method (`Callable[..., dict[str, Skill]]`):
+                An async method that returns the current skills of the agent.
+            middlewares (`List[ToolMiddlewareBase] | None`, optional):
+                Tool middlewares wrapping the tool execution.
+        """
+        super().__init__(middlewares=middlewares)
+        self._get_skills_method = get_skills_method
+
+    async def check_permissions(
+        self,
+        tool_input: dict[str, Any],
+        context: PermissionContext,
+    ) -> PermissionDecision:
+        """The skill markdown reader is always allowed to be called."""
+        return PermissionDecision(
+            behavior=PermissionBehavior.ALLOW,
+            message=(
+                "The skill markdown reader is always allowed to be called."
+            ),
+        )
+
+    async def call(
+        self,
+        skill: str,
+        _agent_state: AgentState,
+    ) -> ToolChunk:
+        """Read the SKILL.md file for the skill with the given name.
+
+        Args:
+            skill (`str`):
+                The name of the skill whose SKILL.md should be read.
+
+        Returns:
+            `ToolChunk`:
+                The raw SKILL.md file content.
+        """
+        if not isinstance(_agent_state, AgentState):
+            raise DeveloperOrientedException(
+                f"Expected AgentState but got {type(_agent_state)} "
+                "instead for the skill markdown reader tool.",
+            )
+
+        skills = await self._get_skills_method(
+            _agent_state.tool_context.activated_groups,
+        )
+        target_skill = skills.get(skill)
+        if not target_skill:
+            return ToolChunk(
+                content=[
+                    TextBlock(
+                        text=f"SkillNotFoundError: Skill '{skill}' "
+                        f"not found.",
+                    ),
+                ],
+                state=ToolResultState.ERROR,
+            )
+
+        skill_root = os.path.abspath(os.path.expanduser(target_skill.dir))
+        skill_md_path = os.path.join(skill_root, "SKILL.md")
+
+        if not os.path.isfile(skill_md_path):
+            return ToolChunk(
+                content=[
+                    TextBlock(
+                        text="SkillFileNotFoundError: SKILL.md not found "
+                        f"for skill '{skill}'.",
+                    ),
+                ],
+                state=ToolResultState.ERROR,
+            )
+
+        def _read_skill_md() -> str:
+            with open(skill_md_path, encoding="utf-8") as f:
+                return f.read()
+
+        return ToolChunk(
+            content=[
+                TextBlock(text=await asyncio.to_thread(_read_skill_md)),
+            ],
+        )

--- a/src/agentscope/tool/_toolkit.py
+++ b/src/agentscope/tool/_toolkit.py
@@ -18,7 +18,7 @@ from pydantic import (
     create_model,
 )
 
-from ._builtin import ResetTools, SkillViewer
+from ._builtin import ResetTools, SkillMarkdownReader, SkillViewer
 from ._base import ToolBase
 from ._response import ToolResponse, ToolChunk
 from ..skill import SkillLoaderBase, Skill
@@ -164,6 +164,11 @@ class Toolkit:
 
         self.builtin_skill_viewer = RegisteredTool(
             tool=SkillViewer(
+                get_skills_method=self._get_available_skills,
+            ),
+        )
+        self.builtin_skill_md_reader = RegisteredTool(
+            tool=SkillMarkdownReader(
                 get_skills_method=self._get_available_skills,
             ),
         )
@@ -492,6 +497,9 @@ class Toolkit:
             available_tools[
                 self.builtin_skill_viewer.tool.name
             ] = self.builtin_skill_viewer
+            available_tools[
+                self.builtin_skill_md_reader.tool.name
+            ] = self.builtin_skill_md_reader
 
         # Builtin meta tool is only included when there is at least one tool
         # group

--- a/tests/skill_loader_test.py
+++ b/tests/skill_loader_test.py
@@ -129,6 +129,51 @@ This is the subdir2 skill content.
         self.assertIsInstance(skills[0].updated_at, float)
         self.assertGreater(skills[0].updated_at, 0)
 
+    async def test_loader_expands_user_directory(self) -> None:
+        """Test that user-relative skill paths are stored as absolute paths."""
+        home_dir = tempfile.mkdtemp()
+        old_home = os.environ.get("HOME")
+        old_userprofile = os.environ.get("USERPROFILE")
+        try:
+            os.environ["HOME"] = home_dir
+            os.environ["USERPROFILE"] = home_dir
+
+            skill_dir = os.path.join(home_dir, "home_skill")
+            os.makedirs(skill_dir)
+            with open(
+                os.path.join(skill_dir, "SKILL.md"),
+                "w",
+                encoding="utf-8",
+            ) as f:
+                f.write(
+                    "---\n"
+                    "name: home_skill\n"
+                    "description: A skill in the home directory\n"
+                    "---\n\n"
+                    "# Home Skill\n",
+                )
+
+            loader = LocalSkillLoader(
+                os.path.join("~", "home_skill"),
+                scan_subdir=False,
+            )
+            skills = await loader.list_skills()
+
+            self.assertEqual(len(skills), 1)
+            self.assertEqual(skills[0].dir, os.path.abspath(skill_dir))
+        finally:
+            if old_home is None:
+                os.environ.pop("HOME", None)
+            else:
+                os.environ["HOME"] = old_home
+
+            if old_userprofile is None:
+                os.environ.pop("USERPROFILE", None)
+            else:
+                os.environ["USERPROFILE"] = old_userprofile
+
+            shutil.rmtree(home_dir)
+
     async def test_load_skill_with_scan_subdir(self) -> None:
         """Test loading skills from subdirectories (scan_subdir=True)."""
         loader = LocalSkillLoader(self.test_dir, scan_subdir=True)

--- a/tests/toolkit_skill_test.py
+++ b/tests/toolkit_skill_test.py
@@ -246,8 +246,99 @@ class ToolkitSkillViewerTest(IsolatedAsyncioTestCase):
                         },
                     },
                 },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read_skill_md",
+                        "description": (
+                            "Read the SKILL.md file for a registered skill."
+                        ),
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "skill": {
+                                    "type": "string",
+                                    "description": (
+                                        "The exact name of the skill whose "
+                                        "SKILL.md should be read."
+                                    ),
+                                },
+                            },
+                            "required": ["skill"],
+                        },
+                    },
+                },
             ],
         )
+
+    async def test_builtin_read_skill_md_tool(self) -> None:
+        """Test that read_skill_md returns the raw SKILL.md content."""
+        skill_md = (
+            "---\n"
+            "name: path_skill\n"
+            "description: A skill loaded from a path\n"
+            "---\n\n"
+            "# Path Skill\n"
+            "Use the path skill.\n"
+        )
+        with tempfile.TemporaryDirectory() as skill_dir:
+            with open(
+                os.path.join(skill_dir, "SKILL.md"),
+                "w",
+                encoding="utf-8",
+            ) as f:
+                f.write(skill_md)
+
+            toolkit = Toolkit(skills_or_loaders=[skill_dir])
+            tool_call = ToolCallBlock(
+                id="test_call_read_skill_md",
+                name="read_skill_md",
+                input=json.dumps({"skill": "path_skill"}),
+            )
+            state = AgentState()
+
+            chunks = []
+            response = None
+            async for result in toolkit.call_tool(tool_call, state):
+                if isinstance(result, ToolChunk):
+                    chunks.append(result)
+                elif isinstance(result, ToolResponse):
+                    response = result
+
+            self.assertEqual(len(chunks), 1)
+            self.assertEqual(chunks[0].content[0].text, skill_md)
+
+            self.assertIsNotNone(response)
+            self.assertEqual(response.state, "success")
+            self.assertEqual(response.content[0].text, skill_md)
+
+    async def test_builtin_read_skill_md_tool_unknown_skill(self) -> None:
+        """Test that read_skill_md reports an unknown skill."""
+        loader = MockSkillLoader([_make_skill("existing_skill")])
+        toolkit = Toolkit(skills_or_loaders=[loader])
+
+        tool_call = ToolCallBlock(
+            id="test_call_read_skill_md_missing",
+            name="read_skill_md",
+            input=json.dumps({"skill": "missing_skill"}),
+        )
+        state = AgentState()
+
+        chunks = []
+        response = None
+        async for result in toolkit.call_tool(tool_call, state):
+            if isinstance(result, ToolChunk):
+                chunks.append(result)
+            elif isinstance(result, ToolResponse):
+                response = result
+
+        expected = "SkillNotFoundError: Skill 'missing_skill' not found."
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(chunks[0].content[0].text, expected)
+
+        self.assertIsNotNone(response)
+        self.assertEqual(response.state, "error")
+        self.assertEqual(response.content[0].text, expected)
 
     async def test_call_skill_viewer_success(self) -> None:
         """Test calling SkillViewer with an existing skill."""


### PR DESCRIPTION
## AgentScope Version

2.0.4dev

## Description

Fixes #1087.

This reimplements the skill `SKILL.md` reader for the current v2 `Toolkit` / `SkillLoader` architecture.

Changes made:

- Add a read-only builtin `read_skill_md` tool that is exposed whenever registered skills are available.
- Return the raw `SKILL.md` file content, including frontmatter, for a registered skill.
- Normalize local skill loader paths with `expanduser` + `abspath` so `~` paths resolve consistently.
- Add tests for tool schema exposure, successful raw `SKILL.md` reads, unknown skill errors, and user-relative skill paths.

No breaking changes, deprecations, or migration steps.

Validation:

- `python -m black --check --line-length=79 src\agentscope\tool\_builtin\_skill.py src\agentscope\tool\_toolkit.py src\agentscope\tool\_builtin\__init__.py src\agentscope\skill\_local_loader.py tests\toolkit_skill_test.py tests\skill_loader_test.py`
- `python -m flake8 --extend-ignore=E203 src\agentscope\tool\_builtin\_skill.py src\agentscope\tool\_toolkit.py src\agentscope\tool\_builtin\__init__.py src\agentscope\skill\_local_loader.py tests\toolkit_skill_test.py tests\skill_loader_test.py`
- `PYTHONPATH=src python -m pytest tests/toolkit_skill_test.py tests/skill_loader_test.py -q` (`18 passed`)
- `python -m py_compile src\agentscope\tool\_builtin\_skill.py src\agentscope\tool\_toolkit.py src\agentscope\tool\_builtin\__init__.py src\agentscope\skill\_local_loader.py tests\toolkit_skill_test.py tests\skill_loader_test.py`


## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ] Code is ready for review