### PR TITLE
fix(permission): require review for mutating find actions

### DIFF
--- a/src/agentscope/tool/_builtin/_bash_parser.py
+++ b/src/agentscope/tool/_builtin/_bash_parser.py
@@ -132,6 +132,46 @@ READ_ONLY_COMMANDS = {
     "pip show",
 }
 
+FIND_MUTATING_ACTIONS = {
+    "-delete",
+    "-exec",
+    "-execdir",
+    "-ok",
+    "-okdir",
+    "-fls",
+    "-fprint",
+    "-fprintf",
+}
+
+FIND_PREDICATES_WITH_VALUE = {
+    "-anewer",
+    "-cnewer",
+    "-context",
+    "-exec",
+    "-execdir",
+    "-fprint",
+    "-fprintf",
+    "-fstype",
+    "-gid",
+    "-group",
+    "-ilname",
+    "-iname",
+    "-inum",
+    "-iwholename",
+    "-lname",
+    "-name",
+    "-newer",
+    "-path",
+    "-perm",
+    "-regex",
+    "-samefile",
+    "-size",
+    "-type",
+    "-user",
+    "-wholename",
+    "-xtype",
+}
+
 
 class BashCommandParser:
     """Parse Bash commands using tree-sitter for accurate syntax analysis."""
@@ -195,6 +235,9 @@ class BashCommandParser:
             `bool`:
                 True if the command is read-only, False otherwise
         """
+        if self._find_command_has_mutating_action(cmd):
+            return False
+
         # Check exact match in read-only commands
         if cmd in READ_ONLY_COMMANDS:
             return True
@@ -220,6 +263,41 @@ class BashCommandParser:
                 return True
 
         return False
+
+    def _find_command_has_mutating_action(self, cmd: str) -> bool:
+        """Check whether a find command contains mutating actions."""
+        try:
+            tokens = shlex.split(cmd)
+        except ValueError:
+            return True
+
+        find_idx = self._find_command_index(tokens)
+        if find_idx is None:
+            return False
+
+        skip_next = False
+        for token in tokens[find_idx + 1 :]:
+            if skip_next:
+                skip_next = False
+                continue
+            if token in FIND_MUTATING_ACTIONS:
+                return True
+            if token in FIND_PREDICATES_WITH_VALUE:
+                skip_next = True
+
+        return False
+
+    @staticmethod
+    def _find_command_index(tokens: List[str]) -> Optional[int]:
+        """Return the token index for a find executable, if present."""
+        for i, token in enumerate(tokens):
+            if "=" in token and not token.startswith("-"):
+                continue
+            if token == "find" or token.endswith("/find"):
+                return i
+            return None
+
+        return None
 
     def extract_file_paths(
         self,

--- a/tests/permission_bash_parser_test.py
+++ b/tests/permission_bash_parser_test.py
@@ -290,6 +290,44 @@ class BashParserReadOnlyTest(IsolatedAsyncioTestCase):
                     f"Expected '{cmd}' to be non-read-only",
                 )
 
+    async def test_find_mutating_actions_are_not_read_only(self) -> None:
+        """Test that mutating find actions require normal permission checks."""
+        mutating_find_commands = [
+            "find . -delete",
+            "find . -name '*.tmp' -delete",
+            "find . -exec rm {} \\;",
+            "find . -execdir chmod 600 {} \\;",
+            "find . -ok rm {} \\;",
+            "find . -okdir rm {} \\;",
+            "find . -fprint files.txt",
+            "find . -fprintf files.txt '%p\\n'",
+            "find . -fls files.txt",
+        ]
+        for cmd in mutating_find_commands:
+            with self.subTest(cmd=cmd):
+                self.assertFalse(
+                    self.parser.is_read_only_command(cmd),
+                    f"Expected '{cmd}' to be non-read-only",
+                )
+
+    async def test_find_quoted_action_like_patterns_are_read_only(
+        self,
+    ) -> None:
+        """Test action-like find predicate values do not become actions."""
+        read_only_find_commands = [
+            "find . -name '-delete'",
+            "find . -name '-exec'",
+            "find . -path './-delete'",
+            "find . -regex '.*-exec.*'",
+            "find . -iname '-fprint'",
+        ]
+        for cmd in read_only_find_commands:
+            with self.subTest(cmd=cmd):
+                self.assertTrue(
+                    self.parser.is_read_only_command(cmd),
+                    f"Expected '{cmd}' to be read-only",
+                )
+
     async def test_compound_command_all_read_only(self) -> None:
         """Test compound commands with all read-only subcommands."""
         compound_commands = [

--- a/tests/permission_engine_test.py
+++ b/tests/permission_engine_test.py
@@ -546,6 +546,16 @@ class PermissionEngineReadOnlyTest(IsolatedAsyncioTestCase):
         # Should ask (not read-only)
         self.assertEqual(decision.behavior, PermissionBehavior.ASK)
 
+    async def test_find_delete_is_not_read_only(self) -> None:
+        """Test that mutating find actions are not auto-allowed."""
+        decision = await self.engine.check_permission(
+            Bash(),
+            {"command": "find . -delete"},
+        )
+
+        # Should ask (find action mutates files)
+        self.assertEqual(decision.behavior, PermissionBehavior.ASK)
+
     async def test_compound_command_with_dangerous_path(self) -> None:
         """Test compound command with read-only and dangerous path o
         perations."""


### PR DESCRIPTION
## Summary
- detect mutating find actions before Bash read-only prefix auto-allow
- keep normal read-only find searches auto-allowable, including action-like values passed to predicates such as -name
- add parser and permission-engine regressions for find -delete and related actions

## Root cause
find was treated as a read-only command by prefix, so actions such as find . -delete and find . -exec rm {} \; could be auto-allowed before the normal permission path.

## Validation
- .venv/bin/python -m pytest -p no:cacheprovider tests/permission_bash_parser_test.py tests/permission_engine_test.py -q
- .venv/bin/pre-commit run --files src/agentscope/tool/_builtin/_bash_parser.py tests/permission_bash_parser_test.py tests/permission_engine_test.py

Closes #2003