### PR TITLE
fix(tracing): avoid cross-context detach on stream close

### DIFF
--- a/src/agentscope/middleware/_tracing/_trace.py
+++ b/src/agentscope/middleware/_tracing/_trace.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """TracingMiddleware and supporting utilities for OpenTelemetry tracing."""
+import asyncio
+import contextvars
 import json
 from typing import (
     Any,
@@ -13,6 +15,7 @@ from typing import (
 
 import aioitertools
 
+from opentelemetry import context as otel_context
 from opentelemetry import trace as otel_trace
 from opentelemetry.trace import StatusCode
 
@@ -50,6 +53,15 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
+# Probe ContextVar used to detect whether span cleanup is running in the
+# same ``contextvars`` Context that attached the span. See
+# :func:`_detach_span`.
+_probe_ctxvar = contextvars.ContextVar(
+    "_agentscope_tracing_ctx_probe",
+    default=False,
+)
+
+
 # ---------------------------------------------------------------------------
 # Utility helpers
 # ---------------------------------------------------------------------------
@@ -82,30 +94,81 @@ def _set_span_error_status(span: "Span", e: BaseException) -> None:
     span.end()
 
 
+def _attach_span(span: "Span") -> tuple[Any, Any]:
+    """Make ``span`` the current span and return a detach handle.
+
+    Unlike ``tracer.start_as_current_span`` (a context manager that
+    detaches on exit), the caller controls when to detach via
+    :func:`_detach_span`. This is required because the hooks are async
+    generators and the span must stay current across ``yield`` points so
+    that nested model/tool spans are parented correctly.
+
+    A probe ``ContextVar`` token is captured alongside the OpenTelemetry
+    token so that :func:`_detach_span` can detect whether cleanup is
+    running in the originating context.
+    """
+    probe_token = _probe_ctxvar.set(True)
+    otel_token = otel_context.attach(
+        otel_trace.set_span_in_context(
+            span,
+            otel_context.get_current(),
+        ),
+    )
+    return otel_token, probe_token
+
+
+def _detach_span(handle: tuple[Any, Any]) -> None:
+    """Detach a span handle, tolerating cross-task stream close.
+
+    ``context.detach`` resets a ``contextvars`` token. When an async
+    generator is closed (``aclose``) from a different asyncio task, the
+    generator's ``finally`` blocks run in the *closing* task's
+    ``Context``, so resetting the OpenTelemetry token (created in the
+    producer task's ``Context``) raises ``ValueError``, which
+    OpenTelemetry logs at ERROR level as ``"Failed to detach context"``.
+
+    The span was never attached in the closing task's ``Context``, so
+    there is genuinely nothing to detach there. A probe ``ContextVar``
+    detects this: resetting its token raises ``ValueError`` in the
+    foreign context (suppressed) and OpenTelemetry is only detached when
+    the probe reset succeeds — i.e. when we are back in the originating
+    context.
+    """
+    otel_token, probe_token = handle
+    try:
+        _probe_ctxvar.reset(probe_token)
+    except ValueError:
+        return
+    otel_context.detach(otel_token)
+
+
 async def _trace_async_generator_wrapper(
     res: AsyncGenerator[T, None],
     span: "Span",
 ) -> AsyncGenerator[T, None]:
     """Wrap an async generator so that response attributes are captured from
     the last yielded chunk before the span is closed."""
-    has_error = False
-
+    last_chunk = None
     try:
-        last_chunk = None
         async for chunk in aioitertools.iter(res):
             last_chunk = chunk
             yield chunk
 
+    except (GeneratorExit, asyncio.CancelledError):
+        # Clean stream shutdown (client disconnect, cancellation or
+        # cross-task ``aclose``). Capture what we have and end the span
+        # normally instead of recording it as an error.
+        span.set_attributes(_get_llm_response_attributes(last_chunk))
+        _set_span_success_status(span)
+        raise
+
     except BaseException as e:
-        has_error = True
         _set_span_error_status(span, e)
         raise
 
-    finally:
-        if not has_error:
-            response_attributes = _get_llm_response_attributes(last_chunk)
-            span.set_attributes(response_attributes)
-            _set_span_success_status(span)
+    response_attributes = _get_llm_response_attributes(last_chunk)
+    span.set_attributes(response_attributes)
+    _set_span_success_status(span)
 
 
 # ---------------------------------------------------------------------------
@@ -154,14 +217,15 @@ class TracingMiddleware(MiddlewareBase):
         )
         span_name = _get_agent_span_name(request_attributes)
 
-        with tracer.start_as_current_span(
+        span = tracer.start_span(
             name=span_name,
             attributes={
                 **request_attributes,
                 **common_attrs,
             },
-            end_on_exit=False,
-        ) as span:
+        )
+        span_handle = _attach_span(span)
+        try:
             # Synthetic execute_tool spans for externally executed tools
             event_arg = input_kwargs.get("inputs")
             if isinstance(event_arg, ExternalExecutionResultEvent):
@@ -210,6 +274,11 @@ class TracingMiddleware(MiddlewareBase):
                     if isinstance(item, Msg):
                         last_msg = item
                     yield item
+            except (GeneratorExit, asyncio.CancelledError):
+                # Clean stream shutdown (client disconnect, cancellation
+                # or cross-task ``aclose``). Not an error — end the span
+                # normally and propagate so the generator closes.
+                raise
             except BaseException as e:
                 has_error = True
                 error_exc = e
@@ -239,6 +308,8 @@ class TracingMiddleware(MiddlewareBase):
                             _get_agent_response_attributes(last_msg),
                         )
                     _set_span_success_status(span)
+        finally:
+            _detach_span(span_handle)
 
     # ------------------------------------------------------------------
     # on_model_call
@@ -321,20 +392,26 @@ class TracingMiddleware(MiddlewareBase):
         )
         span_name = _get_tool_span_name(request_attributes)
 
-        with tracer.start_as_current_span(
+        span = tracer.start_span(
             name=span_name,
             attributes={
                 **request_attributes,
                 **_get_common_attributes(agent.state.session_id),
             },
-            end_on_exit=False,
-        ) as span:
+        )
+        span_handle = _attach_span(span)
+        try:
             has_error = False
             last_item = None
             try:
                 async for item in next_handler(**input_kwargs):
                     last_item = item
                     yield item
+            except (GeneratorExit, asyncio.CancelledError):
+                # Clean stream shutdown (client disconnect, cancellation
+                # or cross-task ``aclose``). Not an error — end the span
+                # normally and propagate so the generator closes.
+                raise
             except BaseException as e:
                 has_error = True
                 _set_span_error_status(span, e)
@@ -346,3 +423,5 @@ class TracingMiddleware(MiddlewareBase):
                             _get_tool_response_attributes(last_item),
                         )
                     _set_span_success_status(span)
+        finally:
+            _detach_span(span_handle)

--- a/tests/tracing_test.py
+++ b/tests/tracing_test.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 """Unit tests for the tracing module using an in-memory OTel exporter."""
+import asyncio
 import json
-from typing import Any
+import logging
+from typing import Any, AsyncGenerator
 from unittest.async_case import IsolatedAsyncioTestCase
 
 from opentelemetry import trace as otel_trace
@@ -226,6 +228,81 @@ class TracingTest(IsolatedAsyncioTestCase):
             1,
             f"All spans must share exactly one conversation_id, "
             f"got: {conv_ids}",
+        )
+
+    async def test_span_detach_survives_cross_task_close(self) -> None:
+        """A span detached after a cross-task async-generator close must
+        not log ``"Failed to detach context"`` (regression test #2076).
+
+        ``on_reply`` / ``on_acting`` are async generators that keep an
+        OpenTelemetry span current across ``yield`` points. When the
+        generator is closed (``aclose``) from a different asyncio task,
+        the cleanup runs in the closing task's ``Context``, and a naive
+        ``context.detach`` raises ``ValueError`` which OpenTelemetry
+        logs at ERROR level. This test exercises the attach/detach
+        helpers with that exact pattern.
+        """
+        from agentscope.middleware._tracing._trace import (
+            _attach_span,
+            _detach_span,
+        )
+
+        tracer = otel_trace.get_tracer("test-cross-task-detach")
+        span = tracer.start_span("cross-task-probe")
+
+        detach_errors: list[logging.LogRecord] = []
+
+        class _Collector(logging.Handler):
+            """Collect ERROR records from the OTel context logger."""
+
+            def emit(self, record: logging.LogRecord) -> None:
+                detach_errors.append(record)
+
+        handler = _Collector()
+        handler.setLevel(logging.ERROR)
+        otel_context_logger = logging.getLogger("opentelemetry.context")
+        otel_context_logger.addHandler(handler)
+        try:
+
+            async def _traced_generator() -> AsyncGenerator[int, None]:
+                # Mirrors on_reply / on_acting: keep the span current
+                # across the yield, end it on clean shutdown, detach in
+                # ``finally``.
+                handle = _attach_span(span)
+                try:
+                    yield 1
+                except (GeneratorExit, asyncio.CancelledError):
+                    span.end()
+                    raise
+                finally:
+                    _detach_span(handle)
+
+            agen = _traced_generator()
+            # Drive the generator to its first yield so the span is
+            # attached and the generator is suspended inside the block.
+            first = await anext(agen)
+            self.assertEqual(first, 1)
+
+            # Close it from a DIFFERENT asyncio task (a fresh
+            # contextvars context) — this is what triggers the
+            # cross-context detach in the unfixed approach.
+            async def _close_from_other_task() -> None:
+                await agen.aclose()
+
+            await asyncio.create_task(_close_from_other_task())
+        finally:
+            otel_context_logger.removeHandler(handler)
+
+        # No ERROR record about a cross-context detach must be emitted.
+        self.assertEqual(
+            [r.getMessage() for r in detach_errors],
+            [],
+            "Cross-task stream close must not log a detach error",
+        )
+        # The span itself must still be ended and exported.
+        self.assertEqual(
+            [s.name for s in self.exporter.get_finished_spans()],
+            ["cross-task-probe"],
         )
 
     async def test_invoke_agent_span_has_response_attributes(self) -> None:


### PR DESCRIPTION
## Summary

`TracingMiddleware` kept OpenTelemetry spans current across async-generator `yield` points via `start_as_current_span`. When a stream is closed (`aclose`) from a different asyncio task — normal for SSE-style replies on client disconnect, cancellation, or cross-task cleanup — the span's `detach` runs in the closing task's `contextvars` Context, so resetting the token raises `ValueError`. OpenTelemetry swallows that and logs `\"Failed to detach context\"` at ERROR level, polluting production monitoring even though the request itself does not fail.

Closes #2076.

## Root cause

`on_reply` and `on_acting` are async generators. `with tracer.start_as_current_span(..., end_on_exit=False)` wraps an `async for ... yield item` loop, so the OTel current-span `ContextVar` stays set across `yield`. `use_span.__exit__` → `context.detach(token)` runs in the closing task's Context (a different `contextvars.Context` than where the token was created). `ContextVar.reset` raises `ValueError`, which OTel's `context.detach` catches and logs via `logger.exception(\"Failed to detach context\")`.

`on_model_call` is unaffected — its `with` block has no `yield` (it returns the generator wrapper), so detach always happens in the originating context.

## Fix

- Replace `start_as_current_span` in `on_reply` and `on_acting` (the two hooks whose `with` block spans a `yield`) with manual `start_span` + new `_attach_span`/`_detach_span` helpers.
- A probe `ContextVar` detects whether cleanup runs in the originating context: `_detach_span` resets the probe token first; only if that succeeds (same context) does it call `context.detach`. In the foreign-context case (cross-task close) it is a no-op — the span was never attached there, so there is genuinely nothing to detach.
- Span parent/child relationships are preserved (the span is still current during `next_handler` iteration, so nested model/tool spans parent correctly) and `span.end()` is still called manually.
- Clean stream shutdowns (`GeneratorExit` / `asyncio.CancelledError`) are now treated as normal completion across `on_reply`, `on_acting`, and the streaming model-call wrapper (`_trace_async_generator_wrapper`), so they no longer mark spans as ERROR.

## Test plan

- [x] New `test_span_detach_survives_cross_task_close` — a minimal async generator mirroring `on_reply`/`on_acting` (attach span, yield, detach in `finally`) is closed from a different asyncio task; asserts no `\"Failed to detach context\"` ERROR log and the span is still ended/exported. Verified it FAILS on the naive unconditional-detach version with the exact `ValueError` from the issue, and PASSES with the probe guard.
- [x] All existing tracing tests pass (`on_reply` / `on_acting` / `on_model_call` span attributes, parenting via shared `conversation.id`, HITL, external execution).
- [x] Broad middleware/agent suite green (63 tests across `tracing`, `middleware`, `middleware_budget`, `agent_basic`, `agent_interrupt`, `hitl_external_execution`, `hitl_user_confirmation`).
- [x] `pre-commit run` passes (black, flake8, mypy, pylint).

```bash
pytest tests/tracing_test.py tests/middleware_test.py tests/middleware_budget_test.py tests/agent_basic_test.py tests/agent_interrupt_test.py tests/hitl_external_execution_test.py tests/hitl_user_confirmation_test.py
# 63 passed
```