### PR TITLE
fix(tool): reject mutating find commands as read-only

### DIFF
--- a/src/agentscope/tool/_builtin/_bash_parser.py
+++ b/src/agentscope/tool/_builtin/_bash_parser.py
@@ -132,6 +132,54 @@ READ_ONLY_COMMANDS = {
     "pip show",
 }
 
+FIND_MUTATING_PREDICATES = {
+    "-delete",
+    "-exec",
+    "-execdir",
+    "-fls",
+    "-fprint",
+    "-fprint0",
+    "-fprintf",
+    "-ok",
+    "-okdir",
+}
+
+FIND_PREDICATES_WITH_ARGUMENTS = {
+    "-amin",
+    "-anewer",
+    "-atime",
+    "-cmin",
+    "-cnewer",
+    "-context",
+    "-ctime",
+    "-fstype",
+    "-gid",
+    "-group",
+    "-ilname",
+    "-iname",
+    "-inum",
+    "-iwholename",
+    "-links",
+    "-lname",
+    "-maxdepth",
+    "-mindepth",
+    "-mmin",
+    "-mtime",
+    "-name",
+    "-newer",
+    "-path",
+    "-perm",
+    "-regex",
+    "-samefile",
+    "-size",
+    "-type",
+    "-uid",
+    "-used",
+    "-user",
+    "-wholename",
+    "-xtype",
+}
+
 
 class BashCommandParser:
     """Parse Bash commands using tree-sitter for accurate syntax analysis."""
@@ -199,6 +247,9 @@ class BashCommandParser:
         if cmd in READ_ONLY_COMMANDS:
             return True
 
+        if self._is_mutating_find_command(cmd):
+            return False
+
         # Check if it starts with a read-only prefix
         for readonly_cmd in READ_ONLY_COMMANDS:
             if cmd == readonly_cmd or cmd.startswith(readonly_cmd + " "):
@@ -218,6 +269,32 @@ class BashCommandParser:
             # Check if base command is in safe commands
             if base_cmd in SAFE_COMMANDS:
                 return True
+
+        return False
+
+    def _is_mutating_find_command(self, cmd: str) -> bool:
+        """Check if a find command contains mutating predicates."""
+        try:
+            tokens = shlex.split(cmd)
+        except ValueError:
+            tokens = cmd.split()
+
+        i = 0
+        while i < len(tokens) and "=" in tokens[i]:
+            i += 1
+
+        if i >= len(tokens) or tokens[i] != "find":
+            return False
+
+        i += 1
+        while i < len(tokens):
+            token = tokens[i]
+            if token in FIND_MUTATING_PREDICATES:
+                return True
+            if token in FIND_PREDICATES_WITH_ARGUMENTS:
+                i += 2
+            else:
+                i += 1
 
         return False
 

--- a/src/agentscope/tool/_builtin/_bash_parser.py
+++ b/src/agentscope/tool/_builtin/_bash_parser.py
@@ -144,42 +144,6 @@ FIND_MUTATING_PREDICATES = {
     "-okdir",
 }
 
-FIND_PREDICATES_WITH_ARGUMENTS = {
-    "-amin",
-    "-anewer",
-    "-atime",
-    "-cmin",
-    "-cnewer",
-    "-context",
-    "-ctime",
-    "-fstype",
-    "-gid",
-    "-group",
-    "-ilname",
-    "-iname",
-    "-inum",
-    "-iwholename",
-    "-links",
-    "-lname",
-    "-maxdepth",
-    "-mindepth",
-    "-mmin",
-    "-mtime",
-    "-name",
-    "-newer",
-    "-path",
-    "-perm",
-    "-regex",
-    "-samefile",
-    "-size",
-    "-type",
-    "-uid",
-    "-used",
-    "-user",
-    "-wholename",
-    "-xtype",
-}
-
 
 class BashCommandParser:
     """Parse Bash commands using tree-sitter for accurate syntax analysis."""
@@ -273,28 +237,26 @@ class BashCommandParser:
         return False
 
     def _is_mutating_find_command(self, cmd: str) -> bool:
-        """Check if a find command contains mutating predicates."""
+        """Check if a find command contains mutating predicates via AST."""
         try:
-            tokens = shlex.split(cmd)
-        except ValueError:
-            tokens = cmd.split()
-
-        i = 0
-        while i < len(tokens) and "=" in tokens[i]:
-            i += 1
-
-        if i >= len(tokens) or tokens[i] != "find":
+            tree = self.parser.parse(bytes(cmd, "utf8"))
+        except Exception:
             return False
 
-        i += 1
-        while i < len(tokens):
-            token = tokens[i]
-            if token in FIND_MUTATING_PREDICATES:
-                return True
-            if token in FIND_PREDICATES_WITH_ARGUMENTS:
-                i += 2
-            else:
-                i += 1
+        root = tree.root_node
+        cmd_node = self._find_first_simple_command(root)
+        if cmd_node is None:
+            return False
+
+        name_node = cmd_node.child_by_field_name("name")
+        if name_node is None or name_node.text.decode("utf8") != "find":
+            return False
+
+        for child in cmd_node.children:
+            if child.type == "word":
+                text = child.text.decode("utf8")
+                if text in FIND_MUTATING_PREDICATES:
+                    return True
 
         return False
 

--- a/tests/builtin_bash_test.py
+++ b/tests/builtin_bash_test.py
@@ -217,12 +217,40 @@ class BashToolInjectionCheckTest(IsolatedAsyncioTestCase):
         self.assertEqual(decision.behavior, PermissionBehavior.ASK)
         self.assertIn("command_substitution", decision.message)
 
+    async def test_mutating_find_commands_not_auto_allowed(self) -> None:
+        """Test mutating find commands are not auto-allowed as read-only."""
+        test_cases = [
+            "find . -delete",
+            "find . -name '*.tmp' -delete",
+            "find . -daystart -delete",
+            "find . -nogroup -delete",
+            "find . -nouser -delete",
+            "find . -exec rm {} \\;",
+            "find . -execdir rm {} \\;",
+            "find . -fls results.txt",
+            "find . -fprint results.txt",
+            "find . -fprint0 results.txt",
+            "find . -fprintf results.txt '%p\\n'",
+            "find . -ok rm {} \\;",
+            "find . -okdir rm {} \\;",
+        ]
+        for cmd in test_cases:
+            with self.subTest(cmd=cmd):
+                decision = await self.bash_tool.check_permissions(
+                    {"command": cmd},
+                    self.context,
+                )
+                self.assertNotEqual(decision.behavior, PermissionBehavior.ALLOW)
+
     async def test_safe_commands_pass(self) -> None:
         """Test that safe commands pass injection check."""
 
         safe_commands = [
             "ls -la",
             "cat file.txt",
+            "find . -name '-delete'",
+            "find . -path './-fprint'",
+            "find . -regex '.*-exec.*'",
             "git status",
             "echo 'hello world'",
         ]

--- a/tests/builtin_bash_test.py
+++ b/tests/builtin_bash_test.py
@@ -240,7 +240,9 @@ class BashToolInjectionCheckTest(IsolatedAsyncioTestCase):
                     {"command": cmd},
                     self.context,
                 )
-                self.assertNotEqual(decision.behavior, PermissionBehavior.ALLOW)
+                self.assertNotEqual(
+                    decision.behavior, PermissionBehavior.ALLOW
+                )
 
     async def test_safe_commands_pass(self) -> None:
         """Test that safe commands pass injection check."""

--- a/tests/builtin_bash_test.py
+++ b/tests/builtin_bash_test.py
@@ -241,7 +241,8 @@ class BashToolInjectionCheckTest(IsolatedAsyncioTestCase):
                     self.context,
                 )
                 self.assertNotEqual(
-                    decision.behavior, PermissionBehavior.ALLOW
+                    decision.behavior,
+                    PermissionBehavior.ALLOW,
                 )
 
     async def test_safe_commands_pass(self) -> None:

--- a/tests/permission_bash_parser_test.py
+++ b/tests/permission_bash_parser_test.py
@@ -244,6 +244,9 @@ class BashParserReadOnlyTest(IsolatedAsyncioTestCase):
             "tail -f log.txt",
             "grep pattern file.txt",
             "find . -name '*.py'",
+            "find . -name '-delete'",
+            "find . -path './-fprint'",
+            "find . -regex '.*-exec.*'",
             "tree",
             "pwd",
             "which python",
@@ -253,6 +256,30 @@ class BashParserReadOnlyTest(IsolatedAsyncioTestCase):
                 self.assertTrue(
                     self.parser.is_read_only_command(cmd),
                     f"Expected '{cmd}' to be read-only",
+                )
+
+    async def test_mutating_find_commands_are_not_read_only(self) -> None:
+        """Test find predicates that can modify files are not read-only."""
+        mutating_find_commands = [
+            "find . -delete",
+            "find . -name '*.tmp' -delete",
+            "find . -daystart -delete",
+            "find . -nogroup -delete",
+            "find . -nouser -delete",
+            "find . -exec rm {} \\;",
+            "find . -execdir rm {} \\;",
+            "find . -fls results.txt",
+            "find . -fprint results.txt",
+            "find . -fprint0 results.txt",
+            "find . -fprintf results.txt '%p\\n'",
+            "find . -ok rm {} \\;",
+            "find . -okdir rm {} \\;",
+        ]
+        for cmd in mutating_find_commands:
+            with self.subTest(cmd=cmd):
+                self.assertFalse(
+                    self.parser.is_read_only_command(cmd),
+                    f"Expected '{cmd}' to be non-read-only",
                 )
 
     async def test_single_read_only_docker_commands(self) -> None:


### PR DESCRIPTION
## AgentScope Version

Current branch based on `main` at `922e673b`. No released version bump is involved.

## Description

Fixes https://github.com/agentscope-ai/agentscope/issues/2003 by preventing mutating GNU `find` actions from being classified as read-only before `Bash.check_permissions()` reaches the normal permission path.

### What Problem This Solves

`Bash.check_permissions()` has an early allow path for commands that `BashCommandParser.is_read_only_command()` marks as safe. This is the right behavior for inspection-only commands such as `ls`, `cat`, `grep`, and ordinary `find` searches, because those commands should not require extra confirmation just to read or list files.

The bug was that `find` was treated as read-only at the command-prefix level. In `_is_single_command_read_only()`, the generic check accepted any command where `cmd == readonly_cmd` or `cmd.startswith(readonly_cmd + " ")`. Since `find` was present in `READ_ONLY_COMMANDS`, the parser could classify a command as read-only immediately after seeing the leading `find ` text, without checking the rest of the `find` expression.

That distinction matters because `find` is not only a search command. A `find` expression can contain actions: some delete matched files, some execute arbitrary commands for each match, and some write matching paths to a named output file. These examples all start with the same read-only-looking prefix, but they cross different permission boundaries:

```text
find . -delete              # deletes matched files
find . -exec rm {} \;       # executes rm for each match
find . -fprint results.txt  # writes results to a named file
```

Before this fix, those commands could be classified through the same prefix path as a harmless search like:

```text
find . -name '*.py'
```

The intended boundary is more precise: `find` should be auto-allowable only when the expression is still read-only. Once the expression contains mutating actions such as `-delete`, `-exec`, `-execdir`, `-ok`, `-okdir`, `-fls`, `-fprint`, `-fprint0`, or `-fprintf`, it should fall through to the normal permission decision instead of being treated like a file listing.

The fix also avoids the opposite mistake: pattern values that merely look like action names should remain read-only. For example, searching for a filename literally called `-delete` should not be treated as deletion:

```text
find . -name '-delete'
find . -path './-fprint'
find . -regex '.*-exec.*'
```

### Changes

This PR adds a small `find`-specific guard before the generic read-only prefix match runs. The new logic tokenizes a single command, confirms the executable is `find`, and checks only expression positions for mutating actions.

The mutating actions covered by this PR are:

```text
-delete
-exec
-execdir
-ok
-okdir
-fls
-fprint
-fprint0
-fprintf
```

The parser also skips arguments for common one-argument `find` predicates so that pattern values which merely look like actions are not misclassified. These remain read-only:

```text
find . -name '-delete'
find . -path './-fprint'
find . -regex '.*-exec.*'
```

The change only narrows internal Bash permission classification. It does not change Bash command execution, dangerous path lists, dedicated file tools, command parsing outside this read-only check, user-facing APIs, or documentation examples. Documentation was not updated for that reason.

### Evidence

Direct parser verification covered both sides of the boundary:

```text
find . -name '-delete'      -> read_only=True
find . -path './-fprint'    -> read_only=True
find . -regex '.*-exec.*'   -> read_only=True
find . -daystart -delete    -> read_only=False
find . -nogroup -delete     -> read_only=False
find . -delete              -> read_only=False
find . -exec rm {} \;       -> read_only=False
find . -fprint results.txt  -> read_only=False
```

Direct `Bash.check_permissions()` verification confirmed the same runtime permission behavior for the tested cases: read-only `find` searches still return automatic `ALLOW`, while mutating `find` actions no longer return automatic `ALLOW`.

Additional validation performed:

```text
python -m py_compile src\agentscope\tool\_builtin\_bash_parser.py tests\permission_bash_parser_test.py tests\builtin_bash_test.py
git diff --check
python -m pytest tests\permission_bash_parser_test.py::BashParserReadOnlyTest::test_single_read_only_file_commands tests\permission_bash_parser_test.py::BashParserReadOnlyTest::test_mutating_find_commands_are_not_read_only tests\builtin_bash_test.py::BashToolInjectionCheckTest::test_safe_commands_pass tests\builtin_bash_test.py::BashToolInjectionCheckTest::test_mutating_find_commands_not_auto_allowed -q
```

The targeted Bash pytest cases were invoked on Windows and reported `4 skipped` because these Bash parser test classes already have an existing `win32` class-level skip. Parser behavior and `Bash.check_permissions()` behavior were therefore verified directly in addition to syntax and whitespace checks.

### Possible call chain / impact

Before this fix, the affected path was:

```text
Bash tool input
  -> Bash.check_permissions(...)
  -> BashCommandParser.is_read_only_command(...)
  -> generic read-only prefix match for "find "
  -> mutating find action could be treated as read-only
  -> command could skip the normal confirmation path
```

After this fix, mutating `find` actions are detected before the generic prefix allow path, so they are classified as non-read-only and continue through the normal permission flow.

Sibling surfaces checked:

- Parser-level classification in `tests/permission_bash_parser_test.py`
- Bash tool permission behavior in `tests/builtin_bash_test.py`
- Read-only `find` searches with action-like pattern values (`-name`, `-path`, `-regex`)
- Zero-argument `find` tests followed by mutating actions (`-daystart`, `-nogroup`, `-nouser`)

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  An issue has been created for this PR
- [x]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [x]  Code is ready for review