### PR TITLE
fix(rag): adapt MilvusLiteStore to milvus-lite 3.1.0 COSINE distance semantics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,8 @@ rag = [
     "pandas",
 ]
 milvuslite = [
-    "pymilvus[milvus-lite]>=2.4.0",
-    "milvus-lite>=3.0; sys_platform == 'win32'",
+    "pymilvus>=2.4.0",
+    "milvus-lite>=3.1.0",
 ]
 # ------------ MongoDB vector store ------------
 mongodb = [

--- a/src/agentscope/rag/_vdb/_milvus_lite.py
+++ b/src/agentscope/rag/_vdb/_milvus_lite.py
@@ -427,12 +427,15 @@ class MilvusLiteStore(VectorStoreBase):
         hit: dict[str, Any],
         metric_type: Literal["COSINE", "IP", "L2"],
     ) -> float:
-        """Extract a score from Milvus search result shapes."""
+        """Extract a score from Milvus search result shapes.
+
+        Since milvus-lite >= 3.1.0 the ``distance`` field for COSINE
+        already carries the cosine similarity (1.0 for identical
+        vectors), so no conversion is needed.
+        """
+        # pylint: disable=unused-argument
         if "distance" in hit:
-            distance = float(hit["distance"])
-            if metric_type == "COSINE":
-                return 1.0 - distance
-            return distance
+            return float(hit["distance"])
         if "score" in hit:
             return float(hit["score"])
         return 0.0


### PR DESCRIPTION
## AgentScope Version

2.0.4

## Description

milvus-lite 3.1.0 changed the `distance` field for COSINE metric to return cosine similarity directly (1.0 for identical vectors), instead of cosine distance (0.0 for identical vectors) as in prior versions.

- Remove the `1.0 - distance` conversion in `_extract_score`
- Pin `milvus-lite>=3.1.0` to match the new behavior
- Simplify dependency declaration (drop pymilvus extra, explicit milvus-lite pin)

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review