### PR TITLE
fix(model): preserve OpenAI Responses reasoning history replay

### DIFF
--- a/src/agentscope/formatter/_openai_response_formatter.py
+++ b/src/agentscope/formatter/_openai_response_formatter.py
@@ -123,18 +123,8 @@ class OpenAIResponseFormatter(_OpenAIResponseFormatterBase):
             msg = msgs[i]
             content_parts: list[dict] = []
             function_calls: list[dict] = []
-            # Responses API requires reasoning items to precede the output
-            # they produced, but streaming accumulates them last; sort to
-            # restore API order for history replay.
-            blocks = sorted(
-                msg.get_content_blocks(),
-                key=lambda block: 0
-                if isinstance(block, ThinkingBlock)
-                and getattr(block, "reasoning_item_id", None)
-                else 1,
-            )
 
-            for block in blocks:
+            for block in msg.get_content_blocks():
                 if isinstance(block, TextBlock):
                     text_type = (
                         "output_text"
@@ -218,7 +208,7 @@ class OpenAIResponseFormatter(_OpenAIResponseFormatterBase):
                         None,
                     )
                     if reasoning_item_id:
-                        if content_parts:
+                        if content_parts and block.thinking:
                             items.append(
                                 {
                                     "role": msg.role,
@@ -226,8 +216,11 @@ class OpenAIResponseFormatter(_OpenAIResponseFormatterBase):
                                 },
                             )
                             content_parts = []
-                        # summary may be empty when the model did not produce
-                        # reasoning summary text (e.g. o4-mini with streaming)
+                        # Empty reasoning blocks can arrive after text deltas
+                        # only to carry reasoning_item_id; emit them before
+                        # pending assistant text for replay. Non-empty
+                        # reasoning starts a new output segment, so flush text
+                        # first.
                         summary = (
                             [{"type": "summary_text", "text": block.thinking}]
                             if block.thinking

--- a/src/agentscope/formatter/_openai_response_formatter.py
+++ b/src/agentscope/formatter/_openai_response_formatter.py
@@ -123,8 +123,18 @@ class OpenAIResponseFormatter(_OpenAIResponseFormatterBase):
             msg = msgs[i]
             content_parts: list[dict] = []
             function_calls: list[dict] = []
+            # Responses API requires reasoning items to precede the output
+            # they produced, but streaming accumulates them last; sort to
+            # restore API order for history replay.
+            blocks = sorted(
+                msg.get_content_blocks(),
+                key=lambda block: 0
+                if isinstance(block, ThinkingBlock)
+                and getattr(block, "reasoning_item_id", None)
+                else 1,
+            )
 
-            for block in msg.get_content_blocks():
+            for block in blocks:
                 if isinstance(block, TextBlock):
                     text_type = (
                         "output_text"

--- a/src/agentscope/model/_openai_response/_model.py
+++ b/src/agentscope/model/_openai_response/_model.py
@@ -379,7 +379,9 @@ class OpenAIResponseModel(ChatModelBase):
                     for s in getattr(item, "summary", [])
                     if getattr(s, "text", "")
                 )
-                if combined_summary:
+                # Keep even empty-summary reasoning items: the API requires
+                # reasoning_item_id to be echoed back in multi-turn history.
+                if combined_summary or reasoning_item_id:
                     content_blocks.append(
                         ThinkingBlock(
                             type="thinking",

--- a/tests/formatter_openai_response_test.py
+++ b/tests/formatter_openai_response_test.py
@@ -430,6 +430,138 @@ class TestOpenAIResponseFormatter(IsolatedAsyncioTestCase):
             res,
         )
 
+    async def test_chat_formatter_reasoning_not_globally_sorted(
+        self,
+    ) -> None:
+        """Reasoning replay keeps existing tool/result boundaries."""
+        fmt = OpenAIResponseFormatter()
+        thinking_1 = ThinkingBlock(thinking="thinking_1")
+        thinking_1.reasoning_item_id = "rs_1"
+        thinking_2 = ThinkingBlock(thinking="thinking_2")
+        thinking_2.reasoning_item_id = "rs_2"
+        msgs = [
+            AssistantMsg(
+                name="assistant",
+                content=[
+                    thinking_1,
+                    TextBlock(text="text_1"),
+                    ToolCallBlock(
+                        id="call_1",
+                        name="func_1",
+                        input='{"arg": "value1"}',
+                    ),
+                    ToolResultBlock(
+                        id="call_1",
+                        name="func_1",
+                        output=[TextBlock(text="result_1")],
+                        state=ToolResultState.SUCCESS,
+                    ),
+                    thinking_2,
+                    TextBlock(text="text_2"),
+                ],
+            ),
+        ]
+        res = await fmt.format(msgs)
+        self.assertListEqual(
+            [
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "summary": [
+                        {"type": "summary_text", "text": "thinking_1"},
+                    ],
+                    "content": [],
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "text_1"},
+                    ],
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "func_1",
+                    "arguments": '{"arg": "value1"}',
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "result_1",
+                },
+                {
+                    "type": "reasoning",
+                    "id": "rs_2",
+                    "summary": [
+                        {"type": "summary_text", "text": "thinking_2"},
+                    ],
+                    "content": [],
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "text_2"},
+                    ],
+                },
+            ],
+            res,
+        )
+
+    async def test_chat_formatter_reasoning_splits_text_segments(
+        self,
+    ) -> None:
+        """Non-empty reasoning starts a new assistant text segment."""
+        fmt = OpenAIResponseFormatter()
+        thinking_1 = ThinkingBlock(thinking="thinking_1")
+        thinking_1.reasoning_item_id = "rs_1"
+        thinking_2 = ThinkingBlock(thinking="thinking_2")
+        thinking_2.reasoning_item_id = "rs_2"
+        msgs = [
+            AssistantMsg(
+                name="assistant",
+                content=[
+                    thinking_1,
+                    TextBlock(text="text_1"),
+                    thinking_2,
+                    TextBlock(text="text_2"),
+                ],
+            ),
+        ]
+        res = await fmt.format(msgs)
+        self.assertListEqual(
+            [
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "summary": [
+                        {"type": "summary_text", "text": "thinking_1"},
+                    ],
+                    "content": [],
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "text_1"},
+                    ],
+                },
+                {
+                    "type": "reasoning",
+                    "id": "rs_2",
+                    "summary": [
+                        {"type": "summary_text", "text": "thinking_2"},
+                    ],
+                    "content": [],
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "text_2"},
+                    ],
+                },
+            ],
+            res,
+        )
+
     @patch(
         "agentscope.formatter._formatter_base.shortuuid.uuid",
         return_value=_FIXED_ID,

--- a/tests/formatter_openai_response_test.py
+++ b/tests/formatter_openai_response_test.py
@@ -398,6 +398,38 @@ class TestOpenAIResponseFormatter(IsolatedAsyncioTestCase):
             res,
         )
 
+    async def test_chat_formatter_empty_thinking_echoed_with_reasoning_item_id(
+        self,
+    ) -> None:
+        """Empty ThinkingBlock with reasoning_item_id is echoed first."""
+        fmt = OpenAIResponseFormatter()
+        thinking = ThinkingBlock(thinking="")
+        thinking.reasoning_item_id = "rs_empty"
+        msgs = [
+            AssistantMsg(
+                name="assistant",
+                content=[TextBlock(text="reply"), thinking],
+            ),
+        ]
+        res = await fmt.format(msgs)
+        self.assertListEqual(
+            [
+                {
+                    "type": "reasoning",
+                    "id": "rs_empty",
+                    "summary": [],
+                    "content": [],
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "reply"},
+                    ],
+                },
+            ],
+            res,
+        )
+
     @patch(
         "agentscope.formatter._formatter_base.shortuuid.uuid",
         return_value=_FIXED_ID,

--- a/tests/model_openai_response_test.py
+++ b/tests/model_openai_response_test.py
@@ -44,13 +44,22 @@ def _mock_completion(
     """Build a mock non-streaming Responses API response."""
     output = []
 
-    if reasoning_summary:
+    if reasoning_summary is not None:
         reasoning_item = MagicMock()
         reasoning_item.type = "reasoning"
         reasoning_item.id = reasoning_id
-        summary_mock = MagicMock()
-        summary_mock.text = reasoning_summary
-        reasoning_item.summary = [summary_mock]
+        summary_texts = (
+            reasoning_summary
+            if isinstance(reasoning_summary, list)
+            else [reasoning_summary]
+            if reasoning_summary is not None
+            else []
+        )
+        reasoning_item.summary = []
+        for summary_text in summary_texts:
+            summary_mock = MagicMock()
+            summary_mock.text = summary_text
+            reasoning_item.summary.append(summary_mock)
         output.append(reasoning_item)
 
     if text:
@@ -207,6 +216,38 @@ class TestOpenAIResponseNonStream(IsolatedAsyncioTestCase):
             ),
         )
 
+    @patch("openai.AsyncClient")
+    async def test_empty_reasoning_summary_response(
+        self,
+        mock_client_cls: MagicMock,
+    ) -> None:
+        """Non-stream empty reasoning summary still preserves its item id."""
+        mock_create = AsyncMock(
+            return_value=_mock_completion(
+                reasoning_summary=[],
+                text="Answer",
+                reasoning_id="rs_empty",
+            ),
+        )
+        mock_client_cls.return_value.responses.create = mock_create
+
+        result = await self.model([])
+
+        self.assertEqual(
+            (result.is_last, result.content),
+            (
+                True,
+                [
+                    ThinkingBlock.model_construct(
+                        id=A,
+                        thinking="",
+                        reasoning_item_id="rs_empty",
+                    ),
+                    TextBlock.model_construct(id=A, text="Answer"),
+                ],
+            ),
+        )
+
 
 class TestOpenAIResponseModelParameters(unittest.TestCase):
     """Tests for OpenAIResponseModel.Parameters."""
@@ -357,6 +398,71 @@ class TestOpenAIResponseStream(IsolatedAsyncioTestCase):
                             reasoning_item_id="rs_123",
                         ),
                         TextBlock.model_construct(id=A, text="Answer"),
+                    ],
+                ),
+            ],
+        )
+
+    @patch("openai.AsyncClient")
+    async def test_stream_empty_reasoning_summary_keeps_reasoning_item_id(
+        self,
+        mock_client_cls: MagicMock,
+    ) -> None:
+        """Stream empty reasoning summary still preserves its item id."""
+        reasoning_item = MagicMock()
+        reasoning_item.type = "reasoning"
+        reasoning_item.id = "rs_empty"
+
+        msg_item = MagicMock()
+        msg_item.type = "message"
+
+        completed_resp = MagicMock()
+        completed_resp.id = "resp-empty"
+        completed_resp.output = [reasoning_item, msg_item]
+        completed_resp.usage = MagicMock()
+        completed_resp.usage.input_tokens = 10
+        completed_resp.usage.output_tokens = 5
+        completed_resp.usage.input_tokens_details = None
+
+        events = [
+            _make_event(
+                "response.output_text.delta",
+                delta="Answer",
+                response=MagicMock(id="resp-empty"),
+            ),
+            _make_event("response.completed", response=completed_resp),
+        ]
+        mock_create = AsyncMock(
+            return_value=_MockAsyncEventStream(events),
+        )
+        mock_client_cls.return_value.responses.create = mock_create
+
+        gen = await self.model([])
+        responses = [r async for r in gen]
+
+        self.assertListEqual(
+            [(r.is_last, r.content) for r in responses],
+            [
+                (False, [TextBlock.model_construct(id=A, text="Answer")]),
+                (
+                    False,
+                    [
+                        ThinkingBlock.model_construct(
+                            id=A,
+                            thinking="",
+                            reasoning_item_id="rs_empty",
+                        ),
+                    ],
+                ),
+                (
+                    True,
+                    [
+                        TextBlock.model_construct(id=A, text="Answer"),
+                        ThinkingBlock.model_construct(
+                            id=A,
+                            thinking="",
+                            reasoning_item_id="rs_empty",
+                        ),
                     ],
                 ),
             ],


### PR DESCRIPTION
## AgentScope Version

2.0.4

## Description

Fix OpenAI Responses parsing and formatting for reasoning items with empty summaries. Non-streaming responses now preserve reasoning items that only carry `reasoning_item_id`, and the Responses formatter restores reasoning items before assistant output during history replay, matching the API requirement for multi-turn reasoning conversations.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review