### PR TITLE
fix(workspace): fix OpenSandbox bootstrap and state filtering

### DIFF
--- a/src/agentscope/workspace/_opensandbox/_constants.py
+++ b/src/agentscope/workspace/_opensandbox/_constants.py
@@ -12,7 +12,7 @@ base class, not here.
 
 #: Default OpenSandbox image. The slim Python image is small but still
 #: has enough package-manager support for installing curl, certificates,
-#: ripgrep, and procps during bootstrap.
+#: and ripgrep during bootstrap.
 DEFAULT_IMAGE = "python:3.11-slim"
 
 #: Default keep-alive timeout in seconds for newly-created sandboxes.

--- a/src/agentscope/workspace/_opensandbox/_opensandbox_workspace.py
+++ b/src/agentscope/workspace/_opensandbox/_opensandbox_workspace.py
@@ -226,14 +226,14 @@ class OpenSandboxWorkspace(SandboxedWorkspaceBase):
 
     async def _find_existing_sandbox(self) -> SandboxInfo | None:
         """Return the most recent sandbox matching this workspace id."""
-        from opensandbox.models.sandboxes import SandboxFilter
+        from opensandbox.models.sandboxes import SandboxFilter, SandboxState
         from opensandbox import SandboxManager
 
         manager = await SandboxManager.create(
             connection_config=self._connection_config(),
         )
         sandbox_filter = SandboxFilter(
-            states=["RUNNING", "PAUSED"],
+            states=[SandboxState.RUNNING, SandboxState.PAUSED],
             metadata={METADATA_WORKSPACE_ID_KEY: self.workspace_id},
         )
         try:
@@ -382,19 +382,19 @@ class OpenSandboxWorkspace(SandboxedWorkspaceBase):
         pip_args = " ".join(shlex.quote(p) for p in pip_pkgs)
 
         return [
-            # 1. System packages used by bootstrap and builtin tools. The
-            # default image runs as root, so no sudo is needed. ``procps``
-            # backs gateway-process cleanup; ``ripgrep`` backs the Grep tool.
+            # System packages used by bootstrap and builtin tools. The
+            # default image runs as root, so no sudo is needed. ``ripgrep``
+            # backs the Grep tool.
             "apt-get update -qq "
             "&& apt-get install -y --no-install-recommends curl "
-            "ca-certificates procps ripgrep "
+            "ca-certificates ripgrep "
             "&& rm -rf /var/lib/apt/lists/*",
-            # 2. Astral uv → /usr/local/bin (on PATH). INSTALLER_NO_MODIFY_PATH
+            # Astral uv → /usr/local/bin (on PATH). INSTALLER_NO_MODIFY_PATH
             # suppresses shell rc edits.
             "curl -LsSf https://astral.sh/uv/install.sh "
             "| env UV_INSTALL_DIR=/usr/local/bin "
             "INSTALLER_NO_MODIFY_PATH=1 sh",
-            # 3. Gateway venv + base requirements + agentscope from PyPI.
+            # Gateway venv + base requirements + agentscope from PyPI.
             # ``uv venv`` creates the gateway home as a parent dir.
             f"uv venv {self._gateway_venv}",
             f"uv pip install --python {self._gateway_python} {pip_args}",


### PR DESCRIPTION
## Summary

- use the OpenSandbox SDK's `SandboxState` constants when filtering running and paused sandboxes
- stop installing `procps` in the stock OpenSandbox bootstrap path

## Why

The lifecycle API expects title-cased state wire values such as `Running` and `Paused`; the previous uppercase strings are rejected by compatible servers.

Installing `procps` also made the shared `pkill -f _mcp_gateway_app.py || true; nohup ...` launch command active in the stock OpenSandbox image. The process match includes the launcher command itself, so the gateway never starts and no gateway log is created. Other workspace images do not install `procps`, and the guarded cleanup remains a no-op there.

## Impact

Fresh OpenSandbox workspaces can complete bootstrap and start the MCP gateway. Existing callers keep the same default image and public configuration surface.

## Validation

- Python syntax checks for the changed modules
- `git diff --check`
- OpenSandbox unit modules load successfully; 12 live tests skip as designed when no endpoint is configured
- local Docker OpenSandbox E2E passed against `http://127.0.0.1:32889`, covering sandbox creation, gateway health, DeepSeek tool calls, Bash, text and binary file I/O, Glob, Grep, list/stat/delete, pause, resume, and kill
