### PR TITLE
fix(tracing): avoid otel context detach error on cross-task stream close

### DIFF
--- a/src/agentscope/middleware/_tracing/_trace.py
+++ b/src/agentscope/middleware/_tracing/_trace.py
@@ -13,6 +13,7 @@ from typing import (
 
 import aioitertools
 
+from opentelemetry import context as otel_context
 from opentelemetry import trace as otel_trace
 from opentelemetry.trace import StatusCode
 
@@ -154,91 +155,103 @@ class TracingMiddleware(MiddlewareBase):
         )
         span_name = _get_agent_span_name(request_attributes)
 
-        with tracer.start_as_current_span(
+        span = tracer.start_span(
             name=span_name,
             attributes={
                 **request_attributes,
                 **common_attrs,
             },
-            end_on_exit=False,
-        ) as span:
-            # Synthetic execute_tool spans for externally executed tools
-            event_arg = input_kwargs.get("inputs")
-            if isinstance(event_arg, ExternalExecutionResultEvent):
-                for result in event_arg.execution_results:
-                    tool_attrs: dict[str, Any] = {
-                        SpanAttributes.GEN_AI_OPERATION_NAME: (
-                            OperationNameValues.EXECUTE_TOOL
-                        ),
-                        SpanAttributes.GEN_AI_TOOL_CALL_ID: result.id,
-                        SpanAttributes.GEN_AI_TOOL_NAME: result.name,
-                        SpanAttributes.AGENTSCOPE_IS_EXTERNAL_EXECUTION: (
-                            True
-                        ),
-                        **common_attrs,
-                    }
-                    if result.output is not None:
-                        tool_attrs[
-                            SpanAttributes.GEN_AI_TOOL_CALL_RESULT
-                        ] = _serialize_to_str(result.output)
-                    with tracer.start_as_current_span(
-                        name=(
-                            f"{OperationNameValues.EXECUTE_TOOL}"
-                            f" {result.name}"
-                        ),
-                        attributes=tool_attrs,
-                    ):
-                        pass
+        )
+        # Keep the reply span as parent for downstream spans, but do NOT hold
+        # it as the current OTel context across ``yield`` boundaries.  The
+        # context is only attached while advancing ``next_handler`` and is
+        # detached again within the same ``__anext__`` step, so the token is
+        # always detached in the context it was created in even when this
+        # async generator is closed from another asyncio task (issue #2076).
+        span_context = otel_trace.set_span_in_context(span)
 
-            has_error = False
-            error_exc: BaseException | None = None
-            last_msg: Msg | None = None
-            hitl_pending: list[str] = []
-            external_pending: list[str] = []
-            observed_reply_id: str | None = None
+        # Synthetic execute_tool spans for externally executed tools
+        event_arg = input_kwargs.get("inputs")
+        if isinstance(event_arg, ExternalExecutionResultEvent):
+            for result in event_arg.execution_results:
+                tool_attrs: dict[str, Any] = {
+                    SpanAttributes.GEN_AI_OPERATION_NAME: (
+                        OperationNameValues.EXECUTE_TOOL
+                    ),
+                    SpanAttributes.GEN_AI_TOOL_CALL_ID: result.id,
+                    SpanAttributes.GEN_AI_TOOL_NAME: result.name,
+                    SpanAttributes.AGENTSCOPE_IS_EXTERNAL_EXECUTION: (True),
+                    **common_attrs,
+                }
+                if result.output is not None:
+                    tool_attrs[
+                        SpanAttributes.GEN_AI_TOOL_CALL_RESULT
+                    ] = _serialize_to_str(result.output)
+                with tracer.start_as_current_span(
+                    name=(
+                        f"{OperationNameValues.EXECUTE_TOOL}" f" {result.name}"
+                    ),
+                    attributes=tool_attrs,
+                    context=span_context,
+                ):
+                    pass
 
-            try:
-                async for item in next_handler(**input_kwargs):
-                    if isinstance(item, ReplyStartEvent):
-                        observed_reply_id = item.reply_id
-                    elif isinstance(item, RequireUserConfirmEvent):
-                        hitl_pending.extend(t.name for t in item.tool_calls)
-                    elif isinstance(item, RequireExternalExecutionEvent):
-                        external_pending.extend(
-                            t.name for t in item.tool_calls
-                        )
-                    if isinstance(item, Msg):
-                        last_msg = item
-                    yield item
-            except BaseException as e:
-                has_error = True
-                error_exc = e
-                raise
-            finally:
-                reply_id = observed_reply_id or agent.state.reply_id
-                if reply_id:
-                    span.set_attribute(
-                        SpanAttributes.AGENTSCOPE_REPLY_ID,
-                        reply_id,
+        has_error = False
+        error_exc: BaseException | None = None
+        last_msg: Msg | None = None
+        hitl_pending: list[str] = []
+        external_pending: list[str] = []
+        observed_reply_id: str | None = None
+
+        gen = next_handler(**input_kwargs)
+        try:
+            while True:
+                token = otel_context.attach(span_context)
+                try:
+                    item = await anext(gen)
+                except StopAsyncIteration:
+                    break
+                finally:
+                    otel_context.detach(token)
+
+                if isinstance(item, ReplyStartEvent):
+                    observed_reply_id = item.reply_id
+                elif isinstance(item, RequireUserConfirmEvent):
+                    hitl_pending.extend(t.name for t in item.tool_calls)
+                elif isinstance(item, RequireExternalExecutionEvent):
+                    external_pending.extend(t.name for t in item.tool_calls)
+                if isinstance(item, Msg):
+                    last_msg = item
+                yield item
+        except BaseException as e:
+            has_error = True
+            error_exc = e
+            raise
+        finally:
+            reply_id = observed_reply_id or agent.state.reply_id
+            if reply_id:
+                span.set_attribute(
+                    SpanAttributes.AGENTSCOPE_REPLY_ID,
+                    reply_id,
+                )
+            if hitl_pending:
+                span.set_attribute(
+                    SpanAttributes.AGENTSCOPE_HITL_PENDING_TOOLS,
+                    json.dumps(hitl_pending, ensure_ascii=False),
+                )
+            if external_pending:
+                span.set_attribute(
+                    SpanAttributes.AGENTSCOPE_EXTERNAL_EXECUTION_PENDING_TOOLS,  # noqa
+                    json.dumps(external_pending, ensure_ascii=False),
+                )
+            if has_error and error_exc is not None:
+                _set_span_error_status(span, error_exc)
+            else:
+                if last_msg is not None:
+                    span.set_attributes(
+                        _get_agent_response_attributes(last_msg),
                     )
-                if hitl_pending:
-                    span.set_attribute(
-                        SpanAttributes.AGENTSCOPE_HITL_PENDING_TOOLS,
-                        json.dumps(hitl_pending, ensure_ascii=False),
-                    )
-                if external_pending:
-                    span.set_attribute(
-                        SpanAttributes.AGENTSCOPE_EXTERNAL_EXECUTION_PENDING_TOOLS,  # noqa
-                        json.dumps(external_pending, ensure_ascii=False),
-                    )
-                if has_error and error_exc is not None:
-                    _set_span_error_status(span, error_exc)
-                else:
-                    if last_msg is not None:
-                        span.set_attributes(
-                            _get_agent_response_attributes(last_msg),
-                        )
-                    _set_span_success_status(span)
+                _set_span_success_status(span)
 
     # ------------------------------------------------------------------
     # on_model_call
@@ -321,28 +334,41 @@ class TracingMiddleware(MiddlewareBase):
         )
         span_name = _get_tool_span_name(request_attributes)
 
-        with tracer.start_as_current_span(
+        span = tracer.start_span(
             name=span_name,
             attributes={
                 **request_attributes,
                 **_get_common_attributes(agent.state.session_id),
             },
-            end_on_exit=False,
-        ) as span:
-            has_error = False
-            last_item = None
-            try:
-                async for item in next_handler(**input_kwargs):
-                    last_item = item
-                    yield item
-            except BaseException as e:
-                has_error = True
-                _set_span_error_status(span, e)
-                raise
-            finally:
-                if not has_error:
-                    if last_item is not None:
-                        span.set_attributes(
-                            _get_tool_response_attributes(last_item),
-                        )
-                    _set_span_success_status(span)
+        )
+        # See ``on_reply``: keep the span as parent for nested spans without
+        # holding it as the current context across ``yield`` boundaries, so a
+        # cross-task generator close does not raise OTel detach errors
+        # (issue #2076).
+        span_context = otel_trace.set_span_in_context(span)
+
+        has_error = False
+        last_item = None
+        gen = next_handler(**input_kwargs)
+        try:
+            while True:
+                token = otel_context.attach(span_context)
+                try:
+                    item = await anext(gen)
+                except StopAsyncIteration:
+                    break
+                finally:
+                    otel_context.detach(token)
+                last_item = item
+                yield item
+        except BaseException as e:
+            has_error = True
+            _set_span_error_status(span, e)
+            raise
+        finally:
+            if not has_error:
+                if last_item is not None:
+                    span.set_attributes(
+                        _get_tool_response_attributes(last_item),
+                    )
+                _set_span_success_status(span)

--- a/tests/tracing_test.py
+++ b/tests/tracing_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Unit tests for the tracing module using an in-memory OTel exporter."""
+import asyncio
 import json
 from typing import Any
 from unittest.async_case import IsolatedAsyncioTestCase
@@ -844,3 +845,65 @@ class TracingTest(IsolatedAsyncioTestCase):
             span_attrs.get("agentscope.agent.incoming_event_type"),
             "external_execution_result",
         )
+
+    # -----------------------------------------------------------------------
+    # Tests: streaming close from another asyncio task (issue #2076)
+    # -----------------------------------------------------------------------
+
+    async def _drive_then_close_from_other_task(self, gen: Any) -> None:
+        """Advance an async generator once, then close it from a *different*
+        asyncio task, reproducing the cross-context close in issue #2076."""
+        await gen.__anext__()
+
+        async def _close() -> None:
+            await gen.aclose()
+
+        await asyncio.create_task(_close())
+
+    async def test_on_reply_close_from_other_task_no_detach_error(
+        self,
+    ) -> None:
+        """on_reply must not emit OTel 'Failed to detach context' errors when
+        its stream is closed from another asyncio task (issue #2076)."""
+        middleware = TracingMiddleware()
+
+        async def next_handler(**_kwargs: Any) -> Any:
+            yield "chunk-1"
+            await asyncio.Event().wait()  # suspend at the yield boundary
+
+        gen = middleware.on_reply(
+            self.agent,
+            {"inputs": UserMsg(name="user", content="hi")},
+            next_handler,
+        )
+        with self.assertNoLogs("opentelemetry.context", level="ERROR"):
+            await self._drive_then_close_from_other_task(gen)
+
+    async def test_on_acting_close_from_other_task_no_detach_error(
+        self,
+    ) -> None:
+        """on_acting must not emit OTel 'Failed to detach context' errors when
+        its stream is closed from another asyncio task (issue #2076)."""
+        middleware = TracingMiddleware()
+
+        async def next_handler(**_kwargs: Any) -> Any:
+            yield ToolResultBlock(
+                id="t1",
+                name="get_weather",
+                output="ok",
+                state=ToolResultState.SUCCESS,
+            )
+            await asyncio.Event().wait()  # suspend at the yield boundary
+
+        tool_call = ToolCallBlock(
+            id="t1",
+            name="get_weather",
+            input=json.dumps({"city": "Hangzhou"}),
+        )
+        gen = middleware.on_acting(
+            self.agent,
+            {"tool_call": tool_call},
+            next_handler,
+        )
+        with self.assertNoLogs("opentelemetry.context", level="ERROR"):
+            await self._drive_then_close_from_other_task(gen)

--- a/tests/tracing_test.py
+++ b/tests/tracing_test.py
@@ -853,7 +853,7 @@ class TracingTest(IsolatedAsyncioTestCase):
     async def _drive_then_close_from_other_task(self, gen: Any) -> None:
         """Advance an async generator once, then close it from a *different*
         asyncio task, reproducing the cross-context close in issue #2076."""
-        await gen.__anext__()
+        await anext(gen)
 
         async def _close() -> None:
             await gen.aclose()


### PR DESCRIPTION
## AgentScope Version

`main` (reproduced on `2.0.4`)

## Description

### Background

`TracingMiddleware.on_reply` and `on_acting` wrapped an async generator with:

```python
with tracer.start_as_current_span(..., end_on_exit=False) as span:
    async for item in next_handler(**input_kwargs):
        yield item
```

`start_as_current_span()` attaches the OpenTelemetry current-span context on
`__enter__` and detaches it on `__exit__`. Because the `with` body contains
`yield`, enter and exit happen at different suspension points. In streaming
scenarios (SSE / cancellation / client disconnect), the async generator is
often closed from a **different asyncio task** than the one that started it.
`asyncio.create_task` runs the coroutine in a copied `contextvars.Context`, so
the detach happens in a different context than the attach, and OpenTelemetry
logs:

```
Failed to detach context
ValueError: <Token ...> was created in a different Context
```

The request itself usually succeeds, but this emits ERROR-level log noise that
pollutes production error monitoring. See #2076 for the minimal reproduction.

### Changes

- Create the reply / tool spans with `tracer.start_span(...)` instead of
  `start_as_current_span(..., end_on_exit=False)`, and manage `span.end()`
  manually (as before, via `_set_span_success_status` / `_set_span_error_status`).
- Attach/detach `set_span_in_context(span)` **within each `__anext__` step**
  and never hold the context across the `yield` to the external consumer. Attach
  and detach therefore always happen in the same context, even when the outer
  async generator is closed from another task.
- Child spans (chat / execute_tool) are still parented correctly because the
  span context is active while `next_handler` runs. Synthetic external-execution
  `execute_tool` spans are now parented explicitly via `context=span_context`.
- `on_model_call` already used a manual span wrapper that never attaches context
  across yields, so it was left unchanged.

### How to test

```bash
pytest tests/tracing_test.py
```

New regression tests `test_on_reply_close_from_other_task_no_detach_error` and
`test_on_acting_close_from_other_task_no_detach_error` drive the middleware one
step, then close the stream from another asyncio task and assert that no
`opentelemetry.context` ERROR is logged. Both fail on `main` (with the exact
`ValueError: ... was created in a different Context`) and pass with this fix.
All 15 existing tracing tests still pass, confirming span parenting/attributes
are preserved.

## Checklist

- [x] An issue has been created for this PR (#2076)
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [x] Code is ready for review

Fixes #2076
