### PR TITLE
fix(formatter): include tool_name in ollama tool result messages

### DIFF
--- a/src/agentscope/formatter/_ollama_formatter.py
+++ b/src/agentscope/formatter/_ollama_formatter.py
@@ -232,9 +232,15 @@ class OllamaChatFormatter(_OllamaFormatterBase):
 
                     # Ollama expects tool results as a separate "tool" role
                     # message, regardless of the containing Msg's role.
+                    # Per the Ollama tool-calling spec, the "tool" message
+                    # must carry a "tool_name" field (not the OpenAI-style
+                    # "tool_call_id") so the model can correlate the result
+                    # with the function that produced it — see
+                    # https://docs.ollama.com/capabilities/tool-calling
                     messages.append(
                         {
                             "role": "tool",
+                            "tool_name": block.name,
                             "content": textual_output,
                         },
                     )

--- a/tests/formatter_ollama_test.py
+++ b/tests/formatter_ollama_test.py
@@ -112,7 +112,11 @@ class TestOllamaFormatter(IsolatedAsyncioTestCase):
                     },
                 ],
             },
-            {"role": "tool", "content": "The capital of Japan is Tokyo."},
+            {
+                "role": "tool",
+                "tool_name": "get_capital",
+                "content": "The capital of Japan is Tokyo.",
+            },
             {"role": "assistant", "content": "The capital of Japan is Tokyo."},
         ]
 
@@ -146,6 +150,7 @@ class TestOllamaFormatter(IsolatedAsyncioTestCase):
         }
         self._gt_tool_result = {
             "role": "tool",
+            "tool_name": "get_capital",
             "content": "The capital of Japan is Tokyo.",
         }
 
@@ -312,6 +317,7 @@ class TestOllamaFormatter(IsolatedAsyncioTestCase):
                 },
                 {
                     "role": "tool",
+                    "tool_name": "get_map",
                     "content": expected_tool_content,
                 },
                 {
@@ -476,8 +482,8 @@ class TestOllamaFormatter(IsolatedAsyncioTestCase):
                         },
                     ],
                 },
-                {"role": "tool", "content": "result_1"},
-                {"role": "tool", "content": "result_2"},
+                {"role": "tool", "tool_name": "func_1", "content": "result_1"},
+                {"role": "tool", "tool_name": "func_2", "content": "result_2"},
                 {
                     "role": "assistant",
                     "content": "text_2",
@@ -490,7 +496,7 @@ class TestOllamaFormatter(IsolatedAsyncioTestCase):
                         },
                     ],
                 },
-                {"role": "tool", "content": "result_3"},
+                {"role": "tool", "tool_name": "func_3", "content": "result_3"},
                 {
                     "role": "assistant",
                     "content": "",
@@ -503,7 +509,7 @@ class TestOllamaFormatter(IsolatedAsyncioTestCase):
                         },
                     ],
                 },
-                {"role": "tool", "content": "result_4"},
+                {"role": "tool", "tool_name": "func_4", "content": "result_4"},
                 {"role": "assistant", "content": "text_3"},
             ],
             res,
@@ -603,3 +609,39 @@ class TestOllamaFormatter(IsolatedAsyncioTestCase):
 
         args = res[0]["tool_calls"][0]["function"]["arguments"]
         self.assertIsInstance(args, dict)
+
+    async def test_tool_result_message_carries_tool_name(self) -> None:
+        """``role: tool`` messages must carry ``tool_name`` per Ollama spec.
+
+        Ollama's tool-calling API correlates a tool result with its function
+        via the ``tool_name`` field (not OpenAI's ``tool_call_id``). Emitting
+        a ``tool`` message without it breaks multi-turn tool use.  See
+        https://docs.ollama.com/capabilities/tool-calling.
+        """
+        fmt = OllamaChatFormatter()
+        msgs = [
+            AssistantMsg(
+                name="assistant",
+                content=[
+                    ToolCallBlock(
+                        id="call_1",
+                        name="get_capital",
+                        input='{"country": "Japan"}',
+                    ),
+                    ToolResultBlock(
+                        id="call_1",
+                        name="get_capital",
+                        output=[TextBlock(text="Tokyo")],
+                        state=ToolResultState.SUCCESS,
+                    ),
+                ],
+            ),
+        ]
+
+        res = await fmt.format(msgs)
+
+        tool_messages = [m for m in res if m.get("role") == "tool"]
+        self.assertEqual(len(tool_messages), 1)
+        self.assertEqual(tool_messages[0]["tool_name"], "get_capital")
+        # The OpenAI-style tool_call_id must NOT be emitted for Ollama.
+        self.assertNotIn("tool_call_id", tool_messages[0])


### PR DESCRIPTION
## Summary

The Ollama chat formatter emitted tool-result messages as `{"role": "tool", "content": ...}`, **omitting the `tool_name` field** that Ollama's tool-calling API requires to correlate a result with its function.

Per the [Ollama tool-calling spec](https://docs.ollama.com/capabilities/tool-calling), the correct shape is:

```json
{"role": "tool", "tool_name": "<function>", "content": "..."}
```

Note this is **NOT** the OpenAI-style `tool_call_id` — Ollama uses `tool_name`. (My initial audit assumed OpenAI-compat `tool_call_id`; checking the official docs corrected this to `tool_name`.)

Without `tool_name`, **multi-turn and parallel tool use on Ollama cannot match results back to calls**, producing 400s or mis-pairing.

## Changes

- `src/agentscope/formatter/_ollama_formatter.py`
  - `OllamaChatFormatter.format` now emits `"tool_name": block.name` on every `role: tool` message. (`ToolResultBlock.name` is a required `str`, so it is always present.)
  - The `OllamaMultiAgentFormatter` delegates tool-sequence formatting to `OllamaChatFormatter.format` (`_format_tool_sequence`), so it is covered by the same change.
- `tests/formatter_ollama_test.py`
  - Updated the four existing ground-truth expectations that contained `role: tool` messages.
  - Added a dedicated regression test `test_tool_result_message_carries_tool_name` that asserts `tool_name` is present and that the OpenAI-style `tool_call_id` is **not** emitted.

## Verification

- [x] `pytest tests/formatter_ollama_test.py -v` → 9 passed (8 existing + 1 new regression)
- [x] `pre-commit run --files ...` → all hooks pass (mypy / black / flake8 / pylint / pyroma)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)