### PR TITLE
feat(service): add workspace artifact browser

### DIFF
--- a/examples/web_ui/frontend/src/api/artifact.ts
+++ b/examples/web_ui/frontend/src/api/artifact.ts
@@ -1,0 +1,20 @@
+import { client } from './client';
+import type { ListArtifactsResponse } from './types';
+
+export const artifactApi = {
+	list: async (agentId: string, sessionId: string, path = '.') => {
+		const response = await client.get<ListArtifactsResponse>('/workspace/artifacts', {
+			agent_id: agentId,
+			session_id: sessionId,
+			path,
+		});
+		return response.artifacts;
+	},
+
+	content: (agentId: string, sessionId: string, path: string) =>
+		client.response('/workspace/artifacts/content', {
+			agent_id: agentId,
+			session_id: sessionId,
+			path,
+		}),
+};

--- a/examples/web_ui/frontend/src/api/client.ts
+++ b/examples/web_ui/frontend/src/api/client.ts
@@ -114,6 +114,8 @@ export const client = {
 	) => request<T>(path, { method: 'PATCH', body, params, silent: options?.silent }),
 	delete: <T = void>(path: string, params?: Record<string, string>) =>
 		request<T>(path, { method: 'DELETE', params }),
+	response: (path: string, params?: Record<string, string>) =>
+		streamRequest(path, { method: 'GET', params }),
 	stream: (path: string, options?: RequestOptions & { signal?: AbortSignal }) =>
 		streamRequest(path, options),
 };

--- a/examples/web_ui/frontend/src/api/index.ts
+++ b/examples/web_ui/frontend/src/api/index.ts
@@ -1,6 +1,7 @@
 export * from './types';
 export { agentApi } from './agent';
 export { sessionApi } from './session';
+export { artifactApi } from './artifact';
 export { credentialApi } from './credential';
 export { chatApi } from './chat';
 export { workspaceApi } from './workspace';

--- a/examples/web_ui/frontend/src/api/types.ts
+++ b/examples/web_ui/frontend/src/api/types.ts
@@ -405,6 +405,21 @@ export interface AddSkillRequest {
 	skill_path: string;
 }
 
+// ─── Artifacts ────────────────────────────────────────────────────────────────
+
+export interface ArtifactEntry {
+	name: string;
+	path: string;
+	is_directory: boolean;
+	media_type: string | null;
+	modified_at: number | null;
+}
+
+export interface ListArtifactsResponse {
+	artifacts: ArtifactEntry[];
+	total: number;
+}
+
 // ─── Schedule ─────────────────────────────────────────────────────────────────
 
 export type PermissionMode =

--- a/examples/web_ui/frontend/src/components/panel/ArtifactPanel.tsx
+++ b/examples/web_ui/frontend/src/components/panel/ArtifactPanel.tsx
@@ -1,0 +1,326 @@
+import {
+	AlertTriangle,
+	ChevronDown,
+	ChevronRight,
+	Download,
+	File,
+	FileSearch,
+	Folder,
+	FolderOpen,
+	LoaderCircle,
+	RefreshCw,
+} from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { artifactApi, type ArtifactEntry } from '@/api';
+import { PanelEmpty } from '@/components/panel/PanelEmpty';
+import { Button } from '@/components/ui/button';
+import { useTranslation } from '@/i18n/useI18n';
+
+interface ArtifactPanelProps {
+	agentId: string | null;
+	sessionId: string | null;
+}
+
+interface ArtifactPreview {
+	entry: ArtifactEntry;
+	mediaType: string;
+	url: string;
+	text: string | null;
+}
+
+const ROOT_PATH = '.';
+
+function isTextMediaType(mediaType: string): boolean {
+	return (
+		mediaType.startsWith('text/') ||
+		/(json|javascript|xml|yaml|toml|x-python|x-shellscript)/.test(mediaType)
+	);
+}
+
+export function ArtifactPanel({ agentId, sessionId }: ArtifactPanelProps) {
+	const { t } = useTranslation();
+	const [directories, setDirectories] = useState<Record<string, ArtifactEntry[]>>({});
+	const [expanded, setExpanded] = useState<Set<string>>(new Set());
+	const [loadingDirectories, setLoadingDirectories] = useState<Set<string>>(new Set());
+	const [selectedPath, setSelectedPath] = useState<string | null>(null);
+	const [preview, setPreview] = useState<ArtifactPreview | null>(null);
+	const [previewLoading, setPreviewLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const previewRequest = useRef(0);
+	const previewUrl = useRef<string | null>(null);
+
+	const clearPreviewUrl = useCallback(() => {
+		if (previewUrl.current) URL.revokeObjectURL(previewUrl.current);
+		previewUrl.current = null;
+	}, []);
+
+	const loadDirectory = useCallback(
+		async (path: string) => {
+			if (!agentId || !sessionId) return;
+			setLoadingDirectories((current) => new Set(current).add(path));
+			setError(null);
+			try {
+				const entries = await artifactApi.list(agentId, sessionId, path);
+				setDirectories((current) => ({ ...current, [path]: entries }));
+			} catch (reason) {
+				setError(reason instanceof Error ? reason.message : String(reason));
+			} finally {
+				setLoadingDirectories((current) => {
+					const next = new Set(current);
+					next.delete(path);
+					return next;
+				});
+			}
+		},
+		[agentId, sessionId],
+	);
+
+	useEffect(() => {
+		previewRequest.current += 1;
+		clearPreviewUrl();
+		setDirectories({});
+		setExpanded(new Set());
+		setSelectedPath(null);
+		setPreview(null);
+		setError(null);
+		if (agentId && sessionId) void loadDirectory(ROOT_PATH);
+	}, [agentId, sessionId, clearPreviewUrl, loadDirectory]);
+
+	useEffect(() => clearPreviewUrl, [clearPreviewUrl]);
+
+	const toggleDirectory = useCallback(
+		(entry: ArtifactEntry) => {
+			setExpanded((current) => {
+				const next = new Set(current);
+				if (next.has(entry.path)) next.delete(entry.path);
+				else next.add(entry.path);
+				return next;
+			});
+			if (!directories[entry.path]) void loadDirectory(entry.path);
+		},
+		[directories, loadDirectory],
+	);
+
+	const selectFile = useCallback(
+		async (entry: ArtifactEntry) => {
+			if (!agentId || !sessionId) return;
+			const requestId = ++previewRequest.current;
+			setSelectedPath(entry.path);
+			setPreviewLoading(true);
+			setError(null);
+			try {
+				const response = await artifactApi.content(agentId, sessionId, entry.path);
+				const blob = await response.blob();
+				if (requestId !== previewRequest.current) return;
+				clearPreviewUrl();
+				const url = URL.createObjectURL(blob);
+				previewUrl.current = url;
+				const mediaType = blob.type || entry.media_type || 'application/octet-stream';
+				const text = isTextMediaType(mediaType) ? await blob.text() : null;
+				if (requestId !== previewRequest.current) {
+					URL.revokeObjectURL(url);
+					return;
+				}
+				setPreview({ entry, mediaType, url, text });
+			} catch (reason) {
+				if (requestId === previewRequest.current) {
+					setPreview(null);
+					setError(reason instanceof Error ? reason.message : String(reason));
+				}
+			} finally {
+				if (requestId === previewRequest.current) setPreviewLoading(false);
+			}
+		},
+		[agentId, sessionId, clearPreviewUrl],
+	);
+
+	const downloadPreview = useCallback(() => {
+		if (!preview) return;
+		const anchor = document.createElement('a');
+		anchor.href = preview.url;
+		anchor.download = preview.entry.name;
+		anchor.click();
+	}, [preview]);
+
+	const refresh = useCallback(() => {
+		setDirectories({});
+		setExpanded(new Set());
+		if (agentId && sessionId) void loadDirectory(ROOT_PATH);
+	}, [agentId, sessionId, loadDirectory]);
+
+	const renderEntries = (entries: ArtifactEntry[], depth = 0) =>
+		entries.map((entry) => {
+			const isExpanded = expanded.has(entry.path);
+			const isLoading = loadingDirectories.has(entry.path);
+			return (
+				<div key={entry.path}>
+					<button
+						type="button"
+						className="flex h-8 w-full items-center gap-1.5 rounded-sm pr-2 text-left text-sm hover:bg-accent data-[selected=true]:bg-accent"
+						style={{ paddingLeft: `${depth * 16 + 4}px` }}
+						data-selected={!entry.is_directory && selectedPath === entry.path}
+						aria-expanded={entry.is_directory ? isExpanded : undefined}
+						onClick={() =>
+							entry.is_directory ? toggleDirectory(entry) : void selectFile(entry)
+						}
+					>
+						{entry.is_directory ? (
+							isLoading ? (
+								<LoaderCircle className="size-3.5 shrink-0 animate-spin" />
+							) : isExpanded ? (
+								<ChevronDown className="size-3.5 shrink-0" />
+							) : (
+								<ChevronRight className="size-3.5 shrink-0" />
+							)
+						) : (
+							<span className="size-3.5 shrink-0" />
+						)}
+						{entry.is_directory ? (
+							isExpanded ? (
+								<FolderOpen className="size-4 shrink-0 text-amber-600" />
+							) : (
+								<Folder className="size-4 shrink-0 text-amber-600" />
+							)
+						) : (
+							<File className="size-4 shrink-0 text-muted-foreground" />
+						)}
+						<span className="truncate">{entry.name}</span>
+					</button>
+					{entry.is_directory && isExpanded && directories[entry.path]
+						? renderEntries(directories[entry.path], depth + 1)
+						: null}
+				</div>
+			);
+		});
+
+	const renderPreview = () => {
+		if (previewLoading) {
+			return <LoaderCircle className="size-5 animate-spin text-muted-foreground" />;
+		}
+		if (error) {
+			return (
+				<PanelEmpty
+					icon={AlertTriangle}
+					title={t('panel.artifact.errorTitle')}
+					description={error}
+				/>
+			);
+		}
+		if (!preview) {
+			return (
+				<PanelEmpty
+					icon={FileSearch}
+					title={t('panel.artifact.emptyPreviewTitle')}
+					description={t('panel.artifact.emptyPreviewDescription')}
+				/>
+			);
+		}
+		if (preview.text !== null) {
+			return (
+				<pre className="size-full overflow-auto whitespace-pre-wrap break-words p-3 font-mono text-xs">
+					{preview.text}
+				</pre>
+			);
+		}
+		if (preview.mediaType.startsWith('image/')) {
+			return (
+				<img
+					src={preview.url}
+					alt={preview.entry.name}
+					className="max-h-full max-w-full object-contain"
+				/>
+			);
+		}
+		if (preview.mediaType.startsWith('audio/')) {
+			return <audio controls src={preview.url} className="w-full" />;
+		}
+		if (preview.mediaType.startsWith('video/')) {
+			return <video controls src={preview.url} className="max-h-full max-w-full" />;
+		}
+		if (preview.mediaType === 'application/pdf') {
+			return (
+				<iframe
+					title={preview.entry.name}
+					src={preview.url}
+					className="size-full border-0"
+				/>
+			);
+		}
+		return (
+			<div className="flex flex-col items-center gap-3 text-muted-foreground">
+				<File className="size-8" />
+				<span className="text-xs">{preview.mediaType}</span>
+				<Button variant="outline" size="sm" onClick={downloadPreview}>
+					<Download />
+					{t('panel.artifact.download')}
+				</Button>
+			</div>
+		);
+	};
+
+	const rootLoading = loadingDirectories.has(ROOT_PATH);
+	const rootEntries = directories[ROOT_PATH] ?? [];
+
+	return (
+		<div className="grid min-h-0 flex-1 grid-rows-[minmax(10rem,40%)_minmax(0,1fr)]">
+			<section className="flex min-h-0 flex-col border-b pb-2">
+				<div className="flex h-8 shrink-0 items-center justify-between">
+					<span className="truncate text-xs text-muted-foreground">
+						{t('panel.artifact.workspaceFiles')}
+					</span>
+					<Button
+						variant="ghost"
+						size="icon-sm"
+						title={t('panel.artifact.refresh')}
+						disabled={!agentId || !sessionId || rootLoading}
+						onClick={refresh}
+					>
+						<RefreshCw className={rootLoading ? 'animate-spin' : undefined} />
+					</Button>
+				</div>
+				<div className="min-h-0 flex-1 overflow-auto">
+					{rootLoading && rootEntries.length === 0 ? (
+						<div className="flex size-full items-center justify-center">
+							<LoaderCircle className="size-5 animate-spin text-muted-foreground" />
+						</div>
+					) : !agentId || !sessionId ? (
+						<PanelEmpty
+							icon={Folder}
+							title={t('panel.artifact.noSessionTitle')}
+							description={t('panel.artifact.noSessionDescription')}
+						/>
+					) : rootEntries.length === 0 ? (
+						<PanelEmpty
+							icon={Folder}
+							title={t('panel.artifact.emptyTitle')}
+							description={t('panel.artifact.emptyDescription')}
+						/>
+					) : (
+						renderEntries(rootEntries)
+					)}
+				</div>
+			</section>
+			<section className="flex min-h-0 flex-col pt-2">
+				<div className="flex h-8 shrink-0 items-center justify-between gap-2 border-b px-1">
+					<span className="truncate text-xs font-medium">
+						{preview?.entry.path ?? t('panel.artifact.preview')}
+					</span>
+					{preview ? (
+						<Button
+							variant="ghost"
+							size="icon-sm"
+							title={t('panel.artifact.download')}
+							onClick={downloadPreview}
+						>
+							<Download />
+						</Button>
+					) : null}
+				</div>
+				<div className="flex min-h-0 flex-1 items-center justify-center overflow-hidden">
+					{renderPreview()}
+				</div>
+			</section>
+		</div>
+	);
+}

--- a/examples/web_ui/frontend/src/components/panel/PanelDock.tsx
+++ b/examples/web_ui/frontend/src/components/panel/PanelDock.tsx
@@ -13,7 +13,7 @@ import { Separator } from '@/components/ui/separator';
  * Identifier for a dockable panel. Used both as the React key and to
  * look its descriptor up in {@link PanelDockProps.panels}.
  */
-export type PanelKey = 'plan' | 'mcp' | 'skill' | 'permission' | 'knowledge';
+export type PanelKey = 'plan' | 'mcp' | 'skill' | 'permission' | 'knowledge' | 'artifact';
 
 /**
  * The presentation of a single panel: header chrome plus its already

--- a/examples/web_ui/frontend/src/i18n/locales/en.json
+++ b/examples/web_ui/frontend/src/i18n/locales/en.json
@@ -562,6 +562,20 @@
 			"parametersDescription": "Knowledge base retrieval settings.",
 			"selectedCount": "{{count}} attached"
 		},
+		"artifact": {
+			"title": "Artifacts",
+			"workspaceFiles": "Workspace files",
+			"preview": "Preview",
+			"refresh": "Refresh artifacts",
+			"download": "Download",
+			"emptyTitle": "No artifacts",
+			"emptyDescription": "Files created in this workspace will appear here.",
+			"emptyPreviewTitle": "Select a file",
+			"emptyPreviewDescription": "Choose a file from the workspace tree to preview it.",
+			"noSessionTitle": "No session selected",
+			"noSessionDescription": "Select a session to browse its workspace.",
+			"errorTitle": "Unable to load artifact"
+		},
 		"permission": {
 			"title": "Permissions",
 			"description": "The permissions applied in this session.",

--- a/examples/web_ui/frontend/src/i18n/locales/zh.json
+++ b/examples/web_ui/frontend/src/i18n/locales/zh.json
@@ -562,6 +562,20 @@
 			"parametersDescription": "知识库检索参数设置",
 			"selectedCount": "已挂载 {{count}} 个"
 		},
+		"artifact": {
+			"title": "产物",
+			"workspaceFiles": "工作区文件",
+			"preview": "预览",
+			"refresh": "刷新产物",
+			"download": "下载",
+			"emptyTitle": "暂无产物",
+			"emptyDescription": "工作区中生成的文件会显示在这里。",
+			"emptyPreviewTitle": "选择文件",
+			"emptyPreviewDescription": "从工作区文件树中选择一个文件进行预览。",
+			"noSessionTitle": "未选择会话",
+			"noSessionDescription": "请选择一个会话以浏览其工作区。",
+			"errorTitle": "无法加载产物"
+		},
 		"permission": {
 			"title": "权限",
 			"description": "本会话应用的权限。",

--- a/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
+++ b/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
@@ -1,6 +1,14 @@
 import type { PermissionContext } from '@agentscope-ai/agentscope/permission';
 import type { TaskContext } from '@agentscope-ai/agentscope/state';
-import { BookText, ChevronDown, Database, ListTodo, PanelRight, ShieldCheck } from 'lucide-react';
+import {
+	BookText,
+	ChevronDown,
+	Database,
+	FolderTree,
+	ListTodo,
+	PanelRight,
+	ShieldCheck,
+} from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import type { ChatModelConfig, SessionKnowledgeConfig, TTSModelConfig } from '@/api';
@@ -9,6 +17,7 @@ import MCPSvg from '@/assets/images/mcp.svg?react';
 import { ChatContent } from '@/components/chat/ChatContent.tsx';
 import { SubagentHitlCard } from '@/components/chat/SubagentHitlCard';
 import { CreateCredentialDialog } from '@/components/dialog/CreateCredentialDialog';
+import { ArtifactPanel } from '@/components/panel/ArtifactPanel';
 import { KnowledgeBasePanel } from '@/components/panel/KnowledgeBasePanel';
 import { McpPanel } from '@/components/panel/McpPanel';
 import { PanelDock, type PanelDescriptor, type PanelKey } from '@/components/panel/PanelDock.tsx';
@@ -293,6 +302,11 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 					/>
 				),
 			},
+			artifact: {
+				title: t('panel.artifact.title'),
+				icon: <FolderTree className="size-4" />,
+				content: <ArtifactPanel agentId={agentId} sessionId={sessionId} />,
+			},
 		}),
 		[
 			t,
@@ -311,6 +325,7 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 			selectedKnowledgeConfig,
 			kbMiddlewareSchema,
 			handleKnowledgeConfigChange,
+			agentId,
 			sessionId,
 		],
 	);
@@ -598,6 +613,14 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 											>
 												<ShieldCheck />
 												{t('panel.permission.title')}
+											</DropdownMenuCheckboxItem>
+											<DropdownMenuCheckboxItem
+												checked={isPanelOpen('artifact')}
+												onCheckedChange={() => togglePanel('artifact')}
+												onSelect={(e) => e.preventDefault()}
+											>
+												<FolderTree />
+												{t('panel.artifact.title')}
 											</DropdownMenuCheckboxItem>
 											<DropdownMenuCheckboxItem
 												checked={isPanelOpen('knowledge')}

--- a/src/agentscope/app/_app.py
+++ b/src/agentscope/app/_app.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """AgentScope app factory."""
+
 from typing import Type, TYPE_CHECKING, Any
 
 from ._lifespan import lifespan
@@ -30,7 +31,6 @@ from ..rag import (
     TextParser,
 )
 from .._version import __version__
-
 
 if TYPE_CHECKING:
     from fastapi import FastAPI

--- a/src/agentscope/app/_router/__init__.py
+++ b/src/agentscope/app/_router/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """App routers."""
+
 from ._agent import agent_router
 from ._chat import chat_router
 from ._credential import credential_router

--- a/src/agentscope/app/_router/_schema/__init__.py
+++ b/src/agentscope/app/_router/_schema/__init__.py
@@ -55,6 +55,7 @@ from ._session import (
     TeamDetailResponse,
     TeamMemberView,
 )
+from ._workspace import ArtifactEntry, ListArtifactsResponse
 
 __all__ = [
     # Agent
@@ -113,4 +114,7 @@ __all__ = [
     "SessionView",
     "TeamDetailResponse",
     "TeamMemberView",
+    # Workspace
+    "ArtifactEntry",
+    "ListArtifactsResponse",
 ]

--- a/src/agentscope/app/_router/_schema/_workspace.py
+++ b/src/agentscope/app/_router/_schema/_workspace.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""Request and response schemas for the workspace router."""
+
+from pydantic import BaseModel, Field
+
+
+class ArtifactEntry(BaseModel):
+    """One file or directory inside a workspace."""
+
+    name: str = Field(description="Base name of the artifact.")
+    path: str = Field(description="Path relative to the workspace root.")
+    is_directory: bool = Field(
+        description="Whether the artifact is a directory.",
+    )
+    media_type: str | None = Field(
+        default=None,
+        description="Detected IANA media type for files.",
+    )
+    modified_at: float | None = Field(
+        default=None,
+        description="POSIX modification timestamp when available.",
+    )
+
+
+class ListArtifactsResponse(BaseModel):
+    """Response body for listing artifacts in a workspace directory."""
+
+    artifacts: list[ArtifactEntry] = Field(
+        description="Immediate children of the requested directory.",
+    )
+    total: int = Field(description="Number of returned artifacts.")

--- a/src/agentscope/app/_router/_workspace.py
+++ b/src/agentscope/app/_router/_workspace.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
-"""Workspace router — manage MCP clients and skills on a workspace."""
+"""Workspace router — manage MCPs, skills, and artifacts."""
+
+import asyncio
+import mimetypes
+from urllib.parse import quote
+
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 from ..deps import (
@@ -10,11 +16,16 @@ from ..deps import (
 )
 from ..workspace_manager import WorkspaceManagerBase
 from ..storage import StorageBase
+from ._schema import ArtifactEntry, ListArtifactsResponse
 from ...mcp import MCPClient
 from ...skill import Skill
+from ...tool._builtin._backend import BackendBase
 from ...workspace import WorkspaceBase
 
 workspace_router = APIRouter(prefix="/workspace", tags=["workspace"])
+
+MAX_ARTIFACT_FILE_SIZE = 50 * 1024 * 1024
+ARTIFACT_CHUNK_SIZE = 64 * 1024
 
 
 class AddSkillRequest(BaseModel):
@@ -57,6 +68,72 @@ async def _resolve_workspace(
         agent_id,
         session_id,
         session_record.config.workspace_id,
+    )
+
+
+def _resolve_artifact_path(
+    workspace: WorkspaceBase,
+    path: str,
+) -> tuple[BackendBase, str, str]:
+    """Resolve a workspace-relative path and reject lexical traversal.
+
+    Artifact paths are client-visible identifiers rooted at the workspace.
+    Accepting absolute paths would let a local workspace read arbitrary host
+    files and would make paths non-portable across workspace backends.
+    """
+    if "\x00" in path:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Artifact path cannot contain null bytes.",
+        )
+
+    backend = workspace.get_backend()
+    relative_path = backend.normpath(path.strip() or ".")
+    if backend.isabs(relative_path):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Artifact path must be relative to the workspace.",
+        )
+
+    root = backend.normpath(workspace.workdir)
+    resolved = backend.abspath(relative_path, cwd=root)
+    root_prefix = backend.join_path(root, "")
+    if resolved != root and not resolved.startswith(root_prefix):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Artifact path must stay inside the workspace.",
+        )
+    return backend, resolved, relative_path
+
+
+async def _artifact_entry(
+    backend: BackendBase,
+    parent_path: str,
+    relative_parent: str,
+    name: str,
+) -> ArtifactEntry:
+    """Build one artifact entry from a backend directory child."""
+    child_path = backend.join_path(parent_path, name)
+    relative_path = (
+        name
+        if relative_parent == "."
+        else backend.join_path(relative_parent, name)
+    )
+    is_directory, modified_at = await asyncio.gather(
+        backend.is_dir(child_path),
+        backend.stat_mtime(child_path),
+    )
+    media_type = None
+    if not is_directory:
+        media_type = (
+            mimetypes.guess_type(name)[0] or "application/octet-stream"
+        )
+    return ArtifactEntry(
+        name=name,
+        path=relative_path,
+        is_directory=is_directory,
+        media_type=media_type,
+        modified_at=modified_at,
     )
 
 
@@ -218,3 +295,128 @@ async def remove_skill(
         workspace_manager,
     )
     await workspace.remove_skill(skill_name)
+
+
+# ---------------------------------------------------------------------------
+# Artifact endpoints
+# ---------------------------------------------------------------------------
+
+
+@workspace_router.get(
+    "/artifacts",
+    response_model=ListArtifactsResponse,
+)
+async def list_artifacts(
+    agent_id: str = Query(...),
+    session_id: str = Query(...),
+    path: str = Query("."),
+    user_id: str = Depends(get_current_user_id),
+    storage: StorageBase = Depends(get_storage),
+    workspace_manager: WorkspaceManagerBase = Depends(get_workspace_manager),
+) -> ListArtifactsResponse:
+    """List immediate children of a directory in the session workspace."""
+    workspace = await _resolve_workspace(
+        user_id,
+        agent_id,
+        session_id,
+        storage,
+        workspace_manager,
+    )
+    backend, resolved, relative_path = _resolve_artifact_path(workspace, path)
+    if not await backend.file_exists(resolved):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Artifact directory {path!r} not found.",
+        )
+    if not await backend.is_dir(resolved):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Artifact path {path!r} is not a directory.",
+        )
+
+    names = await backend.list_dir(resolved)
+    entries = await asyncio.gather(
+        *(
+            _artifact_entry(
+                backend,
+                resolved,
+                relative_path,
+                name,
+            )
+            for name in names
+        ),
+    )
+    entries = sorted(
+        entries,
+        key=lambda entry: (not entry.is_directory, entry.name.lower()),
+    )
+    return ListArtifactsResponse(artifacts=entries, total=len(entries))
+
+
+@workspace_router.get(
+    "/artifacts/content",
+    response_class=StreamingResponse,
+    responses={
+        status.HTTP_413_CONTENT_TOO_LARGE: {
+            "description": "Artifact exceeds the preview size limit.",
+        },
+    },
+)
+async def read_artifact(
+    agent_id: str = Query(...),
+    session_id: str = Query(...),
+    path: str = Query(...),
+    user_id: str = Depends(get_current_user_id),
+    storage: StorageBase = Depends(get_storage),
+    workspace_manager: WorkspaceManagerBase = Depends(get_workspace_manager),
+) -> StreamingResponse:
+    """Stream a size-limited file from the session workspace."""
+    workspace = await _resolve_workspace(
+        user_id,
+        agent_id,
+        session_id,
+        storage,
+        workspace_manager,
+    )
+    backend, resolved, _ = _resolve_artifact_path(workspace, path)
+    if not await backend.file_exists(resolved):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Artifact file {path!r} not found.",
+        )
+    if await backend.is_dir(resolved):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Artifact path {path!r} is a directory.",
+        )
+
+    file_size = await backend.stat_size(resolved)
+    if file_size is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Could not determine the size of artifact {path!r}.",
+        )
+    if file_size > MAX_ARTIFACT_FILE_SIZE:
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail=(
+                f"Artifact file exceeds the {MAX_ARTIFACT_FILE_SIZE}-byte "
+                "preview limit."
+            ),
+        )
+
+    media_type = (
+        mimetypes.guess_type(resolved)[0] or "application/octet-stream"
+    )
+    filename = backend.basename(resolved)
+    return StreamingResponse(
+        backend.iter_file(resolved, chunk_size=ARTIFACT_CHUNK_SIZE),
+        media_type=media_type,
+        headers={
+            "Content-Disposition": (
+                "inline; filename*=UTF-8''" + quote(filename, safe="")
+            ),
+            "Content-Length": str(file_size),
+            "X-Content-Type-Options": "nosniff",
+        },
+    )

--- a/src/agentscope/tool/_builtin/_backend.py
+++ b/src/agentscope/tool/_builtin/_backend.py
@@ -13,11 +13,12 @@ mechanism genuinely differs per environment:
 * :meth:`BackendBase.read_file` — read raw bytes.
 * :meth:`BackendBase.write_file` — write raw bytes.
 
-All remaining filesystem operations (``file_exists``, ``is_dir``,
-``list_dir``, ``stat_mtime``, ``delete_path``) are derived on the base
-class from ``exec_shell`` and work out-of-the-box for any remote
-backend.  A backend that has a cheaper native path (e.g.
-:class:`LocalBackend` using ``os.*``) simply overrides them.
+All remaining filesystem operations (``iter_file``, ``file_exists``,
+``is_dir``, ``list_dir``, ``stat_mtime``, ``stat_size``,
+``delete_path``) are derived on the base class and work out-of-the-box
+for any remote backend. A backend that has a cheaper native path (e.g.
+:class:`LocalBackend` using ``aiofiles`` / ``os.*``) simply
+overrides them.
 
 Concrete implementations:
 
@@ -40,6 +41,7 @@ import posixpath
 import shlex
 import shutil
 from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from types import ModuleType
 from typing import Any
@@ -308,6 +310,34 @@ class BackendBase(ABC):
                 The raw bytes to write.
         """
 
+    async def iter_file(
+        self,
+        path: str,
+        *,
+        chunk_size: int = 64 * 1024,
+    ) -> AsyncIterator[bytes]:
+        """Yield a file in chunks.
+
+        The default implementation adapts :meth:`read_file` for remote
+        backends whose SDK only exposes whole-file reads. Backends with
+        native streaming support should override it.
+
+        Args:
+            path (`str`):
+                Path to the file inside the backend's environment.
+            chunk_size (`int`, defaults to 64 KiB):
+                Maximum number of bytes yielded per chunk.
+
+        Yields:
+            `bytes`:
+                Consecutive chunks of the file.
+        """
+        if chunk_size <= 0:
+            raise ValueError("chunk_size must be positive")
+        content = await self.read_file(path)
+        for offset in range(0, len(content), chunk_size):
+            yield content[offset : offset + chunk_size]
+
     # ── derived filesystem ops (shell-based defaults) ──────────────
 
     async def getcwd(self) -> str:
@@ -479,6 +509,36 @@ class BackendBase(ABC):
         except ValueError:
             return None
 
+    async def stat_size(self, path: str) -> int | None:
+        """Return the size of ``path`` in bytes, or ``None``.
+
+        Tries GNU ``stat -c %s`` first and falls back to BSD
+        ``stat -f %z``. Backends without a POSIX shell should override
+        this method.
+
+        Args:
+            path (`str`):
+                Path to stat inside the backend's environment.
+
+        Returns:
+            `int | None`:
+                File size in bytes, or ``None`` when it cannot be read.
+        """
+        quoted = shlex.quote(path)
+        script = (
+            f"stat -c %s {quoted} 2>/dev/null || "
+            f"stat -f %z {quoted} 2>/dev/null"
+        )
+        result = await self.exec_shell(["sh", "-c", script])
+        if not result.ok():
+            return None
+        try:
+            return int(
+                result.stdout.decode("utf-8", errors="replace").strip(),
+            )
+        except ValueError:
+            return None
+
     async def delete_path(self, path: str) -> None:
         """Delete ``path`` (file or directory tree).
 
@@ -619,6 +679,19 @@ class LocalBackend(BackendBase):
         async with aiofiles.open(path, mode="rb") as f:
             return await f.read()
 
+    async def iter_file(
+        self,
+        path: str,
+        *,
+        chunk_size: int = 64 * 1024,
+    ) -> AsyncIterator[bytes]:
+        """Yield a local file without loading it entirely into memory."""
+        if chunk_size <= 0:
+            raise ValueError("chunk_size must be positive")
+        async with aiofiles.open(path, mode="rb") as f:
+            while chunk := await f.read(chunk_size):
+                yield chunk
+
     async def write_file(self, path: str, data: bytes) -> None:
         """Write *data* to a local file, creating parent dirs.
 
@@ -727,6 +800,13 @@ class LocalBackend(BackendBase):
         """
         try:
             return os.stat(path).st_mtime
+        except (OSError, FileNotFoundError):
+            return None
+
+    async def stat_size(self, path: str) -> int | None:
+        """Return a local file's size in bytes, or ``None``."""
+        try:
+            return os.stat(path).st_size
         except (OSError, FileNotFoundError):
             return None
 

--- a/tests/backend_local_test.py
+++ b/tests/backend_local_test.py
@@ -2,9 +2,10 @@
 """Test cases for :class:`LocalBackend` and the backend helpers.
 
 Exercises the three abstract primitives (``exec_shell``, ``read_file``,
-``write_file``) plus the derived filesystem helpers (``file_exists``,
-``is_dir``, ``list_dir``, ``stat_mtime``, ``delete_path``) of the
-host-local backend, and the module-level ``normalize_newlines`` helper.
+``write_file``) plus the derived filesystem helpers (``iter_file``,
+``file_exists``, ``is_dir``, ``list_dir``, ``stat_mtime``,
+``stat_size``, ``delete_path``) of the host-local backend, and the
+module-level ``normalize_newlines`` helper.
 
 ``LocalBackend`` is designed to run on every platform (it spawns
 programs from an argv list without a shell and implements the
@@ -264,6 +265,28 @@ class TestLocalBackendFilesystemHelpers(IsolatedAsyncioTestCase):
                 os.path.join(self.temp_dir.name, "missing"),
             ),
         )
+
+    async def test_stat_size(self) -> None:
+        """``stat_size`` returns bytes for an existing path, None else."""
+        path = os.path.join(self.temp_dir.name, "f.txt")
+        await self.backend.write_file(path, b"abcdef")
+        self.assertEqual(await self.backend.stat_size(path), 6)
+        self.assertIsNone(
+            await self.backend.stat_size(
+                os.path.join(self.temp_dir.name, "missing"),
+            ),
+        )
+
+    async def test_iter_file(self) -> None:
+        """``iter_file`` yields bounded chunks in file order."""
+        path = os.path.join(self.temp_dir.name, "f.txt")
+        await self.backend.write_file(path, b"abcdef")
+
+        chunks = [
+            chunk async for chunk in self.backend.iter_file(path, chunk_size=2)
+        ]
+
+        self.assertEqual(chunks, [b"ab", b"cd", b"ef"])
 
     async def test_delete_path_file(self) -> None:
         """``delete_path`` removes a single file."""

--- a/tests/service_artifact_router_test.py
+++ b/tests/service_artifact_router_test.py
@@ -1,0 +1,208 @@
+# -*- coding: utf-8 -*-
+"""Tests for the workspace artifact router."""
+
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agentscope.app._router._workspace import workspace_router
+from agentscope.app.deps import (
+    get_current_user_id,
+    get_storage,
+    get_workspace_manager,
+)
+from agentscope.tool._builtin._backend import LocalBackend
+
+
+class _Storage:
+    """Minimal storage stub for resolving a persisted workspace binding."""
+
+    async def get_session(
+        self,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> SimpleNamespace:
+        del user_id, agent_id, session_id
+        return SimpleNamespace(
+            config=SimpleNamespace(workspace_id="workspace-1"),
+        )
+
+
+class _Workspace:
+    """Workspace stub backed by a temporary local directory."""
+
+    def __init__(self, workdir: str) -> None:
+        self.workdir = workdir
+        self._backend = LocalBackend()
+
+    def get_backend(self) -> LocalBackend:
+        """Return the local filesystem backend."""
+        return self._backend
+
+
+class _WorkspaceManager:
+    """Manager stub that always returns the test workspace."""
+
+    def __init__(self, workspace: _Workspace) -> None:
+        self._workspace = workspace
+
+    async def get_workspace(
+        self,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+        workspace_id: str | None = None,
+    ) -> _Workspace:
+        del user_id, agent_id, session_id
+        assert workspace_id == "workspace-1"
+        return self._workspace
+
+
+class ArtifactRouterTest(TestCase):
+    """Exercise directory listing, file reads, and path boundaries."""
+
+    def setUp(self) -> None:
+        """Create a temporary workspace and dependency-overridden app."""
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._root = Path(self._tmpdir.name)
+        (self._root / "reports").mkdir()
+        (self._root / "reports" / "summary.md").write_text(
+            "# Summary\n",
+            encoding="utf-8",
+        )
+        (self._root / "notes.txt").write_text("hello", encoding="utf-8")
+
+        storage = _Storage()
+        manager = _WorkspaceManager(_Workspace(self._tmpdir.name))
+        app = FastAPI()
+        app.include_router(workspace_router)
+
+        async def _current_user() -> str:
+            return "user-1"
+
+        async def _storage() -> _Storage:
+            return storage
+
+        async def _workspace_manager() -> _WorkspaceManager:
+            return manager
+
+        app.dependency_overrides[get_current_user_id] = _current_user
+        app.dependency_overrides[get_storage] = _storage
+        app.dependency_overrides[get_workspace_manager] = _workspace_manager
+        self._client = TestClient(app)
+        self._params = {"agent_id": "agent-1", "session_id": "session-1"}
+
+    def tearDown(self) -> None:
+        """Close the HTTP client and remove the temporary workspace."""
+        self._client.close()
+        self._tmpdir.cleanup()
+
+    def test_list_directory(self) -> None:
+        """Directories sort before files and paths stay workspace-relative."""
+        response = self._client.get(
+            "/workspace/artifacts",
+            params=self._params,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        entries = payload["artifacts"]
+        self.assertEqual(payload["total"], 2)
+        self.assertEqual(
+            [
+                (entry["name"], entry["path"], entry["is_directory"])
+                for entry in entries
+            ],
+            [
+                ("reports", "reports", True),
+                ("notes.txt", "notes.txt", False),
+            ],
+        )
+        self.assertEqual(entries[1]["media_type"], "text/plain")
+
+        nested = self._client.get(
+            "/workspace/artifacts",
+            params={**self._params, "path": "reports"},
+        )
+        self.assertEqual(nested.status_code, 200)
+        self.assertEqual(
+            nested.json()["artifacts"][0]["path"],
+            "reports/summary.md",
+        )
+
+    def test_read_file(self) -> None:
+        """File content is returned inline with its detected media type."""
+        response = self._client.get(
+            "/workspace/artifacts/content",
+            params={**self._params, "path": "reports/summary.md"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"# Summary\n")
+        self.assertEqual(response.headers["content-length"], "10")
+        self.assertEqual(
+            response.headers["content-type"],
+            "text/markdown; charset=utf-8",
+        )
+        self.assertIn("summary.md", response.headers["content-disposition"])
+        self.assertEqual(response.headers["x-content-type-options"], "nosniff")
+
+    def test_rejects_paths_outside_workspace(self) -> None:
+        """Absolute paths and parent traversal cannot escape the workspace."""
+        outside = Path(self._tmpdir.name).parent / "outside-secret.txt"
+        outside.write_text("secret", encoding="utf-8")
+        self.addCleanup(outside.unlink, missing_ok=True)
+
+        for path in ("../outside-secret.txt", str(outside)):
+            with self.subTest(path=path):
+                response = self._client.get(
+                    "/workspace/artifacts/content",
+                    params={**self._params, "path": path},
+                )
+                self.assertEqual(response.status_code, 400)
+
+    def test_rejects_wrong_path_kinds(self) -> None:
+        """List requires a directory and content requires a regular file."""
+        list_response = self._client.get(
+            "/workspace/artifacts",
+            params={**self._params, "path": "notes.txt"},
+        )
+        read_response = self._client.get(
+            "/workspace/artifacts/content",
+            params={**self._params, "path": "reports"},
+        )
+
+        self.assertEqual(list_response.status_code, 400)
+        self.assertEqual(read_response.status_code, 400)
+
+    def test_missing_path_returns_not_found(self) -> None:
+        """Missing directories and files return HTTP 404."""
+        for endpoint in (
+            "/workspace/artifacts",
+            "/workspace/artifacts/content",
+        ):
+            with self.subTest(endpoint=endpoint):
+                response = self._client.get(
+                    endpoint,
+                    params={**self._params, "path": "missing.txt"},
+                )
+                self.assertEqual(response.status_code, 404)
+
+    def test_rejects_file_over_preview_limit(self) -> None:
+        """Oversized artifacts are rejected before their content is read."""
+        with patch(
+            "agentscope.app._router._workspace.MAX_ARTIFACT_FILE_SIZE",
+            4,
+        ):
+            response = self._client.get(
+                "/workspace/artifacts/content",
+                params={**self._params, "path": "notes.txt"},
+            )
+
+        self.assertEqual(response.status_code, 413)


### PR DESCRIPTION
## Summary

- add authenticated `/workspace/artifacts` endpoints for listing workspace
  directories and streaming file content with detected MIME types
- expose a structured `ListArtifactsResponse` schema from
  `_router/_schema/_workspace.py`
- keep artifact identifiers workspace-relative to prevent LocalWorkspace
  clients from selecting arbitrary host paths
- cap previews at 50 MiB and stream content through backend chunk iterators
- add a dockable WebUI artifact tree with text, image, audio, video, and PDF
  previews plus download support
- cover directory ordering, nested paths, streaming responses, size limits,
  missing files, wrong path kinds, and traversal rejection

## Tests

- `pytest tests/service_artifact_router_test.py tests/backend_local_test.py tests/backend_docker_test.py tests/backend_e2b_test.py tests/backend_opensandbox_test.py tests/app_lifespan_dedicated_test.py tests/resource_access_policy_test.py` (43 passed, 36 optional-backend tests skipped)
- Black check with line length 79 and Python 3.11 target
- flake8 on changed Python files
- mypy on workspace schema/router and backend abstraction
- `pnpm format:check` (0 errors; 16 pre-existing warnings)
- `pnpm --filter frontend build`

Fixes #2039
