### PR TITLE
fix(credential): validate discriminator in register_credential

### DIFF
--- a/src/agentscope/credential/_factory.py
+++ b/src/agentscope/credential/_factory.py
@@ -15,6 +15,50 @@ from ._xai import XAICredential
 from ._base import CredentialBase
 
 
+def _get_literal_values(credential_cls: Type[CredentialBase]) -> set[str]:
+    """Return the allowed ``type`` discriminator values for a credential class.
+
+    Reads the ``Literal`` annotation on the ``type`` field.  Returns an empty
+    set when the class does not declare a ``type`` field at all.
+
+    Args:
+        credential_cls (`Type[CredentialBase]`):
+            The credential subclass to inspect.
+
+    Returns:
+        `set[str]`:
+            The set of values permitted by the ``type`` ``Literal`` annotation.
+    """
+    type_hint = get_type_hints(credential_cls).get("type")
+    if type_hint is None:
+        return set()
+    return set(get_args(type_hint))
+
+
+def _get_discriminator_value(
+    credential_cls: Type[CredentialBase],
+) -> str | None:
+    """Return the resolved ``type`` discriminator value for a credential class.
+
+    The discriminator is the field's default value, i.e. the value written into
+    serialized records and the one Pydantic tags the union with.  Returns
+    ``None`` when the class has no ``type`` field.
+
+    Args:
+        credential_cls (`Type[CredentialBase]`):
+            The credential subclass to inspect.
+
+    Returns:
+        `str | None`:
+            The default ``type`` value, or ``None`` if there is no ``type``
+            field.
+    """
+    field = credential_cls.model_fields.get("type")
+    if field is None:
+        return None
+    return field.default
+
+
 class CredentialFactory:
     """Registry and deserializer for :class:`CredentialBase` subclasses.
 
@@ -60,15 +104,73 @@ class CredentialFactory:
         """Register a custom :class:`CredentialBase` subclass.
 
         The class must define a ``type`` field with a unique ``Literal``
-        default so Pydantic can use it as a discriminator.
+        default so Pydantic can use it as a discriminator.  Registration is
+        validated eagerly so that misconfigured credentials fail here, at the
+        call site, rather than producing an opaque ``ValidationError`` from
+        :meth:`from_dict` later (see issue #1961).
 
         Args:
-            credential_cls: The subclass to register.
+            credential_cls (`Type[CredentialBase]`):
+                The subclass to register.
+
+        Raises:
+            `ValueError`:
+                If the class has no ``type`` discriminator field, if its
+                ``type`` default value is not contained in its own ``Literal``
+                annotation, or if its discriminator value is already used by
+                a built-in or previously-registered credential class.
         """
         if credential_cls in cls._classes:
             return
+
+        cls._validate_discriminator(credential_cls)
+
         cls._classes.append(credential_cls)
         cls._adapter = None  # invalidate so it's rebuilt on next use
+
+    @classmethod
+    def _validate_discriminator(
+        cls,
+        credential_cls: Type[CredentialBase],
+    ) -> None:
+        """Validate the ``type`` discriminator of a credential class.
+
+        Ensures the class declares a ``type`` field whose default value is one
+        of its permitted ``Literal`` values, and that the value does not
+        collide with any already-registered credential.  Raises ``ValueError``
+        with an actionable message otherwise.
+
+        Args:
+            credential_cls (`Type[CredentialBase]`):
+                The candidate class about to be registered.
+        """
+        allowed = _get_literal_values(credential_cls)
+        default = _get_discriminator_value(credential_cls)
+
+        if default is None:
+            raise ValueError(
+                f"{credential_cls.__name__} cannot be registered: it must "
+                "declare a `type` field with a Literal default to act as a "
+                "discriminator.",
+            )
+
+        if allowed and default not in allowed:
+            raise ValueError(
+                f"{credential_cls.__name__} cannot be registered: its `type` "
+                f"default {default!r} is not among the permitted Literal "
+                f"values {sorted(allowed)!r}. The default value must appear "
+                "in the Literal annotation, e.g. "
+                "`type: Literal['<value>'] = '<value>'`.",
+            )
+
+        for registered in cls._classes:
+            if _get_discriminator_value(registered) == default:
+                raise ValueError(
+                    f"{credential_cls.__name__} cannot be registered: its "
+                    f"`type` discriminator {default!r} is already used by "
+                    f"{registered.__name__}. Each credential must declare a "
+                    "unique discriminator value.",
+                )
 
     @classmethod
     def from_dict(cls, data: dict) -> CredentialBase:
@@ -97,13 +199,12 @@ class CredentialFactory:
             found.
         """
         for c in cls._classes:
-            hints = get_type_hints(c)
-            type_hint = hints.get("type")
-            if type_hint is None:
+            allowed = _get_literal_values(c)
+            if not allowed:
                 continue
-            args = get_args(type_hint)
-
-            if args and args[0] == provider:
+            # Match against the first declared Literal value to preserve the
+            # historical lookup semantics.
+            if next(iter(allowed)) == provider:
                 return c
         return None
 

--- a/tests/credential_factory_test.py
+++ b/tests/credential_factory_test.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for :class:`CredentialFactory`.
+
+These tests cover discriminator resolution, custom-credential registration,
+and the fail-fast validation that guards against the two silent failure paths
+reported in issue #1961:
+
+- Registering a credential whose ``type`` discriminator collides with an
+  already-registered class (built-in or custom).
+- Registering a credential whose ``type`` field has a ``Literal`` that does
+  not contain its own default value.
+
+The factory stores its registry on the class object
+(``CredentialFactory._classes`` / ``_adapter``), so every test runs through a
+``restore_factory_registry`` fixture that snapshots and restores the
+class-level state to keep tests deterministic and isolated.
+"""
+# pylint: disable=protected-access
+import copy
+from typing import Generator, List, Literal, Type
+from unittest import TestCase
+
+import pytest
+from pydantic import Field, SecretStr
+
+from agentscope.credential import (
+    AnthropicCredential,
+    CredentialBase,
+    CredentialFactory,
+    DashScopeCredential,
+    DeepSeekCredential,
+    GeminiCredential,
+    MoonshotCredential,
+    OllamaCredential,
+    OpenAICredential,
+    XAICredential,
+)
+
+
+class _CustomCredential(CredentialBase):
+    """A valid custom credential with a unique discriminator."""
+
+    type: Literal["custom_credential"] = "custom_credential"
+    api_key: SecretStr = Field(description="The API key.")
+
+    @classmethod
+    def get_chat_model_class(cls) -> Type["CredentialBase"]:
+        """Return ``None`` — only registration is exercised here."""
+        raise NotImplementedError
+
+
+class _CollidingCustomCredential(CredentialBase):
+    """A custom credential that reuses a built-in discriminator value."""
+
+    type: Literal["openai_credential"] = "openai_credential"
+    api_key: SecretStr = Field(description="The API key.")
+
+    @classmethod
+    def get_chat_model_class(cls) -> Type["CredentialBase"]:
+        """Return ``None`` — only registration is exercised here."""
+        raise NotImplementedError
+
+
+class _LiteralDefaultMismatchCredential(CredentialBase):
+    """A credential whose ``type`` Literal excludes its own default.
+
+    Reproduces the reporter's field
+    ``type: Literal["openai_credential"] = "custom_credential"``.
+    """
+
+    type: Literal["openai_credential"] = "custom_credential"  # noqa: S105
+    api_key: SecretStr = Field(default=SecretStr("k"))
+
+    @classmethod
+    def get_chat_model_class(cls) -> Type["CredentialBase"]:
+        """Return ``None`` — only registration is exercised here."""
+        raise NotImplementedError
+
+
+class _TypelessCredential(CredentialBase):
+    """A credential that forgets to declare a ``type`` discriminator."""
+
+    api_key: SecretStr = Field(default=SecretStr("k"))
+
+    @classmethod
+    def get_chat_model_class(cls) -> Type["CredentialBase"]:
+        """Return ``None`` — only registration is exercised here."""
+        raise NotImplementedError
+
+
+@pytest.fixture
+def restore_factory_registry() -> Generator[None, None, None]:
+    """Snapshot and restore the factory's class-level registry.
+
+    ``CredentialFactory`` keeps its registered classes and cached adapter on
+    the class object, so registering a custom type in one test would leak
+    into every other test.  This fixture deep-copies the registry before a
+    test and restores it (and invalidates the adapter) afterwards.
+    """
+    snapshot = {
+        "classes": copy.copy(CredentialFactory._classes),
+        "adapter": CredentialFactory._adapter,
+    }
+    yield
+    CredentialFactory._classes = snapshot["classes"]
+    CredentialFactory._adapter = snapshot["adapter"]
+
+
+@pytest.mark.usefixtures("restore_factory_registry")
+class TestCredentialFactoryRegistration(TestCase):
+    """Registration, validation, and lookup behavior of the factory."""
+
+    def test_builtin_discriminators_resolve_to_correct_class(self) -> None:
+        """``from_dict`` maps each built-in ``type`` to its class."""
+        expected = {
+            "anthropic_credential": AnthropicCredential,
+            "dashscope_credential": DashScopeCredential,
+            "deepseek_credential": DeepSeekCredential,
+            "gemini_credential": GeminiCredential,
+            "moonshot_credential": MoonshotCredential,
+            "ollama_credential": OllamaCredential,
+            "openai_credential": OpenAICredential,
+            "xai_credential": XAICredential,
+        }
+        for discriminator, expected_cls in expected.items():
+            with self.subTest(discriminator=discriminator):
+                instance = CredentialFactory.from_dict(
+                    {"type": discriminator, "api_key": "sk-test"},
+                )
+                self.assertIs(type(instance), expected_cls)
+
+    def test_register_valid_custom_credential_round_trips(self) -> None:
+        """A uniquely-discriminated custom class registers and round-trips."""
+        CredentialFactory.register_credential(_CustomCredential)
+
+        deserialized = CredentialFactory.from_dict(
+            {"type": "custom_credential", "api_key": "sk-test"},
+        )
+        self.assertIs(type(deserialized), _CustomCredential)
+
+        round_tripped = CredentialFactory.from_dict(
+            _CustomCredential(api_key="sk-test").model_dump(),
+        )
+        self.assertIs(type(round_tripped), _CustomCredential)
+
+    def test_register_idempotent_for_same_class(self) -> None:
+        """Registering the same class twice is a silent no-op."""
+        CredentialFactory.register_credential(_CustomCredential)
+        count_after_first = len(CredentialFactory._classes)
+        CredentialFactory.register_credential(_CustomCredential)
+        count_after_second = len(CredentialFactory._classes)
+
+        self.assertEqual(count_after_first, count_after_second)
+
+    def test_register_colliding_discriminator_raises(self) -> None:
+        """Reusing a built-in discriminator value fails fast (#1961-A)."""
+        with self.assertRaises(ValueError) as ctx:
+            CredentialFactory.register_credential(_CollidingCustomCredential)
+
+        message = str(ctx.exception)
+        self.assertIn("openai_credential", message)
+        self.assertIn("OpenAICredential", message)
+
+    def test_register_literal_default_mismatch_raises(self) -> None:
+        """A ``type`` whose default is outside its ``Literal`` fails (#1961-B).
+
+        Reproduces the reporter's field
+        ``type: Literal["openai_credential"] = "custom_credential"``.
+        """
+        with self.assertRaises(ValueError) as ctx:
+            CredentialFactory.register_credential(
+                _LiteralDefaultMismatchCredential,
+            )
+
+        message = str(ctx.exception)
+        self.assertIn("custom_credential", message)
+        self.assertIn("openai_credential", message)
+
+    def test_register_without_type_field_raises(self) -> None:
+        """A class with no ``type`` discriminator cannot be registered."""
+        with self.assertRaises(ValueError):
+            CredentialFactory.register_credential(_TypelessCredential)
+
+
+@pytest.mark.usefixtures("restore_factory_registry")
+class TestCredentialFactoryLookup(TestCase):
+    """``get_credential_class`` and ``list_schemas`` behavior."""
+
+    def test_get_credential_class_for_builtin(self) -> None:
+        """``get_credential_class`` resolves built-in discriminators."""
+        self.assertIs(
+            CredentialFactory.get_credential_class("openai_credential"),
+            OpenAICredential,
+        )
+        self.assertIs(
+            CredentialFactory.get_credential_class("dashscope_credential"),
+            DashScopeCredential,
+        )
+
+    def test_get_credential_class_unknown_returns_none(self) -> None:
+        """Unknown discriminators resolve to ``None``."""
+        self.assertIsNone(
+            CredentialFactory.get_credential_class("does_not_exist"),
+        )
+
+    def test_get_credential_class_after_custom_register(self) -> None:
+        """A registered custom class is resolvable by its discriminator."""
+        CredentialFactory.register_credential(_CustomCredential)
+
+        self.assertIs(
+            CredentialFactory.get_credential_class("custom_credential"),
+            _CustomCredential,
+        )
+
+    def test_list_schemas_includes_registered_custom(self) -> None:
+        """``list_schemas`` exposes registered custom credentials."""
+        CredentialFactory.register_credential(_CustomCredential)
+
+        schema_titles: List[str] = [
+            schema.get("title", "")
+            for schema in CredentialFactory.list_schemas()
+        ]
+        self.assertIn("_CustomCredential", schema_titles)


### PR DESCRIPTION
## Summary

Fixes #1961.

When a user registers a custom `CredentialBase` subclass via `extra_credentials=[...]` (or `CredentialFactory.register_credential` directly), a misconfigured `type` discriminator is currently accepted silently and only surfaces later as an opaque pydantic `ValidationError` deep inside `from_dict` — the traceback the reporter saw ends in a `tagged-union[...]` that does not even mention their custom class.

Reproducing the report shows the factory itself works fine for **valid** custom credentials; the silent failure paths are:

1. **Discriminator collision** — a custom class reuses a `type` Literal value already used by a built-in or another registered class (the reporter's original `type: Literal["openai_credential"] = ...`). `register_credential` accepts it, then `from_dict` later throws `TypeError: Value '...' for discriminator 'type' mapped to multiple choices`.
2. **Literal/default mismatch** — the reporter's own field `type: Literal["openai_credential"] = "custom_credential"` is internally contradictory (Literal permits one value, default is another). Pydantic lets this through at class-definition time.

Per the project's coding-style guideline ("ALWAYS validate at system boundaries… Fail fast with clear error messages"), this PR moves validation to the registration boundary so users get an actionable message at the call site instead of a cryptic pydantic error from a FastAPI request handler.

## Changes

- `src/agentscope/credential/_factory.py`
  - Added two module-private helpers, `_get_literal_values()` and `_get_discriminator_value()`, as a single source of truth for discriminator introspection.
  - Added `CredentialFactory._validate_discriminator()` and call it at the top of `register_credential`. Three fail-fast `ValueError` checks: missing `type` field; `type` default not in its own `Literal`; discriminator colliding with an already-registered class. Each message names the offending class, the conflicting value, and the class it collides with.
  - Refactored `get_credential_class` to reuse `_get_literal_values` (preserving its existing "first Literal value" match semantics).
  - No change to the public API signature; valid registrations behave exactly as before. `extra_credentials` registration in `app/_app.py` is unchanged.
- `tests/credential_factory_test.py` (new) — the **first unit-test suite for `CredentialFactory`** (it previously had zero coverage). 10 cases: built-in discriminator resolution; custom-class registration + round-trip; idempotent re-registration; the two #1961 failure paths (collision + Literal/default mismatch); missing `type` field; `get_credential_class` for built-in / unknown / custom; and `list_schemas` exposure. Includes a `restore_factory_registry` fixture that snapshots the class-level registry so tests stay isolated.

## Note for the reporter

In the issue's reproduction snippet, `OpenAICredentialX.list_models()` returns a `dict`, but the base class contract is `-> list[ModelCard]`. That is a separate caller-side issue, not a framework defect, so it is out of scope here — but worth double-checking in your real class.

## Test plan

- [x] `pytest tests/credential_factory_test.py -v` → 10 passed
- [x] `pre-commit run --files src/agentscope/credential/_factory.py tests/credential_factory_test.py` → all hooks pass (mypy / black / flake8 / pylint / pyroma)
- [x] Manual reproduction: registering a class with `Literal["openai_credential"]` now raises `ValueError` naming `OpenAICredential` as the conflict, instead of crashing later in `from_dict`
- [x] Manual reproduction: a valid uniquely-discriminated custom credential still registers, deserializes, and round-trips correctly
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)