### PR TITLE
fix(model): fix structured output hang on streaming models

### DIFF
--- a/src/agentscope/model/_base.py
+++ b/src/agentscope/model/_base.py
@@ -587,13 +587,30 @@ class ChatModelBase:
 
         completed_response: ChatResponse | None = None
         if self.stream:
+            # ``_call_api`` yields raw incremental chunks whose ``is_last``
+            # is always ``False``; subclasses rely on the ``__call__``
+            # wrapper to accumulate them and emit a final ``is_last=True``
+            # chunk. Since this method calls ``_call_api`` directly (to
+            # avoid duplicating the retry logic in ``__call__``), we must
+            # replicate that accumulation here, otherwise the stream may
+            # end without ever producing an ``is_last=True`` chunk.
+            acc_res = ChatResponse(
+                content=[],
+                is_last=True,
+                finished_reason=FinishedReason.COMPLETED,
+            )
             async for chunk in res:
                 if chunk.is_last:
                     completed_response = chunk
+                    break
+                acc_res.append_chat_response(chunk)
+                acc_res.id = chunk.id
+            if completed_response is None:
+                completed_response = acc_res
         else:
             completed_response = res
 
-        if completed_response is None:
+        if completed_response is None or not completed_response.content:
             raise RuntimeError(
                 f"Failed to get the completed response from model "
                 f"{model_name}.",


### PR DESCRIPTION
## AgentScope Version

2.0.4dev

## Description

`_call_api_with_structured_output` calls `_call_api` directly, bypassing `__call__`'s wrapper that appends the final `is_last=True` chunk. Since all streaming models only yield `is_last=False` deltas, `generate_structured_output()` with `stream=True` never gets a completed response and always raises:

`RuntimeError: Failed to get the completed response from model <name>.`

Affects all chat models with `stream=True`.


## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review