### PR TITLE
fix(skill): expand user home in skill paths

### DIFF
--- a/src/agentscope/skill/_local_loader.py
+++ b/src/agentscope/skill/_local_loader.py
@@ -25,7 +25,7 @@ class LocalSkillLoader(SkillLoaderBase):
                 Whether to scan subdirectories. Defaults to False (only
                 scan current directory).
         """
-        self.directory = os.path.abspath(directory)
+        self.directory = os.path.abspath(os.path.expanduser(directory))
         self.scan_subdir = scan_subdir
         self._cache: dict[str, Skill] = {}
 

--- a/src/agentscope/workspace/_base.py
+++ b/src/agentscope/workspace/_base.py
@@ -184,14 +184,18 @@ class WorkspaceBase:
                 without a persisted ``.mcp`` file.
             skill_paths (`list[str] | None`, optional):
                 Local skill directories to copy into ``skills/`` on
-                first start.
+                first start. Each path is normalised to an absolute
+                path with ``~`` expanded to the user home directory.
         """
         self.workspace_id = workspace_id or _generate_id()
         self.is_alive = False
         self._backend = None
 
         self.default_mcps = list(default_mcps or [])
-        self.skill_paths = list(skill_paths or [])
+        self.skill_paths = [
+            os.path.abspath(os.path.expanduser(path))
+            for path in (skill_paths or [])
+        ]
 
         self._mcps = []
         self._mcp_lock = asyncio.Lock()
@@ -631,6 +635,7 @@ class WorkspaceBase:
         Args:
             skill_path (`str`):
                 Path to a skill directory on the local filesystem.
+                ``~`` is expanded to the user home directory.
 
         Raises:
             ValueError:
@@ -639,6 +644,7 @@ class WorkspaceBase:
             RuntimeError:
                 If extraction inside the sandbox fails.
         """
+        skill_path = os.path.abspath(os.path.expanduser(skill_path))
         skill_md = os.path.join(skill_path, "SKILL.md")
         if not os.path.isfile(skill_md):
             raise ValueError(

--- a/src/agentscope/workspace/_local_workspace.py
+++ b/src/agentscope/workspace/_local_workspace.py
@@ -129,7 +129,9 @@ class LocalWorkspace(WorkspaceBase):
                 persisted ``<workdir>/.mcp`` file.
             skill_paths (`list[str] | None`, optional):
                 Local skill directories seeded into
-                ``<workdir>/skills`` on first :meth:`initialize`.
+                ``<workdir>/skills`` on first :meth:`initialize`. Each
+                path is normalised to an absolute path with ``~``
+                expanded to the user home directory.
             instructions (`str`, defaults to \
             `_DEFAULT_WORKSPACE_INSTRUCTIONS`):
                 System-prompt fragment template returned by
@@ -144,7 +146,10 @@ class LocalWorkspace(WorkspaceBase):
 
         # ── seed-only ───────────────────────────────────────────
         self.default_mcps: list[MCPClient] = list(default_mcps or [])
-        self.skill_paths: list[str] = list(skill_paths or [])
+        self.skill_paths: list[str] = [
+            os.path.abspath(os.path.expanduser(path))
+            for path in (skill_paths or [])
+        ]
 
         # ── runtime state ───────────────────────────────────────
         self._backend = LocalBackend()

--- a/tests/skill_loader_test.py
+++ b/tests/skill_loader_test.py
@@ -74,6 +74,49 @@ This is the subdir2 skill content.
         if os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir)
 
+    async def test_tilde_directory_is_expanded(self) -> None:
+        """Test that ``~`` in the directory is expanded to home.
+
+        Regression test for paths like ``~/.agentscope/skills/my_skill``
+        being treated as a literal segment instead of the home dir.
+        """
+        # Create a real skill directory under the user's home so that
+        # ``~`` expansion is observable end-to-end.
+        home = os.path.expanduser("~")
+        # pylint: disable=consider-using-with
+        home_root = tempfile.TemporaryDirectory(dir=home)
+        try:
+            skill_dir = os.path.join(home_root.name, "home_skill")
+            os.makedirs(skill_dir)
+            with open(
+                os.path.join(skill_dir, "SKILL.md"),
+                "w",
+                encoding="utf-8",
+            ) as f:
+                f.write(
+                    "---\nname: home_skill\n"
+                    "description: a skill under home\n---\nbody\n",
+                )
+
+            tilde_dir = "~/" + os.path.relpath(skill_dir, home)
+            loader = LocalSkillLoader(tilde_dir, scan_subdir=False)
+
+            # The stored directory must be the expanded absolute path,
+            # not a literal ``~/...`` segment.
+            self.assertEqual(
+                loader.directory,
+                os.path.abspath(os.path.expanduser(tilde_dir)),
+            )
+            self.assertNotIn("~", loader.directory)
+
+            # And the skill must actually be loadable.
+            skills = await loader.list_skills()
+            self.assertEqual(len(skills), 1)
+            self.assertEqual(skills[0].name, "home_skill")
+            self.assertEqual(skills[0].dir, skill_dir)
+        finally:
+            home_root.cleanup()
+
     async def test_nonexistent_skill(self) -> None:
         """Test loading from a directory without SKILL.md."""
         # Create a directory without SKILL.md

--- a/tests/workspace_local_test.py
+++ b/tests/workspace_local_test.py
@@ -524,6 +524,53 @@ description: {description}
 
         return skill_dir
 
+    async def test_skill_paths_expand_tilde_before_seeding(self) -> None:
+        """Test that ``~`` in skill_paths is expanded before seeding.
+
+        Regression test for skill paths commonly supplied via config
+        files or env vars (e.g. ``~/.agentscope/skills/foo``) that were
+        treated as literal segments and silently failed to seed.
+        """
+        # Create a real skill directory under the user's home.
+        home = os.path.expanduser("~")
+        # pylint: disable=consider-using-with
+        home_root = tempfile.TemporaryDirectory(dir=home)
+        try:
+            skill_dir = os.path.join(home_root.name, "tilde_skill")
+            os.makedirs(skill_dir)
+            with open(
+                os.path.join(skill_dir, "SKILL.md"),
+                "w",
+                encoding="utf-8",
+            ) as f:
+                f.write(
+                    "---\nname: tilde_skill\n"
+                    "description: a skill referenced via tilde\n---\n"
+                    "# tilde_skill\n",
+                )
+
+            tilde_path = "~/" + os.path.relpath(skill_dir, home)
+            workspace = LocalWorkspace(
+                workdir=self.temp_dir.name,
+                skill_paths=[tilde_path],
+            )
+
+            # Stored paths must be expanded absolute paths.
+            expected = os.path.abspath(os.path.expanduser(tilde_path))
+            self.assertEqual(workspace.skill_paths, [expected])
+
+            # And seeding must actually copy the skill across.
+            await workspace.initialize()
+            seeded = os.path.join(
+                self.temp_dir.name,
+                "skills",
+                "tilde_skill",
+                "SKILL.md",
+            )
+            self.assertTrue(os.path.exists(seeded))
+        finally:
+            home_root.cleanup()
+
     async def test_initialize_copy_skills(self) -> None:
         """Test copying skills to workspace.
 


### PR DESCRIPTION
## Summary

Skill paths supplied via config files, env vars, or CLI args commonly use the `~` shorthand (e.g. `~/.agentscope/skills/my_skill`). `~` was treated as a literal path segment instead of the user home directory, so `LocalSkillLoader` looked in the wrong place and workspace `skill_paths` silently failed to seed.

Closes #2052.

## Root cause

Path normalisation used `os.path.abspath(path)` only, never `os.path.expanduser`. So `~/.agentscope/skills/foo` resolved to `<cwd>/~/.agentscope/skills/foo`.

## Fix

Expand `~` before resolving to an absolute path at every boundary where skill paths enter the system:

- `LocalSkillLoader.__init__`
- `WorkspaceBase.__init__` — covers Docker/E2B/K8S seed paths (they delegate here)
- `LocalWorkspace.__init__` — sets `skill_paths` itself, bypassing the base
- `WorkspaceBase.add_skill` — covers ad-hoc runtime adds and the base seed path

Each normalisation is `os.path.abspath(os.path.expanduser(path))`.

## Test plan

- [x] `tests/skill_loader_test.py::test_tilde_directory_is_expanded` — loads a skill under the real home dir via a `~/...` path; asserts both the normalised `directory` attribute and that the skill is actually loadable.
- [x] `tests/workspace_local_test.py::TestLocalWorkspaceSkills::test_skill_paths_expand_tilde_before_seeding` — seeds via a `~/...` `skill_paths` entry; asserts stored paths are expanded and the skill is copied into `${workdir}/skills`.
- [x] Existing skill/workspace tests still pass (`skill_loader_test`, `workspace_local_test`, `toolkit_skill_test`).
- [x] `pre-commit run --all-files` passes (black, flake8, mypy, pylint).

```bash
pytest tests/skill_loader_test.py tests/workspace_local_test.py tests/toolkit_skill_test.py
# 35 passed
```