### PR TITLE
fix(formatter): drop empty thinking blocks for gemini

### DIFF
--- a/src/agentscope/formatter/_gemini_formatter.py
+++ b/src/agentscope/formatter/_gemini_formatter.py
@@ -157,7 +157,14 @@ class GeminiChatFormatter(_GeminiFormatterBase):
                     # Gemini API requires `thought: true` to mark a part as a
                     # thinking/reasoning block so the model can distinguish it
                     # from normal text and maintain reasoning continuity.
-                    parts.append({"thought": True, "text": block.thinking})
+                    # Skip empty thinking — Gemini rejects a thought part
+                    # whose text is empty with a 400
+                    # ("contents.parts must not be empty"). Empty thinking
+                    # occurs when a reasoning model returns no summary.
+                    if block.thinking:
+                        parts.append(
+                            {"thought": True, "text": block.thinking},
+                        )
 
                 elif isinstance(block, HintBlock):
                     if parts:

--- a/tests/formatter_gemini_test.py
+++ b/tests/formatter_gemini_test.py
@@ -307,6 +307,36 @@ class TestGeminiFormatter(IsolatedAsyncioTestCase):
             res,
         )
 
+    async def test_empty_thinking_block_is_dropped(self) -> None:
+        """An empty ``ThinkingBlock`` must be skipped, not forwarded.
+
+        Gemini rejects a thought part whose text is empty with a 400
+        ("contents.parts must not be empty"). Empty thinking blocks occur
+        when a reasoning model returns no summary, so the formatter must
+        drop them rather than emit ``{"thought": True, "text": ""}``.
+        """
+        fmt = GeminiChatFormatter()
+        msgs = [
+            AssistantMsg(
+                name="assistant",
+                content=[
+                    ThinkingBlock(thinking=""),
+                    TextBlock(text="reply"),
+                ],
+            ),
+        ]
+
+        res = await fmt.format(msgs)
+
+        # Only the text part remains — no empty thought part.
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0]["role"], "model")
+        thought_parts = [
+            p for p in res[0]["parts"] if p.get("thought") is True
+        ]
+        self.assertEqual(thought_parts, [])
+        self.assertEqual(res[0]["parts"], [{"text": "reply"}])
+
     @patch(
         "agentscope.formatter._formatter_base.shortuuid.uuid",
         return_value=_FIXED_ID,


### PR DESCRIPTION
## Summary

The Gemini formatter forwarded a `ThinkingBlock` whose thinking text is empty as `{"thought": True, "text": ""}`, which Gemini rejects with a **400** (`contents.parts must not be empty`).

Empty thinking blocks occur when a reasoning model returns no summary, and are commonly **replayed in multi-turn conversation history** (the failure mode reported across the Gemini ecosystem — see [google-gemini/deprecated-generative-ai-js#124](https://github.com/google-gemini/deprecated-generative-ai-js/issues/124), [agno#2649](https://github.com/agno-agi/agno/issues/2649)).

## Fix

Skip the `ThinkingBlock` when its `thinking` text is empty — mirroring how the Anthropic formatter already drops thinking blocks it cannot serialize (no signature).

```python
elif isinstance(block, ThinkingBlock):
    if block.thinking:
        parts.append({"thought": True, "text": block.thinking})
```

Sibling of #2007 (Anthropic empty TextBlock) — same class of "empty block → 400" defect, applied to Gemini's thinking part.

## Test

`tests/formatter_gemini_test.py::test_empty_thinking_block_is_dropped` — feeds an empty `ThinkingBlock` followed by a `TextBlock`, asserts only the text part is emitted (no empty thought part).

## Verification

- [x] `pytest tests/formatter_gemini_test.py -v` → 8 passed (7 existing + 1 new)
- [x] `pre-commit run --files ...` → all hooks pass (mypy / black / flake8 / pylint / pyroma)
- [ ] CI

> Note: this touches `_gemini_formatter.py` around line 156, while #2012 touches line 202 + imports. The two edits do not overlap, but a rebase may be needed depending on merge order.

