### PR TITLE
fix(service): upload workspace skills from the browser

### DIFF
--- a/examples/web_ui/frontend/package.json
+++ b/examples/web_ui/frontend/package.json
@@ -48,7 +48,8 @@
 		"tailwindcss": "^4.3.0",
 		"tw-animate-css": "^1.4.0",
 		"unidiff": "^1.0.4",
-		"vaul": "^1.1.2"
+		"vaul": "^1.1.2",
+		"yaml": "^2.9.0"
 	},
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",

--- a/examples/web_ui/frontend/src/api/client.ts
+++ b/examples/web_ui/frontend/src/api/client.ts
@@ -27,10 +27,17 @@ interface RequestOptions {
 	silent?: boolean;
 }
 
-function buildHeaders(hasBody: boolean): Record<string, string> {
+function buildHeaders(body: unknown): Record<string, string> {
 	const headers: Record<string, string> = { 'X-User-ID': getUserId() };
-	if (hasBody) headers['Content-Type'] = 'application/json';
+	if (body !== undefined && !(body instanceof FormData)) {
+		headers['Content-Type'] = 'application/json';
+	}
 	return headers;
+}
+
+function serializeBody(body: unknown): BodyInit | undefined {
+	if (body === undefined) return undefined;
+	return body instanceof FormData ? body : JSON.stringify(body);
 }
 
 /** Parse the response body and extract the `detail` field if the backend returned JSON. */
@@ -55,8 +62,8 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
 
 	const res = await fetch(url.toString(), {
 		method,
-		headers: buildHeaders(body !== undefined),
-		body: body ? JSON.stringify(body) : undefined,
+		headers: buildHeaders(body),
+		body: serializeBody(body),
 	});
 
 	if (!res.ok) {
@@ -82,8 +89,8 @@ async function streamRequest(
 
 	const res = await fetch(url.toString(), {
 		method,
-		headers: buildHeaders(body !== undefined),
-		body: body ? JSON.stringify(body) : undefined,
+		headers: buildHeaders(body),
+		body: serializeBody(body),
 		signal,
 	});
 

--- a/examples/web_ui/frontend/src/api/types.ts
+++ b/examples/web_ui/frontend/src/api/types.ts
@@ -401,10 +401,6 @@ export interface Skill {
 	updated_at: number;
 }
 
-export interface AddSkillRequest {
-	skill_path: string;
-}
-
 // ─── Schedule ─────────────────────────────────────────────────────────────────
 
 export type PermissionMode =

--- a/examples/web_ui/frontend/src/api/workspace.ts
+++ b/examples/web_ui/frontend/src/api/workspace.ts
@@ -1,5 +1,5 @@
 import { client } from './client';
-import type { AddSkillRequest, MCPClient, MCPClientStatus, Skill } from './types';
+import type { MCPClient, MCPClientStatus, Skill } from './types';
 
 export const workspaceApi = {
 	mcp: {
@@ -23,11 +23,16 @@ export const workspaceApi = {
 		list: (agentId: string, sessionId: string) =>
 			client.get<Skill[]>('/workspace/skill', { agent_id: agentId, session_id: sessionId }),
 
-		add: (agentId: string, sessionId: string, body: AddSkillRequest) =>
-			client.post<void>('/workspace/skill', body, {
+		add: (agentId: string, sessionId: string, files: File[]) => {
+			const body = new FormData();
+			files.forEach((file) => {
+				body.append('files', file, file.webkitRelativePath || file.name);
+			});
+			return client.post<void>('/workspace/skill', body, {
 				agent_id: agentId,
 				session_id: sessionId,
-			}),
+			});
+		},
 
 		remove: (skillName: string, agentId: string, sessionId: string) =>
 			client.delete(`/workspace/skill/${skillName}`, {

--- a/examples/web_ui/frontend/src/components/dialog/AddSkillDialog.tsx
+++ b/examples/web_ui/frontend/src/components/dialog/AddSkillDialog.tsx
@@ -1,5 +1,6 @@
-import { CircleAlert, Loader2, PlusCircle } from 'lucide-react';
-import { useState, type ReactNode } from 'react';
+import { FolderOpen, Loader2, PlusCircle, X } from 'lucide-react';
+import { useRef, useState, type ChangeEvent, type ReactNode } from 'react';
+import { parse } from 'yaml';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -11,29 +12,94 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useTranslation } from '@/i18n/useI18n';
 
 interface AddSkillDialogProps {
 	children: ReactNode;
-	onAdd: (skillPath: string) => Promise<void>;
+	onAdd: (files: File[]) => Promise<void>;
 }
 
 export function AddSkillDialog({ children, onAdd }: AddSkillDialogProps) {
 	const { t } = useTranslation();
+	const inputRef = useRef<HTMLInputElement>(null);
 	const [open, setOpen] = useState(false);
-	const [skillPath, setSkillPath] = useState('');
+	const [files, setFiles] = useState<File[]>([]);
+	const [folderName, setFolderName] = useState<string | null>(null);
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
+	const resetSelection = () => {
+		setFiles([]);
+		setFolderName(null);
+		setError(null);
+	};
+
+	const handleOpenChange = (nextOpen: boolean) => {
+		if (!nextOpen && loading) return;
+		setOpen(nextOpen);
+		if (!nextOpen) resetSelection();
+	};
+
+	const handleSelection = async (event: ChangeEvent<HTMLInputElement>) => {
+		const selectedFiles = Array.from(event.currentTarget.files ?? []);
+		event.currentTarget.value = '';
+		resetSelection();
+		if (!selectedFiles.length) return;
+
+		const paths = selectedFiles.map((file) => file.webkitRelativePath || file.name);
+		const parts = paths.map((path) => path.split('/'));
+		const validPaths = parts.every(
+			(pathParts) =>
+				pathParts.length >= 2 &&
+				pathParts.every((part) => part && part !== '.' && part !== '..'),
+		);
+		const roots = new Set(parts.map((pathParts) => pathParts[0]));
+		if (!validPaths || roots.size !== 1) {
+			setError(t('dialog-skill-add.invalidSelection'));
+			return;
+		}
+
+		const root = parts[0][0];
+		const skillFile = selectedFiles.find((_, index) => {
+			const pathParts = parts[index];
+			return pathParts.length === 2 && pathParts[1] === 'SKILL.md';
+		});
+		if (!skillFile) {
+			setError(t('dialog-skill-add.missingSkillMd'));
+			return;
+		}
+
+		try {
+			const content = (await skillFile.text()).replace(/^\uFEFF/, '');
+			const frontmatter = content.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/);
+			if (!frontmatter) throw new Error('missing frontmatter');
+			const metadata = parse(frontmatter[1]) as Record<string, unknown> | null;
+			if (
+				!metadata ||
+				typeof metadata.name !== 'string' ||
+				!metadata.name.trim() ||
+				typeof metadata.description !== 'string' ||
+				!metadata.description.trim()
+			) {
+				throw new Error('invalid frontmatter');
+			}
+		} catch {
+			setError(t('dialog-skill-add.invalidSkillMd'));
+			return;
+		}
+
+		setFiles(selectedFiles);
+		setFolderName(root);
+	};
+
 	const handleSubmit = async () => {
-		if (!skillPath.trim()) return;
+		if (!files.length) return;
 		setLoading(true);
 		setError(null);
 		try {
-			await onAdd(skillPath.trim());
-			setSkillPath('');
+			await onAdd(files);
+			resetSelection();
 			setOpen(false);
 		} catch (e) {
 			setError((e as Error).message);
@@ -43,7 +109,7 @@ export function AddSkillDialog({ children, onAdd }: AddSkillDialogProps) {
 	};
 
 	return (
-		<Dialog open={open} onOpenChange={setOpen}>
+		<Dialog open={open} onOpenChange={handleOpenChange}>
 			<DialogTrigger asChild>{children}</DialogTrigger>
 			<DialogContent className="!w-[500px] !max-w-[500px]">
 				<DialogHeader>
@@ -51,24 +117,41 @@ export function AddSkillDialog({ children, onAdd }: AddSkillDialogProps) {
 					<DialogDescription>{t('dialog-skill-add.description')}</DialogDescription>
 				</DialogHeader>
 				<div className="flex flex-col gap-y-2">
-					<Label htmlFor="skill-path">{t('dialog-skill-add.pathLabel')}</Label>
-					<Input
-						id="skill-path"
-						placeholder={t('dialog-skill-add.pathPlaceholder')}
-						value={skillPath}
-						onChange={(e) => setSkillPath(e.target.value)}
-						onKeyDown={(e) => {
-							if (e.key === 'Enter') handleSubmit();
-						}}
+					<Label htmlFor="skill-folder">{t('dialog-skill-add.folderLabel')}</Label>
+					<input
+						ref={inputRef}
+						id="skill-folder"
+						type="file"
+						className="hidden"
+						multiple
+						{...{ webkitdirectory: '' }}
+						onChange={(event) => void handleSelection(event)}
 					/>
+					<div className="flex min-w-0 items-center gap-3">
+						<Button
+							type="button"
+							variant="outline"
+							onClick={() => inputRef.current?.click()}
+						>
+							<FolderOpen className="size-3.5" />
+							{t('dialog-skill-add.selectFolder')}
+						</Button>
+						<span className="min-w-0 truncate text-sm text-muted-foreground">
+							{folderName ?? t('dialog-skill-add.noFolderSelected')}
+						</span>
+					</div>
 					{error && <p className="text-destructive text-sm">{error}</p>}
 				</div>
 				<DialogFooter>
-					<Button variant="ghost" onClick={() => setOpen(false)} disabled={loading}>
-						<CircleAlert className="size-3.5" />
+					<Button
+						variant="ghost"
+						onClick={() => handleOpenChange(false)}
+						disabled={loading}
+					>
+						<X className="size-3.5" />
 						{t('common.cancel')}
 					</Button>
-					<Button onClick={handleSubmit} disabled={loading || !skillPath.trim()}>
+					<Button onClick={handleSubmit} disabled={loading || !files.length}>
 						{loading ? (
 							<Loader2 className="size-3.5 animate-spin" />
 						) : (

--- a/examples/web_ui/frontend/src/components/panel/SkillPanel.tsx
+++ b/examples/web_ui/frontend/src/components/panel/SkillPanel.tsx
@@ -18,9 +18,9 @@ interface SkillPanelProps {
 	/**
 	 * Add a skill to the workspace.
 	 *
-	 * @param skillPath - Path of the skill to add.
+	 * @param files - Files selected from the skill directory.
 	 */
-	onAdd: (skillPath: string) => Promise<void>;
+	onAdd: (files: File[]) => Promise<void>;
 	/**
 	 * Remove a skill by name.
 	 *

--- a/examples/web_ui/frontend/src/hooks/useSkills.ts
+++ b/examples/web_ui/frontend/src/hooks/useSkills.ts
@@ -35,11 +35,11 @@ export function useSkills(agentId: string | null, sessionId: string | null) {
 		refetch();
 	}, [refetch]);
 
-	/** Adds a skill from the given path and refreshes the list. */
+	/** Uploads a skill directory and refreshes the list. */
 	const add = useCallback(
-		async (skillPath: string) => {
+		async (files: File[]) => {
 			if (!agentId || !sessionId) throw new Error('No agent/session selected');
-			await workspaceApi.skill.add(agentId, sessionId, { skill_path: skillPath });
+			await workspaceApi.skill.add(agentId, sessionId, files);
 			await refetch();
 		},
 		[agentId, sessionId, refetch],

--- a/examples/web_ui/frontend/src/hooks/useWorkspace.ts
+++ b/examples/web_ui/frontend/src/hooks/useWorkspace.ts
@@ -82,9 +82,9 @@ export function useWorkspace(agentId: string | null, sessionId: string | null) {
 	);
 
 	const addSkill = useCallback(
-		async (skillPath: string) => {
+		async (files: File[]) => {
 			if (!agentId || !sessionId) throw new Error('No agent/session selected');
-			await workspaceApi.skill.add(agentId, sessionId, { skill_path: skillPath });
+			await workspaceApi.skill.add(agentId, sessionId, files);
 			await refetchSkills();
 		},
 		[agentId, sessionId, refetchSkills],

--- a/examples/web_ui/frontend/src/i18n/locales/en.json
+++ b/examples/web_ui/frontend/src/i18n/locales/en.json
@@ -428,9 +428,13 @@
 	},
 	"dialog-skill-add": {
 		"title": "Add skill",
-		"description": "Enter the path to a skill directory to add it to the workspace.",
-		"pathLabel": "Skill path",
-		"pathPlaceholder": "/path/to/skill"
+		"description": "Select a skill directory to upload to the workspace.",
+		"folderLabel": "Skill folder",
+		"selectFolder": "Select folder",
+		"noFolderSelected": "No folder selected",
+		"invalidSelection": "Select exactly one skill folder.",
+		"missingSkillMd": "The selected folder must contain SKILL.md at its root.",
+		"invalidSkillMd": "SKILL.md must have valid name and description frontmatter."
 	},
 	"schedule": {
 		"calendar": "Calendar",

--- a/examples/web_ui/frontend/src/i18n/locales/zh.json
+++ b/examples/web_ui/frontend/src/i18n/locales/zh.json
@@ -428,9 +428,13 @@
 	},
 	"dialog-skill-add": {
 		"title": "添加技能",
-		"description": "输入技能目录的路径以添加到工作区。",
-		"pathLabel": "技能路径",
-		"pathPlaceholder": "/path/to/skill"
+		"description": "选择一个技能目录并上传到工作区。",
+		"folderLabel": "技能目录",
+		"selectFolder": "选择目录",
+		"noFolderSelected": "尚未选择目录",
+		"invalidSelection": "请选择且仅选择一个技能目录。",
+		"missingSkillMd": "所选目录的根目录必须包含 SKILL.md。",
+		"invalidSkillMd": "SKILL.md 必须包含有效的 name 和 description 元数据。"
 	},
 	"schedule": {
 		"calendar": "日历",

--- a/examples/web_ui/pnpm-lock.yaml
+++ b/examples/web_ui/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ models = [
 service = [
     "fastapi",
     "uvicorn",
+    "python-multipart",
     "apscheduler",
     "ag-ui-protocol>=0.1.10",
 ]

--- a/src/agentscope/app/_router/_workspace.py
+++ b/src/agentscope/app/_router/_workspace.py
@@ -1,6 +1,19 @@
 # -*- coding: utf-8 -*-
 """Workspace router — manage MCP clients and skills on a workspace."""
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+import io
+import tarfile
+from pathlib import PurePosixPath
+
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    HTTPException,
+    Query,
+    UploadFile,
+    status,
+)
 from pydantic import BaseModel, Field
 
 from ..deps import (
@@ -13,14 +26,13 @@ from ..storage import StorageBase
 from ...mcp import MCPClient
 from ...skill import Skill
 from ...workspace import WorkspaceBase
+from ...workspace._skill import (
+    MAX_SKILL_ARCHIVE_SIZE,
+    MAX_SKILL_FILES,
+    validate_skill_archive,
+)
 
 workspace_router = APIRouter(prefix="/workspace", tags=["workspace"])
-
-
-class AddSkillRequest(BaseModel):
-    """The request to add skill."""
-
-    skill_path: str
 
 
 class ToolInfo(BaseModel):
@@ -35,6 +47,73 @@ class MCPClientStatus(MCPClient):
 
     is_healthy: bool = False
     tools: list[ToolInfo] = Field(default_factory=list)
+
+
+async def _build_uploaded_skill_archive(files: list[UploadFile]) -> bytes:
+    """Build a validated flat tar archive from one uploaded directory."""
+    if not files:
+        raise ValueError("No skill files were uploaded.")
+    if len(files) > MAX_SKILL_FILES:
+        raise ValueError("Skill upload contains too many files.")
+
+    root_name: str | None = None
+    seen: set[str] = set()
+    total_size = 0
+    buffer = io.BytesIO()
+
+    with tarfile.open(fileobj=buffer, mode="w") as tar:
+        for uploaded_file in files:
+            filename = uploaded_file.filename or ""
+            if "\x00" in filename or "\\" in filename:
+                raise ValueError(f"Unsafe uploaded skill path: {filename!r}.")
+            path = PurePosixPath(filename)
+            if path.is_absolute() or any(
+                part in ("", ".", "..") for part in path.parts
+            ):
+                raise ValueError(f"Unsafe uploaded skill path: {filename!r}.")
+            if len(path.parts) < 2:
+                raise ValueError(
+                    "Skill files must include their selected directory name.",
+                )
+
+            if root_name is None:
+                root_name = path.parts[0]
+            elif root_name != path.parts[0]:
+                raise ValueError(
+                    "Upload exactly one skill directory at a time.",
+                )
+
+            relative = PurePosixPath(*path.parts[1:]).as_posix()
+            portable_relative = relative.casefold()
+            if portable_relative in seen:
+                raise ValueError(
+                    f"Duplicate uploaded skill file: {relative!r}.",
+                )
+            seen.add(portable_relative)
+
+            content = bytearray()
+            while chunk := await uploaded_file.read(1024 * 1024):
+                total_size += len(chunk)
+                if total_size > MAX_SKILL_ARCHIVE_SIZE:
+                    raise HTTPException(
+                        status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                        detail="Skill upload exceeds the maximum size.",
+                    )
+                content.extend(chunk)
+
+            info = tarfile.TarInfo(relative)
+            info.size = len(content)
+            info.mode = 0o644
+            tar.addfile(info, io.BytesIO(content))
+
+    archive = buffer.getvalue()
+    if len(archive) > MAX_SKILL_ARCHIVE_SIZE:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="Skill upload exceeds the maximum size.",
+        )
+    validate_skill_archive(archive)
+    return archive
 
 
 async def _resolve_workspace(
@@ -179,14 +258,14 @@ async def list_skills(
 
 @workspace_router.post("/skill", status_code=status.HTTP_201_CREATED)
 async def add_skill(
-    body: AddSkillRequest,
+    files: list[UploadFile] = File(...),
     agent_id: str = Query(...),
     session_id: str = Query(...),
     user_id: str = Depends(get_current_user_id),
     storage: StorageBase = Depends(get_storage),
     workspace_manager: WorkspaceManagerBase = Depends(get_workspace_manager),
 ) -> None:
-    """Add a skill to the session's workspace from the given path."""
+    """Add a browser-uploaded skill directory to the workspace."""
     workspace = await _resolve_workspace(
         user_id,
         agent_id,
@@ -194,7 +273,16 @@ async def add_skill(
         storage,
         workspace_manager,
     )
-    await workspace.add_skill(body.skill_path)
+    try:
+        archive = await _build_uploaded_skill_archive(files)
+        await workspace.add_skill(archive)
+    except HTTPException:
+        raise
+    except ValueError as error:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(error),
+        ) from error
 
 
 @workspace_router.delete(

--- a/src/agentscope/workspace/_base.py
+++ b/src/agentscope/workspace/_base.py
@@ -48,11 +48,8 @@ keeping path semantics consistent with whichever backend is bound.
 import asyncio
 import base64
 import hashlib
-import io
 import json
 import mimetypes
-import os
-import tarfile
 from abc import abstractmethod
 from copy import deepcopy
 from pathlib import Path
@@ -79,6 +76,11 @@ from ._utils import (
     DEFAULT_SESSIONS_DIR,
     DEFAULT_SKILLS_DIR,
 )
+from ._skill import (
+    build_skill_archive,
+    sanitize_skill_dir_name,
+    validate_skill_archive,
+)
 
 _EXTRACT_TAR_SHIM = (
     "import tarfile, sys, os\n"
@@ -89,6 +91,8 @@ _EXTRACT_TAR_SHIM = (
     "try:\n"
     "    members = tf.getmembers()\n"
     "    for m in members:\n"
+    "        if not m.isfile():\n"
+    "            raise Exception('unsupported tar member: ' + m.name)\n"
     "        target = os.path.realpath(os.path.join(dst, m.name))\n"
     "        if not (target == dst_real"
     " or target.startswith(dst_real + os.sep)):\n"
@@ -96,7 +100,7 @@ _EXTRACT_TAR_SHIM = (
     "    tf.extractall(dst, members=members)\n"
     "finally:\n"
     "    tf.close()\n"
-    "os.unlink(src)\n"
+    "    if os.path.exists(src): os.unlink(src)\n"
 )
 
 
@@ -618,57 +622,45 @@ class WorkspaceBase:
                 logger.warning("Failed to load skill %s: %s", md_path, e)
         return skills
 
-    async def add_skill(self, skill_path: str) -> None:
-        """Copy a local skill directory into ``${workdir}/skills``.
+    async def add_skill(self, skill_archive: bytes) -> None:
+        """Add a validated skill archive into ``${workdir}/skills``.
 
-        Tars the directory on the host, writes the archive to the
-        backend's tmp area, and extracts it via ``python3 -c`` inside
-        the sandbox — two round trips regardless of skill size, and
-        portable across any backend whose image ships ``python3``
-        (same contract as the gateway shim).
+        The archive contains files relative to the skill root, including a
+        root ``SKILL.md``. It is validated on the host, written to the
+        backend's temporary area, then safely extracted inside the sandbox.
 
         Subclasses with richer dedup (e.g. :class:`LocalWorkspace`
         with hash-indexed conflict resolution) override this method.
 
         Args:
-            skill_path (`str`):
-                Path to a skill directory on the local filesystem.
+            skill_archive (`bytes`):
+                Uncompressed tar bytes containing the skill files.
 
         Raises:
             ValueError:
-                If ``SKILL.md`` is missing or a directory with the
-                same basename already exists in ``skills/``.
+                If the archive is invalid or a skill with the same name
+                already exists in ``skills/``.
             RuntimeError:
                 If extraction inside the sandbox fails.
         """
-        skill_md = os.path.join(skill_path, "SKILL.md")
-        if not os.path.isfile(skill_md):
-            raise ValueError(
-                f"Invalid skill at {skill_path!r}: SKILL.md not found",
-            )
-
+        metadata = validate_skill_archive(skill_archive)
         backend = self.get_backend()
 
         async with self._skill_lock:
-            dir_name = os.path.basename(os.path.abspath(skill_path))
+            dir_name = sanitize_skill_dir_name(metadata.name)
             remote_dir = backend.join_path(self._skills_dir, dir_name)
 
             if await backend.file_exists(remote_dir):
                 raise ValueError(
-                    f"Skill directory {dir_name!r} already exists in "
+                    f"Skill {metadata.name!r} already exists in "
                     f"{self._skills_dir}",
                 )
 
-            buf = io.BytesIO()
-            with tarfile.open(fileobj=buf, mode="w") as tf:
-                tf.add(skill_path, arcname=dir_name)
-            tar_bytes = buf.getvalue()
-
             tmp_path = f"/tmp/skill-{_generate_id()}.tar"
-            await backend.write_file(tmp_path, tar_bytes)
+            await backend.write_file(tmp_path, skill_archive)
 
             await backend.exec_shell(
-                ["mkdir", "-p", self._skills_dir],
+                ["mkdir", "-p", remote_dir],
             )
             result = await backend.exec_shell(
                 [
@@ -676,16 +668,17 @@ class WorkspaceBase:
                     "-c",
                     _EXTRACT_TAR_SHIM,
                     tmp_path,
-                    self._skills_dir,
+                    remote_dir,
                 ],
             )
             if not result.ok():
+                await backend.delete_path(remote_dir)
                 raise RuntimeError(
                     f"Failed to extract skill {dir_name!r}: "
                     f"{result.stderr.decode('utf-8', 'replace')}",
                 )
 
-            logger.info("Added skill %r at %s", dir_name, remote_dir)
+            logger.info("Added skill %r at %s", metadata.name, remote_dir)
 
     async def remove_skill(self, name: str) -> None:
         """Remove a skill by its agent-facing ``name`` (front matter).
@@ -739,7 +732,8 @@ class WorkspaceBase:
             return
         for path in self.skill_paths:
             try:
-                await self.add_skill(path)
+                archive = await asyncio.to_thread(build_skill_archive, path)
+                await self.add_skill(archive)
             except Exception as e:
                 logger.warning(
                     "Skip skill %r: %s",

--- a/src/agentscope/workspace/_local_workspace.py
+++ b/src/agentscope/workspace/_local_workspace.py
@@ -5,7 +5,6 @@ import asyncio
 import hashlib
 import json
 import os
-import re
 import shutil
 from typing import TypedDict
 
@@ -19,6 +18,11 @@ from ..skill import Skill
 from ..tool import ToolBase
 from ..tool._builtin._backend import LocalBackend
 from ._base import WorkspaceBase
+from ._skill import (
+    extract_skill_archive,
+    sanitize_skill_dir_name,
+    validate_skill_archive,
+)
 
 
 class _SkillEntry(TypedDict):
@@ -37,24 +41,6 @@ class _SkillsFile(TypedDict):
     """mtime of skills_dir at the time the index was last written."""
     skills: dict[str, _SkillEntry]
     """Mapping from directory name (relative to skills_dir) to skill entry."""
-
-
-def _sanitize_dir_name(name: str) -> str:
-    """Sanitize a skill name into a safe directory name.
-
-    Allowed characters: ASCII letters, digits, CJK unified ideographs,
-    hyphens, and underscores. Everything else is replaced with ``_``.
-
-    Args:
-        name (`str`):
-            The raw skill name from SKILL.md frontmatter.
-
-    Returns:
-        `str`:
-            A sanitized string safe to use as a directory name on Windows,
-            macOS, and Linux.
-    """
-    return re.sub(r"[^\w一-鿿-]", "_", name)
 
 
 class LocalWorkspace(WorkspaceBase):
@@ -231,7 +217,7 @@ class LocalWorkspace(WorkspaceBase):
                 counter += 1
 
             # Resolve directory name conflict
-            base_dir = _sanitize_dir_name(raw_name)
+            base_dir = sanitize_skill_dir_name(raw_name)
             dir_name = base_dir
             counter = 1
             while dir_name in existing_dir_names:
@@ -710,36 +696,71 @@ class LocalWorkspace(WorkspaceBase):
                     return
         logger.warning("MCP client %r not found in workspace", name)
 
-    async def add_skill(self, skill_path: str) -> None:
-        """Add a skill to the workspace by copying from the given path.
+    # pylint: disable=arguments-renamed, too-many-statements
+    async def add_skill(
+        self,
+        source: str | bytes | os.PathLike[str],
+    ) -> None:
+        """Add a skill from a local path or a validated tar archive.
 
         The skill directory must contain a valid ``SKILL.md`` file with
         ``name`` and ``description`` frontmatter fields.  Duplicate skills
-        (identified by the SHA-256 hash of ``SKILL.md``) are silently skipped.
-        Name and directory conflicts are resolved by appending a numeric
-        suffix.
+        (identified by the SHA-256 hash of ``SKILL.md``) are silently
+        skipped.  Name and directory conflicts are resolved by appending
+        a numeric suffix.
 
         Args:
-            skill_path (`str`):
-                Absolute or relative path to the skill directory to copy.
+            source: Either a filesystem path (``str`` or
+                ``os.PathLike[str]``) to a local skill directory — in
+                which case the directory is copied recursively — or a
+                ``bytes`` payload holding an uncompressed tar archive of
+                the skill files as uploaded from the browser.
 
         Raises:
-            ValueError: If the skill at ``skill_path`` is invalid (missing or
-                malformed ``SKILL.md``).
+            ValueError: If the source is invalid (missing or malformed
+                ``SKILL.md``, path pointing outside ``skills/``, or a
+                corrupt tar archive).
+            TypeError: If ``source`` is neither ``bytes`` nor a path.
         """
-        skill_path = _normalize_local_path(skill_path)
         skills_dir = os.path.join(self.workdir, "skills")
         async with self._skill_lock:
             os.makedirs(skills_dir, exist_ok=True)
 
-            result = await self._validate_and_hash_skill(skill_path)
-            if result is None:
-                raise ValueError(
-                    f"Invalid skill at {skill_path!r}: missing or malformed "
-                    "SKILL.md (requires 'name' and 'description' fields).",
-                )
+            if isinstance(source, (str, os.PathLike)):
+                # ----- path-based upload (mainline API) --------------------
+                skill_path = _normalize_local_path(os.fspath(source))
+                result = await self._validate_and_hash_skill(skill_path)
+                if result is None:
+                    raise ValueError(
+                        f"Invalid skill at {skill_path!r}: missing or "
+                        "malformed SKILL.md (requires 'name' and "
+                        "'description' fields).",
+                    )
+                _, raw_name, skill_hash = result
 
-            _, raw_name, skill_hash = result
+                def materialize(dest: str) -> None:
+                    if os.path.isdir(skill_path):
+                        shutil.copytree(skill_path, dest)
+                    else:
+                        raise ValueError(
+                            f"Skill path {skill_path!r} is not a directory.",
+                        )
+
+            elif isinstance(source, (bytes, bytearray, memoryview)):
+                # ----- byte-archive upload (browser upload API) -----------
+                archive_bytes = bytes(source)
+                metadata = validate_skill_archive(archive_bytes)
+                raw_name = metadata.name
+                skill_hash = metadata.content_hash
+
+                def materialize(dest: str) -> None:
+                    extract_skill_archive(archive_bytes, dest)
+
+            else:
+                raise TypeError(
+                    "add_skill() expects a str/os.PathLike directory path "
+                    f"or bytes tar archive, not {type(source).__name__}.",
+                )
 
             skills_file = await self._load_skills_file(skills_dir)
             existing: dict[str, _SkillEntry] = skills_file["skills"]
@@ -766,7 +787,7 @@ class LocalWorkspace(WorkspaceBase):
                 counter += 1
 
             # Resolve directory name conflict
-            base_dir = _sanitize_dir_name(raw_name)
+            base_dir = sanitize_skill_dir_name(raw_name)
             dir_name = base_dir
             counter = 1
             while dir_name in existing_dir_names:
@@ -779,21 +800,15 @@ class LocalWorkspace(WorkspaceBase):
                 os.path.realpath(skills_dir) + os.sep,
             ):
                 raise ValueError(
-                    f"Skill path {skill_path!r} resolves outside skills_dir.",
+                    f"Skill {raw_name!r} resolves outside skills_dir.",
                 )
 
-            await asyncio.to_thread(
-                shutil.copytree,
-                skill_path,
-                dest_path,
-                dirs_exist_ok=False,
-            )
+            await asyncio.to_thread(materialize, dest_path)
 
             logger.info(
-                "Copied skill '%s' (agent name: '%s') from %s to %s",
+                "Added skill '%s' (agent name: '%s') to %s",
                 raw_name,
                 agent_name,
-                skill_path,
                 dest_path,
             )
 

--- a/src/agentscope/workspace/_skill.py
+++ b/src/agentscope/workspace/_skill.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+"""Validation and packaging helpers for workspace skill archives."""
+
+import hashlib
+import io
+import os
+import re
+import shutil
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+import frontmatter
+from yaml import YAMLError
+
+MAX_SKILL_ARCHIVE_SIZE = 50 * 1024 * 1024
+MAX_SKILL_FILES = 1000
+
+
+@dataclass(frozen=True)
+class SkillArchiveMetadata:
+    """Validated metadata read from an uploaded skill archive."""
+
+    name: str
+    description: str
+    content_hash: str
+
+
+def sanitize_skill_dir_name(name: str) -> str:
+    """Return a portable directory name derived from a skill name."""
+    return re.sub(r"[^\w一-鿿-]", "_", name)
+
+
+def _validate_member_name(name: str) -> str:
+    """Validate and normalize a POSIX-relative archive member name."""
+    if not name or "\x00" in name or "\\" in name:
+        raise ValueError(f"Unsafe skill archive member: {name!r}.")
+    path = PurePosixPath(name)
+    windows_path = PureWindowsPath(name)
+    if (
+        path.is_absolute()
+        or any(part in ("", ".", "..") for part in path.parts)
+        or windows_path.drive
+    ):
+        raise ValueError(f"Unsafe skill archive member: {name!r}.")
+    normalized = path.as_posix()
+    if normalized != name:
+        raise ValueError(f"Unsafe skill archive member: {name!r}.")
+    return normalized
+
+
+def validate_skill_archive(archive: bytes) -> SkillArchiveMetadata:
+    """Validate a flat skill tar archive and parse its root ``SKILL.md``.
+
+    The archive must contain regular files only, use safe relative POSIX
+    paths, and place exactly one ``SKILL.md`` at its root. Symbolic links,
+    hard links, device entries, and compressed tar payloads are rejected.
+    """
+    if not archive:
+        raise ValueError("Skill archive is empty.")
+    if len(archive) > MAX_SKILL_ARCHIVE_SIZE:
+        raise ValueError("Skill archive exceeds the maximum size.")
+
+    try:
+        tar = tarfile.open(fileobj=io.BytesIO(archive), mode="r:")
+    except tarfile.TarError as error:
+        raise ValueError("Skill upload is not a valid tar archive.") from error
+
+    with tar:
+        try:
+            members = tar.getmembers()
+        except tarfile.TarError as error:
+            raise ValueError(
+                "Skill upload is not a valid tar archive.",
+            ) from error
+        if not members:
+            raise ValueError("Skill archive contains no files.")
+        if len(members) > MAX_SKILL_FILES:
+            raise ValueError("Skill archive contains too many files.")
+
+        seen: set[str] = set()
+        total_size = 0
+        skill_md: tarfile.TarInfo | None = None
+        for member in members:
+            if not member.isfile():
+                raise ValueError(
+                    "Skill archive may contain regular files only.",
+                )
+            name = _validate_member_name(member.name)
+            portable_name = name.casefold()
+            if portable_name in seen:
+                raise ValueError(f"Duplicate skill archive member: {name!r}.")
+            seen.add(portable_name)
+            total_size += member.size
+            if total_size > MAX_SKILL_ARCHIVE_SIZE:
+                raise ValueError("Skill archive exceeds the maximum size.")
+            if name == "SKILL.md":
+                skill_md = member
+
+        if skill_md is None:
+            raise ValueError(
+                "Skill archive must contain SKILL.md at its root.",
+            )
+        extracted = tar.extractfile(skill_md)
+        if extracted is None:
+            raise ValueError("Unable to read SKILL.md from skill archive.")
+        try:
+            skill_md_content = extracted.read().decode("utf-8")
+            document = frontmatter.loads(skill_md_content)
+        except (
+            UnicodeDecodeError,
+            TypeError,
+            ValueError,
+            YAMLError,
+            tarfile.TarError,
+        ) as error:
+            raise ValueError(
+                "SKILL.md is not valid UTF-8 frontmatter.",
+            ) from error
+
+    raw_name = document.get("name")
+    raw_description = document.get("description")
+    if not isinstance(raw_name, str) or not isinstance(raw_description, str):
+        raise ValueError(
+            "SKILL.md requires string name and description fields.",
+        )
+    name = raw_name.strip()
+    description = raw_description.strip()
+    if not name or not description:
+        raise ValueError("SKILL.md name and description cannot be empty.")
+    return SkillArchiveMetadata(
+        name=name,
+        description=description,
+        content_hash=hashlib.sha256(
+            skill_md_content.encode("utf-8"),
+        ).hexdigest(),
+    )
+
+
+def build_skill_archive(skill_path: str) -> bytes:
+    """Package a trusted local skill directory for workspace seeding."""
+    root = Path(skill_path).expanduser().resolve()
+    if not root.is_dir():
+        raise ValueError(f"Skill path {skill_path!r} is not a directory.")
+
+    files: list[tuple[Path, str]] = []
+    total_size = 0
+    for current, dir_names, file_names in os.walk(root, followlinks=False):
+        current_path = Path(current)
+        for dir_name in dir_names:
+            if (current_path / dir_name).is_symlink():
+                raise ValueError("Skill directories may not contain symlinks.")
+        dir_names.sort()
+        for file_name in sorted(file_names):
+            source = current_path / file_name
+            if source.is_symlink() or not source.is_file():
+                raise ValueError(
+                    "Skill directories may contain regular files only.",
+                )
+            relative = source.relative_to(root).as_posix()
+            _validate_member_name(relative)
+            total_size += source.stat().st_size
+            if total_size > MAX_SKILL_ARCHIVE_SIZE:
+                raise ValueError("Skill archive exceeds the maximum size.")
+            files.append((source, relative))
+            if len(files) > MAX_SKILL_FILES:
+                raise ValueError("Skill archive contains too many files.")
+
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w") as tar:
+        for source, relative in files:
+            stat = source.stat()
+            info = tarfile.TarInfo(relative)
+            info.size = stat.st_size
+            info.mode = stat.st_mode & 0o777
+            info.mtime = int(stat.st_mtime)
+            with source.open("rb") as file_obj:
+                tar.addfile(info, file_obj)
+    archive = buffer.getvalue()
+    validate_skill_archive(archive)
+    return archive
+
+
+def extract_skill_archive(archive: bytes, destination: str) -> None:
+    """Safely extract a previously validated skill archive."""
+    validate_skill_archive(archive)
+    os.makedirs(destination, exist_ok=False)
+    try:
+        with tarfile.open(fileobj=io.BytesIO(archive), mode="r:") as tar:
+            for member in tar.getmembers():
+                relative = PurePosixPath(_validate_member_name(member.name))
+                target = os.path.join(destination, *relative.parts)
+                os.makedirs(os.path.dirname(target), exist_ok=True)
+                source = tar.extractfile(member)
+                if source is None:
+                    raise ValueError(
+                        "Unable to read skill archive member "
+                        f"{member.name!r}.",
+                    )
+                with source, open(target, "xb") as target_file:
+                    shutil.copyfileobj(source, target_file)
+                os.chmod(target, member.mode & 0o777)
+    except Exception:
+        shutil.rmtree(destination, ignore_errors=True)
+        raise

--- a/tests/service_workspace_skill_router_test.py
+++ b/tests/service_workspace_skill_router_test.py
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*-
+"""Tests for directory uploads in the workspace skill router."""
+
+import io
+import tarfile
+from types import SimpleNamespace
+from unittest import TestCase
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from httpx import Response
+
+from agentscope.app._router._workspace import workspace_router
+from agentscope.app.deps import (
+    get_current_user_id,
+    get_storage,
+    get_workspace_manager,
+)
+from agentscope.workspace._skill import validate_skill_archive
+
+
+class _Storage:
+    """Minimal storage stub for resolving a workspace binding."""
+
+    async def get_session(
+        self,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> SimpleNamespace:
+        """Return a persisted session with a fixed workspace binding."""
+        del user_id, agent_id, session_id
+        return SimpleNamespace(
+            config=SimpleNamespace(workspace_id="workspace-1"),
+        )
+
+
+class _Workspace:
+    """Workspace stub that records validated skill archives."""
+
+    def __init__(self) -> None:
+        self.added_skill_archives: list[bytes] = []
+
+    async def add_skill(self, skill_archive: bytes) -> None:
+        """Revalidate and record the archive forwarded by the router."""
+        validate_skill_archive(skill_archive)
+        self.added_skill_archives.append(skill_archive)
+
+
+class _WorkspaceManager:
+    """Manager stub that always returns the same workspace."""
+
+    def __init__(self, workspace: _Workspace) -> None:
+        self.workspace = workspace
+
+    async def get_workspace(
+        self,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+        workspace_id: str | None = None,
+    ) -> _Workspace:
+        """Return the fixed workspace after checking its binding."""
+        del user_id, agent_id, session_id
+        assert workspace_id == "workspace-1"
+        return self.workspace
+
+
+class WorkspaceSkillRouterTest(TestCase):
+    """Exercise skill directory upload validation and packaging."""
+
+    def setUp(self) -> None:
+        """Create a dependency-overridden app."""
+        self._workspace = _Workspace()
+        storage = _Storage()
+        manager = _WorkspaceManager(self._workspace)
+        self._app = FastAPI()
+        self._app.include_router(workspace_router)
+
+        async def _current_user() -> str:
+            return "user-1"
+
+        async def _storage() -> _Storage:
+            return storage
+
+        async def _workspace_manager() -> _WorkspaceManager:
+            return manager
+
+        self._app.dependency_overrides[get_current_user_id] = _current_user
+        self._app.dependency_overrides[get_storage] = _storage
+        self._app.dependency_overrides[
+            get_workspace_manager
+        ] = _workspace_manager
+        self._client = TestClient(self._app)
+        self._params = {"agent_id": "agent-1", "session_id": "session-1"}
+
+    def tearDown(self) -> None:
+        """Close the test client."""
+        self._client.close()
+
+    def _add_skill(self, files: list[tuple[str, bytes]]) -> Response:
+        """Upload skill files while retaining directory-relative paths."""
+        multipart = [
+            (
+                "files",
+                (filename, content, "application/octet-stream"),
+            )
+            for filename, content in files
+        ]
+        return self._client.post(
+            "/workspace/skill",
+            params=self._params,
+            files=multipart,
+        )
+
+    def test_uploads_valid_skill_directory_as_flat_archive(self) -> None:
+        """The selected root is stripped before forwarding the archive."""
+        response = self._add_skill(
+            [
+                (
+                    "example/SKILL.md",
+                    b"---\nname: example\ndescription: test\n---\n",
+                ),
+                ("example/scripts/run.py", b"print('ok')\n"),
+            ],
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(len(self._workspace.added_skill_archives), 1)
+        archive = self._workspace.added_skill_archives[0]
+        metadata = validate_skill_archive(archive)
+        self.assertEqual(metadata.name, "example")
+        with tarfile.open(fileobj=io.BytesIO(archive), mode="r:") as tar:
+            self.assertEqual(
+                tar.getnames(),
+                ["SKILL.md", "scripts/run.py"],
+            )
+
+    def test_rejects_missing_or_invalid_root_skill_file(self) -> None:
+        """SKILL.md must exist at the root with required frontmatter."""
+        invalid_uploads = (
+            [("example/docs/SKILL.md", b"---\nname: test\n---\n")],
+            [("example/SKILL.md", b"---\nname: test\n---\n")],
+        )
+        for files in invalid_uploads:
+            with self.subTest(files=files):
+                response = self._add_skill(files)
+                self.assertEqual(response.status_code, 400)
+
+        self.assertEqual(self._workspace.added_skill_archives, [])
+
+    def test_rejects_unsafe_or_multiple_directory_paths(self) -> None:
+        """Uploads cannot traverse paths or combine multiple roots."""
+        skill_md = b"---\nname: test\ndescription: test\n---\n"
+        invalid_uploads = (
+            [("example/../SKILL.md", skill_md)],
+            [("example\\SKILL.md", skill_md)],
+            [
+                ("one/SKILL.md", skill_md),
+                ("two/data.txt", b"data"),
+            ],
+        )
+        for files in invalid_uploads:
+            with self.subTest(files=files):
+                response = self._add_skill(files)
+                self.assertEqual(response.status_code, 400)
+
+        self.assertEqual(self._workspace.added_skill_archives, [])
+
+    def test_rejects_portable_duplicate_paths(self) -> None:
+        """Case-only duplicate names cannot overwrite on extraction."""
+        response = self._add_skill(
+            [
+                (
+                    "example/SKILL.md",
+                    b"---\nname: test\ndescription: test\n---\n",
+                ),
+                ("example/readme.txt", b"one"),
+                ("example/README.TXT", b"two"),
+            ],
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(self._workspace.added_skill_archives, [])
+
+    def test_rejects_legacy_server_path_request(self) -> None:
+        """The HTTP contract no longer accepts a host filesystem path."""
+        response = self._client.post(
+            "/workspace/skill",
+            params=self._params,
+            json={"skill_path": "/tmp/example"},
+        )
+
+        self.assertEqual(response.status_code, 422)
+        self.assertEqual(self._workspace.added_skill_archives, [])

--- a/tests/workspace_daytona_test.py
+++ b/tests/workspace_daytona_test.py
@@ -60,6 +60,7 @@ from agentscope.workspace._daytona._constants import (
     DEFAULT_GATEWAY_PORT,
     METADATA_WORKSPACE_ID_KEY,
 )
+from agentscope.workspace._skill import build_skill_archive
 from agentscope.workspace._utils import _GATEWAY_BASE_REQUIREMENTS
 
 
@@ -1139,13 +1140,13 @@ class TestDaytonaWorkspaceBuiltinToolsMock(IsolatedAsyncioTestCase):
                 "Use this skill.\n",
             )
 
-        await self.workspace.add_skill(skill_dir)
+        await self.workspace.add_skill(build_skill_archive(skill_dir))
         skills = await self.workspace.list_skills()
 
         self.assertEqual([skill.name for skill in skills], ["demo-skill"])
         self.assertEqual(
             skills[0].dir,
-            "/home/daytona/skills/local-skill",
+            "/home/daytona/skills/demo-skill",
         )
 
         await self.workspace.remove_skill("demo-skill")
@@ -1153,9 +1154,11 @@ class TestDaytonaWorkspaceBuiltinToolsMock(IsolatedAsyncioTestCase):
 
     async def test_add_skill_rejects_invalid_skill(self) -> None:
         """Skill upload validates local input before sandbox work."""
-        with self.assertRaisesRegex(ValueError, "SKILL.md not found"):
+        with self.assertRaisesRegex(ValueError, "not a directory"):
             await self.workspace.add_skill(
-                os.path.join(self.temp_dir, "missing-skill"),
+                build_skill_archive(
+                    os.path.join(self.temp_dir, "missing-skill"),
+                ),
             )
 
     @unittest.skipIf(
@@ -1179,9 +1182,10 @@ class TestDaytonaWorkspaceBuiltinToolsMock(IsolatedAsyncioTestCase):
                 "Use this skill.\n",
             )
 
-        await self.workspace.add_skill(skill_dir)
+        archive = build_skill_archive(skill_dir)
+        await self.workspace.add_skill(archive)
         with self.assertRaisesRegex(ValueError, "already exists"):
-            await self.workspace.add_skill(skill_dir)
+            await self.workspace.add_skill(archive)
 
     async def test_offload_context_tool_result_and_reset(self) -> None:
         """Offload writes sessions/data and reset clears persistent state."""
@@ -1474,7 +1478,7 @@ class TestDaytonaWorkspaceLive(IsolatedAsyncioTestCase):
                     "live_added_skill",
                     "Added live skill",
                 )
-                await workspace.add_skill(added)
+                await workspace.add_skill(build_skill_archive(added))
                 skills = await workspace.list_skills()
                 self.assertIn(
                     "live_added_skill",

--- a/tests/workspace_docker_test.py
+++ b/tests/workspace_docker_test.py
@@ -55,6 +55,7 @@ from agentscope.permission import PermissionBehavior, PermissionDecision
 from agentscope.tool import ToolBase, ToolChunk
 from agentscope.workspace import DockerWorkspace
 from agentscope.workspace._docker._make_dockerfile import CONTAINER_WORKDIR
+from agentscope.workspace._skill import build_skill_archive
 
 CONTAINER_SKILLS_DIR = f"{CONTAINER_WORKDIR}/skills"
 CONTAINER_SESSIONS_DIR = f"{CONTAINER_WORKDIR}/sessions"
@@ -622,7 +623,7 @@ class TestDockerWorkspaceSkills(IsolatedAsyncioTestCase):
             "added_skill",
             "Added at runtime",
         )
-        await self.workspace.add_skill(new_skill)
+        await self.workspace.add_skill(build_skill_archive(new_skill))
 
         skills = await self.workspace.list_skills()
         self.assertEqual(len(skills), 1)
@@ -647,7 +648,7 @@ class TestDockerWorkspaceSkills(IsolatedAsyncioTestCase):
             f.write("def t():\n    pass\n")
 
         with self.assertRaises(ValueError):
-            await self.workspace.add_skill(invalid)
+            await self.workspace.add_skill(build_skill_archive(invalid))
 
 
 # ── lifecycle tests ───────────────────────────────────────────────

--- a/tests/workspace_k8s_test.py
+++ b/tests/workspace_k8s_test.py
@@ -16,6 +16,7 @@ The pre-baked image (see ``tests/docker/k8s_workspace_test.Dockerfile``)
 ships the gateway script at ``GATEWAY_HOME``, so ``initialize()`` skips
 bootstrap and each test finishes in ~15 s.
 """
+
 import os
 import shutil
 import sys
@@ -30,6 +31,7 @@ from agentscope.workspace._k8s._constants import (
     GATEWAY_HOME,
     POD_WORKDIR,
 )
+from agentscope.workspace._skill import build_skill_archive
 
 # ── cluster availability check ────────────────────────────────────
 
@@ -178,7 +180,7 @@ class TestK8sWorkspaceHappyPath(IsolatedAsyncioTestCase):
         )
         self.assertListEqual(await ws.list_skills(), [])
 
-        await ws.add_skill(skill_path)
+        await ws.add_skill(build_skill_archive(skill_path))
         skills = await ws.list_skills()
         self.assertEqual(len(skills), 1)
         self.assertEqual(
@@ -315,7 +317,7 @@ class TestK8sWorkspaceReset(IsolatedAsyncioTestCase):
             backend = ws.get_backend()
 
             # Seed state.
-            await ws.add_skill(skill_path)
+            await ws.add_skill(build_skill_archive(skill_path))
             await backend.write_file(
                 f"{POD_WORKDIR}/sessions/s1/context.jsonl",
                 b'{"msg": "hi"}\n',

--- a/tests/workspace_skill_archive_test.py
+++ b/tests/workspace_skill_archive_test.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+"""Tests for workspace skill archive validation and extraction."""
+
+import io
+import os
+import tarfile
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+from unittest.async_case import IsolatedAsyncioTestCase
+
+from agentscope.workspace import LocalWorkspace
+from agentscope.workspace._skill import (
+    build_skill_archive,
+    extract_skill_archive,
+    validate_skill_archive,
+)
+
+
+def _archive_with_member(
+    name: str,
+    content: bytes,
+    member_type: bytes = tarfile.REGTYPE,
+) -> bytes:
+    """Return a tar archive containing one custom member."""
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w") as tar:
+        info = tarfile.TarInfo(name)
+        info.type = member_type
+        info.size = len(content) if member_type == tarfile.REGTYPE else 0
+        tar.addfile(info, io.BytesIO(content))
+    return buffer.getvalue()
+
+
+class WorkspaceSkillArchiveTest(TestCase):
+    """Exercise the portable skill archive boundary."""
+
+    def test_build_validate_and_extract_skill_archive(self) -> None:
+        """A trusted skill directory round-trips without its root name."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = Path(tmpdir) / "source-skill"
+            (skill_dir / "scripts").mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: demo\ndescription: Demo skill\n---\nBody\n",
+                encoding="utf-8",
+            )
+            (skill_dir / "scripts" / "run.py").write_text(
+                "print('ok')\n",
+                encoding="utf-8",
+            )
+
+            archive = build_skill_archive(str(skill_dir))
+            metadata = validate_skill_archive(archive)
+            destination = Path(tmpdir) / "extracted"
+            extract_skill_archive(archive, str(destination))
+
+            self.assertEqual(metadata.name, "demo")
+            self.assertEqual(metadata.description, "Demo skill")
+            self.assertTrue((destination / "SKILL.md").is_file())
+            self.assertEqual(
+                (destination / "scripts" / "run.py").read_text(
+                    encoding="utf-8",
+                ),
+                "print('ok')\n",
+            )
+
+    def test_rejects_unsafe_archive_members(self) -> None:
+        """Traversal and link entries cannot reach outside extraction."""
+        skill_md = b"---\nname: demo\ndescription: test\n---\n"
+        invalid_archives = (
+            _archive_with_member("../SKILL.md", skill_md),
+            _archive_with_member("/SKILL.md", skill_md),
+            _archive_with_member("C:/SKILL.md", skill_md),
+            _archive_with_member(
+                "SKILL.md",
+                b"",
+                member_type=tarfile.SYMTYPE,
+            ),
+        )
+
+        for archive in invalid_archives:
+            with self.subTest():
+                with self.assertRaises(ValueError):
+                    validate_skill_archive(archive)
+
+    def test_rejects_compressed_archives(self) -> None:
+        """Only deterministic uncompressed tar bytes cross the API."""
+        buffer = io.BytesIO()
+        with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+            content = b"---\nname: demo\ndescription: test\n---\n"
+            info = tarfile.TarInfo("SKILL.md")
+            info.size = len(content)
+            tar.addfile(info, io.BytesIO(content))
+
+        with self.assertRaisesRegex(ValueError, "valid tar archive"):
+            validate_skill_archive(buffer.getvalue())
+
+    def test_rejects_non_string_frontmatter_fields(self) -> None:
+        """Skill metadata must use non-empty string values."""
+        archive = _archive_with_member(
+            "SKILL.md",
+            b"---\nname:\n  - demo\ndescription: test\n---\n",
+        )
+
+        with self.assertRaisesRegex(ValueError, "string name"):
+            validate_skill_archive(archive)
+
+    def test_build_rejects_symlinks(self) -> None:
+        """Trusted local packaging does not dereference nested links."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = Path(tmpdir) / "skill"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: demo\ndescription: test\n---\n",
+                encoding="utf-8",
+            )
+            try:
+                os.symlink(skill_dir / "SKILL.md", skill_dir / "linked.md")
+            except (OSError, NotImplementedError) as error:
+                self.skipTest(f"Symlinks are unavailable: {error}")
+
+            with self.assertRaisesRegex(ValueError, "regular files only"):
+                build_skill_archive(str(skill_dir))
+
+
+class LocalWorkspaceSkillUploadTest(IsolatedAsyncioTestCase):
+    """Exercise the archive API through the local workspace."""
+
+    async def test_add_skill_from_archive(self) -> None:
+        """Runtime uploads are extracted and indexed as normal skills."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = Path(tmpdir) / "source"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: uploaded\ndescription: Uploaded skill\n---\n",
+                encoding="utf-8",
+            )
+            (skill_dir / "tool.py").write_text(
+                "VALUE = 1\n",
+                encoding="utf-8",
+            )
+            workspace = LocalWorkspace(workdir=str(Path(tmpdir) / "work"))
+            await workspace.initialize()
+            try:
+                await workspace.add_skill(
+                    build_skill_archive(str(skill_dir)),
+                )
+
+                skills = await workspace.list_skills()
+                self.assertEqual(
+                    [skill.name for skill in skills],
+                    ["uploaded"],
+                )
+                self.assertTrue(
+                    (Path(skills[0].dir) / "tool.py").is_file(),
+                )
+            finally:
+                await workspace.close()


### PR DESCRIPTION
## Summary

- replace client-selected host paths with a browser directory picker and multipart file upload
- validate the root `SKILL.md` frontmatter in the web UI, then revalidate filenames, metadata, size, and file count on the server
- change `WorkspaceBase.add_skill` to accept validated uncompressed tar bytes across local and sandbox workspaces
- reject traversal, absolute paths, links, special files, compressed archives, and portable duplicate names before extraction
- retain trusted startup seeding through `skill_paths` by packaging local directories into the same archive contract

## Design

The browser preserves each file's `webkitRelativePath` in multipart filenames. The service accepts exactly one directory, strips its selected root, creates a flat skill archive, and passes bytes rather than a host path to the workspace. Both the HTTP boundary and workspace boundary validate the archive. The web client no longer exposes or sends server filesystem paths.

`python-multipart` is added to the service extra and `yaml` is added as a direct frontend dependency.

Fixes #2069

## Tests

- `pytest tests/service_workspace_skill_router_test.py tests/workspace_skill_archive_test.py tests/workspace_local_test.py tests/workspace_daytona_test.py::TestDaytonaWorkspaceMock -q` (`48 passed`, `9 subtests passed`)
- mypy with the repository hook arguments
- flake8 with the repository hook arguments
- `pnpm --filter frontend build`
- `pnpm --filter frontend lint` (no errors; existing warnings only)
- `git diff --check`