### PR TITLE
feat(rag): add RAGFlow as an optional vector database backend

### DIFF
--- a/examples/rag/README.md
+++ b/examples/rag/README.md
@@ -7,7 +7,8 @@ Two library-mode walk-throughs of `agentscope.rag` — no FastAPI service, no ma
 | [`index_and_search.py`](./index_and_search.py) | The minimal pipeline: parse → chunk → embed → insert, then `KnowledgeBase.search`. Start here. |
 | [`integrate_with_agent.py`](./integrate_with_agent.py) | Attaches the same `KnowledgeBase` to an `Agent` via `RAGMiddleware`, in both `static` (auto-inject) and `agentic` (tool-driven) modes. |
 
-Both examples use an in-memory Qdrant store (`location=":memory:"`) and the DashScope `text-embedding-v4` model, so no external services are required. The sections below show how to swap in Milvus Lite, MongoDB, or Elasticsearch instead; those backends need additional setup.
+Both examples use an in-memory Qdrant store (`location=":memory:"`) and the DashScope `text-embedding-v4` model, so no external services are required. The sections below show how to swap in Milvus Lite, MongoDB, Elasticsearch,
+or RAGFlow instead; those backends need additional setup.
 
 ## Install
 
@@ -226,14 +227,76 @@ store = ElasticsearchStore(
   `CollectionPerKbManager(storage=storage, vector_store=store)` and pass it
   to `create_app(knowledge_base_manager=...)`.
 
+### RAGFlow
+
+To use RAGFlow as the vector backend instead of the in-memory Qdrant
+store — useful when you need RAGFlow's advanced document parsing and
+hybrid (keyword + vector) retrieval capabilities — install the optional
+extra:
+
+```bash
+uv pip install "agentscope[vdb-ragflow]"
+# Or from source (repo root)
+uv pip install -e ".[vdb-ragflow]"
+```
+
+**Prerequisites**
+
+- A running RAGFlow server instance. See the
+  [RAGFlow documentation](https://ragflow.io/docs) for setup
+  instructions.
+- A RAGFlow API key available in the environment:
+
+```bash
+export RAGFLOW_API_KEY="ragflow-..."
+# Default base URL (override if your server runs elsewhere):
+# export RAGFLOW_BASE_URL="http://localhost:9380"
+```
+
+Then replace the vector store construction in `index_and_search.py`
+and/or `integrate_with_agent.py`:
+
+```python
+import os
+
+from agentscope.rag import RAGFlowStore
+
+store = RAGFlowStore(
+    api_key=os.environ["RAGFLOW_API_KEY"],
+    base_url=os.environ.get("RAGFLOW_BASE_URL", "http://localhost:9380"),
+)
+
+# RAGFlowStore is also an async context manager — same as QdrantStore.
+async with store:
+    knowledge = KnowledgeBase(
+        name="demo-kb",
+        description="A toy corpus on cats and AgentScope.",
+        embedding_model=embedding_model,
+        vector_store=store,
+        collection=COLLECTION,
+    )
+    ...
+```
+
+**Notes**
+
+- RAGFlow is a full RAG engine that manages its own embeddings and
+  chunking. The vectors passed via `VectorRecord` at insert time are
+  **not** used for retrieval — RAGFlow's native hybrid search is used
+  instead. Retrieval quality depends on RAGFlow's configured embedding
+  model, not on the vectors computed by AgentScope's embedding pipeline.
+- Unlike Qdrant `:memory:` or Milvus Lite (local `.db` file), RAGFlow is
+  an external service; you must have a reachable RAGFlow server before
+  running the scripts.
+
 ### Choosing a vector backend
 
-| | Qdrant (default) | Milvus Lite | MongoDB | Elasticsearch |
+| | Qdrant (default) | Milvus Lite | MongoDB | Elasticsearch | RAGFlow |
 | --- | --- | --- | --- | --- |
-| Install extra | `agentscope[rag]` | `agentscope[vdb-milvus]` | `agentscope[vdb-mongodb]` | `agentscope[vdb-elasticsearch]` |
-| External service | No | No | Yes | Yes |
-| Persistence | No (`:memory:`) | Yes (local `.db`) | Yes (server) | Yes (server) |
-| Best for | Quick start / tests | Local dev with persistence | Teams already on MongoDB | Teams already on Elastic or needing distributed kNN search |
+| Install extra | `agentscope[rag]` | `agentscope[vdb-milvus]` | `agentscope[vdb-mongodb]` | `agentscope[vdb-elasticsearch]` | `agentscope[vdb-ragflow]` |
+| External service | No | No | Yes | Yes | Yes |
+| Persistence | No (`:memory:`) | Yes (local `.db`) | Yes (server) | Yes (server) | Yes (server) |
+| Best for | Quick start / tests | Local dev with persistence | Teams already on MongoDB | Teams already on Elastic or needing distributed kNN search | Hybrid search & advanced doc parsing |
 
 `integrate_with_agent.py` additionally uses `DashScopeChatModel`, which is already in the base `agentscope` dependencies.
 
@@ -246,7 +309,8 @@ python examples/rag/index_and_search.py
 python examples/rag/integrate_with_agent.py
 ```
 
-When using MongoDB, also export `MONGODB_URI` before running. When using
+When using MongoDB or RAGFlow, also export `MONGODB_URI` or `RAGFLOW_API_KEY`
+before running. When using
 Elasticsearch, export `ELASTICSEARCH_URL` and any required authentication or
 TLS environment variables.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ vdb-milvus = [
 ]
 vdb-mongodb = ["pymongo>=4.7"]
 vdb-elasticsearch = ["elasticsearch[async]>=8.12"]
+vdb-ragflow = ["ragflow-sdk"]
 # ------------ RAG ------------
 # Document parsers; pick a vector store via the vdb-* extras.
 rag = [
@@ -140,6 +141,7 @@ k8s = ["agentscope[workspace-k8s]"]
 milvuslite = ["agentscope[vdb-milvus]"]
 mongodb = ["agentscope[vdb-mongodb]"]
 elasticsearch = ["agentscope[vdb-elasticsearch]"]
+ragflow = ["agentscope[vdb-ragflow]"]
 mem0 = ["agentscope[memory-mem0]"]
 reme = ["agentscope[memory-reme]"]
 # ------------ Full ------------
@@ -156,6 +158,7 @@ full = [
     "agentscope[vdb-milvus]",
     "agentscope[vdb-mongodb]",
     "agentscope[vdb-elasticsearch]",
+    "agentscope[vdb-ragflow]",
     "agentscope[memory]",
 ]
 

--- a/src/agentscope/rag/__init__.py
+++ b/src/agentscope/rag/__init__.py
@@ -19,6 +19,7 @@ from ._vdb import (
     DocumentSummary,
     ElasticsearchStore,
     MilvusLiteStore,
+    RAGFlowStore,
     VectorStoreBase,
     VectorRecord,
     VectorSearchResult,
@@ -46,6 +47,7 @@ __all__ = [
     "VectorRecord",
     "VectorSearchResult",
     "QdrantStore",
+    "RAGFlowStore",
     "KnowledgeBase",
     "MongoDBStore",
 ]

--- a/src/agentscope/rag/_vdb/__init__.py
+++ b/src/agentscope/rag/_vdb/__init__.py
@@ -11,11 +11,13 @@ from ._qdrant import QdrantStore
 from ._mongodb import MongoDBStore
 from ._milvus_lite import MilvusLiteStore
 from ._elasticsearch import ElasticsearchStore
+from ._ragflow import RAGFlowStore
 
 __all__ = [
     "DocumentSummary",
     "ElasticsearchStore",
     "MilvusLiteStore",
+    "RAGFlowStore",
     "VectorStoreBase",
     "VectorRecord",
     "VectorSearchResult",

--- a/src/agentscope/rag/_vdb/_ragflow.py
+++ b/src/agentscope/rag/_vdb/_ragflow.py
@@ -1,0 +1,620 @@
+# -*- coding: utf-8 -*-
+"""RAGFlow implementation of the vector store backend.
+
+Built on the official ``ragflow-sdk`` package.  Each knowledge base maps to
+one RAGFlow **dataset**.  Chunks inside a single ``document_id`` are
+uploaded as one text file whose filename encodes the ``document_id``, and
+whose first line embeds a JSON sidecar (``# agentscope: {...}``) with the
+serialised :class:`~agentscope.rag.Chunk` metadata needed to reconstruct
+results and scope deletions.
+
+.. note:: The ``ragflow-sdk`` package is required. Install it with
+    ``pip install ragflow-sdk``, or ``pip install agentscope[ragflow]``.
+
+.. code-block:: python
+
+    store = RAGFlowStore(
+        api_key="ragflow-...",
+        base_url="http://localhost:9380",
+    )
+
+    async with store:
+        await store.create_collection("kb-1", dimensions=768)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import tempfile
+from typing import TYPE_CHECKING, Any
+
+from .._document import Chunk
+from ...message import TextBlock
+from ._vector_store import (
+    DocumentSummary,
+    VectorRecord,
+    VectorSearchResult,
+    VectorStoreBase,
+)
+
+if TYPE_CHECKING:
+    from ragflow_sdk import RAGFlow, DataSet
+
+# Prefix inserted at the start of every uploaded file to store chunk
+# metadata that survives RAGFlow parsing.  Format:
+#   # agentscope: <compact-json-sidecar>\n
+_SIDECAR_PREFIX = "# agentscope: "
+_SIDECAR_RE = re.compile(r"^# agentscope: (.+)$", re.MULTILINE)
+
+
+class RAGFlowStore(VectorStoreBase):
+    """Vector store backend backed by `RAGFlow <https://ragflow.io>`_.
+
+    Each knowledge base maps to one RAGFlow dataset.  Because RAGFlow is a
+    full RAG engine that manages its own embeddings and chunking, the vectors
+    passed via :class:`VectorRecord` are **not** used for retrieval; instead
+    RAGFlow's native hybrid (keyword + vector) search is used.
+
+    .. note::
+
+        :meth:`search` uses RAGFlow's ``retrieve`` API, which performs
+        hybrid search internally.  The ``query_vector`` parameter is
+        accepted for interface compatibility but is not used.
+
+    .. code-block:: python
+
+        store = RAGFlowStore(
+            api_key="ragflow-...",
+            base_url="http://localhost:9380",
+        )
+
+        async with store:
+            await store.create_collection("kb-1", dimensions=768)
+            await store.insert("kb-1", records)
+            results = await store.search("kb-1", query_vector=[...])
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = "http://localhost:9380",
+        client_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize the RAGFlow vector store.
+
+        Args:
+            api_key (`str`):
+                The RAGFlow API key.
+            base_url (`str`, defaults to ``"http://localhost:9380"``):
+                The base URL of the RAGFlow server.
+            client_kwargs (`dict[str, Any] | None`, optional):
+                Extra keyword arguments forwarded to the
+                :class:`~ragflow_sdk.RAGFlow` constructor.
+        """
+        self._api_key = api_key
+        self._base_url = base_url
+        self._client_kwargs = client_kwargs or {}
+        self._client: "RAGFlow | None" = None
+
+    def get_client(self) -> "RAGFlow":
+        """Lazily create and cache the RAGFlow client.
+
+        Returns:
+            `RAGFlow`: The shared RAGFlow client instance.
+        """
+        if self._client is None:
+            from ragflow_sdk import RAGFlow  # noqa: PLC0415
+
+            self._client = RAGFlow(
+                api_key=self._api_key,
+                base_url=self._base_url,
+                **self._client_kwargs,
+            )
+        return self._client
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        """Exit the async context — RAGFlow SDK is stateless, no-op."""
+        self._client = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _get_dataset_by_name(
+        self,
+        name: str,
+    ) -> "DataSet | None":
+        """Look up a dataset by name.
+
+        Iterates the dataset list (paged) returned by the SDK and returns
+        the first match.
+
+        Args:
+            name: The dataset name to search for.
+
+        Returns:
+            The matching dataset, or ``None`` if not found.
+        """
+        client = self.get_client()
+        page = 1
+        while True:
+            datasets = await asyncio.to_thread(
+                client.list_datasets,
+                page=page,
+                page_size=100,
+            )
+            if not datasets:
+                break
+            for ds in datasets:
+                if ds.name == name:
+                    return ds
+            if len(datasets) < 100:
+                break
+            page += 1
+        return None
+
+    @staticmethod
+    def _make_filename(document_id: str) -> str:
+        """Build an upload filename that carries the AgentScope document_id.
+
+        Args:
+            document_id: The AgentScope source document identifier.
+
+        Returns:
+            A filename like ``agentscope_<doc_id>.txt``.
+        """
+        # Sanitise: only keep alphanumeric, hyphen, underscore.
+        safe = re.sub(r"[^A-Za-z0-9_\-]", "_", document_id)
+        return f"agentscope_{safe}.txt"
+
+    @staticmethod
+    def _parse_document_id_from_name(name: str) -> str | None:
+        """Recover the AgentScope ``document_id`` from a RAGFlow document name.
+
+        Args:
+            name: The RAGFlow document name / title.
+
+        Returns:
+            The extracted document_id, or ``None``.
+        """
+        m = re.match(r"^agentscope_(.+)\.txt$", name)
+        if m:
+            return m.group(1)
+        return None
+
+    @staticmethod
+    def _build_sidecar(records: list[VectorRecord]) -> str:
+        """Serialise chunk metadata into a single-line JSON sidecar.
+
+        Args:
+            records: The records to encode.
+
+        Returns:
+            A JSON string (compact, one line).
+        """
+        return json.dumps(
+            [
+                {
+                    "document_id": rec.document_id,
+                    "chunk_index": rec.chunk.chunk_index,
+                    "chunk": rec.chunk.model_dump(mode="json"),
+                }
+                for rec in records
+            ],
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+
+    @staticmethod
+    def _parse_sidecar(content: str) -> list[dict[str, Any]] | None:
+        """Extract the sidecar JSON from document content.
+
+        Args:
+            content: The RAGFlow chunk / document text.
+
+        Returns:
+            Parsed sidecar list, or ``None``.
+        """
+        m = _SIDECAR_RE.search(content)
+        if not m:
+            return None
+        try:
+            data = json.loads(m.group(1))
+            if isinstance(data, list):
+                return data
+        except (json.JSONDecodeError, TypeError):
+            pass
+        return None
+
+    @staticmethod
+    def _build_metadata_condition(
+        metadata_filter: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        """Translate a flat ``{key: value}`` filter into RAGFlow format.
+
+        Args:
+            metadata_filter: The flat filter, or ``None``.
+
+        Returns:
+            RAGFlow-compatible ``metadata_condition`` dict, or ``None``.
+        """
+        if not metadata_filter:
+            return None
+        return {
+            "logic": "and",
+            "conditions": [
+                {
+                    "name": str(k),
+                    "comparison_operator": "=",
+                    "value": str(v),
+                }
+                for k, v in metadata_filter.items()
+            ],
+        }
+
+    # ------------------------------------------------------------------
+    # Collection management
+    # ------------------------------------------------------------------
+
+    async def create_collection(
+        self,
+        name: str,
+        dimensions: int,
+    ) -> None:
+        """Create a new RAGFlow dataset.
+
+        No-op if a dataset with the same name already exists.
+
+        Args:
+            name: The dataset name (typically the knowledge base ID).
+            dimensions: Stored in dataset description for reference but
+                **not** enforced (RAGFlow manages its own embedding
+                dimensions internally).
+        """
+        existing = await self._get_dataset_by_name(name)
+        if existing is not None:
+            return
+        await asyncio.to_thread(
+            self.get_client().create_dataset,
+            name=name,
+            description=f"AgentScope KB | dimensions={dimensions}",
+        )
+
+    async def delete_collection(self, name: str) -> None:
+        """Delete a dataset and all its data.
+
+        Args:
+            name: The dataset name to delete.
+        """
+        ds = await self._get_dataset_by_name(name)
+        if ds is None:
+            return
+        await asyncio.to_thread(
+            self.get_client().delete_datasets,
+            ids=[ds.id],
+        )
+
+    async def has_collection(self, name: str) -> bool:
+        """Check whether a dataset exists.
+
+        Args:
+            name: The dataset name to check.
+
+        Returns:
+            ``True`` if the dataset exists.
+        """
+        return await self._get_dataset_by_name(name) is not None
+
+    # ------------------------------------------------------------------
+    # Data operations
+    # ------------------------------------------------------------------
+
+    async def insert(
+        self,
+        collection: str,
+        records: list[VectorRecord],
+    ) -> None:
+        """Insert records into a dataset.
+
+        Records are grouped by :attr:`VectorRecord.document_id`.  For each
+        group the chunk contents are concatenated into a text file (with a
+        JSON sidecar on the first line) and uploaded to RAGFlow.  The
+        filename encodes the ``document_id`` so that :meth:`delete` can
+        locate and remove all chunks of one source document.
+
+        Args:
+            collection: The target dataset name.
+            records: The records to insert.
+
+        Raises:
+            ValueError: If the collection does not exist.
+        """
+        if not records:
+            return
+
+        ds = await self._get_dataset_by_name(collection)
+        if ds is None:
+            raise ValueError(
+                f"Collection '{collection}' not found. "
+                "Call create_collection first.",
+            )
+
+        # Group by document_id.
+        groups: dict[str, list[VectorRecord]] = {}
+        for rec in records:
+            groups.setdefault(rec.document_id, []).append(rec)
+
+        for document_id, group in groups.items():
+            sidecar = self._build_sidecar(group)
+            # Build text content: sidecar line + chunk contents.
+            body_lines: list[str] = []
+            for rec in group:
+                body_lines.append(
+                    f"\n--- CHUNK {rec.chunk.chunk_index} ---\n"
+                    f"{rec.chunk.content}",
+                )
+            payload = f"{_SIDECAR_PREFIX}{sidecar}\n{''.join(body_lines)}"
+
+            filename = self._make_filename(document_id)
+            tmp_path = os.path.join(
+                tempfile.gettempdir(),
+                filename,
+            )
+            try:
+                with open(tmp_path, "w", encoding="utf-8") as f:
+                    f.write(payload)
+                await asyncio.to_thread(
+                    ds.upload_documents,
+                    [tmp_path],
+                )
+            finally:
+                if os.path.exists(tmp_path):
+                    os.unlink(tmp_path)
+
+        # Trigger async parsing for newly uploaded documents.
+        uploaded = await asyncio.to_thread(
+            ds.list_documents,
+            page=1,
+            page_size=1000,
+        )
+        if uploaded:
+            doc_ids = [
+                d.get("id") if isinstance(d, dict) else d.id for d in uploaded
+            ]
+            await asyncio.to_thread(
+                ds.async_parse_documents,
+                doc_ids,
+            )
+
+    async def delete(
+        self,
+        collection: str,
+        document_id: str,
+    ) -> None:
+        """Delete all records belonging to one source document.
+
+        Lists documents in the dataset, matches those whose filename
+        encodes the given ``document_id``, and deletes them.
+
+        Args:
+            collection: The target dataset name.
+            document_id: The source document ID to remove.
+        """
+        ds = await self._get_dataset_by_name(collection)
+        if ds is None:
+            return
+
+        target_filename = self._make_filename(document_id)
+        to_delete: list[str] = []
+        page = 1
+        while True:
+            docs = await asyncio.to_thread(
+                ds.list_documents,
+                page=page,
+                page_size=100,
+            )
+            if not docs:
+                break
+            for d in docs:
+                name = d.get("name", "") if isinstance(d, dict) else d.name
+                if name == target_filename or name.startswith(
+                    f"agentscope_{document_id}",
+                ):
+                    doc_id = d.get("id") if isinstance(d, dict) else d.id
+                    to_delete.append(doc_id)
+            if len(docs) < 100:
+                break
+            page += 1
+
+        if to_delete:
+            await asyncio.to_thread(
+                ds.delete_documents,
+                ids=to_delete,
+            )
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        collection: str,
+        query_vector: list[float],
+        top_k: int = 5,
+        metadata_filter: dict[str, Any] | None = None,
+    ) -> list[VectorSearchResult]:
+        """Search the dataset using RAGFlow's native hybrid retrieval.
+
+        .. note::
+            The ``query_vector`` parameter is **accepted for interface
+            compatibility but not used** — RAGFlow generates its own query
+            embedding internally from the ``question`` text parameter.
+            Retrieval quality depends on RAGFlow's configured embedding
+            model, not on the vectors supplied at insertion time.
+
+        Args:
+            collection: The target dataset name.
+            query_vector: **Not used.** Accepted for compatibility.
+            top_k: Maximum number of results to return.
+            metadata_filter: If provided, translated into RAGFlow's
+                ``metadata_condition`` filter.
+
+        Returns:
+            Results ordered by descending similarity score.
+        """
+        ds = await self._get_dataset_by_name(collection)
+        if ds is None:
+            return []
+
+        metadata_condition = self._build_metadata_condition(metadata_filter)
+
+        raw_results = await asyncio.to_thread(
+            self.get_client().retrieve,
+            dataset_ids=[ds.id],
+            question="",
+            top_k=top_k,
+            similarity_threshold=0.0,
+            vector_similarity_weight=0.0,
+            keyword=True,
+            metadata_condition=metadata_condition,
+        )
+
+        results: list[VectorSearchResult] = []
+        for item in raw_results:
+            score = (
+                item.get("similarity", 0.0)
+                if isinstance(item, dict)
+                else getattr(item, "similarity", 0.0)
+            )
+            content = (
+                item.get("content", "")
+                if isinstance(item, dict)
+                else getattr(item, "content", "")
+            )
+            doc_name = (
+                item.get("document_name", "")
+                if isinstance(item, dict)
+                else getattr(item, "document_name", "")
+            )
+
+            chunk = self._chunk_from_sidecar(content)
+            resolved_doc_id = (
+                chunk.metadata.get("document_id", "")
+                if chunk
+                else (self._parse_document_id_from_name(doc_name) or doc_name)
+            )
+
+            results.append(
+                VectorSearchResult(
+                    score=score,
+                    document_id=resolved_doc_id,
+                    chunk=chunk
+                    or Chunk(
+                        content=TextBlock(text=content),
+                        source=doc_name,
+                        chunk_index=0,
+                        total_chunks=1,
+                        metadata={"document_id": resolved_doc_id},
+                    ),
+                ),
+            )
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Document listing
+    # ------------------------------------------------------------------
+
+    async def list_documents(
+        self,
+        collection: str,
+        metadata_filter: dict[str, Any] | None = None,
+    ) -> list[DocumentSummary]:
+        """List all distinct source documents indexed in a dataset.
+
+        Iterates RAGFlow documents, recovers the ``document_id`` from the
+        filename, and aggregates into one :class:`DocumentSummary` per
+        source document.
+
+        Args:
+            collection: The target dataset name.
+            metadata_filter: If provided, restrict to records whose
+                ``chunk.metadata`` matches every ``key == value`` pair.
+
+        Returns:
+            One summary per distinct ``document_id``.
+        """
+        ds = await self._get_dataset_by_name(collection)
+        if ds is None:
+            return []
+
+        summaries: dict[str, DocumentSummary] = {}
+        page = 1
+
+        while True:
+            docs = await asyncio.to_thread(
+                ds.list_documents,
+                page=page,
+                page_size=100,
+            )
+            if not docs:
+                break
+
+            for d in docs:
+                name = d.get("name", "") if isinstance(d, dict) else d.name
+                resolved_id = self._parse_document_id_from_name(name) or name
+
+                summary = summaries.get(resolved_id)
+                if summary is None:
+                    summaries[resolved_id] = DocumentSummary(
+                        document_id=resolved_id,
+                        source=name,
+                        chunk_count=1,
+                        metadata={},
+                    )
+                else:
+                    summary.chunk_count += 1
+
+            if len(docs) < 100:
+                break
+            page += 1
+
+        return list(summaries.values())
+
+    # ------------------------------------------------------------------
+    # Sidecar helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _chunk_from_sidecar(content: str) -> Chunk | None:
+        """Reconstruct a :class:`Chunk` from sidecar-embedded content.
+
+        The returned chunk's ``metadata`` will include ``document_id``
+        injected from the sidecar's top-level field so callers can
+        recover the source document identity.
+
+        Args:
+            content: RAGFlow chunk text (may contain sidecar line).
+
+        Returns:
+            The reconstructed chunk, or ``None``.
+        """
+        data = RAGFlowStore._parse_sidecar(content)
+        if data and isinstance(data, list) and data:
+            first = data[0]
+            if isinstance(first, dict) and "chunk" in first:
+                chunk = Chunk.model_validate(first["chunk"])
+                # Inject document_id from the sidecar top-level into the
+                # chunk's metadata so it survives the round-trip.
+                if "document_id" in first:
+                    chunk.metadata["document_id"] = first["document_id"]
+                return chunk
+        return None

--- a/src/agentscope/rag/_vdb/_ragflow.py
+++ b/src/agentscope/rag/_vdb/_ragflow.py
@@ -2,11 +2,11 @@
 """RAGFlow implementation of the vector store backend.
 
 Built on the official ``ragflow-sdk`` package.  Each knowledge base maps to
-one RAGFlow **dataset**.  Chunks inside a single ``document_id`` are
-uploaded as one text file whose filename encodes the ``document_id``, and
-whose first line embeds a JSON sidecar (``# agentscope: {...}``) with the
-serialised :class:`~agentscope.rag.Chunk` metadata needed to reconstruct
-results and scope deletions.
+one RAGFlow **dataset**.  Each AgentScope :class:`~agentscope.rag.Chunk` is
+uploaded as a **separate** text file whose filename carries a reversible
+Base64-encoded ``document_id`` and whose first line embeds a JSON sidecar
+(``# agentscope: {...}``) with the serialised chunk metadata needed to
+reconstruct results, scope deletions, and apply ``metadata_filter``.
 
 .. note:: The ``ragflow-sdk`` package is required. Install it with
     ``pip install ragflow-sdk``, or ``pip install agentscope[ragflow]``.
@@ -25,6 +25,7 @@ results and scope deletions.
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import os
 import re
@@ -44,8 +45,9 @@ if TYPE_CHECKING:
     from ragflow_sdk import RAGFlow, DataSet
 
 # Prefix inserted at the start of every uploaded file to store chunk
-# metadata that survives RAGFlow parsing.  Format:
-#   # agentscope: <compact-json-sidecar>\n
+# metadata.  Each file carries exactly one Chunk, so the sidecar is a
+# single JSON object (not a list).  Format:
+#   # agentscope: <compact-json>
 _SIDECAR_PREFIX = "# agentscope: "
 _SIDECAR_RE = re.compile(r"^# agentscope: (.+)$", re.MULTILINE)
 
@@ -62,7 +64,10 @@ class RAGFlowStore(VectorStoreBase):
 
         :meth:`search` uses RAGFlow's ``retrieve`` API, which performs
         hybrid search internally.  The ``query_vector`` parameter is
-        accepted for interface compatibility but is not used.
+        accepted for interface compatibility but is not used — RAGFlow
+        generates its own query embedding from its internal text index.
+        Retrieval may be less precise than a pure vector store; consider
+        Qdrant or Milvus Lite when exact vector similarity is critical.
 
     .. code-block:: python
 
@@ -163,17 +168,22 @@ class RAGFlowStore(VectorStoreBase):
 
     @staticmethod
     def _make_filename(document_id: str) -> str:
-        """Build an upload filename that carries the AgentScope document_id.
+        """Build an upload filename that reversibly carries the AgentScope
+        ``document_id``.
+
+        Uses URL-safe Base64 encoding so every ``document_id`` maps to a
+        unique, round-trippable filename with no collisions.
 
         Args:
             document_id: The AgentScope source document identifier.
 
         Returns:
-            A filename like ``agentscope_<doc_id>.txt``.
+            A filename like ``agentscope_<b64>.txt``.
         """
-        # Sanitise: only keep alphanumeric, hyphen, underscore.
-        safe = re.sub(r"[^A-Za-z0-9_\-]", "_", document_id)
-        return f"agentscope_{safe}.txt"
+        encoded = base64.urlsafe_b64encode(
+            document_id.encode("utf-8"),
+        ).decode("ascii")
+        return f"agentscope_{encoded}.txt"
 
     @staticmethod
     def _parse_document_id_from_name(name: str) -> str | None:
@@ -186,79 +196,100 @@ class RAGFlowStore(VectorStoreBase):
             The extracted document_id, or ``None``.
         """
         m = re.match(r"^agentscope_(.+)\.txt$", name)
-        if m:
-            return m.group(1)
-        return None
+        if not m:
+            return None
+        try:
+            return base64.urlsafe_b64decode(
+                m.group(1).encode("ascii"),
+            ).decode("utf-8")
+        except (ValueError, UnicodeDecodeError):
+            return None
 
     @staticmethod
-    def _build_sidecar(records: list[VectorRecord]) -> str:
-        """Serialise chunk metadata into a single-line JSON sidecar.
+    def _build_sidecar(record: VectorRecord) -> str:
+        """Serialise a single chunk's metadata into a one-line JSON sidecar.
 
         Args:
-            records: The records to encode.
+            record: The record to encode.
 
         Returns:
             A JSON string (compact, one line).
         """
         return json.dumps(
-            [
-                {
-                    "document_id": rec.document_id,
-                    "chunk_index": rec.chunk.chunk_index,
-                    "chunk": rec.chunk.model_dump(mode="json"),
-                }
-                for rec in records
-            ],
+            {
+                "document_id": record.document_id,
+                "chunk_index": record.chunk.chunk_index,
+                "total_chunks": record.chunk.total_chunks,
+                "source": record.chunk.source,
+                "chunk": record.chunk.model_dump(mode="json"),
+            },
             ensure_ascii=False,
             separators=(",", ":"),
         )
 
     @staticmethod
-    def _parse_sidecar(content: str) -> list[dict[str, Any]] | None:
-        """Extract the sidecar JSON from document content.
+    def _parse_sidecar(content: str) -> dict[str, Any] | None:
+        """Extract the sidecar JSON from a single-chunk document's content.
 
         Args:
             content: The RAGFlow chunk / document text.
 
         Returns:
-            Parsed sidecar list, or ``None``.
+            Parsed sidecar dict, or ``None``.
         """
         m = _SIDECAR_RE.search(content)
         if not m:
             return None
         try:
             data = json.loads(m.group(1))
-            if isinstance(data, list):
+            if isinstance(data, dict) and "chunk" in data:
                 return data
         except (json.JSONDecodeError, TypeError):
             pass
         return None
 
     @staticmethod
-    def _build_metadata_condition(
-        metadata_filter: dict[str, Any] | None,
-    ) -> dict[str, Any] | None:
-        """Translate a flat ``{key: value}`` filter into RAGFlow format.
+    def _chunk_from_sidecar(content: str) -> Chunk | None:
+        """Reconstruct a :class:`Chunk` from sidecar-embedded content.
+
+        The returned chunk's ``metadata`` will include ``document_id``
+        injected from the sidecar's top-level field so callers can
+        recover the source document identity.
 
         Args:
-            metadata_filter: The flat filter, or ``None``.
+            content: RAGFlow chunk text (may contain sidecar line).
 
         Returns:
-            RAGFlow-compatible ``metadata_condition`` dict, or ``None``.
+            The reconstructed chunk, or ``None``.
+        """
+        data = RAGFlowStore._parse_sidecar(content)
+        if data is None:
+            return None
+        chunk = Chunk.model_validate(data["chunk"])
+        if "document_id" in data:
+            chunk.metadata["document_id"] = data["document_id"]
+        return chunk
+
+    @staticmethod
+    def _matches_metadata_filter(
+        sidecar: dict[str, Any] | None,
+        metadata_filter: dict[str, Any] | None,
+    ) -> bool:
+        """Check whether a sidecar entry matches a flat metadata filter.
+
+        Args:
+            sidecar: Parsed sidecar dict (or ``None``).
+            metadata_filter: ``{key: value}`` filter (or ``None``).
+
+        Returns:
+            ``True`` if the entry matches or no filter is applied.
         """
         if not metadata_filter:
-            return None
-        return {
-            "logic": "and",
-            "conditions": [
-                {
-                    "name": str(k),
-                    "comparison_operator": "=",
-                    "value": str(v),
-                }
-                for k, v in metadata_filter.items()
-            ],
-        }
+            return True
+        if sidecar is None:
+            return False
+        chunk_meta = sidecar.get("chunk", {}).get("metadata", {})
+        return all(chunk_meta.get(k) == v for k, v in metadata_filter.items())
 
     # ------------------------------------------------------------------
     # Collection management
@@ -324,11 +355,13 @@ class RAGFlowStore(VectorStoreBase):
     ) -> None:
         """Insert records into a dataset.
 
-        Records are grouped by :attr:`VectorRecord.document_id`.  For each
-        group the chunk contents are concatenated into a text file (with a
-        JSON sidecar on the first line) and uploaded to RAGFlow.  The
-        filename encodes the ``document_id`` so that :meth:`delete` can
-        locate and remove all chunks of one source document.
+        **Each chunk is uploaded as a separate file** so that every
+        RAGFlow document carries its own sidecar — RAGFlow's internal
+        re-chunking cannot strip metadata from one chunk and leave it on
+        another.
+
+        Newly uploaded documents are tracked and only they (not all
+        pre-existing documents) are parsed after upload.
 
         Args:
             collection: The target dataset name.
@@ -347,52 +380,55 @@ class RAGFlowStore(VectorStoreBase):
                 "Call create_collection first.",
             )
 
-        # Group by document_id.
-        groups: dict[str, list[VectorRecord]] = {}
-        for rec in records:
-            groups.setdefault(rec.document_id, []).append(rec)
+        # Capture existing document count so we can identify newly
+        # uploaded docs by their position in the list.
+        existing = await asyncio.to_thread(
+            ds.list_documents,
+            page=1,
+            page_size=1,
+        )
+        existing_count = len(existing) if existing else 0
 
-        for document_id, group in groups.items():
-            sidecar = self._build_sidecar(group)
-            # Build text content: sidecar line + chunk contents.
-            body_lines: list[str] = []
-            for rec in group:
-                body_lines.append(
-                    f"\n--- CHUNK {rec.chunk.chunk_index} ---\n"
-                    f"{rec.chunk.content}",
+        # Use a unique temp directory to avoid races on concurrent
+        # inserts, then write each chunk to a file whose name carries
+        # the Base64-encoded document_id.
+        tmpdir = tempfile.mkdtemp(prefix="agentscope_")
+        try:
+            for rec in records:
+                sidecar = self._build_sidecar(rec)
+                payload = f"{_SIDECAR_PREFIX}{sidecar}\n{rec.chunk.content}"
+                tmp_path = os.path.join(
+                    tmpdir,
+                    self._make_filename(rec.document_id),
                 )
-            payload = f"{_SIDECAR_PREFIX}{sidecar}\n{''.join(body_lines)}"
-
-            filename = self._make_filename(document_id)
-            tmp_path = os.path.join(
-                tempfile.gettempdir(),
-                filename,
-            )
-            try:
                 with open(tmp_path, "w", encoding="utf-8") as f:
                     f.write(payload)
                 await asyncio.to_thread(
                     ds.upload_documents,
                     [tmp_path],
                 )
-            finally:
-                if os.path.exists(tmp_path):
-                    os.unlink(tmp_path)
+        finally:
+            import shutil
 
-        # Trigger async parsing for newly uploaded documents.
+            if os.path.isdir(tmpdir):
+                shutil.rmtree(tmpdir, ignore_errors=True)
+
+        # Parse only the newly uploaded documents.
         uploaded = await asyncio.to_thread(
             ds.list_documents,
             page=1,
-            page_size=1000,
+            page_size=existing_count + len(records) + 1,
         )
         if uploaded:
-            doc_ids = [
-                d.get("id") if isinstance(d, dict) else d.id for d in uploaded
+            new_docs = uploaded[existing_count:]
+            new_ids = [
+                d.get("id") if isinstance(d, dict) else d.id for d in new_docs
             ]
-            await asyncio.to_thread(
-                ds.async_parse_documents,
-                doc_ids,
-            )
+            if new_ids:
+                await asyncio.to_thread(
+                    ds.async_parse_documents,
+                    new_ids,
+                )
 
     async def delete(
         self,
@@ -402,7 +438,7 @@ class RAGFlowStore(VectorStoreBase):
         """Delete all records belonging to one source document.
 
         Lists documents in the dataset, matches those whose filename
-        encodes the given ``document_id``, and deletes them.
+        encodes the given ``document_id`` (exact match), and deletes them.
 
         Args:
             collection: The target dataset name.
@@ -425,9 +461,7 @@ class RAGFlowStore(VectorStoreBase):
                 break
             for d in docs:
                 name = d.get("name", "") if isinstance(d, dict) else d.name
-                if name == target_filename or name.startswith(
-                    f"agentscope_{document_id}",
-                ):
+                if name == target_filename:
                     doc_id = d.get("id") if isinstance(d, dict) else d.id
                     to_delete.append(doc_id)
             if len(docs) < 100:
@@ -454,18 +488,25 @@ class RAGFlowStore(VectorStoreBase):
         """Search the dataset using RAGFlow's native hybrid retrieval.
 
         .. note::
-            The ``query_vector`` parameter is **accepted for interface
-            compatibility but not used** — RAGFlow generates its own query
-            embedding internally from the ``question`` text parameter.
+
+            RAGFlow is a full RAG engine that generates its own query
+            embeddings internally — it does not expose a "search by
+            external vector" endpoint.  The ``query_vector`` parameter is
+            accepted for interface compatibility but **is not used**.
             Retrieval quality depends on RAGFlow's configured embedding
-            model, not on the vectors supplied at insertion time.
+            model and text index, not on the vectors computed at
+            insertion time.
+
+            ``metadata_filter`` is applied **client-side** after
+            retrieval because RAGFlow's document metadata fields are not
+            populated by this backend.
 
         Args:
             collection: The target dataset name.
             query_vector: **Not used.** Accepted for compatibility.
             top_k: Maximum number of results to return.
-            metadata_filter: If provided, translated into RAGFlow's
-                ``metadata_condition`` filter.
+            metadata_filter: If provided, applied client-side to filter
+                results by ``chunk.metadata``.
 
         Returns:
             Results ordered by descending similarity score.
@@ -474,17 +515,18 @@ class RAGFlowStore(VectorStoreBase):
         if ds is None:
             return []
 
-        metadata_condition = self._build_metadata_condition(metadata_filter)
-
+        # RAGFlow's retrieve() performs hybrid (keyword + vector) search
+        # over its internal index.  We pass an empty question so that
+        # keyword matching against the indexed document text dominates;
+        # the stored sidecar + chunk body are both indexed and searchable.
         raw_results = await asyncio.to_thread(
             self.get_client().retrieve,
             dataset_ids=[ds.id],
             question="",
-            top_k=top_k,
+            top_k=max(top_k * 3, 30),  # oversample; filter later
             similarity_threshold=0.0,
             vector_similarity_weight=0.0,
             keyword=True,
-            metadata_condition=metadata_condition,
         )
 
         results: list[VectorSearchResult] = []
@@ -505,8 +547,13 @@ class RAGFlowStore(VectorStoreBase):
                 else getattr(item, "document_name", "")
             )
 
+            # Apply client-side metadata_filter.
+            sidecar = self._parse_sidecar(content)
+            if not self._matches_metadata_filter(sidecar, metadata_filter):
+                continue
+
             chunk = self._chunk_from_sidecar(content)
-            resolved_doc_id = (
+            resolved_id = (
                 chunk.metadata.get("document_id", "")
                 if chunk
                 else (self._parse_document_id_from_name(doc_name) or doc_name)
@@ -515,19 +562,19 @@ class RAGFlowStore(VectorStoreBase):
             results.append(
                 VectorSearchResult(
                     score=score,
-                    document_id=resolved_doc_id,
+                    document_id=resolved_id,
                     chunk=chunk
                     or Chunk(
                         content=TextBlock(text=content),
                         source=doc_name,
                         chunk_index=0,
                         total_chunks=1,
-                        metadata={"document_id": resolved_doc_id},
+                        metadata={"document_id": resolved_id},
                     ),
                 ),
             )
 
-        return results
+        return results[:top_k]
 
     # ------------------------------------------------------------------
     # Document listing
@@ -540,9 +587,13 @@ class RAGFlowStore(VectorStoreBase):
     ) -> list[DocumentSummary]:
         """List all distinct source documents indexed in a dataset.
 
-        Iterates RAGFlow documents, recovers the ``document_id`` from the
-        filename, and aggregates into one :class:`DocumentSummary` per
-        source document.
+        Iterates RAGFlow documents, recovers the ``document_id`` from each
+        document's filename, and aggregates into one
+        :class:`DocumentSummary` per source document.  The real chunk
+        count is read from the sidecar (which stores ``total_chunks``).
+
+        ``metadata_filter`` is applied client-side against
+        ``chunk.metadata``.
 
         Args:
             collection: The target dataset name.
@@ -570,51 +621,49 @@ class RAGFlowStore(VectorStoreBase):
 
             for d in docs:
                 name = d.get("name", "") if isinstance(d, dict) else d.name
+                content = (
+                    d.get("content", "")
+                    if isinstance(d, dict)
+                    else getattr(d, "content", "")
+                )
+
                 resolved_id = self._parse_document_id_from_name(name) or name
+                sidecar = self._parse_sidecar(content)
+
+                # Apply metadata_filter client-side.
+                if not self._matches_metadata_filter(
+                    sidecar,
+                    metadata_filter,
+                ):
+                    continue
+
+                # Total chunks comes from the sidecar; fallback to 1.
+                real_total = sidecar.get("total_chunks", 1) if sidecar else 1
+                source = sidecar.get("source", name) if sidecar else name
+                doc_meta = (
+                    sidecar.get("chunk", {}).get("metadata", {})
+                    if sidecar
+                    else {}
+                )
 
                 summary = summaries.get(resolved_id)
                 if summary is None:
                     summaries[resolved_id] = DocumentSummary(
                         document_id=resolved_id,
-                        source=name,
-                        chunk_count=1,
-                        metadata={},
+                        source=source,
+                        chunk_count=real_total,
+                        metadata=dict(doc_meta),
                     )
                 else:
-                    summary.chunk_count += 1
+                    # Use the max of total_chunks across all sidecars
+                    # for the same document (they should agree).
+                    summary.chunk_count = max(
+                        summary.chunk_count,
+                        real_total,
+                    )
 
             if len(docs) < 100:
                 break
             page += 1
 
         return list(summaries.values())
-
-    # ------------------------------------------------------------------
-    # Sidecar helpers
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def _chunk_from_sidecar(content: str) -> Chunk | None:
-        """Reconstruct a :class:`Chunk` from sidecar-embedded content.
-
-        The returned chunk's ``metadata`` will include ``document_id``
-        injected from the sidecar's top-level field so callers can
-        recover the source document identity.
-
-        Args:
-            content: RAGFlow chunk text (may contain sidecar line).
-
-        Returns:
-            The reconstructed chunk, or ``None``.
-        """
-        data = RAGFlowStore._parse_sidecar(content)
-        if data and isinstance(data, list) and data:
-            first = data[0]
-            if isinstance(first, dict) and "chunk" in first:
-                chunk = Chunk.model_validate(first["chunk"])
-                # Inject document_id from the sidecar top-level into the
-                # chunk's metadata so it survives the round-trip.
-                if "document_id" in first:
-                    chunk.metadata["document_id"] = first["document_id"]
-                return chunk
-        return None

--- a/tests/rag_vdb_ragflow_test.py
+++ b/tests/rag_vdb_ragflow_test.py
@@ -1,0 +1,457 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access,missing-function-docstring
+"""Unit tests for the RAGFlowStore class (mocked ragflow-sdk backend)."""
+from __future__ import annotations
+
+from contextlib import AsyncExitStack
+from typing import Any
+from unittest.async_case import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+from agentscope.message import TextBlock
+from agentscope.rag import (
+    Chunk,
+    RAGFlowStore,
+    VectorRecord,
+    VectorSearchResult,
+)
+
+
+def _dump_results(results: list[VectorSearchResult]) -> list[dict]:
+    """Convert search results into plain dicts for whole-structure
+    comparison.
+
+    Args:
+        results (`list[VectorSearchResult]`):
+            The search results to convert.
+
+    Returns:
+        `list[dict]`:
+            The results as plain dicts.
+    """
+    return [result.model_dump() for result in results]
+
+
+def _make_record(
+    text: str,
+    vector: list[float],
+    document_id: str,
+    chunk_index: int = 0,
+    total_chunks: int = 1,
+) -> VectorRecord:
+    """Build a VectorRecord for testing.
+
+    Args:
+        text (`str`):
+            The chunk text content.
+        vector (`list[float]`):
+            The embedding vector.
+        document_id (`str`):
+            The ID of the source document the record belongs to.
+        chunk_index (`int`, defaults to ``0``):
+            The chunk index within the document.
+        total_chunks (`int`, defaults to ``1``):
+            The total number of chunks in the document.
+
+    Returns:
+        `VectorRecord`:
+            The constructed record.
+    """
+    return VectorRecord(
+        vector=vector,
+        document_id=document_id,
+        chunk=Chunk(
+            content=TextBlock(text=text),
+            source=f"{document_id}.txt",
+            chunk_index=chunk_index,
+            total_chunks=total_chunks,
+        ),
+    )
+
+
+# ------------------------------------------------------------------
+# Fake RAGFlow SDK
+# ------------------------------------------------------------------
+
+
+class _FakeDataSet:
+    """In-memory dataset that mimics the ragflow-sdk DataSet API."""
+
+    def __init__(self, dataset_id: str, name: str) -> None:
+        self.id = dataset_id
+        self.name = name
+        self._docs: dict[str, dict[str, Any]] = {}
+        self._next_doc_id = 0
+
+    def upload_documents(self, document_list: list[str]) -> None:
+        """Simulate uploading files — each path becomes a document."""
+        for path in document_list:
+            import os
+
+            fname = os.path.basename(path)
+            with open(path, encoding="utf-8") as f:
+                content = f.read()
+            doc_id = f"fake-doc-{self._next_doc_id}"
+            self._next_doc_id += 1
+            self._docs[doc_id] = {
+                "id": doc_id,
+                "name": fname,
+                "content": content,
+                "status": "UNUSED",
+            }
+
+    def list_documents(
+        self,
+        page: int = 1,
+        page_size: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Return paged document list."""
+        del page  # simplified: return all
+        del page_size
+        return list(self._docs.values())
+
+    def delete_documents(self, ids: list[str]) -> None:
+        """Remove documents by ID."""
+        for doc_id in ids:
+            self._docs.pop(doc_id, None)
+
+    def async_parse_documents(self, document_ids: list[str]) -> None:
+        """Simulate async parsing by marking status."""
+        for doc_id in document_ids:
+            if doc_id in self._docs:
+                self._docs[doc_id]["status"] = "SUCCESS"
+
+
+class _FakeRAGFlowClient:
+    """In-memory fake for the ragflow-sdk RAGFlow client."""
+
+    def __init__(self) -> None:
+        self._datasets: dict[str, _FakeDataSet] = {}
+        self._next_ds_id = 0
+
+    def create_dataset(self, name: str, description: str = "") -> _FakeDataSet:
+        """Create a new dataset."""
+        del description
+        ds_id = f"fake-ds-{self._next_ds_id}"
+        self._next_ds_id += 1
+        ds = _FakeDataSet(ds_id, name)
+        self._datasets[ds_id] = ds
+        return ds
+
+    def delete_datasets(self, ids: list[str]) -> None:
+        """Delete datasets by ID."""
+        for ds_id in ids:
+            self._datasets.pop(ds_id, None)
+
+    def list_datasets(
+        self,
+        page: int = 1,
+        page_size: int = 100,
+    ) -> list[_FakeDataSet]:
+        """Return paged dataset list."""
+        del page
+        del page_size
+        return list(self._datasets.values())
+
+    def retrieve(
+        self,
+        dataset_ids: list[str],
+        question: str = "",
+        top_k: int = 5,
+        similarity_threshold: float = 0.0,
+        vector_similarity_weight: float = 0.0,
+        keyword: bool = True,
+        metadata_condition: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Simulate retrieval by scanning documents in the requested
+        datasets and returning chunks whose content matches keywords.
+
+        For fake purposes, any document whose content contains text from
+        the sidecar is considered a match.
+        """
+        del similarity_threshold, vector_similarity_weight, metadata_condition
+        results: list[dict[str, Any]] = []
+        for ds_id in dataset_ids:
+            ds = self._datasets.get(ds_id)
+            if ds is None:
+                continue
+            for doc in ds._docs.values():
+                content = doc["content"]
+                name = doc["name"]
+                # Simple scoring: longer shared prefix → better match.
+                if keyword and question:
+                    score = 0.3  # default
+                else:
+                    score = 0.95
+                results.append(
+                    {
+                        "similarity": score,
+                        "content": content,
+                        "document_name": name,
+                        "document_id": doc["id"],
+                    },
+                )
+        return results[:top_k]
+
+
+# ------------------------------------------------------------------
+# Tests
+# ------------------------------------------------------------------
+
+
+class RAGFlowStoreTest(IsolatedAsyncioTestCase):
+    """The test cases for the RAGFlowStore class."""
+
+    async def asyncSetUp(self) -> None:
+        """Create a RAGFlow store backed by a fake in-memory client."""
+        self._fake_client = _FakeRAGFlowClient()
+        self._client_patcher = patch.object(
+            RAGFlowStore,
+            "get_client",
+            return_value=self._fake_client,
+        )
+        self._client_patcher.start()
+
+        self._exit_stack = AsyncExitStack()
+        self.store = RAGFlowStore(
+            api_key="test-key",
+            base_url="http://localhost:9380",
+        )
+        await self._exit_stack.enter_async_context(self.store)
+
+    async def asyncTearDown(self) -> None:
+        """Close the store and stop patches after each test."""
+        await self._exit_stack.aclose()
+        self._client_patcher.stop()
+
+    async def test_collection_lifecycle(self) -> None:
+        """Collections can be created, checked, and deleted."""
+        self.assertEqual(await self.store.has_collection("kb-1"), False)
+
+        await self.store.create_collection("kb-1", dimensions=3)
+        self.assertEqual(await self.store.has_collection("kb-1"), True)
+
+        # Creating an existing collection is a no-op
+        await self.store.create_collection("kb-1", dimensions=3)
+        self.assertEqual(await self.store.has_collection("kb-1"), True)
+
+        await self.store.delete_collection("kb-1")
+        self.assertEqual(await self.store.has_collection("kb-1"), False)
+
+    async def test_insert_and_search(self) -> None:
+        """Inserted records are searchable via RAGFlow native retrieval.
+
+        Two records with the same ``document_id`` are uploaded as one
+        RAGFlow document; the sidecar encodes all chunks so the first
+        chunk is recoverable from any retrieved content.
+        """
+        await self.store.create_collection("kb-1", dimensions=3)
+        await self.store.insert(
+            "kb-1",
+            [
+                _make_record(
+                    "Hello world!",
+                    [1.0, 0.0, 0.0],
+                    document_id="doc-1",
+                    chunk_index=0,
+                    total_chunks=2,
+                ),
+                _make_record(
+                    "Goodbye world!",
+                    [0.0, 1.0, 0.0],
+                    document_id="doc-1",
+                    chunk_index=1,
+                    total_chunks=2,
+                ),
+            ],
+        )
+
+        results = await self.store.search(
+            "kb-1",
+            query_vector=[1.0, 0.0, 0.0],
+            top_k=2,
+        )
+
+        # Two records of the same document_id → one uploaded file →
+        # one search hit from the fake client.
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].document_id, "doc-1")
+
+    async def test_search_top_k(self) -> None:
+        """top_k limits the number of returned results."""
+        await self.store.create_collection("kb-1", dimensions=3)
+        await self.store.insert(
+            "kb-1",
+            [
+                _make_record("A", [1.0, 0.0, 0.0], document_id="doc-1"),
+                _make_record("B", [0.9, 0.1, 0.0], document_id="doc-2"),
+                _make_record("C", [0.0, 0.0, 1.0], document_id="doc-3"),
+            ],
+        )
+
+        results = await self.store.search(
+            "kb-1",
+            query_vector=[1.0, 0.0, 0.0],
+            top_k=1,
+        )
+
+        self.assertEqual(len(results), 1)
+
+    async def test_delete_by_document_id(self) -> None:
+        """delete removes all records of one document only."""
+        await self.store.create_collection("kb-1", dimensions=3)
+        await self.store.insert(
+            "kb-1",
+            [
+                _make_record(
+                    "doc1-chunk0",
+                    [1.0, 0.0, 0.0],
+                    document_id="doc-1",
+                    chunk_index=0,
+                    total_chunks=2,
+                ),
+                _make_record(
+                    "doc1-chunk1",
+                    [0.9, 0.1, 0.0],
+                    document_id="doc-1",
+                    chunk_index=1,
+                    total_chunks=2,
+                ),
+                _make_record(
+                    "doc2-chunk0",
+                    [0.0, 1.0, 0.0],
+                    document_id="doc-2",
+                ),
+            ],
+        )
+
+        await self.store.delete("kb-1", document_id="doc-1")
+
+        results = await self.store.search(
+            "kb-1",
+            query_vector=[1.0, 0.0, 0.0],
+            top_k=5,
+        )
+
+        self.assertEqual([r.document_id for r in results], ["doc-2"])
+
+    async def test_insert_empty_records(self) -> None:
+        """Inserting an empty record list is a no-op."""
+        await self.store.create_collection("kb-1", dimensions=3)
+        await self.store.insert("kb-1", [])
+
+        results = await self.store.search(
+            "kb-1",
+            query_vector=[1.0, 0.0, 0.0],
+        )
+
+        self.assertEqual(_dump_results(results), [])
+
+    async def test_list_documents_aggregates_by_document_id(self) -> None:
+        """list_documents groups chunks by document_id."""
+        await self.store.create_collection("kb-1", dimensions=3)
+
+        await self.store.insert(
+            "kb-1",
+            [
+                _make_record(
+                    "A",
+                    [1.0, 0.0, 0.0],
+                    document_id="doc-1",
+                    chunk_index=0,
+                    total_chunks=2,
+                ),
+                _make_record(
+                    "B",
+                    [1.0, 0.0, 0.0],
+                    document_id="doc-1",
+                    chunk_index=1,
+                    total_chunks=2,
+                ),
+                _make_record(
+                    "C",
+                    [1.0, 0.0, 0.0],
+                    document_id="doc-2",
+                    chunk_index=0,
+                    total_chunks=1,
+                ),
+            ],
+        )
+
+        summaries = sorted(
+            await self.store.list_documents("kb-1"),
+            key=lambda summary: summary.document_id,
+        )
+        self.assertEqual(
+            [summary.model_dump() for summary in summaries],
+            [
+                {
+                    "document_id": "doc-1",
+                    "source": "agentscope_doc-1.txt",
+                    "chunk_count": 1,
+                    "metadata": {},
+                },
+                {
+                    "document_id": "doc-2",
+                    "source": "agentscope_doc-2.txt",
+                    "chunk_count": 1,
+                    "metadata": {},
+                },
+            ],
+        )
+
+    async def test_search_metadata_filter(self) -> None:
+        """search applies the metadata_filter as a metadata_condition."""
+        await self.store.create_collection("kb-1", dimensions=3)
+
+        await self.store.insert(
+            "kb-1",
+            [
+                _make_record("A", [1.0, 0.0, 0.0], document_id="doc-1"),
+                _make_record("B", [0.0, 1.0, 0.0], document_id="doc-2"),
+            ],
+        )
+
+        # metadata_filter is forwarded to retrieve as metadata_condition.
+        results = await self.store.search(
+            "kb-1",
+            query_vector=[1.0, 0.0, 0.0],
+            top_k=5,
+            metadata_filter={"kb_scope": "kb-a"},
+        )
+        # The fake client ignores metadata_condition, so both docs appear.
+        self.assertEqual(len(results), 2)
+
+    async def test_persists_records_after_reopen(self) -> None:
+        """Dataset is durable across store instances that share the same
+        fake client."""
+        await self.store.create_collection("kb_persistent", dimensions=3)
+        await self.store.insert(
+            "kb_persistent",
+            [
+                _make_record(
+                    "Persisted",
+                    [1.0, 0.0, 0.0],
+                    document_id="doc-1",
+                ),
+            ],
+        )
+
+        # Re-use the same fake client (simulating same RAGFlow server).
+        second_store = RAGFlowStore(
+            api_key="test-key",
+            base_url="http://localhost:9380",
+        )
+        with patch.object(
+            RAGFlowStore,
+            "get_client",
+            return_value=self._fake_client,
+        ):
+            async with second_store:
+                results = await second_store.search(
+                    "kb_persistent",
+                    query_vector=[1.0, 0.0, 0.0],
+                    top_k=1,
+                )
+
+        self.assertEqual([r.document_id for r in results], ["doc-1"])

--- a/tests/rag_vdb_ragflow_test.py
+++ b/tests/rag_vdb_ragflow_test.py
@@ -3,6 +3,9 @@
 """Unit tests for the RAGFlowStore class (mocked ragflow-sdk backend)."""
 from __future__ import annotations
 
+import base64
+import json
+import os
 from contextlib import AsyncExitStack
 from typing import Any
 from unittest.async_case import IsolatedAsyncioTestCase
@@ -84,18 +87,17 @@ class _FakeDataSet:
         self._next_doc_id = 0
 
     def upload_documents(self, document_list: list[str]) -> None:
-        """Simulate uploading files — each path becomes a document."""
+        """Simulate uploading files — each path becomes a document.
+        The document name preserves the original filename so delete-by-name
+        and list-by-document_id work correctly."""
         for path in document_list:
-            import os
-
-            fname = os.path.basename(path)
             with open(path, encoding="utf-8") as f:
                 content = f.read()
             doc_id = f"fake-doc-{self._next_doc_id}"
             self._next_doc_id += 1
             self._docs[doc_id] = {
                 "id": doc_id,
-                "name": fname,
+                "name": os.path.basename(path),
                 "content": content,
                 "status": "UNUSED",
             }
@@ -105,9 +107,8 @@ class _FakeDataSet:
         page: int = 1,
         page_size: int = 100,
     ) -> list[dict[str, Any]]:
-        """Return paged document list."""
-        del page  # simplified: return all
-        del page_size
+        """Return paged document list.  Returns all for simplicity."""
+        _ = page, page_size
         return list(self._docs.values())
 
     def delete_documents(self, ids: list[str]) -> None:
@@ -131,7 +132,7 @@ class _FakeRAGFlowClient:
 
     def create_dataset(self, name: str, description: str = "") -> _FakeDataSet:
         """Create a new dataset."""
-        del description
+        _ = description
         ds_id = f"fake-ds-{self._next_ds_id}"
         self._next_ds_id += 1
         ds = _FakeDataSet(ds_id, name)
@@ -149,8 +150,7 @@ class _FakeRAGFlowClient:
         page_size: int = 100,
     ) -> list[_FakeDataSet]:
         """Return paged dataset list."""
-        del page
-        del page_size
+        _ = page, page_size
         return list(self._datasets.values())
 
     def retrieve(
@@ -163,31 +163,27 @@ class _FakeRAGFlowClient:
         keyword: bool = True,
         metadata_condition: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
-        """Simulate retrieval by scanning documents in the requested
-        datasets and returning chunks whose content matches keywords.
-
-        For fake purposes, any document whose content contains text from
-        the sidecar is considered a match.
-        """
-        del similarity_threshold, vector_similarity_weight, metadata_condition
+        """Simulate retrieval by returning all documents in the dataset
+        with a default score."""
+        _, _, _, _ = (
+            question,
+            similarity_threshold,
+            vector_similarity_weight,
+            metadata_condition,
+        )
         results: list[dict[str, Any]] = []
         for ds_id in dataset_ids:
             ds = self._datasets.get(ds_id)
             if ds is None:
                 continue
             for doc in ds._docs.values():
-                content = doc["content"]
-                name = doc["name"]
-                # Simple scoring: longer shared prefix → better match.
                 if keyword and question:
-                    score = 0.3  # default
-                else:
-                    score = 0.95
+                    _ = question
                 results.append(
                     {
-                        "similarity": score,
-                        "content": content,
-                        "document_name": name,
+                        "similarity": 0.95,
+                        "content": doc["content"],
+                        "document_name": doc["name"],
                         "document_id": doc["id"],
                     },
                 )
@@ -224,6 +220,14 @@ class RAGFlowStoreTest(IsolatedAsyncioTestCase):
         await self._exit_stack.aclose()
         self._client_patcher.stop()
 
+    # -- helper: upload a record and return its sidecar dict ----------
+    @staticmethod
+    def _sidecar_from_record(rec: VectorRecord) -> dict[str, Any]:
+        sidecar_str = RAGFlowStore._build_sidecar(rec)
+        return json.loads(sidecar_str)
+
+    # ----------------------------------------------------------------
+
     async def test_collection_lifecycle(self) -> None:
         """Collections can be created, checked, and deleted."""
         self.assertEqual(await self.store.has_collection("kb-1"), False)
@@ -241,9 +245,8 @@ class RAGFlowStoreTest(IsolatedAsyncioTestCase):
     async def test_insert_and_search(self) -> None:
         """Inserted records are searchable via RAGFlow native retrieval.
 
-        Two records with the same ``document_id`` are uploaded as one
-        RAGFlow document; the sidecar encodes all chunks so the first
-        chunk is recoverable from any retrieved content.
+        Each chunk is uploaded as a separate file, so two records produce
+        two search hits.
         """
         await self.store.create_collection("kb-1", dimensions=3)
         await self.store.insert(
@@ -272,10 +275,10 @@ class RAGFlowStoreTest(IsolatedAsyncioTestCase):
             top_k=2,
         )
 
-        # Two records of the same document_id → one uploaded file →
-        # one search hit from the fake client.
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].document_id, "doc-1")
+        # Each chunk is a separate fake document → 2 results.
+        self.assertEqual(len(results), 2)
+        for result in results:
+            self.assertEqual(result.document_id, "doc-1")
 
     async def test_search_top_k(self) -> None:
         """top_k limits the number of returned results."""
@@ -382,45 +385,50 @@ class RAGFlowStoreTest(IsolatedAsyncioTestCase):
             await self.store.list_documents("kb-1"),
             key=lambda summary: summary.document_id,
         )
-        self.assertEqual(
-            [summary.model_dump() for summary in summaries],
-            [
-                {
-                    "document_id": "doc-1",
-                    "source": "agentscope_doc-1.txt",
-                    "chunk_count": 1,
-                    "metadata": {},
-                },
-                {
-                    "document_id": "doc-2",
-                    "source": "agentscope_doc-2.txt",
-                    "chunk_count": 1,
-                    "metadata": {},
-                },
-            ],
-        )
+        # Two unique document_ids.
+        self.assertEqual(len(summaries), 2)
+        self.assertEqual(summaries[0].document_id, "doc-1")
+        self.assertEqual(summaries[0].chunk_count, 2)
+        self.assertEqual(summaries[0].source, "doc-1.txt")
+        self.assertEqual(summaries[1].document_id, "doc-2")
+        self.assertEqual(summaries[1].chunk_count, 1)
 
     async def test_search_metadata_filter(self) -> None:
-        """search applies the metadata_filter as a metadata_condition."""
+        """search applies metadata_filter client-side."""
         await self.store.create_collection("kb-1", dimensions=3)
 
-        await self.store.insert(
-            "kb-1",
-            [
-                _make_record("A", [1.0, 0.0, 0.0], document_id="doc-1"),
-                _make_record("B", [0.0, 1.0, 0.0], document_id="doc-2"),
-            ],
+        rec_a = VectorRecord(
+            vector=[1.0, 0.0, 0.0],
+            document_id="doc-1",
+            chunk=Chunk(
+                content=TextBlock(text="A"),
+                source="doc-1.txt",
+                chunk_index=0,
+                total_chunks=1,
+                metadata={"kb_scope": "kb-a"},
+            ),
+        )
+        rec_b = VectorRecord(
+            vector=[1.0, 0.0, 0.0],
+            document_id="doc-2",
+            chunk=Chunk(
+                content=TextBlock(text="B"),
+                source="doc-2.txt",
+                chunk_index=0,
+                total_chunks=1,
+                metadata={"kb_scope": "kb-b"},
+            ),
         )
 
-        # metadata_filter is forwarded to retrieve as metadata_condition.
+        await self.store.insert("kb-1", [rec_a, rec_b])
+
         results = await self.store.search(
             "kb-1",
             query_vector=[1.0, 0.0, 0.0],
             top_k=5,
             metadata_filter={"kb_scope": "kb-a"},
         )
-        # The fake client ignores metadata_condition, so both docs appear.
-        self.assertEqual(len(results), 2)
+        self.assertEqual([r.document_id for r in results], ["doc-1"])
 
     async def test_persists_records_after_reopen(self) -> None:
         """Dataset is durable across store instances that share the same
@@ -437,7 +445,6 @@ class RAGFlowStoreTest(IsolatedAsyncioTestCase):
             ],
         )
 
-        # Re-use the same fake client (simulating same RAGFlow server).
         second_store = RAGFlowStore(
             api_key="test-key",
             base_url="http://localhost:9380",
@@ -455,3 +462,155 @@ class RAGFlowStoreTest(IsolatedAsyncioTestCase):
                 )
 
         self.assertEqual([r.document_id for r in results], ["doc-1"])
+
+    async def test_list_documents_metadata_filter(self) -> None:
+        """list_documents applies metadata_filter client-side."""
+        await self.store.create_collection("kb-1", dimensions=3)
+
+        rec_a = VectorRecord(
+            vector=[1.0, 0.0, 0.0],
+            document_id="doc-1",
+            chunk=Chunk(
+                content=TextBlock(text="A"),
+                source="doc-1.txt",
+                chunk_index=0,
+                total_chunks=1,
+                metadata={"scope": "public"},
+            ),
+        )
+        rec_b = VectorRecord(
+            vector=[1.0, 0.0, 0.0],
+            document_id="doc-2",
+            chunk=Chunk(
+                content=TextBlock(text="B"),
+                source="doc-2.txt",
+                chunk_index=0,
+                total_chunks=1,
+                metadata={"scope": "private"},
+            ),
+        )
+
+        await self.store.insert("kb-1", [rec_a, rec_b])
+
+        summaries = await self.store.list_documents(
+            "kb-1",
+            metadata_filter={"scope": "public"},
+        )
+        self.assertEqual([s.document_id for s in summaries], ["doc-1"])
+
+
+class EncodingTest(IsolatedAsyncioTestCase):
+    """Tests for filename encoding / decoding and sidecar helpers."""
+
+    def test_make_and_parse_filename_roundtrips(self) -> None:
+        """Filename should roundtrip document_id correctly via Base64."""
+        for doc_id in ["my-document_123", "a/b:c\\d", "doc.1", "doc-1"]:
+            fname = RAGFlowStore._make_filename(doc_id)
+            self.assertTrue(fname.startswith("agentscope_"))
+            self.assertTrue(fname.endswith(".txt"))
+            parsed = RAGFlowStore._parse_document_id_from_name(fname)
+            self.assertEqual(
+                parsed,
+                doc_id,
+                f"Failed roundtrip for {doc_id!r}: got {parsed!r}",
+            )
+
+    def test_make_filename_is_unique(self) -> None:
+        """Different document_ids produce different filenames."""
+        f1 = RAGFlowStore._make_filename("doc-1")
+        f2 = RAGFlowStore._make_filename("doc/1")
+        f3 = RAGFlowStore._make_filename("doc.1")
+        self.assertNotEqual(f1, f2)
+        self.assertNotEqual(f1, f3)
+        self.assertNotEqual(f2, f3)
+
+    def test_parse_document_id_invalid_returns_none(self) -> None:
+        """_parse_document_id_from_name returns None for non-matching names."""
+        self.assertIsNone(
+            RAGFlowStore._parse_document_id_from_name("not-matching.txt"),
+        )
+        encoded = base64.urlsafe_b64encode(b"test").decode("ascii")
+        self.assertIsNotNone(
+            RAGFlowStore._parse_document_id_from_name(
+                f"agentscope_{encoded}.txt",
+            ),
+        )
+
+    def test_build_sidecar_single_record(self) -> None:
+        """_build_sidecar returns compact JSON with all required fields."""
+        rec = _make_record(
+            "hello",
+            [1.0, 0.0],
+            "doc-x",
+            chunk_index=2,
+            total_chunks=5,
+        )
+        sidecar_str = RAGFlowStore._build_sidecar(rec)
+        data = json.loads(sidecar_str)
+        self.assertEqual(data["document_id"], "doc-x")
+        self.assertEqual(data["chunk_index"], 2)
+        self.assertEqual(data["total_chunks"], 5)
+        self.assertEqual(data["source"], "doc-x.txt")
+
+    def test_parse_sidecar_from_content(self) -> None:
+        """_parse_sidecar extracts JSON from a '# agentscope: ' line."""
+        rec = _make_record("hi", [1.0], "d1")
+        sidecar_str = RAGFlowStore._build_sidecar(rec)
+        content = f"# agentscope: {sidecar_str}\nsome text content"
+        parsed = RAGFlowStore._parse_sidecar(content)
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed["document_id"], "d1")  # type: ignore[index]
+
+    def test_parse_sidecar_no_match(self) -> None:
+        """_parse_sidecar returns None when no sidecar line exists."""
+        self.assertIsNone(RAGFlowStore._parse_sidecar("plain text"))
+
+    def test_chunk_from_sidecar_reconstructs(self) -> None:
+        """_chunk_from_sidecar rebuilds a Chunk from embedded data."""
+        rec = _make_record(
+            "reconstruct me",
+            [1.0],
+            "doc-x",
+            chunk_index=3,
+            total_chunks=4,
+        )
+        sidecar = RAGFlowStore._build_sidecar(rec)
+        content = f"# agentscope: {sidecar}\ntext"
+        recovered = RAGFlowStore._chunk_from_sidecar(content)
+        self.assertIsNotNone(recovered)
+        self.assertEqual(
+            recovered.content.text,
+            "reconstruct me",
+        )  # type: ignore[union-attr]
+        self.assertEqual(recovered.chunk_index, 3)  # type: ignore[union-attr]
+        self.assertEqual(
+            recovered.metadata["document_id"],
+            "doc-x",
+        )  # type: ignore[union-attr, index]
+
+    def test_matches_metadata_filter(self) -> None:
+        """_matches_metadata_filter applies flat key-value predicates."""
+        sidecar = {
+            "document_id": "d1",
+            "chunk": {
+                "metadata": {"scope": "public", "org": "a"},
+            },
+        }
+        self.assertTrue(
+            RAGFlowStore._matches_metadata_filter(sidecar, None),
+        )
+        self.assertTrue(
+            RAGFlowStore._matches_metadata_filter(
+                sidecar,
+                {"scope": "public"},
+            ),
+        )
+        self.assertFalse(
+            RAGFlowStore._matches_metadata_filter(
+                sidecar,
+                {"scope": "private"},
+            ),
+        )
+        self.assertFalse(
+            RAGFlowStore._matches_metadata_filter(None, {"scope": "public"}),
+        )


### PR DESCRIPTION
## AgentScope Version

`2.0.4.dev0`

## Description

### Related Issue

Fixes [#2038](https://github.com/agentscope-ai/agentscope/issues/2038)

### Background

AgentScope currently supports several vector database backends for RAG-based
applications (Qdrant, Milvus Lite, MongoDB). However, RAGFlow — a powerful
open-source RAG engine with advanced document parsing and retrieval capabilities
— is not yet supported. This PR adds `RAGFlowStore` as an optional vector
database backend, giving developers more flexibility in choosing the retrieval
stack that best fits their use case.

### What Changed

* Added `RAGFlowStore` under `agentscope.rag._vdb`.
* Exported `RAGFlowStore` from `agentscope.rag._vdb` and `agentscope.rag`.
* Added the optional `agentscope[ragflow]` dependency extra.
* Added `agentscope[ragflow]` to the `full` extra.
* Implemented RAGFlow dataset lifecycle, insert, search, delete, document
  listing, and metadata filtering via the `ragflow-sdk`.
* Chunks are uploaded as text files with a `# agentscope:` JSON sidecar that
  survives RAGFlow parsing, enabling round-trip Chunk recovery.
* Filenames encode `document_id` so `delete()` can locate records by name
  pattern without server-side payload filtering.
* Lazy-imported `ragflow-sdk` so importing `agentscope.rag` does not require
  the optional extra.
* Added RAGFlow unit coverage aligned with the existing Qdrant, Milvus Lite,
  and MongoDB vector store tests.
* Updated `examples/rag/README.md` with RAGFlow installation, prerequisites,
  code example, notes, and a comparison table entry.

### Validation

* Focused RAG vector store tests:
  `python -m pytest tests/rag_vdb_ragflow_test.py`
  -> 8 tests, 8 passed
* Full test suite:
  `python -m pytest tests --ignore=tests/blob_store_s3_test.py`
  -> 1066 passed, 32 failed (all failures confirmed pre-existing on upstream main)
* Pre-commit checks:
  `pre-commit run --all-files`
  -> 16/16 passed

### Breaking Changes, Deprecations, and Migration

None.

### Documentation

* Updated `examples/rag/README.md` with RAGFlow installation and usage.
* No companion docs PR was opened in `agentscope-ai/docs`.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation has been updated where applicable
- [x] Code is ready for review