### PR TITLE
fix(service): return newest messages and paginate by cursor

### DIFF
--- a/examples/web_ui/frontend/src/api/session.ts
+++ b/examples/web_ui/frontend/src/api/session.ts
@@ -13,6 +13,7 @@ import type {
 export interface MessagesResponse {
 	messages: Msg[];
 	is_running: boolean;
+	has_more: boolean;
 }
 
 export const sessionApi = {
@@ -41,10 +42,18 @@ export const sessionApi = {
 			agent_id: agentId,
 		}),
 
-	messages: (sessionId: string, agentId: string, offset = 0, limit = 50) =>
+	/**
+	 * Fetch a backwards page of persisted messages.
+	 *
+	 * Omit `before` to get the newest `limit` messages; pass the oldest
+	 * id of the previous page as `before` to page further back. The
+	 * response includes `has_more` so the caller knows whether another
+	 * older page exists.
+	 */
+	messages: (sessionId: string, agentId: string, before?: string, limit = 50) =>
 		client.get<MessagesResponse>(`/sessions/${sessionId}/messages`, {
 			agent_id: agentId,
-			offset: String(offset),
+			...(before ? { before } : {}),
 			limit: String(limit),
 		}),
 

--- a/src/agentscope/app/_router/_schema/_session.py
+++ b/src/agentscope/app/_router/_schema/_session.py
@@ -193,6 +193,13 @@ class ListMessagesResponse(BaseModel):
     is_running: bool = Field(
         description="Whether the session is currently running.",
     )
+    has_more: bool = Field(
+        description=(
+            "Whether older messages exist before this page. Use "
+            "``messages[0].id`` as the ``before`` cursor for the next "
+            "request."
+        ),
+    )
 
 
 class SessionStatusResponse(BaseModel):

--- a/src/agentscope/app/_router/_session.py
+++ b/src/agentscope/app/_router/_session.py
@@ -513,25 +513,37 @@ async def update_session(
 async def list_messages(
     session_id: str,
     agent_id: str = Query(description="Agent the session belongs to."),
-    offset: int = Query(0, ge=0, description="Pagination offset."),
     limit: int = Query(50, ge=1, le=200, description="Max messages."),
+    before: str
+    | None = Query(
+        None,
+        description=(
+            "Cursor: return messages older than this message id. "
+            "Omit to fetch the newest page."
+        ),
+    ),
     user_id: str = Depends(get_current_user_id),
     storage: StorageBase = Depends(get_storage),
     message_bus: MessageBus = Depends(get_message_bus),
 ) -> ListMessagesResponse:
     """Return persisted messages for a session.
 
+    Pages backwards via a cursor: omit ``before`` to get the newest
+    ``limit`` messages, then pass ``messages[0].id`` as ``before`` to
+    fetch the next older page. Cursor pagination is stable under
+    concurrent inserts, unlike a numeric offset.
+
     Args:
         session_id: The session to query.
         agent_id: Agent the session belongs to.
-        offset: Pagination offset.
         limit: Maximum number of messages to return.
+        before: Exclusive upper-bound message id (cursor).
         user_id: Injected authenticated user ID.
         storage: Injected storage backend.
         message_bus: Injected message bus.
 
     Returns:
-        Messages and running status.
+        Messages, running status, and whether older messages remain.
     """
     existing = await storage.get_session(user_id, agent_id, session_id)
     if existing is None:
@@ -540,14 +552,15 @@ async def list_messages(
             detail=f"Session '{session_id}' not found.",
         )
 
-    messages = await storage.list_messages(
+    messages, has_more = await storage.list_messages(
         user_id,
         session_id,
-        offset=offset,
         limit=limit,
+        before=before,
     )
     return ListMessagesResponse(
         messages=messages,
+        has_more=has_more,
         is_running=await message_bus.is_locked(
             MessageBusKeys.session_lock(session_id),
         ),

--- a/src/agentscope/app/storage/_base.py
+++ b/src/agentscope/app/storage/_base.py
@@ -439,19 +439,26 @@ class StorageBase(ABC):
         self,
         user_id: str,
         session_id: str,
-        offset: int = 0,
         limit: int = 50,
-    ) -> list[Msg]:
-        """Return messages for a session with pagination.
+        before: str | None = None,
+    ) -> tuple[list[Msg], bool]:
+        """Return a chronologically-ordered window of messages.
+
+        Backwards cursor pagination: the newest ``limit`` messages are
+        returned when ``before`` is ``None``, otherwise the ``limit``
+        messages preceding the message whose id is ``before``.
 
         Args:
             user_id (`str`): The owner user id.
             session_id (`str`): The session id.
-            offset (`int`): Starting index (0-based). Defaults to 0.
             limit (`int`): Maximum number of messages to return.
+            before (`str | None`): Exclusive upper-bound message id.
+                ``None`` anchors the window at the newest message.
 
         Returns:
-            `list[Msg]`: Messages in chronological order.
+            `tuple[list[Msg], bool]`: The messages in chronological
+            order and ``has_more`` — whether older messages exist
+            before this window.
         """
 
     # ------------------------------------------------------------------

--- a/src/agentscope/app/storage/_redis_storage.py
+++ b/src/agentscope/app/storage/_redis_storage.py
@@ -988,17 +988,85 @@ class RedisStorage(StorageBase):
                     return msg
         return None
 
+    async def _find_message_index(
+        self,
+        key: str,
+        message_id: str,
+    ) -> int | None:
+        """Return the list index of the message with ``message_id``.
+
+        Redis lists are not indexed by id, so this scans newest→oldest
+        (the common cursor is a recent message). Returns ``None`` when
+        the id is not present.
+
+        Args:
+            key (`str`): The Redis list key.
+            message_id (`str`): The message id to locate.
+
+        Returns:
+            `int | None`: The 0-based index, or ``None`` if not found.
+        """
+        length = await self._client.llen(key)
+        for i in range(length - 1, -1, -1):
+            raw = await self._client.lindex(key, i)
+            if raw:
+                if Msg.model_validate_json(raw).id == message_id:
+                    return i
+        return None
+
     async def list_messages(
         self,
         user_id: str,
         session_id: str,
-        offset: int = 0,
         limit: int = 50,
-    ) -> list[Msg]:
-        """Return messages for a session with pagination."""
+        before: str | None = None,
+    ) -> tuple[list[Msg], bool]:
+        """Return a chronologically-ordered window of messages.
+
+        Messages are stored oldest→newest (``rpush``), so index ``0`` is
+        the oldest and index ``-1`` is the newest. This returns the
+        newest ``limit`` messages when ``before`` is ``None``, or the
+        ``limit`` messages immediately preceding the message whose id is
+        ``before``. Pages are always returned oldest→newest within the
+        window, which lets the frontend anchor the next request on
+        ``messages[0].id``.
+
+        Cursor-based pagination (rather than a numeric offset) is stable
+        under concurrent inserts: new messages pushed while the user
+        pages backwards never shift the window.
+
+        Args:
+            user_id (`str`): The owner user id.
+            session_id (`str`): The session id.
+            limit (`int`): Maximum number of messages to return.
+            before (`str | None`): Exclusive upper-bound message id.
+                ``None`` anchors the window at the newest message.
+
+        Returns:
+            `tuple[list[Msg], bool]`: The messages in chronological
+            order and ``has_more`` — whether older messages exist
+            before this window.
+        """
         key = self._message_key(user_id, session_id)
-        raw_list = await self._client.lrange(key, offset, offset + limit - 1)
-        return [Msg.model_validate_json(raw) for raw in raw_list]
+        total = await self._client.llen(key)
+        if total == 0:
+            return [], False
+
+        if before is None:
+            end = total - 1
+        else:
+            idx = await self._find_message_index(key, before)
+            if idx is None:
+                return [], False
+            end = idx - 1
+
+        if end < 0:
+            return [], False
+
+        start = max(end - limit + 1, 0)
+        raw_list = await self._client.lrange(key, start, end)
+        has_more = start > 0
+        return [Msg.model_validate_json(raw) for raw in raw_list], has_more
 
     # ------------------------------------------------------------------
     # Team persistence

--- a/tests/storage_redis_test.py
+++ b/tests/storage_redis_test.py
@@ -336,7 +336,7 @@ class TestMessage(IsolatedAsyncioTestCase):
         """Upserting a new message appends it to the session list."""
         msg = UserMsg(name="alice", content="hello")
         await self.storage.upsert_message(self.user_id, self.session_id, msg)
-        messages = await self.storage.list_messages(
+        messages, has_more = await self.storage.list_messages(
             self.user_id,
             self.session_id,
         )
@@ -344,6 +344,7 @@ class TestMessage(IsolatedAsyncioTestCase):
             [m.model_dump() for m in messages],
             [msg.model_dump()],
         )
+        self.assertFalse(has_more)
 
     async def test_upsert_refreshes_message_list_ttl(self) -> None:
         """Message list keys expire with the session storage TTL."""
@@ -373,7 +374,7 @@ class TestMessage(IsolatedAsyncioTestCase):
             updated,
         )
 
-        messages = await self.storage.list_messages(
+        messages, _has_more = await self.storage.list_messages(
             self.user_id,
             self.session_id,
         )
@@ -413,7 +414,7 @@ class TestMessage(IsolatedAsyncioTestCase):
         msg2 = UserMsg(name="alice", content="second")
         await self.storage.upsert_message(self.user_id, self.session_id, msg1)
         await self.storage.upsert_message(self.user_id, self.session_id, msg2)
-        messages = await self.storage.list_messages(
+        messages, _has_more = await self.storage.list_messages(
             self.user_id,
             self.session_id,
         )
@@ -447,35 +448,110 @@ class TestMessage(IsolatedAsyncioTestCase):
         self.assertIsNone(result)
 
     async def test_list_messages_empty_session(self) -> None:
-        """list_messages returns an empty list for a session with no
+        """list_messages returns an empty window for a session with no
         messages."""
-        messages = await self.storage.list_messages(
+        messages, has_more = await self.storage.list_messages(
             self.user_id,
             self.session_id,
         )
         self.assertListEqual(messages, [])
+        self.assertFalse(has_more)
 
-    async def test_list_messages_pagination(self) -> None:
-        """list_messages respects offset and limit parameters."""
-        msgs = [UserMsg(name="alice", content=f"msg-{i}") for i in range(5)]
+    async def _seed_n_messages(self, n: int) -> list[UserMsg]:
+        """Append ``n`` messages (oldest→newest) and return them."""
+        msgs = [UserMsg(name="alice", content=f"msg-{i}") for i in range(n)]
         for m in msgs:
             await self.storage.upsert_message(
                 self.user_id,
                 self.session_id,
                 m,
             )
+        return msgs
 
-        # Fetch the middle slice: offset=1, limit=3 → msgs[1], msgs[2], msgs[3]
-        page = await self.storage.list_messages(
+    async def test_list_messages_returns_newest_window(self) -> None:
+        """Without ``before`` the newest ``limit`` messages are returned
+        in chronological order, with ``has_more`` when older exist."""
+        msgs = await self._seed_n_messages(5)
+
+        messages, has_more = await self.storage.list_messages(
             self.user_id,
             self.session_id,
-            offset=1,
             limit=3,
         )
         self.assertListEqual(
-            [m.model_dump() for m in page],
+            [m.model_dump() for m in messages],
+            [m.model_dump() for m in msgs[2:5]],
+        )
+        self.assertTrue(has_more)
+
+    async def test_list_messages_has_more_false_when_fits(self) -> None:
+        """``has_more`` is False when the whole history fits the page."""
+        msgs = await self._seed_n_messages(3)
+
+        messages, has_more = await self.storage.list_messages(
+            self.user_id,
+            self.session_id,
+            limit=50,
+        )
+        self.assertListEqual(
+            [m.model_dump() for m in messages],
+            [m.model_dump() for m in msgs],
+        )
+        self.assertFalse(has_more)
+
+    async def test_list_messages_cursor_pagination(self) -> None:
+        """Paging backwards with ``before`` (the oldest id of the
+        previous page) yields every older message exactly once."""
+        msgs = await self._seed_n_messages(7)
+
+        # Page 1: newest 3 → msgs[4], msgs[5], msgs[6]; has_more True.
+        page1, has_more_1 = await self.storage.list_messages(
+            self.user_id,
+            self.session_id,
+            limit=3,
+        )
+        self.assertListEqual(
+            [m.model_dump() for m in page1],
+            [m.model_dump() for m in msgs[4:7]],
+        )
+        self.assertTrue(has_more_1)
+
+        # Anchor page 2 at the oldest id of page 1 (msgs[4]).
+        page2, has_more_2 = await self.storage.list_messages(
+            self.user_id,
+            self.session_id,
+            limit=3,
+            before=page1[0].id,
+        )
+        self.assertListEqual(
+            [m.model_dump() for m in page2],
             [m.model_dump() for m in msgs[1:4]],
         )
+        self.assertTrue(has_more_2)
+
+        # Anchor page 3 at the oldest id of page 2 (msgs[1]).
+        page3, has_more_3 = await self.storage.list_messages(
+            self.user_id,
+            self.session_id,
+            limit=3,
+            before=page2[0].id,
+        )
+        self.assertListEqual(
+            [m.model_dump() for m in page3],
+            [m.model_dump() for m in msgs[0:1]],
+        )
+        self.assertFalse(has_more_3)
+
+    async def test_list_messages_before_unknown_id(self) -> None:
+        """An unknown ``before`` id yields an empty window."""
+        await self._seed_n_messages(3)
+        messages, has_more = await self.storage.list_messages(
+            self.user_id,
+            self.session_id,
+            before="does-not-exist",
+        )
+        self.assertListEqual(messages, [])
+        self.assertFalse(has_more)
 
     async def test_list_messages_order_preserved(self) -> None:
         """Messages are returned in the insertion order (chronological)."""
@@ -489,7 +565,7 @@ class TestMessage(IsolatedAsyncioTestCase):
                 self.session_id,
                 m,
             )
-        messages = await self.storage.list_messages(
+        messages, _has_more = await self.storage.list_messages(
             self.user_id,
             self.session_id,
         )
@@ -505,11 +581,12 @@ class TestMessage(IsolatedAsyncioTestCase):
             "session-A",
             UserMsg(name="alice", content="in A"),
         )
-        messages = await self.storage.list_messages(
+        messages, has_more = await self.storage.list_messages(
             self.user_id,
             "session-B",
         )
         self.assertListEqual(messages, [])
+        self.assertFalse(has_more)
 
 
 def make_schedule_record(user_id: str, agent_id: str) -> ScheduleRecord:


### PR DESCRIPTION
## Summary

`RedisStorage.list_messages` read messages from the **head** of the list (`lrange(key, offset, ...)`), but messages are appended with `rpush`, so the **tail is the newest**. With the default `offset=0, limit=50`, only the first 50 messages ever stored were returned — once a session exceeded 50 messages the newest ones became invisible after a page refresh or SSE reconnect. Numeric offset pagination is also unstable for real-time streams: new messages pushed mid-pagination shift the window and cause duplicates/gaps.

Closes #2080.

## Changes

- **`RedisStorage.list_messages`** → `list_messages(user_id, session_id, limit, before) -> tuple[list[Msg], bool]`:
  - `before=None` returns the newest `limit` messages; `before=msg_id` returns the `limit` messages preceding that id (exclusive upper bound).
  - The window is always returned oldest→newest, so the frontend can anchor the next page on `messages[0].id`.
  - Returns `has_more` indicating older messages exist before the window.
  - New `_find_message_index` helper locates the cursor message (Redis lists aren't indexed by id; scans newest→oldest since the cursor is usually recent).
- **`StorageBase`** abstract `list_messages` updated to the new contract (only `RedisStorage` implements it).
- **`ListMessagesResponse`** schema gains `has_more`.
- **Session router** `GET /sessions/{id}/messages` exposes `before` instead of `offset`.
- **Web UI** API client (`examples/web_ui/.../api/session.ts`) drops `offset` for an optional `before` and reads `has_more`. The default load (no `before`) now fetches the newest page — which also fixes the UI silently showing the oldest messages today.

This is a breaking change to the `before`/`has_more` shape of `GET /sessions/{id}/messages` (drops `offset`). The only in-tree caller is the web UI, updated here.

## Test plan

- [x] Updated/added `TestMessage` tests (against `fakeredis`): newest-window default, `has_more` true/false, full backwards cursor paging across three pages (every older message returned exactly once), unknown `before` id → empty, empty session, chronological order, session isolation.
- [x] Full `storage_redis_test.py` green (59) and `service_team_tools_test.py` + `app_lifespan_dedicated_test.py` green (38) — no regressions.
- [x] `pre-commit run` passes (black, flake8, mypy, pylint).

```bash
pytest tests/storage_redis_test.py tests/service_team_tools_test.py tests/app_lifespan_dedicated_test.py
# 97 passed
```