### PR TITLE
fix(webui): surface EXCEED_MAX_ITERS as a visible error banner

### DIFF
--- a/examples/web_ui/frontend/src/hooks/useMessages.ts
+++ b/examples/web_ui/frontend/src/hooks/useMessages.ts
@@ -5,6 +5,7 @@ import type {
 	DataBlockStartEvent,
 	DataBlockDeltaEvent,
 	DataBlockEndEvent,
+	ExceedMaxItersEvent,
 	ReplyStartEvent,
 	UserConfirmResultEvent,
 } from '@agentscope-ai/agentscope/event';
@@ -16,6 +17,7 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import { sessionApi } from '@/api';
 import { chatApi } from '@/api';
 import { useAudioManager } from '@/context/AudioContext';
+import { useTranslation } from '@/i18n/useI18n';
 
 /**
  * One pending subagent HITL request, projected from a team *member*
@@ -147,6 +149,7 @@ export function useMessages(
 	}, []);
 
 	const audioManager = useAudioManager();
+	const { t } = useTranslation();
 
 	const optionsRef = useRef(options);
 	useEffect(() => {
@@ -187,15 +190,22 @@ export function useMessages(
 				}
 				return;
 			}
-			if (event.type === EventType.REPLY_START) {
-				audioManager?.stopAllPlayback();
-				const e = event as ReplyStartEvent;
-				const msg = AssistantMsg({ id: e.reply_id, name: e.name, content: [] });
-				msgsRef.current = [...msgsRef.current, msg];
-				currentReplyRef.current = msg;
-				clearInterruptTimer();
-				setPhase('streaming');
-			} else if (event.type === EventType.REPLY_END) {
+		if (event.type === EventType.REPLY_START) {
+			audioManager?.stopAllPlayback();
+			const e = event as ReplyStartEvent;
+			const msg = AssistantMsg({ id: e.reply_id, name: e.name, content: [] });
+			msgsRef.current = [...msgsRef.current, msg];
+			currentReplyRef.current = msg;
+			clearInterruptTimer();
+			setError(null);
+			setPhase('streaming');
+		} else if (event.type === EventType.EXCEED_MAX_ITERS) {
+			// The agent hit its iteration cap and stopped early. Surface a
+			// visible error so the user understands why the reply was
+			// truncated instead of silently dropping the run.
+			const e = event as ExceedMaxItersEvent;
+			setError(new Error(t('chat.error.exceedMaxIters', { name: e.name })));
+		} else if (event.type === EventType.REPLY_END) {
 				if (currentReplyRef.current) {
 					appendEvent(currentReplyRef.current, event);
 				}
@@ -231,7 +241,7 @@ export function useMessages(
 
 			scheduleUpdate();
 		},
-		[scheduleUpdate, audioManager, clearInterruptTimer],
+		[scheduleUpdate, audioManager, clearInterruptTimer, t],
 	);
 
 	// ── Lifecycle: fetch history + open SSE stream ──────────────────
@@ -481,6 +491,7 @@ export function useMessages(
 		loading,
 		phase,
 		error,
+		clearError: () => setError(null),
 		send,
 		onUserConfirm,
 		onSubagentConfirm,

--- a/examples/web_ui/frontend/src/i18n/locales/en.json
+++ b/examples/web_ui/frontend/src/i18n/locales/en.json
@@ -116,6 +116,9 @@
 		"send": "Send",
 		"confirmToolCall": "Allow this action?",
 		"subagentConfirmTitle": "{{name}} requests confirmation",
+		"error": {
+			"exceedMaxIters": "Agent \"{{name}}\" reached the maximum iteration limit and stopped early. The response may be incomplete — try breaking the task into smaller steps or increasing max_iters."
+		},
 		"newSession": "New Session",
 		"noSessions": "No sessions yet",
 		"noMessages": "No Messages Yet",

--- a/examples/web_ui/frontend/src/i18n/locales/zh.json
+++ b/examples/web_ui/frontend/src/i18n/locales/zh.json
@@ -116,6 +116,9 @@
 		"send": "发送",
 		"confirmToolCall": "允许此操作？",
 		"subagentConfirmTitle": "{{name}} 请求确认",
+		"error": {
+			"exceedMaxIters": "Agent “{{name}}” 已达到最大迭代次数上限并提前停止，回复可能不完整——请尝试将任务拆分成更小的步骤，或调大 max_iters。"
+		},
 		"newSession": "新会话",
 		"noSessions": "暂无会话",
 		"noMessages": "暂无消息",

--- a/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
+++ b/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
@@ -1,6 +1,6 @@
 import type { PermissionContext } from '@agentscope-ai/agentscope/permission';
 import type { TaskContext } from '@agentscope-ai/agentscope/state';
-import { BookText, ChevronDown, Database, ListTodo, PanelRight, ShieldCheck } from 'lucide-react';
+import { BookText, ChevronDown, CircleAlert, Database, ListTodo, PanelRight, ShieldCheck } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import type { ChatModelConfig, SessionKnowledgeConfig, TTSModelConfig } from '@/api';
@@ -19,6 +19,7 @@ import { KnowledgeBaseParametersPopover } from '@/components/popover/KnowledgeBa
 import { ModelParametersPopover } from '@/components/popover/ModelParametersPopover';
 import { LlmSelect } from '@/components/select/LlmSelect';
 import { PermissionModeSelect } from '@/components/select/PermissionModeSelect.tsx';
+import { Alert, AlertDescription, AlertAction } from '@/components/ui/alert.tsx';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -156,7 +157,7 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 		}
 	}, []);
 
-	const { msgs, phase, send, onUserConfirm, onSubagentConfirm, subagentHitl, interrupt } =
+	const { msgs, phase, error, clearError, send, onUserConfirm, onSubagentConfirm, subagentHitl, interrupt } =
 		useMessages(agentId, sessionId, {
 			onTeamUpdated: handleTeamUpdated,
 			onStateUpdated: handleStateUpdated,
@@ -611,8 +612,21 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 									</DropdownMenu>
 								</div>
 							</div>
-							<div className="flex flex-1 justify-center min-h-0 overflow-hidden relative [--chat-content-w:48rem]">
-								<ChatContent
+						<div className="flex flex-1 justify-center min-h-0 overflow-hidden relative [--chat-content-w:48rem]">
+							{error && (
+								<div className="absolute top-0 left-0 right-0 z-10 p-2">
+									<Alert variant="destructive">
+										<CircleAlert />
+										<AlertDescription>{error.message}</AlertDescription>
+										<AlertAction>
+											<Button variant="outline" size="sm" onClick={clearError}>
+												{t('common.dismiss')}
+											</Button>
+										</AlertAction>
+									</Alert>
+								</div>
+							)}
+							<ChatContent
 									className={'max-w-[var(--chat-content-w)] w-full'}
 									msgs={msgs}
 									phase={phase}


### PR DESCRIPTION

<img width="460" height="1122" alt="image" src="https://github.com/user-attachments/assets/775aa850-c5b7-4259-94de-604717d98024" />




The WebUI silently dropped the ExceedMaxItersEvent, so when an agent hit its
iteration cap the reply was truncated with no explanation to the user.

Handle the event in useMessages (set an error carrying the agent name) and
render a dismissible destructive Alert in ChatViewport. The error is cleared
at the start of each new reply. Add chat.error.exceedMaxIters i18n strings for
en/zh and reuse common.dismiss for the close button.

## AgentScope Version

2.0.4dev

## Description

**Background**
When a ReAct agent reaches its `max_iters` cap, AgentScope emits an
`ExceedMaxItersEvent`. The WebUI (`examples/web_ui/frontend`) never handled
this event type, and the `error` state exposed by `useMessages` was never
rendered in `ChatViewport`. The run stopped mid-reply with no explanation — the
error was silently dropped.

**Purpose**
Surface the iteration-cap condition as a clear, dismissible error banner so the
stop is no longer silent.

**Changes made**
- `src/hooks/useMessages.ts`: handle `EXCEED_MAX_ITERS`, set an `error` carrying
  the agent name; clear it at the start of each new reply; expose `clearError`.
- `src/pages/chat/ChatViewport.tsx`: render a dismissible destructive `Alert` at
  the top of the chat area, reusing `common.dismiss` for the close button.
- `src/i18n/locales/en.json` / `zh.json`: add `chat.error.exceedMaxIters` i18n
  strings (en/zh).

**How to test**
1. Run the AgentScope WebUI against an agent with a low `max_iters` (e.g. the
   default 20).
2. Send a task complex enough to exceed the cap.
3. Observe the dismissible error banner explaining the agent reached the
   iteration limit.

**Verification**
eslint 0 errors, `tsc -b` passed, pre-commit passed (check-json /
trim-trailing-whitespace / detect-private-key).

## Checklist

- [ ]  An issue has been created for this PR
       (optional — this is a small atomic frontend-only fix; CONTRIBUTING's
        "open issue first" targets PRs touching many files / changing public
        APIs. A Discussion(ideas) can be opened instead if maintainers prefer.)
- [x]  I have read the CONTRIBUTING.md
- [x]  Docstrings are in Google style
       (N/A — frontend TypeScript change, no Python docstrings)
- [ ]  Related documentation has been updated in documentation repository
       (N/A — UI-only error banner, no user-facing API/doc change)
- [x]  Code is ready for review
