### PR TITLE
fix(gemini): sanitize const schema field for gemini tool parameters

### DIFF
--- a/src/agentscope/model/_gemini/_model.py
+++ b/src/agentscope/model/_gemini/_model.py
@@ -29,6 +29,8 @@ def _sanitize_schema_for_gemini(schema: Any) -> Any:
     function removes or rewrites the following:
 
     - ``additionalProperties``: removed entirely.
+    - ``const``: converted to an equivalent single-value ``enum``,
+      since Gemini's ``Schema`` model does not support ``const``.
     - ``anyOf`` containing a ``{"type": "null"}`` entry: simplified to
       the single non-null type. If there is exactly one non-null
       alternative it is inlined directly; otherwise the ``anyOf`` is
@@ -55,6 +57,12 @@ def _sanitize_schema_for_gemini(schema: Any) -> Any:
 
     # Remove additionalProperties — not supported by Gemini
     schema.pop("additionalProperties", None)
+
+    # Convert `const` into an equivalent single-value `enum` — Gemini's
+    # Schema model does not support the `const` keyword.
+    if "const" in schema:
+        const_value = schema.pop("const")
+        schema.setdefault("enum", [const_value])
 
     # Simplify anyOf that only differs by a null type, e.g. Optional[X]
     if "anyOf" in schema and isinstance(schema["anyOf"], list):

--- a/tests/model_gemini_test.py
+++ b/tests/model_gemini_test.py
@@ -600,6 +600,35 @@ class TestGeminiSchemaUtils(unittest.TestCase):
             },
         )
 
+    def test_sanitize_converts_const_to_enum(self) -> None:
+        """`const` is converted into a single-value `enum` for Gemini."""
+        self.assertEqual(
+            _sanitize_schema_for_gemini(
+                {
+                    "type": "object",
+                    "properties": {
+                        "topic": {"type": "string", "const": "general"},
+                        "query": {
+                            "type": "string",
+                            "description": "Search query",
+                        },
+                    },
+                    "required": ["query"],
+                },
+            ),
+            {
+                "type": "object",
+                "properties": {
+                    "topic": {"type": "string", "enum": ["general"]},
+                    "query": {
+                        "type": "string",
+                        "description": "Search query",
+                    },
+                },
+                "required": ["query"],
+            },
+        )
+
     def test_flatten_resolves_ref_and_removes_defs(self) -> None:
         """$ref inlined with extra keys merged; $defs removed."""
         self.assertEqual(


### PR DESCRIPTION
## AgentScope Version

2.0.4dev

## Description

Fixed a `pydantic.ValidationError` raised when constructing `GenerateContentConfig` for tools whose JSON Schema parameters contain a const field, which the google-genai SDK's Schema model does not support. Updated `_sanitize_schema_for_gemini` to convert `const: value` into an equivalent single-value `enum: [value]` before building Gemini tool schemas, so tools emitted by MCP servers or Pydantic models with fixed-value parameters now work correctly with GeminiChatModel.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review