### PR TITLE
fix(agent): tolerate missing compression summary fields

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -94,6 +94,18 @@ else:
     MiddlewareBase = Any
 
 
+class _SummaryFormatDict(dict):
+    """Format mapping that leaves missing summary fields empty."""
+
+    def __missing__(self, key: str) -> str:
+        """Return an empty value for optional/missing summary fields."""
+        logger.warning(
+            "Compression summary is missing field %r; using an empty value.",
+            key,
+        )
+        return ""
+
+
 class Agent:
     """The agent class."""
 
@@ -517,7 +529,9 @@ class Agent:
         # Update the summary
         async def _apply_change() -> None:
             """Apply the context change with interruption protection."""
-            new_summary = cfg.summary_template.format(**res.content)
+            new_summary = cfg.summary_template.format_map(
+                _SummaryFormatDict(res.content),
+            )
             if self.offloader:
                 path = await self.offloader.offload_context(
                     self.state.session_id,

--- a/tests/compress_context_test.py
+++ b/tests/compress_context_test.py
@@ -739,6 +739,72 @@ class ContextCompressionTest(IsolatedAsyncioTestCase):
             ],
         )
 
+    async def test_context_compression_missing_summary_field(self) -> None:
+        """Missing structured summary fields do not break compression."""
+        model = MockModel(context_size=100)
+        agent = Agent(
+            name="Friday",
+            system_prompt="".join(["0" for _ in range(20 * 4)]),
+            model=model,
+            context_config=ContextConfig(
+                trigger_ratio=0.7,
+                reserve_ratio=0.4,
+            ),
+            state=AgentState(
+                session_id="123",
+                context=[
+                    UserMsg(
+                        "User",
+                        "".join(["1" for _ in range(30 * 4)]),
+                        id="1",
+                    ),
+                    AssistantMsg(
+                        "Friday",
+                        "".join(["2" for _ in range(10 * 4)]),
+                        id="2",
+                    ),
+                    UserMsg(
+                        "User",
+                        "".join(["3" for _ in range(10 * 4)]),
+                        id="3",
+                    ),
+                ],
+            ),
+            toolkit=Toolkit(),
+        )
+
+        model.set_structured_response(
+            StructuredResponse(
+                content={
+                    "task_overview": "1",
+                    "current_state": "2",
+                    "important_discoveries": "3",
+                    "context_to_preserve": "5",
+                },
+            ),
+        )
+
+        await agent.compress_context()
+
+        self.assertEqual(
+            agent.state.summary,
+            """<system-info>Here is a summary of your previous work
+# Task Overview
+1
+
+# Current State
+2
+
+# Important Discoveries
+3
+
+# Next Steps
+
+
+# Context to Preserve
+5</system-info>""",
+        )
+
     async def test_context_compression_clears_evicted_read_cache(self) -> None:
         """Read cache is cleared when its Read block is compressed out."""
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- avoid crashing context compression when a structured summary omits a field referenced by the summary template
- render missing summary fields as empty strings and log a warning
- add a regression test for a missing next_steps field

## Tests
- PYTHONPATH=/tmp/agentscope-issue1388/src:/tmp/agentscope-issue1388/tests /tmp/agentscope-issue1999/.venv/bin/python -m pytest tests/compress_context_test.py
- PYTHONPATH=/tmp/agentscope-issue1388/src /tmp/agentscope-issue1999/.venv/bin/python -m py_compile src/agentscope/agent/_agent.py

Refs #1388