### PR TITLE
feat(app): support forking sessions

### DIFF
--- a/examples/web_ui/frontend/src/api/session.ts
+++ b/examples/web_ui/frontend/src/api/session.ts
@@ -20,6 +20,11 @@ export const sessionApi = {
 
 	create: (body: CreateSessionRequest) => client.post<CreateSessionResponse>('/sessions/', body),
 
+	fork: (sessionId: string, agentId: string) =>
+		client.post<CreateSessionResponse>(`/sessions/${sessionId}/fork`, undefined, {
+			agent_id: agentId,
+		}),
+
 	update: (sessionId: string, agentId: string, body: UpdateSessionRequest) =>
 		client.patch<SessionRecord>(`/sessions/${sessionId}`, body, { agent_id: agentId }),
 

--- a/examples/web_ui/frontend/src/hooks/useSessions.ts
+++ b/examples/web_ui/frontend/src/hooks/useSessions.ts
@@ -62,6 +62,22 @@ export function useSessions(agentId: string | null) {
 		[agentId, refetch],
 	);
 
+	/** Forks a session and returns the new Session ID. */
+	const fork = useCallback(
+		async (sessionId: string): Promise<string> => {
+			if (!agentId) throw new Error('No agent selected');
+			const response = await sessionApi.fork(sessionId, agentId);
+			const newSessionId = response.session_id;
+			try {
+				await refetch();
+			} catch {
+				// The API already created the Fork; navigation still uses its ID.
+			}
+			return newSessionId;
+		},
+		[agentId, refetch],
+	);
+
 	/** Deletes a session and refreshes the list. */
 	const remove = useCallback(
 		async (sessionId: string) => {
@@ -72,5 +88,5 @@ export function useSessions(agentId: string | null) {
 		[agentId, refetch],
 	);
 
-	return { sessions, loading, error, refetch, create, update, remove };
+	return { sessions, loading, error, refetch, create, update, remove, fork };
 }

--- a/examples/web_ui/frontend/src/i18n/locales/en.json
+++ b/examples/web_ui/frontend/src/i18n/locales/en.json
@@ -176,6 +176,7 @@
 		"placeholder": "Session name"
 	},
 	"session-menu": {
+		"fork": "Fork",
 		"rename": "Rename",
 		"delete": "Delete"
 	},

--- a/examples/web_ui/frontend/src/i18n/locales/zh.json
+++ b/examples/web_ui/frontend/src/i18n/locales/zh.json
@@ -176,6 +176,7 @@
 		"placeholder": "会话名称"
 	},
 	"session-menu": {
+		"fork": "创建副本",
 		"rename": "重命名",
 		"delete": "删除"
 	},

--- a/examples/web_ui/frontend/src/pages/chat/index.tsx
+++ b/examples/web_ui/frontend/src/pages/chat/index.tsx
@@ -2,6 +2,7 @@ import {
 	BotMessageSquare,
 	CalendarClock,
 	Ellipsis,
+	GitFork,
 	MessageSquareDashed,
 	Pencil,
 	Plus,
@@ -96,6 +97,7 @@ const ChatPageInner = () => {
 		create: createSession,
 		update: updateSession,
 		remove: removeSession,
+		fork: forkSession,
 	} = useSessions(urlAgentId ?? null);
 
 	const { isMobile, setOpen, setOpenMobile } = useSidebar();
@@ -105,6 +107,7 @@ const ChatPageInner = () => {
 	const [renameSession, setRenameSession] = useState<SessionRecord | null>(null);
 	const [deleteSessionOpen, setDeleteSessionOpen] = useState(false);
 	const [sessionToDelete, setSessionToDelete] = useState<SessionRecord | null>(null);
+	const [forkingSessionId, setForkingSessionId] = useState<string | null>(null);
 
 	const selectedAgent = agents.find((a) => a.id === urlAgentId) ?? null;
 	const currentView = sessions.find((v) => v.session.id === urlSessionId) ?? null;
@@ -191,6 +194,17 @@ const ChatPageInner = () => {
 	const handleRenameConfirm = async (name: string) => {
 		if (!renameSession) return;
 		await updateSession(renameSession.id, { name });
+	};
+
+	const handleForkSession = async (session: SessionRecord) => {
+		if (!urlAgentId || forkingSessionId !== null) return;
+		setForkingSessionId(session.id);
+		try {
+			const newSessionId = await forkSession(session.id);
+			navigate(`/chat/${urlAgentId}/${newSessionId}`);
+		} finally {
+			setForkingSessionId(null);
+		}
 	};
 
 	return (
@@ -319,6 +333,16 @@ const ChatPageInner = () => {
 															side="right"
 															align="start"
 														>
+															<DropdownMenuItem
+																disabled={forkingSessionId !== null}
+																onClick={(event) => {
+																	event.stopPropagation();
+																	void handleForkSession(session);
+																}}
+															>
+																<GitFork />
+																{t('session-menu.fork')}
+															</DropdownMenuItem>
 															<DropdownMenuItem
 																onClick={() => {
 																	setRenameSession(session);

--- a/src/agentscope/app/_router/_session.py
+++ b/src/agentscope/app/_router/_session.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
 
 from ..._utils._common import _generate_id
+from ..._logging import logger
 from ..access import ResourceKind
 from ..deps import (
     get_chat_service,
@@ -47,6 +48,11 @@ from ..storage import (
     SessionRecord,
     StorageBase,
     TeamRecord,
+)
+from ..storage._exceptions import (
+    SessionForkConflictError,
+    SessionForkCorruptedGraphError,
+    SessionForkNotFoundError,
 )
 from ...message import ToolCallState
 from ..storage._utils import _ensure_team_members
@@ -333,6 +339,49 @@ async def create_session(
         ),
     )
     return CreateSessionResponse(session_id=session_record.id)
+
+
+@session_router.post(
+    "/{session_id}/fork",
+    response_model=CreateSessionResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Fork an existing session",
+)
+async def fork_session(
+    session_id: str,
+    agent_id: str = Query(description="Agent the session belongs to."),
+    user_id: str = Depends(get_current_user_id),
+    session_service: SessionService = Depends(get_session_service),
+) -> CreateSessionResponse:
+    """Create a fork through :class:`SessionService`.
+
+    The service owns authorization, status checks, and the Storage call.
+    This router only translates the service exceptions into the public HTTP
+    contract.
+    """
+    try:
+        forked_session = await session_service.fork_session(
+            user_id,
+            agent_id,
+            session_id,
+        )
+    except SessionForkNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="The session does not exist or is not accessible.",
+        ) from error
+    except SessionForkConflictError as error:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="The session cannot be forked in its current state.",
+        ) from error
+    except SessionForkCorruptedGraphError as error:
+        logger.exception("Failed to fork a corrupted session graph.")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Unable to fork the session.",
+        ) from error
+    return CreateSessionResponse(session_id=forked_session.id)
 
 
 @session_router.delete(

--- a/src/agentscope/app/_service/_session.py
+++ b/src/agentscope/app/_service/_session.py
@@ -49,7 +49,11 @@ import asyncio
 from enum import StrEnum
 
 from ..message_bus import MessageBus, MessageBusKeys
-from ..storage import StorageBase
+from ..storage import SessionRecord, StorageBase
+from ..storage._exceptions import (
+    SessionForkConflictError,
+    SessionForkNotFoundError,
+)
 from ..storage._utils import _ensure_team_members
 from ._session_projection import SessionProjection
 from ._projectors import SubagentHitlProjector
@@ -200,6 +204,87 @@ class SessionService:
             return None
 
         return self._derive_parked_status(session.state.context)
+
+    async def fork_session(
+        self,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> SessionRecord:
+        """Fork an owned, idle Session through the Storage backend.
+
+        Ownership is checked before consulting the MessageBus so an
+        unauthorized caller cannot learn whether another user's Session is
+        currently running. Team leader member checks are best-effort; the
+        Storage backend remains responsible for re-reading and validating the
+        complete graph.
+        """
+        source_session = await self._storage.get_session(
+            user_id,
+            agent_id,
+            session_id,
+        )
+        if (
+            source_session is None
+            or source_session.id != session_id
+            or source_session.user_id != user_id
+            or source_session.agent_id != agent_id
+        ):
+            raise SessionForkNotFoundError(
+                "The session does not exist or is not accessible.",
+            )
+
+        await self._ensure_fork_session_idle(
+            user_id,
+            agent_id,
+            session_id,
+            root=True,
+        )
+
+        if source_session.team_id is not None:
+            team = await self._storage.get_team(
+                user_id,
+                source_session.team_id,
+            )
+            if team is not None and team.session_id == source_session.id:
+                for member in team.data.members:
+                    await self._ensure_fork_session_idle(
+                        member.owner_id,
+                        member.agent_id,
+                        member.session_id,
+                        root=False,
+                    )
+
+        return await self._storage.fork_session(
+            user_id,
+            agent_id,
+            session_id,
+        )
+
+    async def _ensure_fork_session_idle(
+        self,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+        *,
+        root: bool,
+    ) -> None:
+        """Reject a fork target unless its current status is IDLE."""
+        session_status = await self.get_session_status(
+            user_id,
+            agent_id,
+            session_id,
+        )
+        if session_status is None:
+            if root:
+                raise SessionForkNotFoundError(
+                    "The session does not exist or is not accessible.",
+                )
+            return
+        if session_status is not SessionStatus.IDLE:
+            raise SessionForkConflictError(
+                "Only idle sessions can be forked.",
+            )
 
     @staticmethod
     def _derive_parked_status(context: list) -> SessionStatus:

--- a/src/agentscope/app/_tool/_agent_invite.py
+++ b/src/agentscope/app/_tool/_agent_invite.py
@@ -292,12 +292,14 @@ class AgentInvite(_TeamToolBase):
 
             # Re-fetch fresh — the snapshot could be stale if the user
             # just toggled the invite off.
+            member_owner_lookup_id = invited.user_id
             fresh = await self._storage.get_agent(
-                self._user_id,
+                member_owner_lookup_id,
                 invited.id,
             )
             if (
                 fresh is None
+                or fresh.user_id != member_owner_lookup_id
                 or not fresh.data.invite_config.invitable
                 or not (
                     fresh.data.invite_config.invite_description or ""
@@ -308,6 +310,7 @@ class AgentInvite(_TeamToolBase):
                     f"longer invitable.",
                 )
             invited = fresh
+            member_owner_id = invited.user_id
 
             # Duplicate-borrow guard — one team, one borrow per agent.
             existing_members = await _ensure_team_members(
@@ -354,7 +357,7 @@ class AgentInvite(_TeamToolBase):
             # lazily by the workspace manager on first chat, so a bare
             # id is enough.
             invited_sessions = await self._storage.list_sessions(
-                self._user_id,
+                member_owner_id,
                 invited.id,
             )
             if invited_sessions:
@@ -371,7 +374,7 @@ class AgentInvite(_TeamToolBase):
             else:
                 borrowed_workspace_id = (
                     self._workspace_manager.assign_workspace_id(
-                        user_id=self._user_id,
+                        user_id=member_owner_id,
                         agent_id=invited.id,
                         session_id=_generate_id(),
                     )
@@ -407,7 +410,7 @@ class AgentInvite(_TeamToolBase):
             )
             invited_handle = _display_handle(invited.id)
             borrowed = await self._storage.upsert_session(
-                user_id=self._user_id,
+                user_id=member_owner_id,
                 agent_id=invited.id,
                 config=SessionConfig(
                     workspace_id=borrowed_workspace_id,
@@ -418,7 +421,7 @@ class AgentInvite(_TeamToolBase):
                 state=worker_state,
             )
             await self._storage.set_session_team_id(
-                self._user_id,
+                member_owner_id,
                 borrowed.id,
                 team.id,
             )
@@ -426,7 +429,7 @@ class AgentInvite(_TeamToolBase):
             team.data.members = [
                 *existing_members,
                 TeamMember(
-                    owner_id=self._user_id,
+                    owner_id=member_owner_id,
                     agent_id=invited.id,
                     session_id=borrowed.id,
                     role="invited",
@@ -461,7 +464,7 @@ class AgentInvite(_TeamToolBase):
             )
             await enqueue_run_trigger(
                 self._message_bus,
-                user_id=self._user_id,
+                user_id=member_owner_id,
                 session_id=borrowed.id,
                 agent_id=invited.id,
             )

--- a/src/agentscope/app/storage/__init__.py
+++ b/src/agentscope/app/storage/__init__.py
@@ -2,6 +2,11 @@
 """The storage module in agentscope."""
 
 from ._base import StorageBase
+from ._exceptions import (
+    SessionForkConflictError,
+    SessionForkCorruptedGraphError,
+    SessionForkNotFoundError,
+)
 from ._redis_storage import RedisStorage
 from ._model import (
     AgentData,
@@ -31,6 +36,9 @@ from ._model import (
 __all__ = [
     "StorageBase",
     "RedisStorage",
+    "SessionForkConflictError",
+    "SessionForkCorruptedGraphError",
+    "SessionForkNotFoundError",
     # The ORM models
     "InviteConfig",
     "AgentData",

--- a/src/agentscope/app/storage/_base.py
+++ b/src/agentscope/app/storage/_base.py
@@ -206,6 +206,22 @@ class StorageBase(ABC):
             `SessionRecord`: The created or updated record.
         """
 
+    async def fork_session(
+        self,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> SessionRecord:
+        """Fork a session using the storage backend's native semantics.
+
+        Backends that do not implement session forking fail explicitly while
+        remaining instantiable during the phased rollout.
+        """
+        del user_id, agent_id, session_id
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support session forking.",
+        )
+
     @abstractmethod
     async def set_session_team_id(
         self,

--- a/src/agentscope/app/storage/_exceptions.py
+++ b/src/agentscope/app/storage/_exceptions.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""Exceptions raised by storage-level session fork operations."""
+
+
+class SessionForkNotFoundError(LookupError):
+    """The requested source session was not found."""
+
+
+class SessionForkConflictError(RuntimeError):
+    """The source session cannot be forked under current conditions."""
+
+
+class SessionForkCorruptedGraphError(RuntimeError):
+    """The source session graph is inconsistent or incomplete."""

--- a/src/agentscope/app/storage/_fork.py
+++ b/src/agentscope/app/storage/_fork.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Small, ordinary-session-only helpers for storage session forking."""
+"""Helpers shared by ordinary and Schedule session forking."""
 
 from dataclasses import dataclass
 
@@ -31,13 +31,13 @@ class SessionForkPlan:
     target_session_index_key: str
 
 
-def validate_regular_fork_source(
+def validate_session_fork_source(
     session: SessionRecord,
     user_id: str,
     agent_id: str,
     session_id: str,
 ) -> None:
-    """Validate the source constraints supported by phase one."""
+    """Validate source identity, provenance, and non-team boundaries."""
     if session.id != session_id:
         raise SessionForkCorruptedGraphError(
             "The source session record does not match its storage key.",
@@ -52,14 +52,19 @@ def validate_regular_fork_source(
         )
     if session.team_id is not None:
         raise SessionForkConflictError(
-            "Team sessions are not supported by the first fork phase.",
+            "Team sessions are not supported by the current fork phase.",
         )
-    if session.source == SessionSource.SCHEDULE:
-        raise SessionForkConflictError(
-            "Schedule sessions are not supported by the first fork phase.",
-        )
-    if session.source_schedule_id is not None:
-        raise SessionForkConflictError(
-            "Sessions with schedule provenance are not supported by the "
-            "first fork phase.",
-        )
+    is_regular = (
+        session.source == SessionSource.USER
+        and session.source_schedule_id is None
+    )
+    is_schedule = (
+        session.source == SessionSource.SCHEDULE
+        and isinstance(session.source_schedule_id, str)
+        and bool(session.source_schedule_id.strip())
+    )
+    if is_regular or is_schedule:
+        return
+    raise SessionForkCorruptedGraphError(
+        "Session source and schedule provenance are inconsistent.",
+    )

--- a/src/agentscope/app/storage/_fork.py
+++ b/src/agentscope/app/storage/_fork.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+"""Small, ordinary-session-only helpers for storage session forking."""
+
+from dataclasses import dataclass
+
+from ._exceptions import (
+    SessionForkConflictError,
+    SessionForkCorruptedGraphError,
+    SessionForkNotFoundError,
+)
+from ._model import SessionRecord, SessionSource
+from ._model._session import default_session_name
+
+
+def build_fork_session_name(name: str | None) -> str:
+    """Return the default display name for a forked session."""
+    if name and name.strip():
+        return f"{name} (Fork)"
+    return default_session_name()
+
+
+@dataclass(frozen=True)
+class SessionForkPlan:
+    """Immutable write plan for a regular, non-team session fork."""
+
+    source_session_id: str
+    target_session: SessionRecord
+    source_messages: tuple[str | bytes, ...]
+    target_session_key: str
+    target_messages_key: str
+    target_session_index_key: str
+
+
+def validate_regular_fork_source(
+    session: SessionRecord,
+    user_id: str,
+    agent_id: str,
+    session_id: str,
+) -> None:
+    """Validate the source constraints supported by phase one."""
+    if session.id != session_id:
+        raise SessionForkCorruptedGraphError(
+            "The source session record does not match its storage key.",
+        )
+    if session.user_id != user_id:
+        raise SessionForkNotFoundError(
+            "The source session does not belong to the requested user.",
+        )
+    if session.agent_id != agent_id:
+        raise SessionForkNotFoundError(
+            "The source session does not belong to the requested agent.",
+        )
+    if session.team_id is not None:
+        raise SessionForkConflictError(
+            "Team sessions are not supported by the first fork phase.",
+        )
+    if session.source == SessionSource.SCHEDULE:
+        raise SessionForkConflictError(
+            "Schedule sessions are not supported by the first fork phase.",
+        )
+    if session.source_schedule_id is not None:
+        raise SessionForkConflictError(
+            "Sessions with schedule provenance are not supported by the "
+            "first fork phase.",
+        )

--- a/src/agentscope/app/storage/_model/_session.py
+++ b/src/agentscope/app/storage/_model/_session.py
@@ -9,6 +9,11 @@ from ._base import _RecordBase
 from ....state import AgentState
 
 
+def default_session_name() -> str:
+    """Return the default display name used for new sessions."""
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
 class SessionSource(str, Enum):
     """The source that created the session."""
 
@@ -125,7 +130,7 @@ class SessionConfig(BaseModel):
     :meth:`WorkspaceManagerBase.get_workspace`."""
 
     name: str = Field(
-        default_factory=lambda: datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        default_factory=default_session_name,
         description="Display name for the session.",
     )
     """The session display name."""

--- a/src/agentscope/app/storage/_redis_storage.py
+++ b/src/agentscope/app/storage/_redis_storage.py
@@ -20,6 +20,13 @@ from ._fork import (
     build_fork_session_name,
     validate_session_fork_source,
 )
+from ._team_fork import (
+    TeamForkPlan,
+    TeamMemberForkPlan,
+    validate_created_member_resources,
+    validate_team_members,
+    validate_team_source_identity,
+)
 from ._model import (
     AgentRecord,
     CredentialRecord,
@@ -33,6 +40,7 @@ from ._model import (
     TeamRecord,
 )
 from ._utils import _dump_with_secrets
+from ..._utils._common import _generate_id
 from ...credential import CredentialBase
 from ...message import Msg
 from ...state import AgentState
@@ -656,6 +664,666 @@ class RedisStorage(StorageBase):
         return record
 
     async def fork_session(
+        self,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> SessionRecord:
+        """Fork a regular, Schedule, or created-member Team session."""
+        source_team_id = await self._peek_team_id(
+            user_id,
+            agent_id,
+            session_id,
+        )
+        if source_team_id is not None:
+            return await self._fork_team_session(
+                user_id,
+                agent_id,
+                session_id,
+                source_team_id,
+            )
+        return await self._fork_regular_session(user_id, agent_id, session_id)
+
+    async def _peek_team_id(
+        self,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> str | None:
+        """Detect a Team source without migrating or retaining a snapshot."""
+        source_key = self._key(
+            self.key_config.session,
+            user_id=user_id,
+            session_id=session_id,
+        )
+        for _ in range(_SESSION_FORK_MAX_RETRIES):
+            try:
+                source_type = _normalize_redis_type(
+                    await self._client.type(source_key),
+                )
+                if source_type == "none" or source_type != "string":
+                    return None
+                raw_session = await self._client.get(source_key)
+                if not raw_session:
+                    return None
+                try:
+                    source_session = SessionRecord.model_validate_json(
+                        raw_session,
+                    )
+                except ValidationError:
+                    return None
+                if source_session.team_id is None:
+                    return None
+                validate_team_source_identity(
+                    source_session,
+                    user_id,
+                    agent_id,
+                    session_id,
+                )
+                return source_session.team_id
+            except ResponseError as error:
+                if _is_wrongtype_response_error(error):
+                    continue
+                raise
+        raise SessionForkConflictError(
+            "The source session changed during pre-read.",
+        )
+
+    async def _read_team_prerequisites(
+        self,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> tuple[SessionRecord, TeamRecord]:
+        """Safely read and validate source Session plus Team for migration."""
+        source_key = self._key(
+            self.key_config.session,
+            user_id=user_id,
+            session_id=session_id,
+        )
+        for _ in range(_SESSION_FORK_MAX_RETRIES):
+            try:
+                source_type = _normalize_redis_type(
+                    await self._client.type(source_key),
+                )
+                if source_type == "none":
+                    raise SessionForkNotFoundError(
+                        f"Session '{session_id}' not found.",
+                    )
+                if source_type != "string":
+                    raise SessionForkCorruptedGraphError(
+                        "The source session key has an invalid type.",
+                    )
+                raw_session = await self._client.get(source_key)
+                if not raw_session:
+                    raise SessionForkNotFoundError(
+                        f"Session '{session_id}' not found.",
+                    )
+                try:
+                    source_session = SessionRecord.model_validate_json(
+                        raw_session,
+                    )
+                except ValidationError as error:
+                    raise SessionForkCorruptedGraphError(
+                        "The source session record is invalid.",
+                    ) from error
+                validate_team_source_identity(
+                    source_session,
+                    user_id,
+                    agent_id,
+                    session_id,
+                )
+                assert source_session.team_id is not None
+                team_key = self._key(
+                    self.key_config.team,
+                    user_id=user_id,
+                    team_id=source_session.team_id,
+                )
+                team_type = _normalize_redis_type(
+                    await self._client.type(team_key),
+                )
+                if team_type == "none":
+                    raise SessionForkCorruptedGraphError(
+                        "The Team record is missing.",
+                    )
+                if team_type != "string":
+                    raise SessionForkCorruptedGraphError(
+                        "The Team record key has an invalid type.",
+                    )
+                raw_team = await self._client.get(team_key)
+                if not raw_team:
+                    raise SessionForkCorruptedGraphError(
+                        "The Team record is missing.",
+                    )
+                try:
+                    team = TeamRecord.model_validate_json(raw_team)
+                except ValidationError as error:
+                    raise SessionForkCorruptedGraphError(
+                        "The Team record is invalid.",
+                    ) from error
+                if team.id != source_session.team_id:
+                    raise SessionForkCorruptedGraphError(
+                        "The Team record does not match the source session.",
+                    )
+                if team.user_id != user_id:
+                    raise SessionForkCorruptedGraphError(
+                        "The Team record does not belong to the requested "
+                        "user.",
+                    )
+                return source_session, team
+            except ResponseError as error:
+                if _is_wrongtype_response_error(error):
+                    continue
+                raise
+        raise SessionForkConflictError(
+            "The source Team graph changed during pre-read.",
+        )
+
+    async def _fork_team_session(
+        self,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+        team_id: str,
+    ) -> SessionRecord:
+        """Fork a Team leader with created members atomically."""
+        for _ in range(_SESSION_FORK_MAX_RETRIES):
+            _, team = await self._read_team_prerequisites(
+                user_id,
+                agent_id,
+                session_id,
+            )
+            team_id = team.id
+            from ._utils import _ensure_team_members
+
+            await _ensure_team_members(self, user_id, team)
+            async with self._client.pipeline(transaction=True) as pipe:
+                try:
+                    plan = await self._build_team_fork_plan(
+                        pipe,
+                        user_id,
+                        agent_id,
+                        session_id,
+                        team_id,
+                    )
+                    await self._check_team_target_keys(pipe, plan)
+                    pipe.multi()
+                    await self._queue_team_fork_writes(pipe, user_id, plan)
+                    await pipe.execute()
+                    return SessionRecord.model_validate_json(
+                        plan.target_leader_session_payload,
+                    )
+                except _watch_error():
+                    continue
+        raise SessionForkConflictError(
+            "The Team could not be forked due to concurrent changes or "
+            "target identifier conflicts.",
+        )
+
+    # The Team graph read and clone construction intentionally stays in one
+    # transaction-plan builder so every resource is derived from one WATCHed
+    # snapshot.
+    # pylint: disable=too-many-branches,too-many-statements
+    async def _build_team_fork_plan(
+        self,
+        pipe: Any,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+        prepared_team_id: str,
+    ) -> TeamForkPlan:
+        """Read and clone the complete Team graph under WATCH."""
+        source_key = self._key(
+            self.key_config.session,
+            user_id=user_id,
+            session_id=session_id,
+        )
+        await pipe.watch(source_key)
+        source_type = _normalize_redis_type(await pipe.type(source_key))
+        if source_type == "none":
+            raise SessionForkNotFoundError(
+                f"Session '{session_id}' not found.",
+            )
+        if source_type != "string":
+            raise SessionForkCorruptedGraphError(
+                "The source session key has an invalid type.",
+            )
+        try:
+            raw_session = await pipe.get(source_key)
+        except ResponseError as error:
+            if _is_wrongtype_response_error(error):
+                raise _watch_error() from error
+            raise
+        if not raw_session:
+            raise SessionForkNotFoundError(
+                f"Session '{session_id}' not found.",
+            )
+        try:
+            source_session = SessionRecord.model_validate_json(raw_session)
+        except ValidationError as error:
+            raise SessionForkCorruptedGraphError(
+                "The source session record is invalid.",
+            ) from error
+        validate_team_source_identity(
+            source_session,
+            user_id,
+            agent_id,
+            session_id,
+        )
+        assert source_session.team_id is not None
+        if source_session.team_id != prepared_team_id:
+            raise _watch_error()
+
+        team_key = self._key(
+            self.key_config.team,
+            user_id=user_id,
+            team_id=source_session.team_id,
+        )
+        await pipe.watch(team_key)
+        team_type = _normalize_redis_type(await pipe.type(team_key))
+        if team_type != "string":
+            raise SessionForkCorruptedGraphError(
+                "The Team record is missing or has an invalid type.",
+            )
+        try:
+            raw_team = await pipe.get(team_key)
+        except ResponseError as error:
+            if _is_wrongtype_response_error(error):
+                raise _watch_error() from error
+            raise
+        if not raw_team:
+            raise SessionForkCorruptedGraphError("The Team record is missing.")
+        try:
+            team = TeamRecord.model_validate_json(raw_team)
+        except ValidationError as error:
+            raise SessionForkCorruptedGraphError(
+                "The Team record is invalid.",
+            ) from error
+        if team.id != source_session.team_id or team.user_id != user_id:
+            raise SessionForkCorruptedGraphError(
+                "The Team record does not match the source graph.",
+            )
+        members = validate_team_members(team, session_id)
+        expected_member_ids = [member.agent_id for member in members]
+        if team.data.member_ids != expected_member_ids:
+            raise SessionForkCorruptedGraphError(
+                "Team member_ids do not match the normalized member graph.",
+            )
+
+        leader_messages_key = self._message_key(user_id, session_id)
+        member_keys: list[tuple[str, str, str]] = []
+        for member in members:
+            if member.owner_id != team.user_id:
+                raise SessionForkCorruptedGraphError(
+                    "Created member owner does not match the Team owner.",
+                )
+            member_keys.append(
+                (
+                    self._key(
+                        self.key_config.agent,
+                        user_id=member.owner_id,
+                        agent_id=member.agent_id,
+                    ),
+                    self._key(
+                        self.key_config.session,
+                        user_id=member.owner_id,
+                        session_id=member.session_id,
+                    ),
+                    self._message_key(member.owner_id, member.session_id),
+                ),
+            )
+        await pipe.watch(
+            leader_messages_key,
+            *(key for triple in member_keys for key in triple),
+        )
+        try:
+            leader_message_type = _normalize_redis_type(
+                await pipe.type(leader_messages_key),
+            )
+            if leader_message_type not in {"none", "list"}:
+                raise SessionForkCorruptedGraphError(
+                    "The source Leader message key has an invalid type.",
+                )
+            raw_leader_messages = (
+                await pipe.lrange(leader_messages_key, 0, -1)
+                if leader_message_type == "list"
+                else []
+            )
+            source_members: list[tuple[AgentRecord, SessionRecord, list]] = []
+            for agent_key, member_session_key, message_key in member_keys:
+                if (
+                    _normalize_redis_type(await pipe.type(agent_key))
+                    != "string"
+                ):
+                    raise SessionForkCorruptedGraphError(
+                        "A member Agent record is missing or invalid.",
+                    )
+                if (
+                    _normalize_redis_type(await pipe.type(member_session_key))
+                    != "string"
+                ):
+                    raise SessionForkCorruptedGraphError(
+                        "A member Session record is missing or invalid.",
+                    )
+                agent_raw = await pipe.get(agent_key)
+                session_raw = await pipe.get(member_session_key)
+                message_type = _normalize_redis_type(
+                    await pipe.type(message_key),
+                )
+                if message_type not in {"none", "list"}:
+                    raise SessionForkCorruptedGraphError(
+                        "A member message key has an invalid type.",
+                    )
+                messages = (
+                    await pipe.lrange(message_key, 0, -1)
+                    if message_type == "list"
+                    else []
+                )
+                if not agent_raw or not session_raw:
+                    raise SessionForkCorruptedGraphError(
+                        "A Team member resource is missing.",
+                    )
+                try:
+                    member_agent = AgentRecord.model_validate_json(agent_raw)
+                    member_session = SessionRecord.model_validate_json(
+                        session_raw,
+                    )
+                except ValidationError as error:
+                    raise SessionForkCorruptedGraphError(
+                        "A Team member resource is invalid.",
+                    ) from error
+                validate_created_member_resources(
+                    members[len(source_members)],
+                    member_agent,
+                    member_session,
+                    team,
+                )
+                source_members.append(
+                    (member_agent, member_session, messages),
+                )
+        except ResponseError as error:
+            if _is_wrongtype_response_error(error):
+                raise _watch_error() from error
+            raise
+
+        forked_at = datetime.now()
+        target_team_id = _generate_id()
+        target_leader_id = _generate_id()
+        target_leader = source_session.model_copy(deep=True)
+        target_leader.id = target_leader_id
+        target_leader.created_at = forked_at
+        target_leader.updated_at = forked_at
+        target_leader.team_id = target_team_id
+        target_leader.source = SessionSource.USER
+        target_leader.source_schedule_id = None
+        target_leader.config.name = build_fork_session_name(
+            source_session.config.name,
+        )
+
+        target_team = team.model_copy(deep=True)
+        target_team.id = target_team_id
+        target_team.created_at = forked_at
+        target_team.updated_at = forked_at
+        target_team.session_id = target_leader.id
+        target_members: list[TeamMemberForkPlan] = []
+        new_member_ids: list[str] = []
+        target_agent_ids: list[str] = []
+        target_data_ids: list[str] = []
+        target_session_ids: list[str] = [target_leader.id]
+        source_data_ids = {source.data.id for source, _, _ in source_members}
+        for member, (source_agent, source_member_session, messages) in zip(
+            members,
+            source_members,
+        ):
+            target_agent_id = _generate_id()
+            target_data_id = _generate_id()
+            target_session_id = _generate_id()
+            if target_data_id in source_data_ids:
+                raise _watch_error()
+            target_agent = source_agent.model_copy(deep=True)
+            target_agent.id = target_agent_id
+            target_agent.created_at = forked_at
+            target_agent.updated_at = forked_at
+            target_agent.data.id = target_data_id
+            target_member_session = source_member_session.model_copy(deep=True)
+            target_member_session.id = target_session_id
+            target_member_session.created_at = forked_at
+            target_member_session.updated_at = forked_at
+            target_member_session.agent_id = target_agent_id
+            target_member_session.team_id = target_team_id
+            target_member_session.source = SessionSource.USER
+            target_member_session.source_schedule_id = None
+            target_member_session.config.name = (
+                source_member_session.config.name
+            )
+            target_agent_payload = target_agent.model_dump_json()
+            target_session_payload = target_member_session.model_dump_json()
+            target_members.append(
+                TeamMemberForkPlan(
+                    source_member=member,
+                    target_agent_id=target_agent.id,
+                    target_session_id=target_member_session.id,
+                    target_agent_payload=target_agent_payload,
+                    target_session_payload=target_session_payload,
+                    source_messages=tuple(messages),
+                ),
+            )
+            new_member_ids.append(target_agent_id)
+            target_agent_ids.append(target_agent_id)
+            target_data_ids.append(target_data_id)
+            target_session_ids.append(target_session_id)
+
+        if (
+            len(target_agent_ids) != len(set(target_agent_ids))
+            or len(target_data_ids) != len(set(target_data_ids))
+            or len(target_session_ids) != len(set(target_session_ids))
+            or len(new_member_ids) != len(set(new_member_ids))
+            or len(
+                [member.target_session_id for member in target_members],
+            )
+            != len(
+                {member.target_session_id for member in target_members},
+            )
+        ):
+            raise _watch_error()
+
+        target_team.data.members = [
+            member.source_member.model_copy(
+                update={
+                    "agent_id": member.target_agent_id,
+                    "session_id": member.target_session_id,
+                },
+            )
+            for member in target_members
+        ]
+        target_team.data.member_ids = new_member_ids
+        target_team_payload = target_team.model_dump_json()
+        target_leader_session_payload = target_leader.model_dump_json()
+
+        target_keys = [
+            self._key(
+                self.key_config.team,
+                user_id=user_id,
+                team_id=target_team.id,
+            ),
+            self._key(
+                self.key_config.session,
+                user_id=user_id,
+                session_id=target_leader.id,
+            ),
+            self._message_key(user_id, target_leader.id),
+        ]
+        for member in target_members:
+            target_keys.extend(
+                [
+                    self._key(
+                        self.key_config.agent,
+                        user_id=user_id,
+                        agent_id=member.target_agent_id,
+                    ),
+                    self._key(
+                        self.key_config.session,
+                        user_id=user_id,
+                        session_id=member.target_session_id,
+                    ),
+                    self._message_key(user_id, member.target_session_id),
+                ],
+            )
+        owner_agent_index = self._key(
+            self.key_config.agent_index,
+            user_id=user_id,
+        )
+        owner_team_index = self._key(
+            self.key_config.team_index,
+            user_id=user_id,
+        )
+        leader_session_index = self._key(
+            self.key_config.session_index,
+            user_id=user_id,
+            agent_id=source_session.agent_id,
+        )
+        new_member_session_indexes = tuple(
+            self._key(
+                self.key_config.session_index,
+                user_id=user_id,
+                agent_id=member.target_agent_id,
+            )
+            for member in target_members
+        )
+        target_keys.extend(new_member_session_indexes)
+        exclusive_target_keys = tuple(target_keys)
+        if len(exclusive_target_keys) != len(set(exclusive_target_keys)):
+            raise _watch_error()
+        shared_index_keys = [owner_team_index, leader_session_index]
+        if target_members:
+            shared_index_keys.append(owner_agent_index)
+        if len(shared_index_keys) != len(set(shared_index_keys)):
+            raise SessionForkCorruptedGraphError(
+                "Team fork shared index key templates overlap.",
+            )
+        if set(exclusive_target_keys) & set(shared_index_keys):
+            raise _watch_error()
+        return TeamForkPlan(
+            forked_at=forked_at,
+            source_session_id=session_id,
+            target_team_id=target_team.id,
+            target_leader_agent_id=target_leader.agent_id,
+            target_leader_session_id=target_leader.id,
+            target_team_payload=target_team_payload,
+            target_leader_session_payload=target_leader_session_payload,
+            target_leader_messages=tuple(raw_leader_messages),
+            target_members=tuple(target_members),
+            exclusive_target_keys=exclusive_target_keys,
+            shared_index_keys=tuple(shared_index_keys),
+        )
+
+    async def _check_team_target_keys(
+        self,
+        pipe: Any,
+        plan: TeamForkPlan,
+    ) -> None:
+        """WATCH and validate all Team fork target keys and indexes."""
+        await pipe.watch(
+            *plan.exclusive_target_keys,
+            *plan.shared_index_keys,
+        )
+        for key in plan.exclusive_target_keys:
+            if _normalize_redis_type(await pipe.type(key)) != "none":
+                raise _watch_error()
+        for key in plan.shared_index_keys:
+            if _normalize_redis_type(await pipe.type(key)) not in {
+                "none",
+                "set",
+            }:
+                raise SessionForkCorruptedGraphError(
+                    "A shared Team index has an invalid type.",
+                )
+
+    async def _queue_team_fork_writes(
+        self,
+        pipe: Any,
+        user_id: str,
+        plan: TeamForkPlan,
+    ) -> None:
+        """Queue all Team fork writes after plan validation."""
+        team_key = self._key(
+            self.key_config.team,
+            user_id=user_id,
+            team_id=plan.target_team_id,
+        )
+        leader_key = self._key(
+            self.key_config.session,
+            user_id=user_id,
+            session_id=plan.target_leader_session_id,
+        )
+        pipe.set(team_key, plan.target_team_payload)
+        pipe.set(leader_key, plan.target_leader_session_payload)
+        if self.key_ttl is not None:
+            pipe.expire(team_key, self.key_ttl)
+            pipe.expire(leader_key, self.key_ttl)
+        for member in plan.target_members:
+            agent_key = self._key(
+                self.key_config.agent,
+                user_id=user_id,
+                agent_id=member.target_agent_id,
+            )
+            session_key = self._key(
+                self.key_config.session,
+                user_id=user_id,
+                session_id=member.target_session_id,
+            )
+            pipe.set(agent_key, member.target_agent_payload)
+            pipe.set(session_key, member.target_session_payload)
+            if self.key_ttl is not None:
+                pipe.expire(agent_key, self.key_ttl)
+                pipe.expire(session_key, self.key_ttl)
+        pipe.sadd(
+            self._key(self.key_config.team_index, user_id=user_id),
+            plan.target_team_id,
+        )
+        pipe.sadd(
+            self._key(
+                self.key_config.session_index,
+                user_id=user_id,
+                agent_id=plan.target_leader_agent_id,
+            ),
+            plan.target_leader_session_id,
+        )
+        for member in plan.target_members:
+            pipe.sadd(
+                self._key(
+                    self.key_config.agent_index,
+                    user_id=user_id,
+                ),
+                member.target_agent_id,
+            )
+            pipe.sadd(
+                self._key(
+                    self.key_config.session_index,
+                    user_id=user_id,
+                    agent_id=member.target_agent_id,
+                ),
+                member.target_session_id,
+            )
+        leader_messages_key = self._message_key(
+            user_id,
+            plan.target_leader_session_id,
+        )
+        if plan.target_leader_messages:
+            pipe.rpush(leader_messages_key, *plan.target_leader_messages)
+            if self.key_ttl is not None:
+                pipe.expire(leader_messages_key, self.key_ttl)
+        for member in plan.target_members:
+            if member.source_messages:
+                message_key = self._message_key(
+                    user_id,
+                    member.target_session_id,
+                )
+                pipe.rpush(message_key, *member.source_messages)
+                if self.key_ttl is not None:
+                    pipe.expire(message_key, self.key_ttl)
+
+    async def _fork_regular_session(
         self,
         user_id: str,
         agent_id: str,

--- a/src/agentscope/app/storage/_redis_storage.py
+++ b/src/agentscope/app/storage/_redis_storage.py
@@ -22,8 +22,9 @@ from ._fork import (
 )
 from ._team_fork import (
     TeamForkPlan,
+    TeamIndexPlan,
     TeamMemberForkPlan,
-    validate_created_member_resources,
+    validate_member_resources,
     validate_team_members,
     validate_team_source_identity,
 )
@@ -819,6 +820,22 @@ class RedisStorage(StorageBase):
             "The source Team graph changed during pre-read.",
         )
 
+    async def _validate_legacy_team_members(
+        self,
+        user_id: str,
+        team: TeamRecord,
+    ) -> None:
+        """Validate legacy ids before the helper migrates them as created."""
+        if team.data.members or not team.data.member_ids:
+            return
+        for agent_id in team.data.member_ids:
+            agent = await self.get_agent(user_id, agent_id)
+            sessions = await self.list_sessions(user_id, agent_id)
+            if agent is None or agent.user_id != user_id or not sessions:
+                raise SessionForkCorruptedGraphError(
+                    "Legacy Team members cannot be reliably normalized.",
+                )
+
     async def _fork_team_session(
         self,
         user_id: str,
@@ -836,6 +853,7 @@ class RedisStorage(StorageBase):
             team_id = team.id
             from ._utils import _ensure_team_members
 
+            await self._validate_legacy_team_members(user_id, team)
             await _ensure_team_members(self, user_id, team)
             async with self._client.pipeline(transaction=True) as pipe:
                 try:
@@ -953,7 +971,7 @@ class RedisStorage(StorageBase):
         leader_messages_key = self._message_key(user_id, session_id)
         member_keys: list[tuple[str, str, str]] = []
         for member in members:
-            if member.owner_id != team.user_id:
+            if member.role == "created" and member.owner_id != team.user_id:
                 raise SessionForkCorruptedGraphError(
                     "Created member owner does not match the Team owner.",
                 )
@@ -1032,7 +1050,7 @@ class RedisStorage(StorageBase):
                     raise SessionForkCorruptedGraphError(
                         "A Team member resource is invalid.",
                     ) from error
-                validate_created_member_resources(
+                validate_member_resources(
                     members[len(source_members)],
                     member_agent,
                     member_session,
@@ -1075,18 +1093,27 @@ class RedisStorage(StorageBase):
             members,
             source_members,
         ):
-            target_agent_id = _generate_id()
-            target_data_id = _generate_id()
             target_session_id = _generate_id()
-            if target_data_id in source_data_ids:
-                raise _watch_error()
-            target_agent = source_agent.model_copy(deep=True)
-            target_agent.id = target_agent_id
-            target_agent.created_at = forked_at
-            target_agent.updated_at = forked_at
-            target_agent.data.id = target_data_id
+            target_owner_id = member.owner_id
+            target_agent_payload: str | None = None
+            if member.role == "created":
+                target_agent_id = _generate_id()
+                target_data_id = _generate_id()
+                if target_data_id in source_data_ids:
+                    raise _watch_error()
+                target_agent = source_agent.model_copy(deep=True)
+                target_agent.id = target_agent_id
+                target_agent.created_at = forked_at
+                target_agent.updated_at = forked_at
+                target_agent.data.id = target_data_id
+                target_agent_payload = target_agent.model_dump_json()
+                target_data_ids.append(target_data_id)
+            else:
+                target_agent_id = source_agent.id
+            target_agent_ids.append(target_agent_id)
             target_member_session = source_member_session.model_copy(deep=True)
             target_member_session.id = target_session_id
+            target_member_session.user_id = target_owner_id
             target_member_session.created_at = forked_at
             target_member_session.updated_at = forked_at
             target_member_session.agent_id = target_agent_id
@@ -1096,12 +1123,12 @@ class RedisStorage(StorageBase):
             target_member_session.config.name = (
                 source_member_session.config.name
             )
-            target_agent_payload = target_agent.model_dump_json()
             target_session_payload = target_member_session.model_dump_json()
             target_members.append(
                 TeamMemberForkPlan(
                     source_member=member,
-                    target_agent_id=target_agent.id,
+                    target_owner_id=target_owner_id,
+                    target_agent_id=target_agent_id,
                     target_session_id=target_member_session.id,
                     target_agent_payload=target_agent_payload,
                     target_session_payload=target_session_payload,
@@ -1109,8 +1136,6 @@ class RedisStorage(StorageBase):
                 ),
             )
             new_member_ids.append(target_agent_id)
-            target_agent_ids.append(target_agent_id)
-            target_data_ids.append(target_data_id)
             target_session_ids.append(target_session_id)
 
         if (
@@ -1154,19 +1179,25 @@ class RedisStorage(StorageBase):
             self._message_key(user_id, target_leader.id),
         ]
         for member in target_members:
+            if member.target_agent_payload is not None:
+                target_keys.append(
+                    self._key(
+                        self.key_config.agent,
+                        user_id=member.target_owner_id,
+                        agent_id=member.target_agent_id,
+                    ),
+                )
             target_keys.extend(
                 [
                     self._key(
-                        self.key_config.agent,
-                        user_id=user_id,
-                        agent_id=member.target_agent_id,
-                    ),
-                    self._key(
                         self.key_config.session,
-                        user_id=user_id,
+                        user_id=member.target_owner_id,
                         session_id=member.target_session_id,
                     ),
-                    self._message_key(user_id, member.target_session_id),
+                    self._message_key(
+                        member.target_owner_id,
+                        member.target_session_id,
+                    ),
                 ],
             )
         owner_agent_index = self._key(
@@ -1182,27 +1213,47 @@ class RedisStorage(StorageBase):
             user_id=user_id,
             agent_id=source_session.agent_id,
         )
-        new_member_session_indexes = tuple(
-            self._key(
+        index_plans: list[TeamIndexPlan] = [
+            TeamIndexPlan(owner_team_index, "team", True),
+            TeamIndexPlan(leader_session_index, "session", True),
+        ]
+        if any(
+            member.target_agent_payload is not None
+            for member in target_members
+        ):
+            index_plans.append(TeamIndexPlan(owner_agent_index, "agent", True))
+        created_session_index_keys: list[str] = []
+        for member in target_members:
+            member_session_index = self._key(
                 self.key_config.session_index,
-                user_id=user_id,
+                user_id=member.target_owner_id,
                 agent_id=member.target_agent_id,
             )
-            for member in target_members
-        )
-        target_keys.extend(new_member_session_indexes)
+            if member.target_agent_payload is not None:
+                created_session_index_keys.append(member_session_index)
+                index_plans.append(
+                    TeamIndexPlan(member_session_index, "session", False),
+                )
+            else:
+                index_plans.append(
+                    TeamIndexPlan(member_session_index, "session", True),
+                )
+        target_keys.extend(created_session_index_keys)
         exclusive_target_keys = tuple(target_keys)
         if len(exclusive_target_keys) != len(set(exclusive_target_keys)):
             raise _watch_error()
-        shared_index_keys = [owner_team_index, leader_session_index]
-        if target_members:
-            shared_index_keys.append(owner_agent_index)
-        if len(shared_index_keys) != len(set(shared_index_keys)):
-            raise SessionForkCorruptedGraphError(
-                "Team fork shared index key templates overlap.",
+        category_by_key: dict[str, str] = {}
+        for index_plan in index_plans:
+            previous_category = category_by_key.setdefault(
+                index_plan.key,
+                index_plan.category,
             )
-        if set(exclusive_target_keys) & set(shared_index_keys):
-            raise _watch_error()
+            if previous_category != index_plan.category:
+                raise SessionForkCorruptedGraphError(
+                    "Team fork Index categories overlap.",
+                )
+            if index_plan.shared and index_plan.key in exclusive_target_keys:
+                raise _watch_error()
         return TeamForkPlan(
             forked_at=forked_at,
             source_session_id=session_id,
@@ -1214,7 +1265,7 @@ class RedisStorage(StorageBase):
             target_leader_messages=tuple(raw_leader_messages),
             target_members=tuple(target_members),
             exclusive_target_keys=exclusive_target_keys,
-            shared_index_keys=tuple(shared_index_keys),
+            index_plans=tuple(index_plans),
         )
 
     async def _check_team_target_keys(
@@ -1225,19 +1276,21 @@ class RedisStorage(StorageBase):
         """WATCH and validate all Team fork target keys and indexes."""
         await pipe.watch(
             *plan.exclusive_target_keys,
-            *plan.shared_index_keys,
+            *(index_plan.key for index_plan in plan.index_plans),
         )
         for key in plan.exclusive_target_keys:
             if _normalize_redis_type(await pipe.type(key)) != "none":
                 raise _watch_error()
-        for key in plan.shared_index_keys:
-            if _normalize_redis_type(await pipe.type(key)) not in {
-                "none",
-                "set",
-            }:
+        for index_plan in plan.index_plans:
+            index_type = _normalize_redis_type(
+                await pipe.type(index_plan.key),
+            )
+            if index_plan.shared and index_type not in {"none", "set"}:
                 raise SessionForkCorruptedGraphError(
                     "A shared Team index has an invalid type.",
                 )
+            if not index_plan.shared and index_type != "none":
+                raise _watch_error()
 
     async def _queue_team_fork_writes(
         self,
@@ -1262,20 +1315,22 @@ class RedisStorage(StorageBase):
             pipe.expire(team_key, self.key_ttl)
             pipe.expire(leader_key, self.key_ttl)
         for member in plan.target_members:
-            agent_key = self._key(
-                self.key_config.agent,
-                user_id=user_id,
-                agent_id=member.target_agent_id,
-            )
             session_key = self._key(
                 self.key_config.session,
-                user_id=user_id,
+                user_id=member.target_owner_id,
                 session_id=member.target_session_id,
             )
-            pipe.set(agent_key, member.target_agent_payload)
+            if member.target_agent_payload is not None:
+                agent_key = self._key(
+                    self.key_config.agent,
+                    user_id=member.target_owner_id,
+                    agent_id=member.target_agent_id,
+                )
+                pipe.set(agent_key, member.target_agent_payload)
             pipe.set(session_key, member.target_session_payload)
             if self.key_ttl is not None:
-                pipe.expire(agent_key, self.key_ttl)
+                if member.target_agent_payload is not None:
+                    pipe.expire(agent_key, self.key_ttl)
                 pipe.expire(session_key, self.key_ttl)
         pipe.sadd(
             self._key(self.key_config.team_index, user_id=user_id),
@@ -1290,17 +1345,18 @@ class RedisStorage(StorageBase):
             plan.target_leader_session_id,
         )
         for member in plan.target_members:
-            pipe.sadd(
-                self._key(
-                    self.key_config.agent_index,
-                    user_id=user_id,
-                ),
-                member.target_agent_id,
-            )
+            if member.target_agent_payload is not None:
+                pipe.sadd(
+                    self._key(
+                        self.key_config.agent_index,
+                        user_id=user_id,
+                    ),
+                    member.target_agent_id,
+                )
             pipe.sadd(
                 self._key(
                     self.key_config.session_index,
-                    user_id=user_id,
+                    user_id=member.target_owner_id,
                     agent_id=member.target_agent_id,
                 ),
                 member.target_session_id,
@@ -1316,7 +1372,7 @@ class RedisStorage(StorageBase):
         for member in plan.target_members:
             if member.source_messages:
                 message_key = self._message_key(
-                    user_id,
+                    member.target_owner_id,
                     member.target_session_id,
                 )
                 pipe.rpush(message_key, *member.source_messages)

--- a/src/agentscope/app/storage/_redis_storage.py
+++ b/src/agentscope/app/storage/_redis_storage.py
@@ -40,6 +40,7 @@ from ._model import (
     SessionSource,
     TeamRecord,
 )
+from . import _utils
 from ._utils import _dump_with_secrets
 from ..._utils._common import _generate_id
 from ...credential import CredentialBase
@@ -820,21 +821,194 @@ class RedisStorage(StorageBase):
             "The source Team graph changed during pre-read.",
         )
 
-    async def _validate_legacy_team_members(
+    async def _ensure_legacy_team_members_atomically(
         self,
         user_id: str,
-        team: TeamRecord,
-    ) -> None:
-        """Validate legacy ids before the helper migrates them as created."""
-        if team.data.members or not team.data.member_ids:
-            return
-        for agent_id in team.data.member_ids:
-            agent = await self.get_agent(user_id, agent_id)
-            sessions = await self.list_sessions(user_id, agent_id)
-            if agent is None or agent.user_id != user_id or not sessions:
-                raise SessionForkCorruptedGraphError(
-                    "Legacy Team members cannot be reliably normalized.",
-                )
+        team_id: str,
+    ) -> TeamRecord:
+        """Normalize legacy members under one optimistic transaction."""
+        team_key = self._key(
+            self.key_config.team,
+            user_id=user_id,
+            team_id=team_id,
+        )
+        team_index_key = self._key(
+            self.key_config.team_index,
+            user_id=user_id,
+        )
+        for _ in range(_SESSION_FORK_MAX_RETRIES):
+            async with self._client.pipeline(transaction=True) as pipe:
+                try:
+                    await pipe.watch(team_key)
+                    if (
+                        _normalize_redis_type(await pipe.type(team_key))
+                        != "string"
+                    ):
+                        raise SessionForkCorruptedGraphError(
+                            "The legacy Team record is missing or corrupted.",
+                        )
+                    raw_team = await pipe.get(team_key)
+                    try:
+                        team = TeamRecord.model_validate_json(raw_team)
+                    except ValidationError as error:
+                        raise SessionForkCorruptedGraphError(
+                            "The legacy Team record is corrupted.",
+                        ) from error
+                    if team.id != team_id or team.user_id != user_id:
+                        raise SessionForkCorruptedGraphError(
+                            "The legacy Team record identity is inconsistent.",
+                        )
+                    if team.data.members or not team.data.member_ids:
+                        return team
+                    if len(team.data.member_ids) != len(
+                        set(team.data.member_ids),
+                    ):
+                        raise SessionForkCorruptedGraphError(
+                            "Legacy Team members cannot be reliably "
+                            "normalized.",
+                        )
+
+                    agent_keys = [
+                        self._key(
+                            self.key_config.agent,
+                            user_id=user_id,
+                            agent_id=member_id,
+                        )
+                        for member_id in team.data.member_ids
+                    ]
+                    session_index_keys = [
+                        self._key(
+                            self.key_config.session_index,
+                            user_id=user_id,
+                            agent_id=member_id,
+                        )
+                        for member_id in team.data.member_ids
+                    ]
+                    await pipe.watch(
+                        *agent_keys,
+                        *session_index_keys,
+                    )
+                    legacy_sessions: dict[str, SessionRecord] = {}
+                    for member_id, agent_key, index_key in zip(
+                        team.data.member_ids,
+                        agent_keys,
+                        session_index_keys,
+                    ):
+                        if (
+                            _normalize_redis_type(await pipe.type(agent_key))
+                            != "string"
+                        ):
+                            raise SessionForkCorruptedGraphError(
+                                "Legacy Team member Agent is missing or "
+                                "corrupted.",
+                            )
+                        raw_agent = await pipe.get(agent_key)
+                        try:
+                            agent = AgentRecord.model_validate_json(raw_agent)
+                        except ValidationError as error:
+                            raise SessionForkCorruptedGraphError(
+                                "Legacy Team member Agent is corrupted.",
+                            ) from error
+                        agent_is_valid = (
+                            agent.id == member_id
+                            and agent.user_id == user_id
+                            and agent.source == "team"
+                        )
+                        if not agent_is_valid:
+                            raise SessionForkCorruptedGraphError(
+                                "Legacy Team member Agent is inconsistent.",
+                            )
+                        if (
+                            _normalize_redis_type(await pipe.type(index_key))
+                            != "set"
+                        ):
+                            raise SessionForkCorruptedGraphError(
+                                "Legacy Team member Session Index is "
+                                "corrupted.",
+                            )
+                        session_ids = await pipe.smembers(index_key)
+                        if len(session_ids) != 1:
+                            raise SessionForkCorruptedGraphError(
+                                "Legacy Team member Session is not unique.",
+                            )
+                        legacy_session_id = next(iter(session_ids))
+                        if isinstance(legacy_session_id, bytes):
+                            legacy_session_id = legacy_session_id.decode()
+                        session_key = self._key(
+                            self.key_config.session,
+                            user_id=user_id,
+                            session_id=legacy_session_id,
+                        )
+                        await pipe.watch(session_key)
+                        if (
+                            _normalize_redis_type(await pipe.type(session_key))
+                            != "string"
+                        ):
+                            raise SessionForkCorruptedGraphError(
+                                "Legacy Team member Session is missing or "
+                                "corrupted.",
+                            )
+                        raw_session = await pipe.get(session_key)
+                        try:
+                            legacy_session = SessionRecord.model_validate_json(
+                                raw_session,
+                            )
+                        except ValidationError as error:
+                            raise SessionForkCorruptedGraphError(
+                                "Legacy Team member Session is corrupted.",
+                            ) from error
+                        session_is_valid = all(
+                            (
+                                legacy_session.id == legacy_session_id,
+                                legacy_session.user_id == user_id,
+                                legacy_session.agent_id == member_id,
+                                legacy_session.team_id == team.id,
+                                legacy_session.source == SessionSource.USER,
+                                legacy_session.source_schedule_id is None,
+                            ),
+                        )
+                        if not session_is_valid:
+                            raise SessionForkCorruptedGraphError(
+                                "Legacy Team member Session is inconsistent.",
+                            )
+                        legacy_sessions[member_id] = legacy_session
+
+                    await pipe.watch(team_index_key)
+                    team_index_type = _normalize_redis_type(
+                        await pipe.type(team_index_key),
+                    )
+                    if team_index_type not in {"none", "set"}:
+                        raise SessionForkCorruptedGraphError(
+                            "The Team Index is corrupted.",
+                        )
+                    # The helper only builds the normalized members here;
+                    # the enclosing pipeline owns the atomic Team write.
+                    # pylint: disable=protected-access
+                    await _utils._ensure_team_members(
+                        self,
+                        user_id,
+                        team,
+                        legacy_sessions=legacy_sessions,
+                        persist=False,
+                    )
+                    team.updated_at = datetime.now()
+                    team_payload = team.model_dump_json()
+                    pipe.multi()
+                    pipe.set(team_key, team_payload)
+                    if self.key_ttl is not None:
+                        pipe.expire(team_key, self.key_ttl)
+                    pipe.sadd(team_index_key, team.id)
+                    await pipe.execute()
+                    return team
+                except _watch_error():
+                    continue
+                except ResponseError as error:
+                    if _is_wrongtype_response_error(error):
+                        continue
+                    raise
+        raise SessionForkConflictError(
+            "The legacy Team graph changed during normalization.",
+        )
 
     async def _fork_team_session(
         self,
@@ -851,10 +1025,7 @@ class RedisStorage(StorageBase):
                 session_id,
             )
             team_id = team.id
-            from ._utils import _ensure_team_members
-
-            await self._validate_legacy_team_members(user_id, team)
-            await _ensure_team_members(self, user_id, team)
+            await self._ensure_legacy_team_members_atomically(user_id, team_id)
             async with self._client.pipeline(transaction=True) as pipe:
                 try:
                     plan = await self._build_team_fork_plan(

--- a/src/agentscope/app/storage/_redis_storage.py
+++ b/src/agentscope/app/storage/_redis_storage.py
@@ -7,6 +7,7 @@ from typing import Any, TYPE_CHECKING, Self
 
 from pydantic import BaseModel
 from pydantic import ValidationError
+from redis.exceptions import ResponseError
 
 from ._base import StorageBase
 from ._exceptions import (
@@ -17,7 +18,7 @@ from ._exceptions import (
 from ._fork import (
     SessionForkPlan,
     build_fork_session_name,
-    validate_regular_fork_source,
+    validate_session_fork_source,
 )
 from ._model import (
     AgentRecord,
@@ -38,6 +39,19 @@ from ...state import AgentState
 
 
 _SESSION_FORK_MAX_RETRIES = 3
+
+
+def _normalize_redis_type(value: str | bytes) -> str:
+    """Normalize Redis TYPE responses from decoded and raw clients."""
+    if isinstance(value, bytes):
+        return value.decode("ascii")
+    return value
+
+
+def _is_wrongtype_response_error(error: ResponseError) -> bool:
+    """Return whether an error is Redis' concurrent WRONGTYPE failure."""
+    return str(error).upper().startswith("WRONGTYPE")
+
 
 if TYPE_CHECKING:
     from redis.asyncio import ConnectionPool, Redis
@@ -647,7 +661,7 @@ class RedisStorage(StorageBase):
         agent_id: str,
         session_id: str,
     ) -> SessionRecord:
-        """Atomically fork a regular, non-scheduled, non-team session."""
+        """Atomically fork a regular or Schedule non-team session."""
         for _ in range(_SESSION_FORK_MAX_RETRIES):
             async with self._client.pipeline(transaction=True) as pipe:
                 try:
@@ -660,8 +674,25 @@ class RedisStorage(StorageBase):
                         user_id,
                         session_id,
                     )
-                    await pipe.watch(source_key, source_messages_key)
-                    raw_session = await pipe.get(source_key)
+                    await pipe.watch(source_key)
+
+                    source_type = _normalize_redis_type(
+                        await pipe.type(source_key),
+                    )
+                    if source_type == "none":
+                        raise SessionForkNotFoundError(
+                            f"Session '{session_id}' not found.",
+                        )
+                    if source_type != "string":
+                        raise SessionForkCorruptedGraphError(
+                            "The source session key has an invalid type.",
+                        )
+                    try:
+                        raw_session = await pipe.get(source_key)
+                    except ResponseError as error:
+                        if _is_wrongtype_response_error(error):
+                            continue
+                        raise
                     if not raw_session:
                         raise SessionForkNotFoundError(
                             f"Session '{session_id}' not found.",
@@ -674,18 +705,42 @@ class RedisStorage(StorageBase):
                         raise SessionForkCorruptedGraphError(
                             "The source session record is invalid.",
                         ) from error
-                    validate_regular_fork_source(
+                    validate_session_fork_source(
                         source_session,
                         user_id,
                         agent_id,
                         session_id,
                     )
-                    raw_messages = await pipe.lrange(
-                        source_messages_key,
-                        0,
-                        -1,
+                    target_index_key = self._key(
+                        self.key_config.session_index,
+                        user_id=user_id,
+                        agent_id=source_session.agent_id,
                     )
-
+                    await pipe.watch(source_messages_key, target_index_key)
+                    message_type = _normalize_redis_type(
+                        await pipe.type(source_messages_key),
+                    )
+                    index_type = _normalize_redis_type(
+                        await pipe.type(target_index_key),
+                    )
+                    if message_type not in {"none", "list"}:
+                        raise SessionForkCorruptedGraphError(
+                            "The source message key has an invalid type.",
+                        )
+                    if index_type not in {"none", "set"}:
+                        raise SessionForkCorruptedGraphError(
+                            "The target session index has an invalid type.",
+                        )
+                    try:
+                        raw_messages = (
+                            await pipe.lrange(source_messages_key, 0, -1)
+                            if message_type == "list"
+                            else []
+                        )
+                    except ResponseError as error:
+                        if _is_wrongtype_response_error(error):
+                            continue
+                        raise
                     target_session = SessionRecord(
                         user_id=user_id,
                         agent_id=agent_id,
@@ -707,11 +762,6 @@ class RedisStorage(StorageBase):
                         user_id,
                         target_session.id,
                     )
-                    target_index_key = self._key(
-                        self.key_config.session_index,
-                        user_id=user_id,
-                        agent_id=agent_id,
-                    )
                     plan = SessionForkPlan(
                         source_session_id=session_id,
                         target_session=target_session,
@@ -721,17 +771,20 @@ class RedisStorage(StorageBase):
                         target_session_index_key=target_index_key,
                     )
 
-                    target_keys = [
+                    await pipe.watch(
                         plan.target_session_key,
                         plan.target_messages_key,
-                    ]
-                    await pipe.watch(*target_keys)
-                    target_exists = False
-                    for target_key in target_keys:
-                        if await pipe.exists(target_key):
-                            target_exists = True
-                            break
-                    if target_exists:
+                    )
+                    target_session_type = _normalize_redis_type(
+                        await pipe.type(plan.target_session_key),
+                    )
+                    target_message_type = _normalize_redis_type(
+                        await pipe.type(plan.target_messages_key),
+                    )
+                    if (
+                        target_session_type != "none"
+                        or target_message_type != "none"
+                    ):
                         continue
 
                     pipe.multi()

--- a/src/agentscope/app/storage/_redis_storage.py
+++ b/src/agentscope/app/storage/_redis_storage.py
@@ -6,8 +6,19 @@ from datetime import datetime, timedelta
 from typing import Any, TYPE_CHECKING, Self
 
 from pydantic import BaseModel
+from pydantic import ValidationError
 
 from ._base import StorageBase
+from ._exceptions import (
+    SessionForkConflictError,
+    SessionForkCorruptedGraphError,
+    SessionForkNotFoundError,
+)
+from ._fork import (
+    SessionForkPlan,
+    build_fork_session_name,
+    validate_regular_fork_source,
+)
 from ._model import (
     AgentRecord,
     CredentialRecord,
@@ -24,6 +35,9 @@ from ._utils import _dump_with_secrets
 from ...credential import CredentialBase
 from ...message import Msg
 from ...state import AgentState
+
+
+_SESSION_FORK_MAX_RETRIES = 3
 
 if TYPE_CHECKING:
     from redis.asyncio import ConnectionPool, Redis
@@ -626,6 +640,129 @@ class RedisStorage(StorageBase):
             await self._client.sadd(schedule_session_key, record.id)
 
         return record
+
+    async def fork_session(
+        self,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> SessionRecord:
+        """Atomically fork a regular, non-scheduled, non-team session."""
+        for _ in range(_SESSION_FORK_MAX_RETRIES):
+            async with self._client.pipeline(transaction=True) as pipe:
+                try:
+                    source_key = self._key(
+                        self.key_config.session,
+                        user_id=user_id,
+                        session_id=session_id,
+                    )
+                    source_messages_key = self._message_key(
+                        user_id,
+                        session_id,
+                    )
+                    await pipe.watch(source_key, source_messages_key)
+                    raw_session = await pipe.get(source_key)
+                    if not raw_session:
+                        raise SessionForkNotFoundError(
+                            f"Session '{session_id}' not found.",
+                        )
+                    try:
+                        source_session = SessionRecord.model_validate_json(
+                            raw_session,
+                        )
+                    except ValidationError as error:
+                        raise SessionForkCorruptedGraphError(
+                            "The source session record is invalid.",
+                        ) from error
+                    validate_regular_fork_source(
+                        source_session,
+                        user_id,
+                        agent_id,
+                        session_id,
+                    )
+                    raw_messages = await pipe.lrange(
+                        source_messages_key,
+                        0,
+                        -1,
+                    )
+
+                    target_session = SessionRecord(
+                        user_id=user_id,
+                        agent_id=agent_id,
+                        source=SessionSource.USER,
+                        source_schedule_id=None,
+                        team_id=None,
+                        config=source_session.config.model_copy(deep=True),
+                        state=source_session.state.model_copy(deep=True),
+                    )
+                    target_session.config.name = build_fork_session_name(
+                        source_session.config.name,
+                    )
+                    target_session_key = self._key(
+                        self.key_config.session,
+                        user_id=user_id,
+                        session_id=target_session.id,
+                    )
+                    target_messages_key = self._message_key(
+                        user_id,
+                        target_session.id,
+                    )
+                    target_index_key = self._key(
+                        self.key_config.session_index,
+                        user_id=user_id,
+                        agent_id=agent_id,
+                    )
+                    plan = SessionForkPlan(
+                        source_session_id=session_id,
+                        target_session=target_session,
+                        source_messages=tuple(raw_messages),
+                        target_session_key=target_session_key,
+                        target_messages_key=target_messages_key,
+                        target_session_index_key=target_index_key,
+                    )
+
+                    target_keys = [
+                        plan.target_session_key,
+                        plan.target_messages_key,
+                    ]
+                    await pipe.watch(*target_keys)
+                    target_exists = False
+                    for target_key in target_keys:
+                        if await pipe.exists(target_key):
+                            target_exists = True
+                            break
+                    if target_exists:
+                        continue
+
+                    pipe.multi()
+                    pipe.set(
+                        plan.target_session_key,
+                        plan.target_session.model_dump_json(),
+                    )
+                    if self.key_ttl is not None:
+                        pipe.expire(plan.target_session_key, self.key_ttl)
+                    pipe.sadd(
+                        plan.target_session_index_key,
+                        plan.target_session.id,
+                    )
+                    if plan.source_messages:
+                        pipe.rpush(
+                            plan.target_messages_key,
+                            *plan.source_messages,
+                        )
+                        if self.key_ttl is not None:
+                            pipe.expire(
+                                plan.target_messages_key,
+                                self.key_ttl,
+                            )
+                    await pipe.execute()
+                    return plan.target_session
+                except _watch_error():
+                    continue
+        raise SessionForkConflictError(
+            "The session could not be forked due to concurrent changes "
+            "or target identifier conflicts.",
+        )
 
     async def update_session_state(
         self,

--- a/src/agentscope/app/storage/_team_fork.py
+++ b/src/agentscope/app/storage/_team_fork.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+"""Helpers for forking Team graphs with created members."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from ._exceptions import (
+    SessionForkConflictError,
+    SessionForkCorruptedGraphError,
+    SessionForkNotFoundError,
+)
+from ._model import AgentRecord, SessionRecord, SessionSource, TeamMember
+from ._model import TeamRecord
+
+
+@dataclass(frozen=True)
+class TeamMemberForkPlan:
+    """Serialized Agent, Session, and raw messages for one member."""
+
+    source_member: TeamMember
+    target_agent_id: str
+    target_session_id: str
+    target_agent_payload: str
+    target_session_payload: str
+    source_messages: tuple[str | bytes, ...]
+
+
+@dataclass(frozen=True)
+class TeamForkPlan:
+    """Immutable Redis write plan for a created-member Team fork."""
+
+    forked_at: datetime
+    source_session_id: str
+    target_team_id: str
+    target_leader_agent_id: str
+    target_leader_session_id: str
+    target_team_payload: str
+    target_leader_session_payload: str
+    target_leader_messages: tuple[str | bytes, ...]
+    target_members: tuple[TeamMemberForkPlan, ...]
+    exclusive_target_keys: tuple[str, ...]
+    shared_index_keys: tuple[str, ...]
+
+
+def validate_team_source_identity(
+    session: SessionRecord,
+    user_id: str,
+    agent_id: str,
+    session_id: str,
+) -> None:
+    """Validate a Team source before accessing its TeamRecord."""
+    if session.id != session_id:
+        raise SessionForkCorruptedGraphError(
+            "The source session record does not match its storage key.",
+        )
+    if session.user_id != user_id:
+        raise SessionForkNotFoundError(
+            "The source session does not belong to the requested user.",
+        )
+    if session.agent_id != agent_id:
+        raise SessionForkNotFoundError(
+            "The source session does not belong to the requested agent.",
+        )
+    if session.team_id is None:
+        raise SessionForkCorruptedGraphError(
+            "The source session is not attached to a Team.",
+        )
+    if (
+        session.source != SessionSource.USER
+        or session.source_schedule_id is not None
+    ):
+        raise SessionForkCorruptedGraphError(
+            "Team session provenance is inconsistent.",
+        )
+
+
+def validate_team_members(
+    team: TeamRecord,
+    source_session_id: str,
+) -> tuple[TeamMember, ...]:
+    """Validate roles, duplicate references, and Leader membership."""
+    seen_agents: set[str] = set()
+    seen_sessions: set[str] = set()
+    source_is_member = False
+    for member in team.data.members:
+        if member.role == "invited":
+            raise SessionForkConflictError(
+                "Teams with invited members are not supported yet.",
+            )
+        if member.role != "created":
+            raise SessionForkCorruptedGraphError(
+                "The Team contains an unknown member role.",
+            )
+        if member.agent_id in seen_agents:
+            raise SessionForkCorruptedGraphError(
+                "The Team contains duplicate member agent ids.",
+            )
+        if member.session_id in seen_sessions:
+            raise SessionForkCorruptedGraphError(
+                "The Team contains duplicate member session ids.",
+            )
+        seen_agents.add(member.agent_id)
+        seen_sessions.add(member.session_id)
+        source_is_member |= member.session_id == source_session_id
+
+    is_leader = team.session_id == source_session_id
+    if is_leader and source_is_member:
+        raise SessionForkCorruptedGraphError(
+            "The source session is both Team leader and member.",
+        )
+    if not is_leader and source_is_member:
+        raise SessionForkConflictError(
+            "Worker sessions cannot be forked.",
+        )
+    if not is_leader:
+        raise SessionForkCorruptedGraphError(
+            "The source session is not the Team leader.",
+        )
+    return tuple(team.data.members)
+
+
+def validate_created_member_resources(
+    member: TeamMember,
+    agent: AgentRecord,
+    session: SessionRecord,
+    team: TeamRecord,
+) -> None:
+    """Validate one created member's Agent and Session relationships."""
+    if agent.id != member.agent_id or agent.user_id != team.user_id:
+        raise SessionForkCorruptedGraphError(
+            "A Team member Agent does not match its graph entry.",
+        )
+    if session.id != member.session_id or session.user_id != member.owner_id:
+        raise SessionForkCorruptedGraphError(
+            "A Team member Session does not match its graph entry.",
+        )
+    if session.agent_id != agent.id or session.team_id != team.id:
+        raise SessionForkCorruptedGraphError(
+            "A Team member Session does not match its graph entry.",
+        )
+    if (
+        session.source != SessionSource.USER
+        or session.source_schedule_id is not None
+    ):
+        raise SessionForkCorruptedGraphError(
+            "A Team member Session has invalid provenance.",
+        )

--- a/src/agentscope/app/storage/_team_fork.py
+++ b/src/agentscope/app/storage/_team_fork.py
@@ -18,11 +18,21 @@ class TeamMemberForkPlan:
     """Serialized Agent, Session, and raw messages for one member."""
 
     source_member: TeamMember
+    target_owner_id: str
     target_agent_id: str
     target_session_id: str
-    target_agent_payload: str
+    target_agent_payload: str | None
     target_session_payload: str
     source_messages: tuple[str | bytes, ...]
+
+
+@dataclass(frozen=True)
+class TeamIndexPlan:
+    """An Index Key, its semantic category, and sharing behavior."""
+
+    key: str
+    category: str
+    shared: bool
 
 
 @dataclass(frozen=True)
@@ -39,7 +49,7 @@ class TeamForkPlan:
     target_leader_messages: tuple[str | bytes, ...]
     target_members: tuple[TeamMemberForkPlan, ...]
     exclusive_target_keys: tuple[str, ...]
-    shared_index_keys: tuple[str, ...]
+    index_plans: tuple[TeamIndexPlan, ...]
 
 
 def validate_team_source_identity(
@@ -83,11 +93,7 @@ def validate_team_members(
     seen_sessions: set[str] = set()
     source_is_member = False
     for member in team.data.members:
-        if member.role == "invited":
-            raise SessionForkConflictError(
-                "Teams with invited members are not supported yet.",
-            )
-        if member.role != "created":
+        if member.role not in {"created", "invited"}:
             raise SessionForkCorruptedGraphError(
                 "The Team contains an unknown member role.",
             )
@@ -119,14 +125,14 @@ def validate_team_members(
     return tuple(team.data.members)
 
 
-def validate_created_member_resources(
+def validate_member_resources(
     member: TeamMember,
     agent: AgentRecord,
     session: SessionRecord,
     team: TeamRecord,
 ) -> None:
-    """Validate one created member's Agent and Session relationships."""
-    if agent.id != member.agent_id or agent.user_id != team.user_id:
+    """Validate one member's Agent and Session relationships."""
+    if agent.id != member.agent_id or agent.user_id != member.owner_id:
         raise SessionForkCorruptedGraphError(
             "A Team member Agent does not match its graph entry.",
         )
@@ -144,4 +150,12 @@ def validate_created_member_resources(
     ):
         raise SessionForkCorruptedGraphError(
             "A Team member Session has invalid provenance.",
+        )
+    if member.role == "created" and member.owner_id != team.user_id:
+        raise SessionForkCorruptedGraphError(
+            "A created member owner does not match the Team owner.",
+        )
+    if member.role == "invited" and agent.source != "user":
+        raise SessionForkCorruptedGraphError(
+            "An invited member Agent must be user-owned.",
         )

--- a/src/agentscope/app/storage/_utils.py
+++ b/src/agentscope/app/storage/_utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """The utils for storage."""
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, SecretStr
 
@@ -40,6 +40,9 @@ async def _ensure_team_members(
     storage: "StorageBase",
     user_id: str,
     team: "TeamRecord",
+    *,
+    legacy_sessions: dict[str, Any] | None = None,
+    persist: bool = True,
 ) -> list[TeamMember]:
     """Return the team's members, lazily migrating legacy ``member_ids``.
 
@@ -80,7 +83,11 @@ async def _ensure_team_members(
 
     migrated: list[TeamMember] = []
     for agent_id in team.data.member_ids:
-        sessions = await storage.list_sessions(user_id, agent_id)
+        sessions = (
+            [legacy_sessions[agent_id]]
+            if legacy_sessions is not None and agent_id in legacy_sessions
+            else await storage.list_sessions(user_id, agent_id)
+        )
         if not sessions:
             # Session already deleted — nothing sensible to route to.
             continue
@@ -103,5 +110,6 @@ async def _ensure_team_members(
     # ``member_ids`` to match ``migrated`` keeps the record consistent
     # and terminates the migration.
     team.data.member_ids = [m.agent_id for m in migrated]
-    await storage.upsert_team(user_id, team)
+    if persist:
+        await storage.upsert_team(user_id, team)
     return migrated

--- a/tests/_storage_test_helpers.py
+++ b/tests/_storage_test_helpers.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Shared white-box storage fixtures for Session Fork tests."""
+# pylint: disable=protected-access
+
+import fakeredis.aioredis
+
+from agentscope.app.storage import ChatModelConfig, RedisStorage, SessionConfig
+
+
+def make_storage(
+    *,
+    key_ttl: int | None = None,
+    decode_responses: bool = True,
+) -> RedisStorage:
+    """Create a RedisStorage backed by fakeredis."""
+    storage = RedisStorage.__new__(RedisStorage)
+    storage._client = fakeredis.aioredis.FakeRedis(
+        decode_responses=decode_responses,
+    )
+    storage.key_ttl = key_ttl
+    storage.key_config = RedisStorage.KeyConfig()
+    return storage
+
+
+def make_config(name: str = "Original") -> SessionConfig:
+    """Build a session config with nested mutable data."""
+    return SessionConfig(
+        workspace_id="shared-workspace",
+        name=name,
+        chat_model_config=ChatModelConfig(
+            type="openai",
+            credential_id="credential",
+            model="model",
+            parameters={"temperature": 0.2},
+        ),
+    )

--- a/tests/router_session_fork_test.py
+++ b/tests/router_session_fork_test.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+"""Tests for the Session Fork HTTP endpoint."""
+
+import inspect
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+from fastapi import FastAPI
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from agentscope.app._router._session import fork_session, session_router
+from agentscope.app.deps import get_current_user_id, get_session_service
+from agentscope.app.storage import (
+    SessionForkConflictError,
+    SessionForkCorruptedGraphError,
+    SessionForkNotFoundError,
+)
+
+
+class TestSessionForkRouter(IsolatedAsyncioTestCase):
+    """Verify HTTP mapping and the Router-to-Service boundary."""
+
+    def setUp(self) -> None:
+        self.service = SimpleNamespace(
+            fork_session=AsyncMock(
+                return_value=SimpleNamespace(id="forked-session"),
+            ),
+        )
+        self.app = FastAPI()
+        self.app.include_router(session_router)
+        self.app.dependency_overrides[
+            get_current_user_id
+        ] = lambda: "authenticated-user"
+        self.app.dependency_overrides[
+            get_session_service
+        ] = lambda: self.service
+        self.client = TestClient(self.app)
+        self.addCleanup(self.client.close)
+
+    async def test_success_returns_session_id(self) -> None:
+        """A successful Service call returns the new Session ID."""
+        response = await fork_session(
+            "source-session",
+            agent_id="agent-1",
+            user_id="user-1",
+            session_service=self.service,
+        )
+
+        self.assertEqual(response.session_id, "forked-session")
+        self.service.fork_session.assert_awaited_once_with(
+            "user-1",
+            "agent-1",
+            "source-session",
+        )
+
+    async def test_http_success_uses_authenticated_user(self) -> None:
+        """The real endpoint returns 201 and ignores a fake user query."""
+        response = self.client.post(
+            "/sessions/source-session/fork",
+            params={"agent_id": "agent-1", "user_id": "attacker"},
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json(), {"session_id": "forked-session"})
+        self.service.fork_session.assert_awaited_once_with(
+            "authenticated-user",
+            "agent-1",
+            "source-session",
+        )
+
+    async def test_http_error_mappings(self) -> None:
+        """The real endpoint preserves the 404/409/500 contract."""
+        cases = (
+            (SessionForkNotFoundError("not found"), 404),
+            (SessionForkConflictError("conflict"), 409),
+            (SessionForkCorruptedGraphError("corrupted"), 500),
+        )
+        for error, expected_status in cases:
+            self.service.fork_session.reset_mock(side_effect=True)
+            self.service.fork_session.side_effect = error
+            response = self.client.post(
+                "/sessions/source-session/fork",
+                params={"agent_id": "agent-1"},
+            )
+            self.assertEqual(response.status_code, expected_status)
+
+    async def test_route_is_service_only(self) -> None:
+        """The endpoint has no Storage dependency."""
+        parameters = inspect.signature(fork_session).parameters
+        self.assertNotIn("storage", parameters)
+        self.assertIn("session_service", parameters)
+
+    async def test_not_found_maps_to_404(self) -> None:
+        """NotFound is exposed as HTTP 404 without internal detail."""
+        self.service.fork_session.side_effect = SessionForkNotFoundError(
+            "internal ownership detail",
+        )
+
+        with self.assertRaises(HTTPException) as context:
+            await fork_session(
+                "source-session",
+                agent_id="agent-1",
+                user_id="user-1",
+                session_service=self.service,
+            )
+
+        self.assertEqual(context.exception.status_code, 404)
+        self.assertNotIn("internal", str(context.exception.detail))
+
+    async def test_conflict_maps_to_409(self) -> None:
+        """Conflict is exposed as HTTP 409."""
+        self.service.fork_session.side_effect = SessionForkConflictError(
+            "internal status detail",
+        )
+
+        with self.assertRaises(HTTPException) as context:
+            await fork_session(
+                "source-session",
+                agent_id="agent-1",
+                user_id="user-1",
+                session_service=self.service,
+            )
+
+        self.assertEqual(context.exception.status_code, 409)
+
+    @patch("agentscope.app._router._session.logger.exception")
+    async def test_corrupted_graph_logs_and_maps_to_generic_500(
+        self,
+        log_exception: AsyncMock,
+    ) -> None:
+        """Corrupted Graph is logged and hidden behind HTTP 500."""
+        self.service.fork_session.side_effect = SessionForkCorruptedGraphError(
+            "internal Redis graph detail",
+        )
+
+        with self.assertRaises(HTTPException) as context:
+            await fork_session(
+                "source-session",
+                agent_id="agent-1",
+                user_id="user-1",
+                session_service=self.service,
+            )
+
+        self.assertEqual(context.exception.status_code, 500)
+        self.assertEqual(
+            context.exception.detail,
+            "Unable to fork the session.",
+        )
+        log_exception.assert_called_once()

--- a/tests/service_session_fork_test.py
+++ b/tests/service_session_fork_test.py
@@ -1,0 +1,314 @@
+# -*- coding: utf-8 -*-
+"""Tests for the SessionService Fork orchestration."""
+
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+
+from agentscope.app._service import SessionService, SessionStatus
+from agentscope.app.storage import (
+    SessionForkConflictError,
+    SessionForkNotFoundError,
+)
+
+
+def _session(
+    session_id: str = "source-session",
+    user_id: str = "user-1",
+    agent_id: str = "agent-1",
+    team_id: str | None = None,
+) -> SimpleNamespace:
+    """Build the minimal SessionRecord shape used by the service tests."""
+    return SimpleNamespace(
+        id=session_id,
+        user_id=user_id,
+        agent_id=agent_id,
+        team_id=team_id,
+    )
+
+
+class TestSessionServiceFork(IsolatedAsyncioTestCase):
+    """Verify ownership-first status checks and Storage delegation."""
+
+    def setUp(self) -> None:
+        self.source = _session()
+        self.storage = SimpleNamespace(
+            get_session=AsyncMock(return_value=self.source),
+            get_team=AsyncMock(return_value=None),
+            fork_session=AsyncMock(return_value=_session("forked")),
+        )
+        self.bus = SimpleNamespace(
+            is_locked=AsyncMock(return_value=False),
+        )
+        self.service = SessionService(self.storage, self.bus)
+
+    async def test_fork_checks_ownership_before_status(self) -> None:
+        """An inaccessible Session never reaches lock/status probing."""
+        self.storage.get_session.return_value = _session(user_id="owner")
+
+        with self.assertRaises(SessionForkNotFoundError):
+            await self.service.fork_session(
+                "user-1",
+                "agent-1",
+                "source-session",
+            )
+
+        self.bus.is_locked.assert_not_awaited()
+        self.storage.fork_session.assert_not_awaited()
+
+    async def test_record_id_and_agent_mismatch_are_not_found(self) -> None:
+        """Record identity mismatches are hidden as NotFound."""
+        for mismatched in (
+            _session(session_id="other-session"),
+            _session(agent_id="other-agent"),
+        ):
+            self.storage.get_session.return_value = mismatched
+            with self.assertRaises(SessionForkNotFoundError):
+                await self.service.fork_session(
+                    "user-1",
+                    "agent-1",
+                    "source-session",
+                )
+        self.storage.fork_session.assert_not_awaited()
+
+    async def test_every_non_idle_status_conflicts(self) -> None:
+        """All non-IDLE statuses are rejected uniformly."""
+        for session_status in (
+            SessionStatus.RUNNING,
+            SessionStatus.AWAITING_PERMISSION,
+            SessionStatus.AWAITING_EXTERNAL_RESULT,
+        ):
+            self.service.get_session_status = AsyncMock(
+                return_value=session_status,
+            )
+            with self.assertRaises(SessionForkConflictError):
+                await self.service.fork_session(
+                    "user-1",
+                    "agent-1",
+                    "source-session",
+                )
+        self.storage.fork_session.assert_not_awaited()
+
+    async def test_root_status_none_is_not_found(self) -> None:
+        """A missing root status is not treated as an idle Session."""
+        self.service.get_session_status = AsyncMock(return_value=None)
+
+        with self.assertRaises(SessionForkNotFoundError):
+            await self.service.fork_session(
+                "user-1",
+                "agent-1",
+                "source-session",
+            )
+
+        self.storage.fork_session.assert_not_awaited()
+
+    async def test_idle_regular_session_delegates_to_storage(self) -> None:
+        """An owned idle regular Session is delegated to Storage."""
+        self.service.get_session_status = AsyncMock(
+            return_value=SessionStatus.IDLE,
+        )
+
+        result = await self.service.fork_session(
+            "user-1",
+            "agent-1",
+            "source-session",
+        )
+
+        self.assertEqual(result.id, "forked")
+        self.storage.fork_session.assert_awaited_once_with(
+            "user-1",
+            "agent-1",
+            "source-session",
+        )
+
+    async def test_team_leader_checks_members_in_member_namespace(
+        self,
+    ) -> None:
+        """A Team Leader checks every normalized member by owner_id."""
+        self.source.team_id = "team-1"
+        member = SimpleNamespace(
+            owner_id="member-owner",
+            agent_id="member-agent",
+            session_id="member-session",
+        )
+        self.storage.get_team.return_value = SimpleNamespace(
+            session_id=self.source.id,
+            data=SimpleNamespace(members=[member]),
+        )
+        self.service.get_session_status = AsyncMock(
+            return_value=SessionStatus.IDLE,
+        )
+
+        await self.service.fork_session(
+            "user-1",
+            "agent-1",
+            "source-session",
+        )
+
+        self.assertEqual(
+            self.service.get_session_status.await_args_list[0].args,
+            ("user-1", "agent-1", "source-session"),
+        )
+        self.assertEqual(
+            self.service.get_session_status.await_args_list[1].args,
+            ("member-owner", "member-agent", "member-session"),
+        )
+
+    async def test_team_worker_is_left_to_storage(self) -> None:
+        """A non-Leader Team Session is not interpreted by the service."""
+        self.source.team_id = "team-1"
+        self.storage.get_team.return_value = SimpleNamespace(
+            session_id="leader-session",
+            data=SimpleNamespace(members=[]),
+        )
+
+        self.service.get_session_status = AsyncMock(
+            return_value=SessionStatus.IDLE,
+        )
+        await self.service.fork_session(
+            "user-1",
+            "agent-1",
+            "source-session",
+        )
+        self.service.get_session_status.assert_awaited_once_with(
+            "user-1",
+            "agent-1",
+            "source-session",
+        )
+        self.storage.fork_session.assert_awaited_once()
+
+    async def test_missing_team_is_left_to_storage(self) -> None:
+        """A missing Team is not converted into a regular Session."""
+        self.source.team_id = "missing-team"
+
+        self.service.get_session_status = AsyncMock(
+            return_value=SessionStatus.IDLE,
+        )
+        await self.service.fork_session(
+            "user-1",
+            "agent-1",
+            "source-session",
+        )
+        self.service.get_session_status.assert_awaited_once_with(
+            "user-1",
+            "agent-1",
+            "source-session",
+        )
+        self.storage.fork_session.assert_awaited_once()
+
+    async def test_worker_non_idle_root_does_not_fork(self) -> None:
+        """A worker root is checked before Storage handles worker rules."""
+        self.source.team_id = "team-1"
+        self.storage.get_team.return_value = SimpleNamespace(
+            session_id="leader-session",
+            data=SimpleNamespace(members=[]),
+        )
+        self.service.get_session_status = AsyncMock(
+            return_value=SessionStatus.RUNNING,
+        )
+
+        with self.assertRaises(SessionForkConflictError):
+            await self.service.fork_session(
+                "user-1",
+                "agent-1",
+                "source-session",
+            )
+
+        self.storage.fork_session.assert_not_awaited()
+
+    async def test_missing_team_non_idle_root_does_not_fork(self) -> None:
+        """A missing Team does not bypass the root status check."""
+        self.source.team_id = "missing-team"
+        self.service.get_session_status = AsyncMock(
+            return_value=SessionStatus.RUNNING,
+        )
+
+        with self.assertRaises(SessionForkConflictError):
+            await self.service.fork_session(
+                "user-1",
+                "agent-1",
+                "source-session",
+            )
+
+        self.storage.fork_session.assert_not_awaited()
+
+    async def test_team_leader_non_idle_root_skips_members(self) -> None:
+        """A non-idle Leader stops before checking member statuses."""
+        self.source.team_id = "team-1"
+        member = SimpleNamespace(
+            owner_id="member-owner",
+            agent_id="member-agent",
+            session_id="member-session",
+        )
+        self.storage.get_team.return_value = SimpleNamespace(
+            session_id=self.source.id,
+            data=SimpleNamespace(members=[member]),
+        )
+        self.service.get_session_status = AsyncMock(
+            return_value=SessionStatus.RUNNING,
+        )
+
+        with self.assertRaises(SessionForkConflictError):
+            await self.service.fork_session(
+                "user-1",
+                "agent-1",
+                "source-session",
+            )
+
+        self.service.get_session_status.assert_awaited_once_with(
+            "user-1",
+            "agent-1",
+            "source-session",
+        )
+        self.storage.fork_session.assert_not_awaited()
+
+    async def test_team_member_status_none_is_deferred_to_storage(
+        self,
+    ) -> None:
+        """A missing member status does not make Service infer corruption."""
+        self.source.team_id = "team-1"
+        member = SimpleNamespace(
+            owner_id="member-owner",
+            agent_id="member-agent",
+            session_id="member-session",
+        )
+        self.storage.get_team.return_value = SimpleNamespace(
+            session_id=self.source.id,
+            data=SimpleNamespace(members=[member]),
+        )
+        self.service.get_session_status = AsyncMock(
+            side_effect=[SessionStatus.IDLE, None],
+        )
+
+        await self.service.fork_session(
+            "user-1",
+            "agent-1",
+            "source-session",
+        )
+
+        self.storage.fork_session.assert_awaited_once()
+
+    async def test_team_member_non_idle_does_not_fork(self) -> None:
+        """A non-idle Team member blocks the whole Fork."""
+        self.source.team_id = "team-1"
+        member = SimpleNamespace(
+            owner_id="member-owner",
+            agent_id="member-agent",
+            session_id="member-session",
+        )
+        self.storage.get_team.return_value = SimpleNamespace(
+            session_id=self.source.id,
+            data=SimpleNamespace(members=[member]),
+        )
+        self.service.get_session_status = AsyncMock(
+            side_effect=[SessionStatus.IDLE, SessionStatus.RUNNING],
+        )
+
+        with self.assertRaises(SessionForkConflictError):
+            await self.service.fork_session(
+                "user-1",
+                "agent-1",
+                "source-session",
+            )
+
+        self.storage.fork_session.assert_not_awaited()

--- a/tests/service_team_tools_test.py
+++ b/tests/service_team_tools_test.py
@@ -45,6 +45,7 @@ from agentscope.permission import (
     PermissionMode,
     PermissionRule,
 )
+from agentscope.message import TextBlock, UserMsg
 from agentscope.state import AgentState
 
 
@@ -1413,6 +1414,33 @@ class TestAgentInviteSuccess(_AgentInviteTestBase):
             invited.id,
             SessionConfig(workspace_id="remote-workspace"),
         )
+        await self.storage.upsert_message(
+            member_owner_id,
+            standalone.id,
+            UserMsg(
+                name="user",
+                content=[TextBlock(text="standalone history")],
+            ),
+        )
+        standalone_messages_before = await self.storage._client.lrange(
+            self.storage._message_key(member_owner_id, standalone.id),
+            0,
+            -1,
+        )
+        standalone_before = await self.storage.get_session(
+            member_owner_id,
+            invited.id,
+            standalone.id,
+        )
+        assert standalone_before is not None
+        standalone_index_key = self.storage._key(
+            self.storage.key_config.session_index,
+            user_id=member_owner_id,
+            agent_id=invited.id,
+        )
+        standalone_index_before = await self.storage._client.smembers(
+            standalone_index_key,
+        )
         tool = AgentInvite(
             storage=self.storage,
             message_bus=self.bus,
@@ -1438,7 +1466,29 @@ class TestAgentInviteSuccess(_AgentInviteTestBase):
         assert team is not None
         member = team.data.members[0]
         self.assertEqual(member.owner_id, member_owner_id)
-        self.assertIsNone(standalone.team_id)
+        standalone_after = await self.storage.get_session(
+            member_owner_id,
+            invited.id,
+            standalone.id,
+        )
+        assert standalone_after is not None
+        self.assertEqual(
+            standalone_after.model_dump_json(),
+            standalone_before.model_dump_json(),
+        )
+        self.assertIsNone(standalone_after.team_id)
+        self.assertEqual(
+            await self.storage._client.smembers(standalone_index_key),
+            standalone_index_before | {member.session_id},
+        )
+        self.assertEqual(
+            await self.storage._client.lrange(
+                self.storage._message_key(member_owner_id, standalone.id),
+                0,
+                -1,
+            ),
+            standalone_messages_before,
+        )
         borrowed = await self.storage.get_session(
             member_owner_id,
             invited.id,

--- a/tests/service_team_tools_test.py
+++ b/tests/service_team_tools_test.py
@@ -1386,6 +1386,73 @@ class TestAgentInviteSuccess(_AgentInviteTestBase):
         )
         self.assertEqual(primary_inbox, [])
 
+    async def test_cross_owner_invite_uses_verified_member_namespace(
+        self,
+    ) -> None:
+        """Team and invited Agent resources keep separate owners."""
+        from agentscope.app.storage._model._agent import InviteConfig
+
+        member_owner_id = "member-owner"
+        invited = AgentRecord(
+            user_id=member_owner_id,
+            source="user",
+            data=AgentData(
+                name="Remote Monday",
+                system_prompt="I am remote Monday.",
+                context_config=ContextConfig(),
+                react_config=ReActConfig(),
+                invite_config=InviteConfig(
+                    invitable=True,
+                    invite_description="Remote expert.",
+                ),
+            ),
+        )
+        await self.storage.upsert_agent(member_owner_id, invited)
+        standalone = await self.storage.upsert_session(
+            member_owner_id,
+            invited.id,
+            SessionConfig(workspace_id="remote-workspace"),
+        )
+        tool = AgentInvite(
+            storage=self.storage,
+            message_bus=self.bus,
+            workspace_manager=self.workspace_manager,
+            user_id=self.user_id,
+            session_id=self.leader_session.id,
+            agent_id=self.leader_agent.id,
+            invitable_pool=[invited],
+        )
+
+        chunk = await tool(
+            target=f"Remote Monday@{invited.id[:8]}",
+            prompt="remote task",
+        )
+        self.assertEqual(chunk.state.value, "running")
+        leader = await self.storage.get_session(
+            self.user_id,
+            self.leader_agent.id,
+            self.leader_session.id,
+        )
+        assert leader is not None and leader.team_id is not None
+        team = await self.storage.get_team(self.user_id, leader.team_id)
+        assert team is not None
+        member = team.data.members[0]
+        self.assertEqual(member.owner_id, member_owner_id)
+        self.assertIsNone(standalone.team_id)
+        borrowed = await self.storage.get_session(
+            member_owner_id,
+            invited.id,
+            member.session_id,
+        )
+        self.assertIsNotNone(borrowed)
+        self.assertIsNone(
+            await self.storage.get_session(
+                self.user_id,
+                invited.id,
+                member.session_id,
+            ),
+        )
+
 
 class TestAgentInviteRejections(_AgentInviteTestBase):
     """``AgentInvite`` rejects the obvious bad inputs / states."""

--- a/tests/session_fork_schedule_storage_test.py
+++ b/tests/session_fork_schedule_storage_test.py
@@ -10,7 +10,6 @@ from redis.exceptions import ResponseError
 from _storage_test_helpers import make_config, make_storage
 from agentscope._utils import _common
 from agentscope.app.storage import (
-    SessionForkConflictError,
     SessionForkCorruptedGraphError,
     SessionSource,
 )
@@ -142,7 +141,7 @@ class TestScheduleSessionFork(IsolatedAsyncioTestCase):
             self.source_id,
             "team-1",
         )
-        with self.assertRaises(SessionForkConflictError):
+        with self.assertRaises(SessionForkCorruptedGraphError):
             await self.storage.fork_session(
                 self.user_id,
                 self.agent_id,

--- a/tests/session_fork_schedule_storage_test.py
+++ b/tests/session_fork_schedule_storage_test.py
@@ -1,0 +1,275 @@
+# -*- coding: utf-8 -*-
+"""Schedule-specific Storage Fork tests."""
+# pylint: disable=protected-access
+
+from unittest import IsolatedAsyncioTestCase
+from typing import Any
+
+from redis.exceptions import ResponseError
+
+from _storage_test_helpers import make_config, make_storage
+from agentscope._utils import _common
+from agentscope.app.storage import (
+    SessionForkConflictError,
+    SessionForkCorruptedGraphError,
+    SessionSource,
+)
+from agentscope.message import TextBlock, UserMsg
+from agentscope.state import AgentState
+
+
+class TestScheduleSessionFork(IsolatedAsyncioTestCase):
+    """Verify Schedule provenance and Schedule-specific side effects."""
+
+    async def asyncSetUp(self) -> None:
+        self.storage = make_storage()
+        self.user_id = "user-1"
+        self.agent_id = "agent-1"
+        self.schedule_id = "schedule-1"
+        self.source_id = "schedule-session"
+        await self.storage.upsert_session(
+            self.user_id,
+            self.agent_id,
+            make_config(name="Scheduled"),
+            state=AgentState(),
+            session_id=self.source_id,
+            source=SessionSource.SCHEDULE,
+            source_schedule_id=self.schedule_id,
+        )
+
+    async def test_schedule_fork_resets_provenance_and_preserves_index(
+        self,
+    ) -> None:
+        """A Schedule fork becomes a normal user-owned Session."""
+        await self.storage.upsert_message(
+            self.user_id,
+            self.source_id,
+            UserMsg(
+                name="user",
+                content=[TextBlock(text="scheduled content")],
+            ),
+        )
+        schedule_index_key = self.storage._key(
+            self.storage.key_config.schedule_session_index,
+            user_id=self.user_id,
+            schedule_id=self.schedule_id,
+        )
+        index_before = await self.storage._client.smembers(schedule_index_key)
+        self.assertIn(self.source_id, index_before)
+
+        fork = await self.storage.fork_session(
+            self.user_id,
+            self.agent_id,
+            self.source_id,
+        )
+
+        self.assertEqual(fork.source, SessionSource.USER)
+        self.assertIsNone(fork.source_schedule_id)
+        self.assertIsNone(fork.team_id)
+        self.assertEqual(fork.config.name, "Scheduled (Fork)")
+        self.assertEqual(
+            await self.storage._client.smembers(schedule_index_key),
+            index_before,
+        )
+        self.assertNotIn(
+            fork.id,
+            await self.storage._client.smembers(schedule_index_key),
+        )
+        self.assertEqual(
+            await self.storage.list_messages(
+                self.user_id,
+                fork.id,
+                limit=10,
+            ),
+            await self.storage.list_messages(
+                self.user_id,
+                self.source_id,
+                limit=10,
+            ),
+        )
+
+    async def test_schedule_provenance_requires_nonempty_schedule_id(
+        self,
+    ) -> None:
+        """Schedule records without provenance are corrupted."""
+        storage = make_storage()
+        for suffix, schedule_id in (
+            ("none", None),
+            ("empty", ""),
+            ("whitespace", "   "),
+        ):
+            session_id = f"missing-schedule-id-{suffix}"
+            await storage.upsert_session(
+                self.user_id,
+                self.agent_id,
+                make_config(),
+                session_id=session_id,
+                source=SessionSource.SCHEDULE,
+                source_schedule_id=schedule_id,
+            )
+            with self.assertRaises(SessionForkCorruptedGraphError):
+                await storage.fork_session(
+                    self.user_id,
+                    self.agent_id,
+                    session_id,
+                )
+
+    async def test_user_session_cannot_carry_schedule_provenance(self) -> None:
+        """A USER record with a schedule id is corrupted."""
+        for suffix in ("empty", "whitespace"):
+            storage = make_storage()
+            schedule_id = "" if suffix == "empty" else "   "
+            session_id = f"inconsistent-provenance-{suffix}"
+            await storage.upsert_session(
+                self.user_id,
+                self.agent_id,
+                make_config(),
+                session_id=session_id,
+                source=SessionSource.USER,
+                source_schedule_id=schedule_id,
+            )
+            with self.assertRaises(SessionForkCorruptedGraphError):
+                await storage.fork_session(
+                    self.user_id,
+                    self.agent_id,
+                    session_id,
+                )
+
+    async def test_team_session_remains_conflict(self) -> None:
+        """Team sessions remain outside the Schedule/ordinary phase."""
+        await self.storage.set_session_team_id(
+            self.user_id,
+            self.source_id,
+            "team-1",
+        )
+        with self.assertRaises(SessionForkConflictError):
+            await self.storage.fork_session(
+                self.user_id,
+                self.agent_id,
+                self.source_id,
+            )
+
+    async def test_source_message_wrong_type_is_corrupted(self) -> None:
+        """A non-list source Message Key is rejected before reading."""
+        message_key = self.storage._message_key(self.user_id, self.source_id)
+        await self.storage._client.set(message_key, "wrong-type")
+        with self.assertRaises(SessionForkCorruptedGraphError):
+            await self.storage.fork_session(
+                self.user_id,
+                self.agent_id,
+                self.source_id,
+            )
+
+    async def test_source_session_wrong_type_is_corrupted(self) -> None:
+        """A non-string source Session Key is rejected before reading."""
+        session_key = self.storage._key(
+            self.storage.key_config.session,
+            user_id=self.user_id,
+            session_id=self.source_id,
+        )
+        await self.storage._client.delete(session_key)
+        await self.storage._client.rpush(session_key, "wrong-type")
+        with self.assertRaises(SessionForkCorruptedGraphError):
+            await self.storage.fork_session(
+                self.user_id,
+                self.agent_id,
+                self.source_id,
+            )
+
+    async def test_target_index_wrong_type_is_corrupted(self) -> None:
+        """A non-set target Agent Session Index is rejected."""
+        index_key = self.storage._key(
+            self.storage.key_config.session_index,
+            user_id=self.user_id,
+            agent_id=self.agent_id,
+        )
+        await self.storage._client.delete(index_key)
+        await self.storage._client.set(index_key, "wrong-type")
+        with self.assertRaises(SessionForkCorruptedGraphError):
+            await self.storage.fork_session(
+                self.user_id,
+                self.agent_id,
+                self.source_id,
+            )
+
+    async def test_wrongtype_get_rebuilds_pipeline(self) -> None:
+        """A concurrent source type change rebuilds the full pipeline."""
+        original_pipeline = self.storage._client.pipeline
+        pipeline_count = 0
+        wrongtype_raised = False
+
+        class _WrongTypeOnGet:
+            def __init__(self, inner: Any) -> None:
+                self.inner = inner
+
+            async def __aenter__(self) -> "_WrongTypeOnGet":
+                await self.inner.__aenter__()
+                return self
+
+            async def __aexit__(self, *args: Any) -> Any:
+                """Close the wrapped pipeline context."""
+                return await self.inner.__aexit__(*args)
+
+            async def get(self, key: Any) -> Any:
+                """Raise WRONGTYPE once, then delegate source reads."""
+                nonlocal wrongtype_raised
+                if not wrongtype_raised:
+                    wrongtype_raised = True
+                    raise ResponseError("WRONGTYPE concurrent change")
+                return await self.inner.get(key)
+
+            def __getattr__(self, name: str) -> Any:
+                return getattr(self.inner, name)
+
+        def pipeline(*args: Any, **kwargs: Any) -> _WrongTypeOnGet:
+            nonlocal pipeline_count
+            pipeline_count += 1
+            return _WrongTypeOnGet(original_pipeline(*args, **kwargs))
+
+        old_factory = _common._id_factory
+        _common.set_id_factory(lambda: "after-wrongtype")
+        self.storage._client.pipeline = pipeline
+        try:
+            fork = await self.storage.fork_session(
+                self.user_id,
+                self.agent_id,
+                self.source_id,
+            )
+        finally:
+            _common.set_id_factory(old_factory)
+
+        self.assertEqual(pipeline_count, 2)
+        self.assertEqual(fork.id, "after-wrongtype")
+
+    async def test_non_wrongtype_response_error_is_propagated(self) -> None:
+        """Non-WRONGTYPE source read errors are not swallowed."""
+        original_pipeline = self.storage._client.pipeline
+
+        class _OtherResponseError:
+            def __init__(self, inner: Any) -> None:
+                self.inner = inner
+
+            async def __aenter__(self) -> "_OtherResponseError":
+                await self.inner.__aenter__()
+                return self
+
+            async def __aexit__(self, *args: Any) -> Any:
+                """Close the wrapped pipeline context."""
+                return await self.inner.__aexit__(*args)
+
+            async def get(self, key: Any) -> Any:
+                """Raise a non-WRONGTYPE Redis error for source reads."""
+                raise ResponseError("READONLY replica")
+
+            def __getattr__(self, name: str) -> Any:
+                return getattr(self.inner, name)
+
+        self.storage._client.pipeline = lambda *args, **kwargs: (
+            _OtherResponseError(original_pipeline(*args, **kwargs))
+        )
+        with self.assertRaises(ResponseError):
+            await self.storage.fork_session(
+                self.user_id,
+                self.agent_id,
+                self.source_id,
+            )

--- a/tests/session_fork_storage_test.py
+++ b/tests/session_fork_storage_test.py
@@ -226,7 +226,7 @@ class TestRegularSessionFork(IsolatedAsyncioTestCase):
             self.source_id,
             "team-1",
         )
-        with self.assertRaises(SessionForkConflictError):
+        with self.assertRaises(SessionForkCorruptedGraphError):
             await self.storage.fork_session(
                 self.user_id,
                 self.agent_id,

--- a/tests/session_fork_storage_test.py
+++ b/tests/session_fork_storage_test.py
@@ -1,0 +1,724 @@
+# -*- coding: utf-8 -*-
+"""Tests for phase-one ordinary session storage forking."""
+# pylint: disable=protected-access
+
+from datetime import datetime
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+from typing import Any
+
+import fakeredis.aioredis
+from redis.exceptions import WatchError
+
+from agentscope._utils import _common
+import agentscope.app.storage._redis_storage as redis_storage_module
+from agentscope.app.storage import (
+    ChatModelConfig,
+    RedisStorage,
+    SessionConfig,
+    SessionForkConflictError,
+    SessionForkCorruptedGraphError,
+    SessionForkNotFoundError,
+    SessionSource,
+)
+from agentscope.message import TextBlock, UserMsg
+from agentscope.state import AgentState
+
+
+def make_storage(
+    *,
+    key_ttl: int | None = None,
+    decode_responses: bool = True,
+) -> RedisStorage:
+    """Create a RedisStorage backed by fakeredis."""
+    storage = RedisStorage.__new__(RedisStorage)
+    storage._client = fakeredis.aioredis.FakeRedis(
+        decode_responses=decode_responses,
+    )
+    storage.key_ttl = key_ttl
+    storage.key_config = RedisStorage.KeyConfig()
+    return storage
+
+
+def make_config(name: str = "Original") -> SessionConfig:
+    """Build a session config with nested mutable data."""
+    return SessionConfig(
+        workspace_id="shared-workspace",
+        name=name,
+        chat_model_config=ChatModelConfig(
+            type="openai",
+            credential_id="credential",
+            model="model",
+            parameters={"temperature": 0.2},
+        ),
+    )
+
+
+class TestRegularSessionFork(IsolatedAsyncioTestCase):
+    """Verify ordinary non-team, non-schedule session cloning."""
+
+    async def asyncSetUp(self) -> None:
+        self.storage = make_storage()
+        self.user_id = "user-1"
+        self.agent_id = "agent-1"
+        self.source_id = "source-session"
+        await self.storage.upsert_session(
+            self.user_id,
+            self.agent_id,
+            make_config(),
+            state=AgentState(),
+            session_id=self.source_id,
+        )
+
+    async def test_fork_copies_record_and_messages(self) -> None:
+        """The fork has independent record data and exact message JSON."""
+        source = await self.storage.get_session(
+            self.user_id,
+            self.agent_id,
+            self.source_id,
+        )
+        assert source is not None
+        old_timestamp = datetime(2000, 1, 1)
+        source.created_at = old_timestamp
+        source.updated_at = old_timestamp
+        await self.storage._client.set(
+            self.storage._key(
+                self.storage.key_config.session,
+                user_id=self.user_id,
+                session_id=self.source_id,
+            ),
+            source.model_dump_json(),
+        )
+        source_messages = [
+            UserMsg(
+                name="user",
+                content=[TextBlock(text="hello")],
+            ),
+            UserMsg(
+                name="user",
+                content=[TextBlock(text="world")],
+            ),
+        ]
+        for message in source_messages:
+            await self.storage.upsert_message(
+                self.user_id,
+                self.source_id,
+                message,
+            )
+        source_raw = await self.storage._client.lrange(
+            self.storage._message_key(self.user_id, self.source_id),
+            0,
+            -1,
+        )
+
+        fork = await self.storage.fork_session(
+            self.user_id,
+            self.agent_id,
+            self.source_id,
+        )
+
+        self.assertNotEqual(fork.id, source.id)
+        self.assertNotEqual(fork.created_at, source.created_at)
+        self.assertNotEqual(fork.updated_at, source.updated_at)
+        self.assertEqual(fork.source, SessionSource.USER)
+        self.assertIsNone(fork.source_schedule_id)
+        self.assertIsNone(fork.team_id)
+        self.assertEqual(fork.config.name, "Original (Fork)")
+        self.assertEqual(fork.config.workspace_id, source.config.workspace_id)
+        source_config = source.config.model_dump()
+        fork_config = fork.config.model_dump()
+        source_config.pop("name")
+        fork_config.pop("name")
+        self.assertEqual(fork_config, source_config)
+        self.assertEqual(fork.state.model_dump(), source.state.model_dump())
+
+        fork_raw = await self.storage._client.lrange(
+            self.storage._message_key(self.user_id, fork.id),
+            0,
+            -1,
+        )
+        self.assertEqual(fork_raw, source_raw)
+        self.assertIn(
+            fork.id,
+            await self.storage._client.smembers(
+                self.storage._key(
+                    self.storage.key_config.session_index,
+                    user_id=self.user_id,
+                    agent_id=self.agent_id,
+                ),
+            ),
+        )
+
+        fork.config.chat_model_config.parameters["temperature"] = 0.9
+        fork.state.cur_iter = 7
+        fork.state.tool_context.activated_groups.append("fork-only")
+        source_after = await self.storage.get_session(
+            self.user_id,
+            self.agent_id,
+            self.source_id,
+        )
+        assert source_after is not None
+        self.assertEqual(
+            source_after.config.chat_model_config.parameters["temperature"],
+            0.2,
+        )
+        self.assertEqual(source_after.state.cur_iter, 0)
+        self.assertEqual(source_after.state.tool_context.activated_groups, [])
+
+    async def test_empty_source_does_not_create_message_key(self) -> None:
+        """An empty source history produces no target Redis list."""
+        fork = await self.storage.fork_session(
+            self.user_id,
+            self.agent_id,
+            self.source_id,
+        )
+        self.assertFalse(
+            await self.storage._client.exists(
+                self.storage._message_key(self.user_id, fork.id),
+            ),
+        )
+
+    async def test_empty_name_uses_default_name(self) -> None:
+        """An empty source name does not produce ``None (Fork)``."""
+        storage = make_storage()
+        await storage.upsert_session(
+            self.user_id,
+            self.agent_id,
+            make_config(name=""),
+            session_id=self.source_id,
+        )
+        fork = await storage.fork_session(
+            self.user_id,
+            self.agent_id,
+            self.source_id,
+        )
+        self.assertTrue(fork.config.name)
+        self.assertNotIn("None (Fork)", fork.config.name)
+
+    async def test_ttl_is_applied_to_record_and_nonempty_messages(
+        self,
+    ) -> None:
+        """New record and nonempty message list use the configured TTL."""
+        storage = make_storage(key_ttl=60)
+        await storage.upsert_session(
+            self.user_id,
+            self.agent_id,
+            make_config(),
+            session_id=self.source_id,
+        )
+        await storage.upsert_message(
+            self.user_id,
+            self.source_id,
+            UserMsg(
+                name="user",
+                content=[TextBlock(text="hello")],
+            ),
+        )
+        fork = await storage.fork_session(
+            self.user_id,
+            self.agent_id,
+            self.source_id,
+        )
+        self.assertGreater(
+            await storage._client.ttl(
+                storage._key(
+                    storage.key_config.session,
+                    user_id=self.user_id,
+                    session_id=fork.id,
+                ),
+            ),
+            0,
+        )
+        self.assertGreater(
+            await storage._client.ttl(
+                storage._message_key(self.user_id, fork.id),
+            ),
+            0,
+        )
+
+    async def test_team_and_schedule_sources_are_conflicts(self) -> None:
+        """Phase one rejects both unsupported source categories."""
+        schedule = await self.storage.upsert_session(
+            self.user_id,
+            self.agent_id,
+            make_config(),
+            source=SessionSource.SCHEDULE,
+            session_id="schedule-session",
+        )
+        self.assertEqual(schedule.source, SessionSource.SCHEDULE)
+        with self.assertRaises(SessionForkConflictError):
+            await self.storage.fork_session(
+                self.user_id,
+                self.agent_id,
+                schedule.id,
+            )
+
+        await self.storage.set_session_team_id(
+            self.user_id,
+            self.source_id,
+            "team-1",
+        )
+        with self.assertRaises(SessionForkConflictError):
+            await self.storage.fork_session(
+                self.user_id,
+                self.agent_id,
+                self.source_id,
+            )
+
+        await self.storage.upsert_session(
+            self.user_id,
+            self.agent_id,
+            make_config(),
+            source_schedule_id="schedule-provenance",
+            session_id="schedule-provenance-session",
+        )
+        with self.assertRaises(SessionForkConflictError):
+            await self.storage.fork_session(
+                self.user_id,
+                self.agent_id,
+                "schedule-provenance-session",
+            )
+
+    async def test_bytes_message_payloads_are_copied_verbatim(self) -> None:
+        """External pools without decode_responses keep bytes unchanged."""
+        storage = make_storage(decode_responses=False)
+        await storage.upsert_session(
+            self.user_id,
+            self.agent_id,
+            make_config(),
+            session_id=self.source_id,
+        )
+        await storage.upsert_message(
+            self.user_id,
+            self.source_id,
+            UserMsg(
+                name="user",
+                content=[TextBlock(text="bytes")],
+            ),
+        )
+        source_key = storage._message_key(self.user_id, self.source_id)
+        source_raw = await storage._client.lrange(source_key, 0, -1)
+        fork = await storage.fork_session(
+            self.user_id,
+            self.agent_id,
+            self.source_id,
+        )
+        fork_raw = await storage._client.lrange(
+            storage._message_key(self.user_id, fork.id),
+            0,
+            -1,
+        )
+        self.assertEqual(source_raw, fork_raw)
+        self.assertIsInstance(fork_raw[0], bytes)
+
+    async def test_agent_mismatch_is_not_forkable(self) -> None:
+        """The requested agent id is checked explicitly."""
+        with self.assertRaises(SessionForkNotFoundError):
+            await self.storage.fork_session(
+                self.user_id,
+                "different-agent",
+                self.source_id,
+            )
+
+    async def test_missing_source_is_not_found(self) -> None:
+        """A missing source Session maps to SessionForkNotFoundError."""
+        with self.assertRaises(SessionForkNotFoundError):
+            await self.storage.fork_session(
+                self.user_id,
+                self.agent_id,
+                "missing-session",
+            )
+
+    async def test_storage_key_id_mismatch_is_corrupted_graph(self) -> None:
+        """A record ID must match the session key used to load it."""
+        source_key = self.storage._key(
+            self.storage.key_config.session,
+            user_id=self.user_id,
+            session_id=self.source_id,
+        )
+        source = await self.storage.get_session(
+            self.user_id,
+            self.agent_id,
+            self.source_id,
+        )
+        assert source is not None
+        await self.storage._client.set(
+            source_key,
+            source.model_copy(
+                update={"id": "different-record-id"},
+            ).model_dump_json(),
+        )
+        with self.assertRaises(SessionForkCorruptedGraphError):
+            await self.storage.fork_session(
+                self.user_id,
+                self.agent_id,
+                self.source_id,
+            )
+
+    async def test_invalid_source_json_is_corrupted_graph(self) -> None:
+        """Malformed source JSON is normalized to the storage exception."""
+        source_key = self.storage._key(
+            self.storage.key_config.session,
+            user_id=self.user_id,
+            session_id=self.source_id,
+        )
+        await self.storage._client.set(source_key, "{invalid-json")
+        with self.assertRaises(SessionForkCorruptedGraphError):
+            await self.storage.fork_session(
+                self.user_id,
+                self.agent_id,
+                self.source_id,
+            )
+
+    async def test_user_mismatch_is_not_forkable(self) -> None:
+        """A corrupted record with another owner is treated as not found."""
+        source_key = self.storage._key(
+            self.storage.key_config.session,
+            user_id=self.user_id,
+            session_id=self.source_id,
+        )
+        source = await self.storage.get_session(
+            self.user_id,
+            self.agent_id,
+            self.source_id,
+        )
+        assert source is not None
+        await self.storage._client.set(
+            source_key,
+            source.model_copy(
+                update={"user_id": "other-user"},
+            ).model_dump_json(),
+        )
+        with self.assertRaises(SessionForkNotFoundError):
+            await self.storage.fork_session(
+                self.user_id,
+                self.agent_id,
+                self.source_id,
+            )
+
+
+class TestForkPlanFailureTargets(IsolatedAsyncioTestCase):
+    """Keep deterministic target ids available for failure assertions."""
+
+    async def test_id_factory_can_pin_target_id(self) -> None:
+        """The global ID factory supports precise target-key assertions."""
+        storage = make_storage()
+        await storage.upsert_session(
+            "user-1",
+            "agent-1",
+            make_config(),
+            session_id="source-session",
+        )
+        old_factory = _common._id_factory
+        ids = iter(["target-id"])
+        _common.set_id_factory(lambda: next(ids))
+        try:
+            fork = await storage.fork_session(
+                "user-1",
+                "agent-1",
+                "source-session",
+            )
+            self.assertEqual(fork.id, "target-id")
+            self.assertTrue(
+                await storage._client.exists(
+                    storage._key(
+                        storage.key_config.session,
+                        user_id="user-1",
+                        session_id="target-id",
+                    ),
+                ),
+            )
+        finally:
+            _common.set_id_factory(old_factory)
+
+    async def test_target_id_collision_does_not_overwrite_existing_data(
+        self,
+    ) -> None:
+        """A colliding target ID is skipped and never overwritten."""
+        storage = make_storage()
+        await storage.upsert_session(
+            "user-1",
+            "agent-1",
+            make_config(name="source"),
+            session_id="source-session",
+        )
+        await storage.upsert_message(
+            "user-1",
+            "source-session",
+            UserMsg(
+                name="user",
+                content=[TextBlock(text="source")],
+            ),
+        )
+        await storage.upsert_session(
+            "user-1",
+            "agent-1",
+            make_config(name="existing"),
+            session_id="existing-target",
+        )
+        await storage.upsert_message(
+            "user-1",
+            "existing-target",
+            UserMsg(
+                name="user",
+                content=[TextBlock(text="existing")],
+            ),
+        )
+        existing_before = await storage.get_session(
+            "user-1",
+            "agent-1",
+            "existing-target",
+        )
+        assert existing_before is not None
+        old_factory = _common._id_factory
+        ids = iter(["existing-target", "fresh-target"])
+        _common.set_id_factory(lambda: next(ids))
+        try:
+            fork = await storage.fork_session(
+                "user-1",
+                "agent-1",
+                "source-session",
+            )
+        finally:
+            _common.set_id_factory(old_factory)
+
+        self.assertEqual(fork.id, "fresh-target")
+        existing_after = await storage.get_session(
+            "user-1",
+            "agent-1",
+            "existing-target",
+        )
+        assert existing_after is not None
+        self.assertEqual(
+            existing_after.model_dump(),
+            existing_before.model_dump(),
+        )
+        existing_messages = await storage.list_messages(
+            "user-1",
+            "existing-target",
+            limit=10,
+        )
+        self.assertEqual(existing_messages[0].content[0].text, "existing")
+
+    async def test_empty_source_checks_orphan_target_message_key(self) -> None:
+        """An orphan target list also prevents target ID reuse."""
+        storage = make_storage()
+        await storage.upsert_session(
+            "user-1",
+            "agent-1",
+            make_config(name="source"),
+            session_id="source-session",
+        )
+        orphan_key = storage._message_key("user-1", "orphan-target")
+        await storage._client.rpush(orphan_key, "orphan-message")
+        old_factory = _common._id_factory
+        ids = iter(["orphan-target", "clean-target"])
+        _common.set_id_factory(lambda: next(ids))
+        try:
+            fork = await storage.fork_session(
+                "user-1",
+                "agent-1",
+                "source-session",
+            )
+        finally:
+            _common.set_id_factory(old_factory)
+
+        self.assertEqual(fork.id, "clean-target")
+        self.assertEqual(
+            await storage._client.lrange(orphan_key, 0, -1),
+            ["orphan-message"],
+        )
+        self.assertFalse(
+            await storage._client.exists(
+                storage._message_key("user-1", "clean-target"),
+            ),
+        )
+
+    async def test_watch_error_rebuilds_plan_without_first_target(
+        self,
+    ) -> None:
+        """A retried transaction gets a new plan and leaves no first target."""
+        storage = make_storage()
+        await storage.upsert_session(
+            "user-1",
+            "agent-1",
+            make_config(),
+            session_id="source-session",
+        )
+        old_factory = _common._id_factory
+        ids = iter(["target-first", "target-second"])
+        _common.set_id_factory(lambda: next(ids))
+        original_pipeline = storage._client.pipeline
+        calls = 0
+        pipeline_count = 0
+
+        class _ExecuteOnceAsWatchError:
+            def __init__(self, inner: Any) -> None:
+                self.inner = inner
+
+            async def __aenter__(self) -> "_ExecuteOnceAsWatchError":
+                await self.inner.__aenter__()
+                return self
+
+            async def __aexit__(self, *args: Any) -> Any:
+                return await self.inner.__aexit__(*args)
+
+            async def execute(self) -> Any:
+                """Raise once, then delegate transaction execution."""
+                nonlocal calls
+                calls += 1
+                if calls == 1:
+                    raise WatchError()
+                return await self.inner.execute()
+
+            def __getattr__(self, name: str) -> Any:
+                return getattr(self.inner, name)
+
+        def pipeline(*args: Any, **kwargs: Any) -> _ExecuteOnceAsWatchError:
+            """Create a pipeline wrapper that fails once on execute."""
+            nonlocal pipeline_count
+            pipeline_count += 1
+            return _ExecuteOnceAsWatchError(original_pipeline(*args, **kwargs))
+
+        storage._client.pipeline = pipeline
+        try:
+            fork = await storage.fork_session(
+                "user-1",
+                "agent-1",
+                "source-session",
+            )
+        finally:
+            _common.set_id_factory(old_factory)
+
+        self.assertEqual(fork.id, "target-second")
+        self.assertEqual(calls, 2)
+        self.assertEqual(pipeline_count, 2)
+        self.assertFalse(
+            await storage._client.exists(
+                storage._key(
+                    storage.key_config.session,
+                    user_id="user-1",
+                    session_id="target-first",
+                ),
+            ),
+        )
+        self.assertTrue(
+            await storage._client.exists(
+                storage._key(
+                    storage.key_config.session,
+                    user_id="user-1",
+                    session_id="target-second",
+                ),
+            ),
+        )
+
+    async def test_clone_plan_failure_leaves_no_target(self) -> None:
+        """A pre-MULTI plan error cannot create target keys."""
+        storage = make_storage()
+        await storage.upsert_session(
+            "user-1",
+            "agent-1",
+            make_config(),
+            session_id="source-session",
+        )
+        old_factory = _common._id_factory
+        _common.set_id_factory(lambda: "target-plan-error")
+        try:
+            with patch.object(
+                redis_storage_module,
+                "build_fork_session_name",
+                side_effect=ValueError("invalid clone plan"),
+            ):
+                with self.assertRaises(ValueError):
+                    await storage.fork_session(
+                        "user-1",
+                        "agent-1",
+                        "source-session",
+                    )
+        finally:
+            _common.set_id_factory(old_factory)
+
+        target_key = storage._key(
+            storage.key_config.session,
+            user_id="user-1",
+            session_id="target-plan-error",
+        )
+        self.assertFalse(await storage._client.exists(target_key))
+
+    async def test_watch_retry_exhaustion_leaves_no_targets(self) -> None:
+        """Exhausted WatchError retries do not leave records or indexes."""
+        storage = make_storage()
+        await storage.upsert_session(
+            "user-1",
+            "agent-1",
+            make_config(),
+            session_id="source-session",
+        )
+        old_factory = _common._id_factory
+        ids = iter(["target-one", "target-two", "target-three"])
+        _common.set_id_factory(lambda: next(ids))
+        original_pipeline = storage._client.pipeline
+        pipeline_count = 0
+
+        class _AlwaysWatchError:
+            def __init__(self, inner: Any) -> None:
+                self.inner = inner
+
+            async def __aenter__(self) -> "_AlwaysWatchError":
+                await self.inner.__aenter__()
+                return self
+
+            async def __aexit__(self, *args: Any) -> Any:
+                return await self.inner.__aexit__(*args)
+
+            async def execute(self) -> Any:
+                """Always raise WatchError to exhaust retries."""
+                raise WatchError()
+
+            def __getattr__(self, name: str) -> Any:
+                return getattr(self.inner, name)
+
+        def pipeline(*args: Any, **kwargs: Any) -> _AlwaysWatchError:
+            """Create a pipeline wrapper that always raises WatchError."""
+            nonlocal pipeline_count
+            pipeline_count += 1
+            return _AlwaysWatchError(original_pipeline(*args, **kwargs))
+
+        storage._client.pipeline = pipeline
+        try:
+            with self.assertRaises(SessionForkConflictError):
+                await storage.fork_session(
+                    "user-1",
+                    "agent-1",
+                    "source-session",
+                )
+        finally:
+            _common.set_id_factory(old_factory)
+
+        self.assertEqual(pipeline_count, 3)
+        for target_id in (
+            "target-one",
+            "target-two",
+            "target-three",
+        ):
+            self.assertFalse(
+                await storage._client.exists(
+                    storage._key(
+                        storage.key_config.session,
+                        user_id="user-1",
+                        session_id=target_id,
+                    ),
+                ),
+            )
+        index_key = storage._key(
+            storage.key_config.session_index,
+            user_id="user-1",
+            agent_id="agent-1",
+        )
+        self.assertTrue(
+            {
+                "target-one",
+                "target-two",
+                "target-three",
+            }.isdisjoint(await storage._client.smembers(index_key)),
+        )

--- a/tests/session_fork_storage_test.py
+++ b/tests/session_fork_storage_test.py
@@ -7,15 +7,12 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch
 from typing import Any
 
-import fakeredis.aioredis
 from redis.exceptions import WatchError
 
+from _storage_test_helpers import make_config, make_storage
 from agentscope._utils import _common
 import agentscope.app.storage._redis_storage as redis_storage_module
 from agentscope.app.storage import (
-    ChatModelConfig,
-    RedisStorage,
-    SessionConfig,
     SessionForkConflictError,
     SessionForkCorruptedGraphError,
     SessionForkNotFoundError,
@@ -23,35 +20,6 @@ from agentscope.app.storage import (
 )
 from agentscope.message import TextBlock, UserMsg
 from agentscope.state import AgentState
-
-
-def make_storage(
-    *,
-    key_ttl: int | None = None,
-    decode_responses: bool = True,
-) -> RedisStorage:
-    """Create a RedisStorage backed by fakeredis."""
-    storage = RedisStorage.__new__(RedisStorage)
-    storage._client = fakeredis.aioredis.FakeRedis(
-        decode_responses=decode_responses,
-    )
-    storage.key_ttl = key_ttl
-    storage.key_config = RedisStorage.KeyConfig()
-    return storage
-
-
-def make_config(name: str = "Original") -> SessionConfig:
-    """Build a session config with nested mutable data."""
-    return SessionConfig(
-        workspace_id="shared-workspace",
-        name=name,
-        chat_model_config=ChatModelConfig(
-            type="openai",
-            credential_id="credential",
-            model="model",
-            parameters={"temperature": 0.2},
-        ),
-    )
 
 
 class TestRegularSessionFork(IsolatedAsyncioTestCase):
@@ -246,7 +214,7 @@ class TestRegularSessionFork(IsolatedAsyncioTestCase):
             session_id="schedule-session",
         )
         self.assertEqual(schedule.source, SessionSource.SCHEDULE)
-        with self.assertRaises(SessionForkConflictError):
+        with self.assertRaises(SessionForkCorruptedGraphError):
             await self.storage.fork_session(
                 self.user_id,
                 self.agent_id,
@@ -272,7 +240,7 @@ class TestRegularSessionFork(IsolatedAsyncioTestCase):
             source_schedule_id="schedule-provenance",
             session_id="schedule-provenance-session",
         )
-        with self.assertRaises(SessionForkConflictError):
+        with self.assertRaises(SessionForkCorruptedGraphError):
             await self.storage.fork_session(
                 self.user_id,
                 self.agent_id,
@@ -313,6 +281,21 @@ class TestRegularSessionFork(IsolatedAsyncioTestCase):
 
     async def test_agent_mismatch_is_not_forkable(self) -> None:
         """The requested agent id is checked explicitly."""
+        with self.assertRaises(SessionForkNotFoundError):
+            await self.storage.fork_session(
+                self.user_id,
+                "different-agent",
+                self.source_id,
+            )
+
+    async def test_agent_mismatch_hides_corrupt_requested_index(self) -> None:
+        """An unrelated corrupt agent index does not change the 404 result."""
+        wrong_index_key = self.storage._key(
+            self.storage.key_config.session_index,
+            user_id=self.user_id,
+            agent_id="different-agent",
+        )
+        await self.storage._client.set(wrong_index_key, "wrong-type")
         with self.assertRaises(SessionForkNotFoundError):
             await self.storage.fork_session(
                 self.user_id,

--- a/tests/session_fork_team_storage_test.py
+++ b/tests/session_fork_team_storage_test.py
@@ -272,8 +272,8 @@ class TestTeamCreatedMemberFork(IsolatedAsyncioTestCase):
             {self.leader_agent_id},
         )
 
-    async def test_invited_member_is_conflict(self) -> None:
-        """The created-only phase rejects invited members."""
+    async def test_missing_invited_member_is_corrupted_graph(self) -> None:
+        """An invited member without its Agent is corrupted."""
         self.team.data.members = [
             TeamMember(
                 owner_id=self.user_id,
@@ -283,12 +283,110 @@ class TestTeamCreatedMemberFork(IsolatedAsyncioTestCase):
             ),
         ]
         await self.storage.upsert_team(self.user_id, self.team)
-        with self.assertRaises(SessionForkConflictError):
+        with self.assertRaises(SessionForkCorruptedGraphError):
             await self.storage.fork_session(
                 self.user_id,
                 self.leader_agent_id,
                 self.leader_session_id,
             )
+
+    async def test_invited_member_reuses_agent_and_owner_namespace(
+        self,
+    ) -> None:
+        """An invited Agent is reused while its Session is cloned."""
+        member_owner_id = "member-owner"
+        invited_agent = self._agent(
+            "invited-agent",
+            "invited-data",
+            "Invited",
+        ).model_copy(update={"user_id": member_owner_id, "source": "user"})
+        await self.storage.upsert_agent(member_owner_id, invited_agent)
+        standalone = await self.storage.upsert_session(
+            member_owner_id,
+            invited_agent.id,
+            make_config("Standalone"),
+            session_id="standalone-session",
+        )
+        source_team_session = await self.storage.upsert_session(
+            member_owner_id,
+            invited_agent.id,
+            make_config("Team Session"),
+            session_id="team-session",
+        )
+        await self.storage.set_session_team_id(
+            member_owner_id,
+            source_team_session.id,
+            self.team.id,
+        )
+        await self.storage.upsert_message(
+            member_owner_id,
+            source_team_session.id,
+            UserMsg(name="user", content=[TextBlock(text="history")]),
+        )
+        self.team.data.members = [
+            TeamMember(
+                owner_id=member_owner_id,
+                agent_id=invited_agent.id,
+                session_id=source_team_session.id,
+                role="invited",
+            ),
+        ]
+        self.team.data.member_ids = [invited_agent.id]
+        await self.storage.upsert_team(self.user_id, self.team)
+        owner_agent_index_before = await self.storage._client.smembers(
+            self.storage._key(
+                self.storage.key_config.agent_index,
+                user_id=member_owner_id,
+            ),
+        )
+
+        fork = await self.storage.fork_session(
+            self.user_id,
+            self.leader_agent_id,
+            self.leader_session_id,
+        )
+        fork_team = await self.storage.get_team(self.user_id, fork.team_id)
+        assert fork_team is not None
+        member = fork_team.data.members[0]
+        self.assertEqual(member.owner_id, member_owner_id)
+        self.assertEqual(member.agent_id, invited_agent.id)
+        self.assertNotEqual(member.session_id, standalone.id)
+        self.assertIsNone(standalone.team_id)
+        self.assertIsNotNone(
+            await self.storage.get_session(
+                member_owner_id,
+                invited_agent.id,
+                member.session_id,
+            ),
+        )
+        self.assertIsNone(
+            await self.storage.get_session(
+                self.user_id,
+                invited_agent.id,
+                member.session_id,
+            ),
+        )
+        self.assertEqual(
+            owner_agent_index_before,
+            await self.storage._client.smembers(
+                self.storage._key(
+                    self.storage.key_config.agent_index,
+                    user_id=member_owner_id,
+                ),
+            ),
+        )
+        self.assertEqual(
+            await self.storage.list_messages(
+                member_owner_id,
+                member.session_id,
+                limit=10,
+            ),
+            await self.storage.list_messages(
+                member_owner_id,
+                source_team_session.id,
+                limit=10,
+            ),
+        )
 
     async def test_worker_is_conflict(self) -> None:
         """A created worker Session cannot be forked as a Team root."""

--- a/tests/session_fork_team_storage_test.py
+++ b/tests/session_fork_team_storage_test.py
@@ -1,0 +1,612 @@
+# -*- coding: utf-8 -*-
+"""Storage Fork tests for Teams with created members."""
+# pylint: disable=protected-access
+
+from unittest import IsolatedAsyncioTestCase
+from itertools import cycle
+from typing import Any
+
+from _storage_test_helpers import make_config, make_storage
+from redis.exceptions import ResponseError, WatchError
+
+from agentscope._utils import _common
+from agentscope.agent import ContextConfig, ReActConfig
+import agentscope.app.storage._utils as storage_utils
+from agentscope.app.storage import (
+    AgentData,
+    AgentRecord,
+    SessionForkConflictError,
+    SessionForkCorruptedGraphError,
+    SessionSource,
+    TeamData,
+    TeamMember,
+    TeamRecord,
+)
+from agentscope.message import TextBlock, UserMsg
+from agentscope.state import AgentState
+
+
+class TestTeamCreatedMemberFork(IsolatedAsyncioTestCase):
+    """Verify complete Team Graph cloning for created members."""
+
+    async def asyncSetUp(self) -> None:
+        self.storage = make_storage(key_ttl=60)
+        self.user_id = "user-1"
+        self.leader_agent_id = "leader-agent"
+        self.leader_session_id = "leader-session"
+        await self.storage.upsert_agent(
+            self.user_id,
+            self._agent(self.leader_agent_id, "leader-data", "leader"),
+        )
+        await self.storage.upsert_session(
+            self.user_id,
+            self.leader_agent_id,
+            make_config("Leader"),
+            state=AgentState(),
+            session_id=self.leader_session_id,
+        )
+        self.team = TeamRecord(
+            user_id=self.user_id,
+            session_id=self.leader_session_id,
+            data=TeamData(name="Team", description="Description"),
+        )
+        await self.storage.upsert_team(self.user_id, self.team)
+        await self.storage.set_session_team_id(
+            self.user_id,
+            self.leader_session_id,
+            self.team.id,
+        )
+
+    @staticmethod
+    def _agent(agent_id: str, data_id: str, name: str) -> AgentRecord:
+        """Build a complete AgentRecord for a graph fixture."""
+        return AgentRecord(
+            id=agent_id,
+            user_id="user-1",
+            source="team" if name != "leader" else "user",
+            data=AgentData(
+                id=data_id,
+                name=name,
+                system_prompt=f"Prompt for {name}",
+                context_config=ContextConfig(),
+                react_config=ReActConfig(),
+            ),
+        )
+
+    async def _add_member(
+        self,
+        agent_id: str,
+        data_id: str,
+        session_id: str,
+        name: str,
+    ) -> None:
+        """Add one created member and append its Team roster entry."""
+        await self.storage.upsert_agent(
+            self.user_id,
+            self._agent(agent_id, data_id, name),
+        )
+        await self.storage.upsert_session(
+            self.user_id,
+            agent_id,
+            make_config(name),
+            state=AgentState(),
+            session_id=session_id,
+        )
+        await self.storage.set_session_team_id(
+            self.user_id,
+            session_id,
+            self.team.id,
+        )
+        self.team.data.members.append(
+            TeamMember(
+                owner_id=self.user_id,
+                agent_id=agent_id,
+                session_id=session_id,
+                role="created",
+            ),
+        )
+        self.team.data.member_ids.append(agent_id)
+        await self.storage.upsert_team(self.user_id, self.team)
+
+    async def test_fork_copies_leader_and_created_graph(self) -> None:
+        """Fork all Team resources and rewrite every graph identity."""
+        await self._add_member(
+            "member-agent",
+            "member-data",
+            "member-session",
+            "Member",
+        )
+        await self.storage.upsert_message(
+            self.user_id,
+            self.leader_session_id,
+            UserMsg(name="user", content=[TextBlock(text="leader")]),
+        )
+        await self.storage.upsert_message(
+            self.user_id,
+            "member-session",
+            UserMsg(name="user", content=[TextBlock(text="member")]),
+        )
+
+        fork = await self.storage.fork_session(
+            self.user_id,
+            self.leader_agent_id,
+            self.leader_session_id,
+        )
+        self.assertNotEqual(fork.id, self.leader_session_id)
+        self.assertEqual(fork.agent_id, self.leader_agent_id)
+        self.assertEqual(fork.source, SessionSource.USER)
+        self.assertIsNone(fork.source_schedule_id)
+        self.assertEqual(fork.config.name, "Leader (Fork)")
+
+        fork_team = await self.storage.get_team(self.user_id, fork.team_id)
+        assert fork_team is not None
+        self.assertEqual(fork_team.session_id, fork.id)
+        self.assertEqual(
+            fork_team.data.member_ids,
+            [
+                fork_team.data.members[0].agent_id,
+            ],
+        )
+        self.assertNotEqual(fork_team.id, self.team.id)
+
+        member = fork_team.data.members[0]
+        self.assertNotEqual(member.agent_id, "member-agent")
+        self.assertNotEqual(member.session_id, "member-session")
+        agent = await self.storage.get_agent(self.user_id, member.agent_id)
+        member_session = await self.storage.get_session(
+            self.user_id,
+            member.agent_id,
+            member.session_id,
+        )
+        assert agent is not None
+        assert member_session is not None
+        self.assertEqual(agent.id, member.agent_id)
+        self.assertNotEqual(agent.data.id, "member-data")
+        self.assertEqual(member_session.team_id, fork_team.id)
+        self.assertEqual(member_session.agent_id, agent.id)
+        self.assertEqual(member_session.config.name, "Member")
+        owner_agent_index = await self.storage._client.smembers(
+            self.storage._key(
+                self.storage.key_config.agent_index,
+                user_id=self.user_id,
+            ),
+        )
+        self.assertIn(member.agent_id, owner_agent_index)
+        self.assertIn(self.leader_agent_id, owner_agent_index)
+        self.assertIn(
+            fork_team.id,
+            await self.storage._client.smembers(
+                self.storage._key(
+                    self.storage.key_config.team_index,
+                    user_id=self.user_id,
+                ),
+            ),
+        )
+        self.assertIn(
+            fork.id,
+            await self.storage._client.smembers(
+                self.storage._key(
+                    self.storage.key_config.session_index,
+                    user_id=self.user_id,
+                    agent_id=self.leader_agent_id,
+                ),
+            ),
+        )
+        self.assertIn(
+            member.session_id,
+            await self.storage._client.smembers(
+                self.storage._key(
+                    self.storage.key_config.session_index,
+                    user_id=self.user_id,
+                    agent_id=member.agent_id,
+                ),
+            ),
+        )
+        self.assertEqual(
+            await self.storage.list_messages(
+                self.user_id,
+                fork.id,
+                limit=10,
+            ),
+            await self.storage.list_messages(
+                self.user_id,
+                self.leader_session_id,
+                limit=10,
+            ),
+        )
+        self.assertEqual(
+            await self.storage.list_messages(
+                self.user_id,
+                member.session_id,
+                limit=10,
+            ),
+            await self.storage.list_messages(
+                self.user_id,
+                "member-session",
+                limit=10,
+            ),
+        )
+        self.assertGreater(
+            await self.storage._client.ttl(
+                self.storage._key(
+                    self.storage.key_config.team,
+                    user_id=self.user_id,
+                    team_id=fork_team.id,
+                ),
+            ),
+            0,
+        )
+
+        fork.config.chat_model_config.parameters["temperature"] = 0.9
+        fork.state.cur_iter = 3
+        source = await self.storage.get_session(
+            self.user_id,
+            self.leader_agent_id,
+            self.leader_session_id,
+        )
+        assert source is not None
+        self.assertEqual(
+            source.config.chat_model_config.parameters["temperature"],
+            0.2,
+        )
+        self.assertEqual(source.state.cur_iter, 0)
+
+    async def test_empty_team_has_no_member_index_or_empty_sadd(self) -> None:
+        """An empty Team creates no member Agent or Session indexes."""
+        fork = await self.storage.fork_session(
+            self.user_id,
+            self.leader_agent_id,
+            self.leader_session_id,
+        )
+        fork_team = await self.storage.get_team(self.user_id, fork.team_id)
+        assert fork_team is not None
+        self.assertEqual(fork_team.data.members, [])
+        self.assertEqual(fork_team.data.member_ids, [])
+        self.assertEqual(
+            await self.storage._client.smembers(
+                self.storage._key(
+                    self.storage.key_config.agent_index,
+                    user_id=self.user_id,
+                ),
+            ),
+            {self.leader_agent_id},
+        )
+
+    async def test_invited_member_is_conflict(self) -> None:
+        """The created-only phase rejects invited members."""
+        self.team.data.members = [
+            TeamMember(
+                owner_id=self.user_id,
+                agent_id="invited-agent",
+                session_id="invited-session",
+                role="invited",
+            ),
+        ]
+        await self.storage.upsert_team(self.user_id, self.team)
+        with self.assertRaises(SessionForkConflictError):
+            await self.storage.fork_session(
+                self.user_id,
+                self.leader_agent_id,
+                self.leader_session_id,
+            )
+
+    async def test_worker_is_conflict(self) -> None:
+        """A created worker Session cannot be forked as a Team root."""
+        await self._add_member(
+            "member-agent",
+            "member-data",
+            "member-session",
+            "Member",
+        )
+        with self.assertRaises(SessionForkConflictError):
+            await self.storage.fork_session(
+                self.user_id,
+                "member-agent",
+                "member-session",
+            )
+
+    async def test_missing_team_is_corrupted_graph(self) -> None:
+        """A Team reference without a TeamRecord is corrupted."""
+        await self.storage.set_session_team_id(
+            self.user_id,
+            self.leader_session_id,
+            "missing-team",
+        )
+        with self.assertRaises(SessionForkCorruptedGraphError):
+            await self.storage.fork_session(
+                self.user_id,
+                self.leader_agent_id,
+                self.leader_session_id,
+            )
+
+    async def test_missing_member_agent_is_corrupted_graph(self) -> None:
+        """A Team member without its Agent record is corrupted."""
+        await self._add_member(
+            "member-agent",
+            "member-data",
+            "member-session",
+            "Member",
+        )
+        await self.storage._client.delete(
+            self.storage._key(
+                self.storage.key_config.agent,
+                user_id=self.user_id,
+                agent_id="member-agent",
+            ),
+        )
+        with self.assertRaises(SessionForkCorruptedGraphError):
+            await self.storage.fork_session(
+                self.user_id,
+                self.leader_agent_id,
+                self.leader_session_id,
+            )
+
+    async def test_target_collision_rebuilds_the_complete_plan(self) -> None:
+        """A target collision retries with a fresh Team and Session ID."""
+        collision_team_key = self.storage._key(
+            self.storage.key_config.team,
+            user_id=self.user_id,
+            team_id="collision-team",
+        )
+        await self.storage._client.set(collision_team_key, "occupied")
+        old_factory = _common._id_factory
+        ids = iter(
+            (
+                "collision-team",
+                "collision-session",
+                "fresh-team",
+                "fresh-session",
+            ),
+        )
+        _common.set_id_factory(lambda: next(ids))
+        try:
+            fork = await self.storage.fork_session(
+                self.user_id,
+                self.leader_agent_id,
+                self.leader_session_id,
+            )
+        finally:
+            _common.set_id_factory(old_factory)
+        self.assertEqual(fork.id, "fresh-session")
+        self.assertEqual(fork.team_id, "fresh-team")
+        self.assertEqual(
+            await self.storage._client.get(collision_team_key),
+            "occupied",
+        )
+
+    async def test_legacy_members_are_migrated_before_formal_read(
+        self,
+    ) -> None:
+        """The formal graph read sees the migrated member roster."""
+        await self.storage.upsert_agent(
+            self.user_id,
+            self._agent("legacy-agent", "legacy-data", "Legacy"),
+        )
+        await self.storage.upsert_session(
+            self.user_id,
+            "legacy-agent",
+            make_config("Legacy"),
+            session_id="legacy-session",
+        )
+        await self.storage.set_session_team_id(
+            self.user_id,
+            "legacy-session",
+            self.team.id,
+        )
+        self.team.data.member_ids = ["legacy-agent"]
+        self.team.data.members = []
+        await self.storage.upsert_team(self.user_id, self.team)
+
+        fork = await self.storage.fork_session(
+            self.user_id,
+            self.leader_agent_id,
+            self.leader_session_id,
+        )
+        fork_team = await self.storage.get_team(self.user_id, fork.team_id)
+        assert fork_team is not None
+        self.assertEqual(len(fork_team.data.members), 1)
+        self.assertEqual(
+            fork_team.data.member_ids,
+            [fork_team.data.members[0].agent_id],
+        )
+
+    async def test_two_created_members_are_fully_forked(self) -> None:
+        """Every created member in order receives a new Graph identity."""
+        await self._add_member(
+            "member-a",
+            "data-a",
+            "session-a",
+            "A",
+        )
+        await self._add_member(
+            "member-b",
+            "data-b",
+            "session-b",
+            "B",
+        )
+        fork = await self.storage.fork_session(
+            self.user_id,
+            self.leader_agent_id,
+            self.leader_session_id,
+        )
+        fork_team = await self.storage.get_team(self.user_id, fork.team_id)
+        assert fork_team is not None
+        self.assertEqual(len(fork_team.data.members), 2)
+        self.assertEqual(
+            fork_team.data.member_ids,
+            [member.agent_id for member in fork_team.data.members],
+        )
+        self.assertNotEqual(
+            [member.agent_id for member in fork_team.data.members],
+            ["member-a", "member-b"],
+        )
+
+    async def test_source_team_change_restarts_migration(self) -> None:
+        """A changed Team ID causes migration and reading to restart."""
+        team_b = TeamRecord(
+            user_id=self.user_id,
+            session_id=self.leader_session_id,
+            data=TeamData(name="Team B", member_ids=["member-b"]),
+        )
+        await self.storage.upsert_team(self.user_id, team_b)
+        await self.storage.upsert_agent(
+            self.user_id,
+            self._agent("member-b", "data-b", "B"),
+        )
+        await self.storage.upsert_session(
+            self.user_id,
+            "member-b",
+            make_config("B"),
+            session_id="session-b",
+        )
+        await self.storage.set_session_team_id(
+            self.user_id,
+            "session-b",
+            team_b.id,
+        )
+        original_ensure = storage_utils._ensure_team_members
+        changed = False
+
+        async def ensure_and_change(
+            storage: Any,
+            user_id: str,
+            team: TeamRecord,
+        ) -> list[TeamMember]:
+            nonlocal changed
+            result = await original_ensure(storage, user_id, team)
+            if not changed:
+                changed = True
+                source = await storage.get_session(
+                    self.user_id,
+                    self.leader_agent_id,
+                    self.leader_session_id,
+                )
+                assert source is not None
+                source.team_id = team_b.id
+                await storage._client.set(
+                    storage._key(
+                        storage.key_config.session,
+                        user_id=self.user_id,
+                        session_id=self.leader_session_id,
+                    ),
+                    source.model_dump_json(),
+                )
+            return result
+
+        storage_utils._ensure_team_members = ensure_and_change
+        try:
+            fork = await self.storage.fork_session(
+                self.user_id,
+                self.leader_agent_id,
+                self.leader_session_id,
+            )
+        finally:
+            storage_utils._ensure_team_members = original_ensure
+        fork_team = await self.storage.get_team(self.user_id, fork.team_id)
+        assert fork_team is not None
+        self.assertEqual(len(fork_team.data.members), 1)
+
+    async def test_exclusive_member_index_key_overlap_is_rejected(
+        self,
+    ) -> None:
+        """A new member Session Index cannot overlap another target Key."""
+        await self._add_member(
+            "member-agent",
+            "member-data",
+            "member-session",
+            "Member",
+        )
+        self.storage.key_config.session_index = "agentscope:collision"
+        old_factory = _common._id_factory
+        ids = cycle(("same", "leader-new", "same", "new-data", "new-session"))
+        _common.set_id_factory(lambda: next(ids))
+        try:
+            with self.assertRaises(SessionForkConflictError):
+                await self.storage.fork_session(
+                    self.user_id,
+                    self.leader_agent_id,
+                    self.leader_session_id,
+                )
+        finally:
+            _common.set_id_factory(old_factory)
+
+    async def test_shared_index_template_overlap_is_corrupted(self) -> None:
+        """Overlapping shared Index templates are rejected as corruption."""
+        self.storage.key_config.team_index = "agentscope:overlap"
+        self.storage.key_config.session_index = "agentscope:overlap"
+        with self.assertRaises(SessionForkCorruptedGraphError):
+            await self.storage.fork_session(
+                self.user_id,
+                self.leader_agent_id,
+                self.leader_session_id,
+            )
+
+    async def test_watch_error_rebuilds_team_pipeline(self) -> None:
+        """A transaction WatchError rebuilds the whole Team plan."""
+        original_pipeline = self.storage._client.pipeline
+        pipeline_count = 0
+        raised = False
+
+        class WatchOnce:
+            """Wrap one pipeline and fail its first execution."""
+
+            def __init__(self, inner: Any) -> None:
+                self.inner = inner
+
+            async def __aenter__(self) -> "WatchOnce":
+                await self.inner.__aenter__()
+                return self
+
+            async def __aexit__(self, *args: Any) -> Any:
+                """Close the wrapped pipeline."""
+                return await self.inner.__aexit__(*args)
+
+            async def execute(self, *args: Any, **kwargs: Any) -> Any:
+                """Raise once, then execute normally."""
+                nonlocal raised
+                if not raised:
+                    raised = True
+                    raise WatchError()
+                return await self.inner.execute(*args, **kwargs)
+
+            def __getattr__(self, name: str) -> Any:
+                return getattr(self.inner, name)
+
+        def pipeline(*args: Any, **kwargs: Any) -> WatchOnce:
+            nonlocal pipeline_count
+            pipeline_count += 1
+            return WatchOnce(original_pipeline(*args, **kwargs))
+
+        self.storage._client.pipeline = pipeline
+        try:
+            await self.storage.fork_session(
+                self.user_id,
+                self.leader_agent_id,
+                self.leader_session_id,
+            )
+        finally:
+            self.storage._client.pipeline = original_pipeline
+        self.assertEqual(pipeline_count, 2)
+
+    async def test_wrongtype_during_preread_retries(self) -> None:
+        """A pre-read WRONGTYPE retries before member migration."""
+        original_get = self.storage._client.get
+        raised = False
+
+        async def get_once(key: Any, *args: Any, **kwargs: Any) -> Any:
+            nonlocal raised
+            if not raised:
+                raised = True
+                raise ResponseError("WRONGTYPE concurrent change")
+            return await original_get(key, *args, **kwargs)
+
+        self.storage._client.get = get_once
+        try:
+            result = await self.storage.fork_session(
+                self.user_id,
+                self.leader_agent_id,
+                self.leader_session_id,
+            )
+        finally:
+            self.storage._client.get = original_get
+        self.assertIsNotNone(result.team_id)

--- a/tests/session_fork_team_storage_test.py
+++ b/tests/session_fork_team_storage_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Storage Fork tests for Teams with created members."""
-# pylint: disable=protected-access
+# pylint: disable=protected-access,too-many-public-methods
 
 from unittest import IsolatedAsyncioTestCase
 from itertools import cycle
@@ -11,7 +11,6 @@ from redis.exceptions import ResponseError, WatchError
 
 from agentscope._utils import _common
 from agentscope.agent import ContextConfig, ReActConfig
-import agentscope.app.storage._utils as storage_utils
 from agentscope.app.storage import (
     AgentData,
     AgentRecord,
@@ -333,6 +332,25 @@ class TestTeamCreatedMemberFork(IsolatedAsyncioTestCase):
         ]
         self.team.data.member_ids = [invited_agent.id]
         await self.storage.upsert_team(self.user_id, self.team)
+        standalone_before = await self.storage.get_session(
+            member_owner_id,
+            invited_agent.id,
+            standalone.id,
+        )
+        assert standalone_before is not None
+        standalone_index_key = self.storage._key(
+            self.storage.key_config.session_index,
+            user_id=member_owner_id,
+            agent_id=invited_agent.id,
+        )
+        standalone_index_before = await self.storage._client.smembers(
+            standalone_index_key,
+        )
+        standalone_messages_before = await self.storage._client.lrange(
+            self.storage._message_key(member_owner_id, standalone.id),
+            0,
+            -1,
+        )
         owner_agent_index_before = await self.storage._client.smembers(
             self.storage._key(
                 self.storage.key_config.agent_index,
@@ -351,7 +369,31 @@ class TestTeamCreatedMemberFork(IsolatedAsyncioTestCase):
         self.assertEqual(member.owner_id, member_owner_id)
         self.assertEqual(member.agent_id, invited_agent.id)
         self.assertNotEqual(member.session_id, standalone.id)
-        self.assertIsNone(standalone.team_id)
+        standalone_after = await self.storage.get_session(
+            member_owner_id,
+            invited_agent.id,
+            standalone.id,
+        )
+        assert standalone_after is not None
+        self.assertEqual(
+            standalone_after.model_dump_json(),
+            standalone_before.model_dump_json(),
+        )
+        standalone_index_after = await self.storage._client.smembers(
+            standalone_index_key,
+        )
+        self.assertEqual(
+            standalone_index_after,
+            standalone_index_before | {member.session_id},
+        )
+        self.assertEqual(
+            standalone_messages_before,
+            await self.storage._client.lrange(
+                self.storage._message_key(member_owner_id, standalone.id),
+                0,
+                -1,
+            ),
+        )
         self.assertIsNotNone(
             await self.storage.get_session(
                 member_owner_id,
@@ -387,6 +429,217 @@ class TestTeamCreatedMemberFork(IsolatedAsyncioTestCase):
                 limit=10,
             ),
         )
+
+    async def test_legacy_multiple_sessions_is_not_migrated(self) -> None:
+        """Reject legacy members when their Agent has multiple Sessions."""
+        member_agent_id = "legacy-agent"
+        self.team.data.members = []
+        self.team.data.member_ids = [member_agent_id]
+        await self.storage.upsert_agent(
+            self.user_id,
+            self._agent(member_agent_id, "legacy-data", "legacy"),
+        )
+        await self.storage.upsert_session(
+            self.user_id,
+            member_agent_id,
+            make_config("Legacy 1"),
+            session_id="legacy-session-1",
+        )
+        await self.storage.set_session_team_id(
+            self.user_id,
+            "legacy-session-1",
+            self.team.id,
+        )
+        await self.storage.upsert_session(
+            self.user_id,
+            member_agent_id,
+            make_config("Legacy 2"),
+            session_id="legacy-session-2",
+        )
+        await self.storage.set_session_team_id(
+            self.user_id,
+            "legacy-session-2",
+            self.team.id,
+        )
+        await self.storage.upsert_team(self.user_id, self.team)
+        before = await self.storage.get_team(self.user_id, self.team.id)
+        assert before is not None
+
+        with self.assertRaises(SessionForkCorruptedGraphError):
+            await self.storage.fork_session(
+                self.user_id,
+                self.leader_agent_id,
+                self.leader_session_id,
+            )
+
+        after = await self.storage.get_team(self.user_id, self.team.id)
+        assert after is not None
+        self.assertEqual(after.data.members, before.data.members)
+        self.assertEqual(after.data.member_ids, before.data.member_ids)
+
+    async def test_legacy_session_for_another_team_is_not_migrated(
+        self,
+    ) -> None:
+        """Reject a legacy member whose only Session belongs elsewhere."""
+        member_agent_id = "legacy-agent"
+        self.team.data.members = []
+        self.team.data.member_ids = [member_agent_id]
+        await self.storage.upsert_agent(
+            self.user_id,
+            self._agent(member_agent_id, "legacy-data", "legacy"),
+        )
+        await self.storage.upsert_session(
+            self.user_id,
+            member_agent_id,
+            make_config("Legacy"),
+            session_id="legacy-session",
+        )
+        other_team = TeamRecord(
+            user_id=self.user_id,
+            session_id=self.leader_session_id,
+            data=TeamData(name="Other Team"),
+        )
+        await self.storage.upsert_team(self.user_id, other_team)
+        await self.storage.set_session_team_id(
+            self.user_id,
+            "legacy-session",
+            other_team.id,
+        )
+        await self.storage.upsert_team(self.user_id, self.team)
+        before = await self.storage.get_team(self.user_id, self.team.id)
+        assert before is not None
+
+        with self.assertRaises(SessionForkCorruptedGraphError):
+            await self.storage.fork_session(
+                self.user_id,
+                self.leader_agent_id,
+                self.leader_session_id,
+            )
+
+        after = await self.storage.get_team(self.user_id, self.team.id)
+        assert after is not None
+        self.assertEqual(after.data.members, before.data.members)
+        self.assertEqual(after.data.member_ids, before.data.member_ids)
+
+    async def test_legacy_user_agent_is_not_migrated(self) -> None:
+        """Reject a legacy member whose Agent is not team-created."""
+        member_agent_id = "legacy-agent"
+        self.team.data.members = []
+        self.team.data.member_ids = [member_agent_id]
+        user_agent = self._agent(member_agent_id, "legacy-data", "leader")
+        await self.storage.upsert_agent(self.user_id, user_agent)
+        await self.storage.upsert_session(
+            self.user_id,
+            member_agent_id,
+            make_config("Legacy"),
+            session_id="legacy-session",
+        )
+        await self.storage.set_session_team_id(
+            self.user_id,
+            "legacy-session",
+            self.team.id,
+        )
+        await self.storage.upsert_team(self.user_id, self.team)
+        before = await self.storage.get_team(self.user_id, self.team.id)
+        assert before is not None
+
+        with self.assertRaises(SessionForkCorruptedGraphError):
+            await self.storage.fork_session(
+                self.user_id,
+                self.leader_agent_id,
+                self.leader_session_id,
+            )
+
+        after = await self.storage.get_team(self.user_id, self.team.id)
+        assert after is not None
+        self.assertEqual(after.data.members, before.data.members)
+        self.assertEqual(after.data.member_ids, before.data.member_ids)
+
+    async def test_legacy_duplicate_member_ids_are_not_migrated(self) -> None:
+        """Reject duplicate legacy ids without changing the Team."""
+        member_agent_id = "legacy-agent"
+        self.team.data.members = []
+        self.team.data.member_ids = [member_agent_id, member_agent_id]
+        await self.storage.upsert_agent(
+            self.user_id,
+            self._agent(member_agent_id, "legacy-data", "legacy"),
+        )
+        await self.storage.upsert_session(
+            self.user_id,
+            member_agent_id,
+            make_config("Legacy"),
+            session_id="legacy-session",
+        )
+        await self.storage.set_session_team_id(
+            self.user_id,
+            "legacy-session",
+            self.team.id,
+        )
+        await self.storage.upsert_team(self.user_id, self.team)
+        before = await self.storage.get_team(self.user_id, self.team.id)
+        assert before is not None
+
+        with self.assertRaises(SessionForkCorruptedGraphError):
+            await self.storage.fork_session(
+                self.user_id,
+                self.leader_agent_id,
+                self.leader_session_id,
+            )
+
+        after = await self.storage.get_team(self.user_id, self.team.id)
+        assert after is not None
+        self.assertEqual(after.data.members, [])
+        self.assertEqual(after.data.member_ids, before.data.member_ids)
+
+    async def test_legacy_agent_key_id_mismatch_is_not_migrated(self) -> None:
+        """Reject a legacy Agent whose payload id differs from its key."""
+        member_agent_id = "legacy-agent"
+        self.team.data.members = []
+        self.team.data.member_ids = [member_agent_id]
+        mismatched_agent = self._agent(
+            "different-agent",
+            "legacy-data",
+            "legacy",
+        )
+        await self.storage.upsert_agent(
+            self.user_id,
+            mismatched_agent.model_copy(update={"id": member_agent_id}),
+        )
+        raw_agent = mismatched_agent.model_dump_json()
+        await self.storage._client.set(
+            self.storage._key(
+                self.storage.key_config.agent,
+                user_id=self.user_id,
+                agent_id=member_agent_id,
+            ),
+            raw_agent,
+        )
+        await self.storage.upsert_session(
+            self.user_id,
+            member_agent_id,
+            make_config("Legacy"),
+            session_id="legacy-session",
+        )
+        await self.storage.set_session_team_id(
+            self.user_id,
+            "legacy-session",
+            self.team.id,
+        )
+        await self.storage.upsert_team(self.user_id, self.team)
+        before = await self.storage.get_team(self.user_id, self.team.id)
+        assert before is not None
+
+        with self.assertRaises(SessionForkCorruptedGraphError):
+            await self.storage.fork_session(
+                self.user_id,
+                self.leader_agent_id,
+                self.leader_session_id,
+            )
+
+        after = await self.storage.get_team(self.user_id, self.team.id)
+        assert after is not None
+        self.assertEqual(after.data.members, [])
+        self.assertEqual(after.data.member_ids, before.data.member_ids)
 
     async def test_worker_is_conflict(self) -> None:
         """A created worker Session cannot be forked as a Team root."""
@@ -562,28 +815,27 @@ class TestTeamCreatedMemberFork(IsolatedAsyncioTestCase):
             "session-b",
             team_b.id,
         )
-        original_ensure = storage_utils._ensure_team_members
+        original_ensure = self.storage._ensure_legacy_team_members_atomically
         changed = False
 
         async def ensure_and_change(
-            storage: Any,
             user_id: str,
-            team: TeamRecord,
-        ) -> list[TeamMember]:
+            team_id: str,
+        ) -> TeamRecord:
             nonlocal changed
-            result = await original_ensure(storage, user_id, team)
+            result = await original_ensure(user_id, team_id)
             if not changed:
                 changed = True
-                source = await storage.get_session(
+                source = await self.storage.get_session(
                     self.user_id,
                     self.leader_agent_id,
                     self.leader_session_id,
                 )
                 assert source is not None
                 source.team_id = team_b.id
-                await storage._client.set(
-                    storage._key(
-                        storage.key_config.session,
+                await self.storage._client.set(
+                    self.storage._key(
+                        self.storage.key_config.session,
                         user_id=self.user_id,
                         session_id=self.leader_session_id,
                     ),
@@ -591,7 +843,7 @@ class TestTeamCreatedMemberFork(IsolatedAsyncioTestCase):
                 )
             return result
 
-        storage_utils._ensure_team_members = ensure_and_change
+        self.storage._ensure_legacy_team_members_atomically = ensure_and_change
         try:
             fork = await self.storage.fork_session(
                 self.user_id,
@@ -599,7 +851,9 @@ class TestTeamCreatedMemberFork(IsolatedAsyncioTestCase):
                 self.leader_session_id,
             )
         finally:
-            storage_utils._ensure_team_members = original_ensure
+            self.storage._ensure_legacy_team_members_atomically = (
+                original_ensure
+            )
         fork_team = await self.storage.get_team(self.user_id, fork.team_id)
         assert fork_team is not None
         self.assertEqual(len(fork_team.data.members), 1)
@@ -684,7 +938,7 @@ class TestTeamCreatedMemberFork(IsolatedAsyncioTestCase):
             )
         finally:
             self.storage._client.pipeline = original_pipeline
-        self.assertEqual(pipeline_count, 2)
+        self.assertGreaterEqual(pipeline_count, 3)
 
     async def test_wrongtype_during_preread_retries(self) -> None:
         """A pre-read WRONGTYPE retries before member migration."""


### PR DESCRIPTION
## AgentScope Version

`2.0.4.dev0`

## Related Issue

Fixes #2041

## Background

AgentScope did not previously provide an end-to-end way to fork an existing session.

This PR adds session forking across the storage, service, API, and Web UI layers. A fork preserves the persisted session configuration, state, and message history while creating independent session records with new identities.

## What Changed

### Storage

* Added regular Session Fork support.
* Added Schedule Session Fork support.

  * Forked Schedule Sessions become normal user-created Sessions.
  * `source_schedule_id` is cleared.
* Added Team Session Fork support.

  * Supports Teams with created members.
  * Supports Teams with invited members.
  * Supports mixed created and invited members.
* Creates a new Team when forking a Team Leader Session.
* Clones created member Agents and creates new member Sessions.
* Reuses invited Agent records and Agent data while creating new owner-scoped Team Sessions.
* Preserves message history and existing TTL behavior.
* Uses Redis `WATCH` and `MULTI/EXEC` for optimistic concurrency control.
* Validates source graph identity, ownership, provenance, indexes, and key types.
* Detects target key collisions and rebuilds the complete Fork plan when required.
* Adds atomic and validated migration for legacy Team `member_ids`.

### Team Invitation

* Fixed invited Agent owner namespace handling.
* Keeps the invited Agent's standalone Session unchanged.
* Creates a separate Team-scoped Session under the invited Agent owner namespace.
* Does not modify the invited Agent index.

### Service

* Added `SessionService.fork_session()`.
* Validates Session ownership before reading runtime status.
* Rejects cross-user and cross-Agent requests as not found.
* Requires the source Session to be idle before invoking the Storage Fork operation.
* Checks normalized Team member statuses before forking a Team Leader.
* Leaves Team Worker and corrupted graph decisions to the Storage layer.
* Reads MessageBus run locks only for status checks.
* Does not copy or modify MessageBus runtime state.

### API

Added the following endpoint:

`POST /sessions/{session_id}/fork?agent_id={agent_id}`

Successful requests return `201 Created` with:

`{"session_id": "new-session-id"}`

Error mapping:

* Inaccessible or missing Session: `404 Not Found`
* Running, waiting, or unsupported Fork: `409 Conflict`
* Corrupted persisted graph: `500 Internal Server Error`

Internal Redis and graph error details are logged on the server and are not exposed to clients.

### Frontend

* Added “Fork” / “创建副本” to the Session menu.
* Calls the new Fork endpoint using the currently selected Agent.
* Refreshes the Session list after a successful Fork.
* Navigates directly to the newly created Session.
* Prevents duplicate Fork requests while a Fork is in progress.
* Keeps Team Leader, Worker, Schedule, and ownership decisions on the backend.

## Fork Semantics

* Each forked Session receives a new Session ID.
* Forked records are independent from the source records.
* Persisted messages are copied.
* Existing `workspace_id` references are preserved, so Workspace files remain shared.
* Schedule provenance is not inherited.
* Team Worker Sessions cannot be forked directly.
* Invited Agents are reused rather than cloned.
* MessageBus events, inboxes, locks, cancellation state, and transient runtime state are not copied.

## Safety and Consistency

* Cross-user Fork requests are rejected.
* Cross-Agent Fork requests are rejected.
* Team Worker Fork requests are rejected.
* Team Leader Fork requires the root Session and all normalized members to be idle.
* Source records are protected by Redis optimistic locking.
* Target records, messages, and indexes are validated before commit.
* Redis key physical types and business index categories are validated separately.
* Corrupted legacy Team graphs are rejected without modifying the source Team.
* Serialization and complete Fork planning occur before `MULTI`.

## Tests

* Service and Router tests: 20 passed
* Storage Fork regression tests: 47 passed
* RedisStorage regression tests: 56 passed
* Frontend format check: passed
* Frontend production build: passed
* ESLint: 0 errors, 16 pre-existing warnings
* pre-commit: passed
* `git diff --check`: passed

## Manual Validation

Verified:

* Regular Session menu displays the Fork action.
* Successful Fork returns `201` and a new Session ID.
* The UI navigates to the newly created Session.
* Forked messages match the source Session.
* Updating the Forked Session does not modify the source Session.
* Schedule Session Fork succeeds and is detached from its Schedule.
* Idle Team Leader Fork succeeds.
* Team Worker Fork returns `409`.
* Permission-waiting and external-result-waiting Sessions return `409`.
* Cross-user and cross-Agent requests return `404`.
* Rejected repeated requests do not create duplicate Sessions.
* Fork creates no copied MessageBus events, inboxes, locks, cancellation channels, or other transient runtime state.

A real running Agent was not manually triggered during validation. The `RUNNING` rejection path was not exercised manually, but is covered by automated Service tests.
