### PR TITLE
feat(service): allow disabling embedded scheduler

### DIFF
--- a/src/agentscope/app/_app.py
+++ b/src/agentscope/app/_app.py
@@ -49,6 +49,7 @@ def create_app(
     knowledge_chunker: ChunkerBase | None = None,
     blob_store: BlobStoreBase | None = None,
     enable_index_worker: bool = True,
+    enable_scheduler: bool = True,
     *,
     extra_credentials: list[Type[CredentialBase]] | None = None,
     extra_middlewares: list[FastAPIMiddleware] | None = None,
@@ -143,6 +144,13 @@ def create_app(
             process is expected to consume tasks from the message
             bus.  No effect when ``knowledge_base_manager`` is
             ``None``.
+        enable_scheduler (`bool`, defaults to ``True``):
+            When ``True`` the API process starts the embedded APScheduler
+            and restores persisted schedules into local jobs.  When
+            ``False`` schedule records can still be created, listed, and
+            stored, but this process does not fire scheduled tasks.  Use this
+            for multi-process deployments that run a single dedicated
+            scheduler process.
         extra_credentials (`list[Type[CredentialBase]] | None`, optional):
             Additional :class:`~agentscope.credential.CredentialBase`
             subclasses to register before the app starts.  Equivalent to
@@ -237,6 +245,7 @@ def create_app(
     app.state.enable_index_worker = (
         enable_index_worker and knowledge_base_manager is not None
     )
+    app.state.enable_scheduler = enable_scheduler
 
     # Validate custom sub-agent templates for duplicate types and store in
     #  app.state

--- a/src/agentscope/app/_lifespan.py
+++ b/src/agentscope/app/_lifespan.py
@@ -48,6 +48,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     blob_store = app.state.blob_store
     enable_index_worker = app.state.enable_index_worker
     resource_access_policy = app.state.resource_access_policy
+    enable_scheduler = app.state.enable_scheduler
 
     async with AsyncExitStack() as stack:
         await stack.enter_async_context(storage)
@@ -79,6 +80,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             SchedulerManager(
                 storage=storage,
                 message_bus=message_bus,
+                enabled=enable_scheduler,
             ),
         )
         app.state.scheduler_manager = scheduler

--- a/src/agentscope/app/_manager/_scheduler/_scheduler_manager.py
+++ b/src/agentscope/app/_manager/_scheduler/_scheduler_manager.py
@@ -39,6 +39,7 @@ class SchedulerManager:
         self,
         storage: StorageBase,
         message_bus: MessageBus,
+        enabled: bool = True,
     ) -> None:
         """Initialize the scheduler manager.
 
@@ -50,12 +51,17 @@ class SchedulerManager:
                 The application message bus. Each scheduled fire pushes
                 a :class:`HintBlock` to the target session's inbox and
                 enqueues a wakeup via this bus.
+            enabled (`bool`, defaults to ``True``):
+                Whether this process should start APScheduler and register
+                local jobs. Disable this for API-only workers in
+                multi-process deployments.
         """
         from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
         self._storage = storage
         self._message_bus = message_bus
         self._scheduler = AsyncIOScheduler()
+        self._enabled = enabled
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -72,6 +78,10 @@ class SchedulerManager:
         Returns:
             `Self`: This manager instance.
         """
+        if not self._enabled:
+            logger.info("SchedulerManager APScheduler disabled")
+            return self
+
         logger.info("SchedulerManager starting APScheduler")
         self._scheduler.start()
         logger.info("SchedulerManager APScheduler started")
@@ -84,6 +94,9 @@ class SchedulerManager:
 
     async def __aexit__(self, *exc: object) -> None:
         """Shut down the underlying APScheduler on context exit."""
+        if not self._enabled:
+            return
+
         logger.info("SchedulerManager shutting down APScheduler")
         self._scheduler.shutdown()
         logger.info("SchedulerManager APScheduler shut down")
@@ -289,6 +302,14 @@ class SchedulerManager:
             record.data.cron_expression,
             record.data.timezone,
         )
+        if not self._enabled:
+            logger.info(
+                "SchedulerManager disabled; schedule %s(%s) stored without "
+                "local APScheduler job",
+                record.id,
+                record.data.name,
+            )
+            return record.id
 
         # ``CronTrigger.from_crontab`` is a thin helper that only forwards
         # the 5 parsed fields and ``timezone`` — it has no parameter for
@@ -335,6 +356,13 @@ class SchedulerManager:
                 The APScheduler job ID to remove.
         """
         from apscheduler.jobstores.base import JobLookupError
+
+        if not self._enabled:
+            logger.info(
+                "SchedulerManager disabled; skipping local job removal %s",
+                job_id,
+            )
+            return
 
         logger.info("Removing schedule job %s", job_id)
         try:

--- a/tests/service_scheduler_test.py
+++ b/tests/service_scheduler_test.py
@@ -122,6 +122,37 @@ class _SchedulerFireTestBase(IsolatedAsyncioTestCase):
         await self.fr.aclose()
 
 
+class TestSchedulerManagerDisabled(_SchedulerFireTestBase):
+    """Disabled scheduler managers do not register local jobs."""
+
+    async def test_disabled_context_does_not_restore_jobs(self) -> None:
+        """Disabled manager leaves persisted schedules out of APScheduler."""
+        record = _make_record()
+        await self.storage.upsert_schedule(record.user_id, record)
+
+        async with SchedulerManager(
+            storage=self.storage,
+            message_bus=self.bus,
+            enabled=False,
+        ) as manager:
+            self.assertEqual(await manager.list_tasks(), [])
+
+    async def test_disabled_register_returns_record_id_without_job(
+        self,
+    ) -> None:
+        """Disabled manager accepts registration without adding a local job."""
+        record = _make_record()
+
+        async with SchedulerManager(
+            storage=self.storage,
+            message_bus=self.bus,
+            enabled=False,
+        ) as manager:
+            job_id = await manager.register_schedule(record)
+            self.assertEqual(job_id, record.id)
+            self.assertEqual(await manager.list_tasks(), [])
+
+
 class TestSchedulerFireDelivery(_SchedulerFireTestBase):
     """A fire delivers the prompt as a HintBlock + wakeup."""
 


### PR DESCRIPTION
## Summary

Adds `create_app(enable_scheduler=False)` so API-only service workers
don't double-spawn scheduled jobs in multi-process deployments:

- New lifespan option `enable_scheduler: bool = True` on `create_app`.
- When `False`, `SchedulerManager` skips local APScheduler
  start/restore/job registration.
- Schedule records remain usable for storage/listing so a dedicated
  scheduler process can still own firing.

Refs agentscope-ai/agentscope#1722.

## Maintainer design context

This implements the lighter-weight direction that maintainers
already endorsed on #1722:

> @YingchaoX (2026-06-10): "Just sharing a thought here. I wonder
> if we can start with a lighter deployment model before
> introducing a full distributed manager design. From my
> understanding, the current architecture already has some
> multi-process-friendly pieces: shared `StorageBase`, `MessageBus`,
> session locks, inbox, wakeup queue, ev..."

> @DavdGao (2026-06-11): "Agree with this. For the current
> scheduler refactoring, we're planning to add a configuration
> option to control whether the embedded scheduler thread is
> enabled..."

(`enable_scheduler=False` is exactly that configuration option.)

## Tests

`tests/service_scheduler_test.py` covers:

- `enable_scheduler=False` ⇒ `SchedulerManager.start()` does not
  start the APScheduler and skips restore/registration.
- `enable_scheduler=True` (default) preserves existing behavior.
- Lifespan path with `enable_scheduler=False` exits cleanly.

Local command for reviewer reproduction:

```
uv pip install -e .[dev]
pytest tests/service_scheduler_test.py tests/app_lifespan_dedicated_test.py
```