### PR TITLE
fix(agent): prevent cross-message tool_call/tool_result orphan in context compression

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -2073,6 +2073,44 @@ class Agent:
         if len(boundary_msg_to_reserve.content) > 0:
             msgs_to_reserve = [boundary_msg_to_reserve] + msgs_to_reserve
 
+        # ── Cross-message orphan detection ──
+        # The boundary-message pairing guard above only protects
+        # tool_call/tool_result pairs *within* the same message.  When
+        # tool_call and tool_result are in different messages (flat
+        # timeline format), a tool_result message can still be orphaned
+        # because its tool_call was evicted into msgs_to_compress.
+        # Move orphaned tool_result messages to msgs_to_compress so
+        # pairing is preserved and the model never sees orphans.
+        compress_tc_ids: set[str] = set()
+        for msg in msgs_to_compress:
+            for block in msg.get_content_blocks("tool_call"):
+                if isinstance(block, ToolCallBlock):
+                    compress_tc_ids.add(block.id)
+
+        if compress_tc_ids:
+            reserve_tc_ids: set[str] = set()
+            for msg in msgs_to_reserve:
+                for block in msg.get_content_blocks("tool_call"):
+                    if isinstance(block, ToolCallBlock):
+                        reserve_tc_ids.add(block.id)
+
+            still_reserve: list[Msg] = []
+            for msg in msgs_to_reserve:
+                is_orphan = False
+                for block in msg.get_content_blocks("tool_result"):
+                    if (
+                        isinstance(block, ToolResultBlock)
+                        and block.id in compress_tc_ids
+                        and block.id not in reserve_tc_ids
+                    ):
+                        is_orphan = True
+                        break
+                if is_orphan:
+                    msgs_to_compress.append(msg)
+                else:
+                    still_reserve.append(msg)
+            msgs_to_reserve = still_reserve
+
         return msgs_to_compress, msgs_to_reserve
 
     async def _clear_unreserved_read_cache(


### PR DESCRIPTION
## Problem

`_split_context_for_compression` only guarantees intra-message (block-level) `tool_call`/`tool_result` pairing at the boundary message. When `tool_call` and `tool_result` are in **different** flat-timeline messages, a `tool_result` message can be orphaned — its `tool_call` was evicted into `msgs_to_compress` but the orphan stays in `msgs_to_reserve` until it hits the model API.

This causes downstream consumers (e.g. QwenPaw) to receive:
```
400 - Messages with role "tool" must be a response to a preceding message with "tool_calls"
```

Reported upstream: [QwenPaw #5986](https://github.com/agentscope-ai/QwenPaw/issues/5986)

## Fix

After the existing boundary-message block-pairing guard, add **cross-message orphan detection**:

1. Collect all `tool_call` IDs from `msgs_to_compress`
2. Collect all `tool_call` IDs from `msgs_to_reserve`
3. Scan `msgs_to_reserve` for `tool_result` blocks whose ID is in `compress_tc_ids` but NOT in `reserve_tc_ids` → orphan
4. Move orphan messages to `msgs_to_compress`

Safe because it only moves messages **from** reserve **to** compress (never the reverse), preserving token budget and pairing integrity.

## Defense layers (combined with QwenPaw #5989)

| Layer | Where | What |
|-------|-------|------|
| **1** (this PR) | AgentScope `_split_context_for_compression` | Prevent split-time break |
| 2 | QwenPaw `manager.py` | Post-split tail sanitize |
| 3 | QwenPaw `react_agent.py` `compress_context()` | Pre-reasoning guard |
| 4 | QwenPaw `react_agent.py` `load_state_dict()` | Session restore sanitize |