### PR TITLE
fix(tool): reject negative grep context flags

### DIFF
--- a/src/agentscope/tool/_builtin/_grep.py
+++ b/src/agentscope/tool/_builtin/_grep.py
@@ -93,21 +93,25 @@ class Grep(ToolBase):
                 "type": "integer",
                 "description": "Number of lines to show after each match. "
                 "Requires output_mode: 'content'.",
+                "minimum": 0,
             },
             "-B": {
                 "type": "integer",
                 "description": "Number of lines to show before each match. "
                 "Requires output_mode: 'content'.",
+                "minimum": 0,
             },
             "-C": {
                 "type": "integer",
                 "description": "Alias for context.",
+                "minimum": 0,
             },
             "context": {
                 "type": "integer",
                 "description": "Number of context lines to show before and "
                 "after matches. Requires output_mode: "
                 "'content'.",
+                "minimum": 0,
             },
             "n": {
                 "type": "boolean",
@@ -408,6 +412,29 @@ class Grep(ToolBase):
             A = kwargs.get("-A")
             B = kwargs.get("-B")
             C = kwargs.get("-C")
+
+            # Reject negative context values up front. Otherwise the value is
+            # stringified and forwarded to ripgrep, which fails with an opaque
+            # "error parsing flag -C: value is not a valid number".
+            for flag_name, flag_value in [
+                ("context", context),
+                ("-A", A),
+                ("-B", B),
+                ("-C", C),
+            ]:
+                if flag_value is not None and flag_value < 0:
+                    return ToolChunk(
+                        content=[
+                            TextBlock(
+                                text=(
+                                    f"Error: {flag_name} must be "
+                                    "non-negative."
+                                ),
+                            ),
+                        ],
+                        state=ToolResultState.ERROR,
+                        is_last=True,
+                    )
 
             if context is not None:
                 args.extend(["-C", str(context)])

--- a/tests/builtin_grep_test.py
+++ b/tests/builtin_grep_test.py
@@ -252,3 +252,57 @@ class GrepToolTest(IsolatedAsyncioTestCase):
         expected_pattern = os.path.abspath(cwd).rstrip("/") + "/**"
         suggestion_contents = [s.rule_content for s in suggestions]
         self.assertIn(expected_pattern, suggestion_contents)
+
+    async def test_negative_context_returns_clear_error(self) -> None:
+        """Negative ``context`` must error, not reach ripgrep.
+
+        Sibling of the fixed #1936 (negative ``head_limit``/``offset``).
+        """
+        chunk = await self.grep_tool(
+            pattern="hello",
+            path=self.temp_dir,
+            output_mode="content",
+            context=-5,
+        )
+
+        self.assertEqual(chunk.state, ToolResultState.ERROR)
+        self.assertIn("context", chunk.content[0].text)
+        self.assertIn("non-negative", chunk.content[0].text)
+
+    async def test_negative_context_flags_return_clear_error(self) -> None:
+        """Negative ``-A``/``-B``/``-C`` must error, not reach ripgrep."""
+        for flag, value in [("-A", -3), ("-B", -2), ("-C", -1)]:
+            with self.subTest(flag=flag):
+                chunk = await self.grep_tool(
+                    pattern="hello",
+                    path=self.temp_dir,
+                    output_mode="content",
+                    **{flag: value},
+                )
+
+                self.assertEqual(chunk.state, ToolResultState.ERROR)
+                self.assertIn(flag, chunk.content[0].text)
+                self.assertIn("non-negative", chunk.content[0].text)
+
+    async def test_positive_context_works(self) -> None:
+        """A positive ``context`` value still produces normal results."""
+        chunk = await self.grep_tool(
+            pattern="hello",
+            path=self.temp_dir,
+            output_mode="content",
+            context=1,
+            i=True,
+        )
+
+        self.assertEqual(chunk.state, ToolResultState.SUCCESS)
+
+    async def test_context_schema_rejects_negative(self) -> None:
+        """The input schema caps ``-A``/``-B``/``-C``/``context`` at 0."""
+        for flag in ["-A", "-B", "-C", "context"]:
+            with self.subTest(flag=flag):
+                self.assertEqual(
+                    self.grep_tool.input_schema["properties"][flag].get(
+                        "minimum",
+                    ),
+                    0,
+                )


### PR DESCRIPTION
## Summary

The `Grep` tool's `-A`, `-B`, `-C`, and `context` parameters were declared as plain integers with **no `minimum`** in the input schema and **no in-code guard**. A negative value was stringified and forwarded to ripgrep, which failed with an opaque message:

```
ripgrep error (code 2): rg: error parsing flag -C: value is not a valid number: invalid digit found in string
```

…instead of a clear validation error.

This is the **same class of bug as #1936** (negative `head_limit`/`offset`), which was fixed with a schema `minimum` plus an in-code guard. This PR applies the same treatment to the four context-line parameters.

## Changes

- `src/agentscope/tool/_builtin/_grep.py`
  - Added `"minimum": 0` to the input schema for `-A`, `-B`, `-C`, and `context`.
  - Added an in-code guard in `call()` (right after the flags are parsed) that returns a clear `ToolChunk(state=ERROR)` reading `Error: <flag> must be non-negative.` for any negative value — mirroring the existing `head_limit`/`offset` guards.
- `tests/builtin_grep_test.py`
  - `test_negative_context_returns_clear_error` — `context=-5` → ERROR mentioning `context` + `non-negative`.
  - `test_negative_context_flags_return_clear_error` — `-A`/`-B`/`-C` negative → ERROR naming the flag.
  - `test_positive_context_works` — `context=1` still returns SUCCESS (no regression).
  - `test_context_schema_rejects_negative` — asserts all four schema entries have `minimum: 0`.

## Verification

- [x] `pytest tests/builtin_grep_test.py -v` → 17 passed (13 existing + 4 new)
- [x] `pytest tests/builtin_grep_test.py tests/builtin_glob_test.py tests/builtin_read_test.py` → 37 passed, no regression
- [x] Manual repro: `context=-5` now returns `Error: context must be non-negative.` (state=error) instead of the opaque ripgrep error
- [x] `pre-commit run --files src/agentscope/tool/_builtin/_grep.py tests/builtin_grep_test.py` → all hooks pass (mypy / black / flake8 / pylint / pyroma)
- [ ] CI

