### PR TITLE
fix(formatter): repair truncated tool-call input instead of crashing

### DIFF
--- a/src/agentscope/formatter/_anthropic_formatter.py
+++ b/src/agentscope/formatter/_anthropic_formatter.py
@@ -2,7 +2,6 @@
 """The Anthropic formatter module."""
 import base64
 import fnmatch
-import json
 from abc import ABC
 from typing import Any
 
@@ -11,6 +10,7 @@ from pydantic import Field
 
 from ._formatter_base import FormatterBase
 from .._logging import logger
+from .._utils._common import _json_loads_with_repair
 from ..message import (
     Msg,
     TextBlock,
@@ -145,8 +145,13 @@ class _AnthropicFormatterBase(FormatterBase, ABC):
                             "id": block.id,
                             "name": block.name,
                             # Anthropic API expects input as a dict, not a
-                            # JSON string.
-                            "input": json.loads(block.input or "{}"),
+                            # JSON string. Use the repair helper so a
+                            # truncated input (from interrupted streaming or
+                            # context compression) degrades to {} instead of
+                            # raising JSONDecodeError.
+                            "input": _json_loads_with_repair(
+                                block.input or "{}",
+                            ),
                         },
                     )
 

--- a/src/agentscope/formatter/_gemini_formatter.py
+++ b/src/agentscope/formatter/_gemini_formatter.py
@@ -2,7 +2,6 @@
 """Google Gemini API formatter in agentscope."""
 import base64
 import fnmatch
-import json
 from abc import ABC
 from typing import Any
 
@@ -11,6 +10,7 @@ from pydantic import Field
 
 from ._formatter_base import FormatterBase
 from .._logging import logger
+from .._utils._common import _json_loads_with_repair
 from ..message import (
     Msg,
     TextBlock,
@@ -199,7 +199,13 @@ class GeminiChatFormatter(_GeminiFormatterBase):
                             "function_call": {
                                 "id": block.id,
                                 "name": block.name,
-                                "args": json.loads(block.input or "{}"),
+                                # Use the repair helper so a truncated input
+                                # (from interrupted streaming or context
+                                # compression) degrades to {} instead of
+                                # raising JSONDecodeError.
+                                "args": _json_loads_with_repair(
+                                    block.input or "{}",
+                                ),
                             },
                         },
                     )

--- a/src/agentscope/formatter/_ollama_formatter.py
+++ b/src/agentscope/formatter/_ollama_formatter.py
@@ -2,7 +2,6 @@
 """The Ollama formatter module."""
 import base64
 import fnmatch
-import json
 from abc import ABC
 from typing import Any
 
@@ -11,6 +10,7 @@ from pydantic import Field
 
 from ._formatter_base import FormatterBase
 from .._logging import logger
+from .._utils._common import _json_loads_with_repair
 from ..message import (
     Msg,
     TextBlock,
@@ -197,8 +197,12 @@ class OllamaChatFormatter(_OllamaFormatterBase):
                                     "function": {
                                         "name": block.name,
                                         # Ollama SDK expects a dict, not a
-                                        # JSON string.
-                                        "arguments": json.loads(
+                                        # JSON string. Use the repair helper
+                                        # so a truncated input (from
+                                        # interrupted streaming or context
+                                        # compression) degrades to {} instead
+                                        # of raising JSONDecodeError.
+                                        "arguments": _json_loads_with_repair(
                                             block.input or "{}",
                                         ),
                                     },

--- a/tests/formatter_anthropic_test.py
+++ b/tests/formatter_anthropic_test.py
@@ -956,3 +956,35 @@ class TestAnthropicFormatter(IsolatedAsyncioTestCase):
             ],
             res,
         )
+
+    async def test_tool_call_with_incomplete_input_does_not_crash(
+        self,
+    ) -> None:
+        """A truncated ``block.input`` must not crash the formatter.
+
+        Context compression or interrupted streaming can leave a
+        ``ToolCallBlock.input`` as an incomplete JSON fragment (e.g.
+        ``'{"key'``). The formatter must repair it into a dict (here
+        ``{}``) instead of raising ``JSONDecodeError``.
+        """
+        fmt = AnthropicChatFormatter()
+        msgs = [
+            AssistantMsg(
+                name="assistant",
+                content=[
+                    ToolCallBlock(
+                        id="call_1",
+                        name="get_weather",
+                        input='{"city": "Tok',
+                    ),
+                ],
+            ),
+        ]
+
+        res = await fmt.format(msgs)
+
+        tool_use = [
+            b for b in res[0]["content"] if b.get("type") == "tool_use"
+        ][0]
+        # Repaired to a dict rather than crashing.
+        self.assertIsInstance(tool_use["input"], dict)

--- a/tests/formatter_gemini_test.py
+++ b/tests/formatter_gemini_test.py
@@ -716,3 +716,37 @@ class TestGeminiFormatter(IsolatedAsyncioTestCase):
             ],
             res,
         )
+
+    async def test_tool_call_with_incomplete_input_does_not_crash(
+        self,
+    ) -> None:
+        """A truncated ``block.input`` must not crash the formatter.
+
+        Context compression or interrupted streaming can leave a
+        ``ToolCallBlock.input`` as an incomplete JSON fragment. The
+        formatter must repair it into a dict instead of raising
+        ``JSONDecodeError``.
+        """
+        fmt = GeminiChatFormatter()
+        msgs = [
+            AssistantMsg(
+                name="assistant",
+                content=[
+                    ToolCallBlock(
+                        id="call_1",
+                        name="get_weather",
+                        input='{"city": "Tok',
+                    ),
+                ],
+            ),
+        ]
+
+        res = await fmt.format(msgs)
+
+        function_call = [
+            part
+            for m in res
+            for part in m.get("parts", [])
+            if "function_call" in part
+        ][0]["function_call"]
+        self.assertIsInstance(function_call["args"], dict)

--- a/tests/formatter_ollama_test.py
+++ b/tests/formatter_ollama_test.py
@@ -574,3 +574,32 @@ class TestOllamaFormatter(IsolatedAsyncioTestCase):
             ],
             res,
         )
+
+    async def test_tool_call_with_incomplete_input_does_not_crash(
+        self,
+    ) -> None:
+        """A truncated ``block.input`` must not crash the formatter.
+
+        Context compression or interrupted streaming can leave a
+        ``ToolCallBlock.input`` as an incomplete JSON fragment. Ollama
+        expects ``arguments`` as a dict, so the formatter must repair the
+        fragment instead of raising ``JSONDecodeError``.
+        """
+        fmt = OllamaChatFormatter()
+        msgs = [
+            AssistantMsg(
+                name="assistant",
+                content=[
+                    ToolCallBlock(
+                        id="call_1",
+                        name="get_weather",
+                        input='{"city": "Tok',
+                    ),
+                ],
+            ),
+        ]
+
+        res = await fmt.format(msgs)
+
+        args = res[0]["tool_calls"][0]["function"]["arguments"]
+        self.assertIsInstance(args, dict)


### PR DESCRIPTION
## Summary

The **Anthropic**, **Gemini**, and **Ollama** formatters parsed `ToolCallBlock.input` with `json.loads(block.input or "{}")`, which **raised `JSONDecodeError`** when the input was a truncated/incomplete JSON fragment. Such fragments arise when **context compression truncates a tool call mid-content** or when **streaming is interrupted** — turning a recoverable state into a hard crash of the whole `format()` call.

## Root cause

`block.input or "{}"` only guards against `None` / `""`. A non-empty but incomplete fragment like `'{"city": "Tok'` reaches `json.loads` and raises.

## Fix

Replace the raw `json.loads` with the existing **`_json_loads_with_repair`** helper (`src/agentscope/_utils/_common.py`), which the agent loop already uses for exactly this purpose (`agent/_agent.py:1386`). It degrades a malformed fragment to `{}` instead of raising.

The three formatters that require `input`/`arguments`/`args` as a **dict** are fixed:
- `_anthropic_formatter.py` — `"input": _json_loads_with_repair(...)`
- `_gemini_formatter.py` — `"args": _json_loads_with_repair(...)`
- `_ollama_formatter.py` — `"arguments": _json_loads_with_repair(...)`

The OpenAI / DashScope / DeepSeek / Moonshot formatters are **unaffected** — they pass `block.input` as a raw string to SDKs that accept strings, so no parsing occurs.

The now-unused `import json` is removed from each of the three modules.

## Tests

One regression test per formatter, each feeding an incomplete fragment `'{"city": "Tok'` and asserting the formatter returns a dict instead of raising:
- `tests/formatter_anthropic_test.py::test_tool_call_with_incomplete_input_does_not_crash`
- `tests/formatter_gemini_test.py::test_tool_call_with_incomplete_input_does_not_crash`
- `tests/formatter_ollama_test.py::test_tool_call_with_incomplete_input_does_not_crash`

## Verification

- [x] `pytest tests/formatter_anthropic_test.py tests/formatter_gemini_test.py tests/formatter_ollama_test.py` → 29 passed (26 existing + 3 new)
- [x] Manual repro: `input='{"city": "Tok'` previously raised `JSONDecodeError: Unterminated string`; now returns `{}`
- [x] `pre-commit run --files ...` → all hooks pass (mypy / black / flake8 / pylint / pyroma)
- [ ] CI
