### PR TITLE
fix(agent): preserve multi-tool pairs during context compression

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -2045,21 +2045,30 @@ class Agent:
                 break
             block_index -= 1
 
-        # Adjust the block_index to avoid splitting tool call and result pairs
+        # Adjust the block_index to avoid splitting tool call and result pairs.
+        # Moving the boundary can bring another tool call into the compressed
+        # part while leaving its result reserved, so repeat until it is stable.
+        while True:
+            # Check if the reserved part has tool results that don't have the
+            # corresponding tool calls
+            remain_result_ids = {}
+            for i in range(
+                len(boundary_msg_content) - 1,
+                block_index,
+                -1,
+            ):
+                block = boundary_msg_content[i]
+                if isinstance(block, ToolResultBlock):
+                    remain_result_ids[block.id] = i
+                elif isinstance(block, ToolCallBlock):
+                    remain_result_ids.pop(block.id, None)
 
-        # Check if the reserved part has tool results that don't have the
-        # corresponding tool calls
-        remain_result_ids = {}
-        for i in range(len(boundary_msg_content) - 1, block_index, -1):
-            block = boundary_msg_content[i]
-            if isinstance(block, ToolResultBlock):
-                remain_result_ids[block.id] = i
-            elif isinstance(block, ToolCallBlock):
-                remain_result_ids.pop(block.id, None)
+            # All tool result blocks in the reserved part are paired.
+            if not remain_result_ids:
+                break
 
-        # Find the largest index of the remaining tool results, which doesn't
-        # have the corresponding tool calls in the reserved parts
-        if remain_result_ids:
+            # Move unmatched results into the compressed part and recheck,
+            # because this move can split another tool call/result pair.
             block_index = max(remain_result_ids.values())
 
         # Split the boundary msg content

--- a/tests/compress_context_test.py
+++ b/tests/compress_context_test.py
@@ -700,31 +700,117 @@ class ContextCompressionTest(IsolatedAsyncioTestCase):
         )
 
         self.assertListEqual(
-            [msg.id for msg in to_compress],
-            ["old-user", "multi-tool-msg"],
+            [msg.model_dump() for msg in to_compress],
+            [
+                {
+                    "id": "old-user",
+                    "created_at": AnyString(),
+                    "finished_at": AnyString(),
+                    "name": "User",
+                    "role": "user",
+                    "content": [
+                        {
+                            "id": AnyString(),
+                            "type": "text",
+                            "text": "old" * 80,
+                        },
+                    ],
+                    "metadata": {},
+                    "usage": None,
+                },
+                {
+                    "id": "multi-tool-msg",
+                    "created_at": AnyString(),
+                    "finished_at": None,
+                    "name": "Friday",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "id": "tc1",
+                            "type": "tool_call",
+                            "name": "first_tool",
+                            "input": json.dumps({"value": "a" * 80}),
+                            "state": "pending",
+                            "suggested_rules": [],
+                        },
+                        {
+                            "id": "tc2",
+                            "type": "tool_call",
+                            "name": "second_tool",
+                            "input": json.dumps({"value": "b" * 80}),
+                            "state": "pending",
+                            "suggested_rules": [],
+                        },
+                        {
+                            "id": "tc1",
+                            "type": "tool_result",
+                            "name": "first_tool",
+                            "output": [
+                                {
+                                    "id": AnyString(),
+                                    "type": "text",
+                                    "text": "first result " * 8,
+                                },
+                            ],
+                            "state": "success",
+                            "metadata": {},
+                        },
+                        {
+                            "id": "tc2",
+                            "type": "tool_result",
+                            "name": "second_tool",
+                            "output": [
+                                {
+                                    "id": AnyString(),
+                                    "type": "text",
+                                    "text": "second result " * 8,
+                                },
+                            ],
+                            "state": "success",
+                            "metadata": {},
+                        },
+                    ],
+                    "metadata": {},
+                    "usage": None,
+                },
+            ],
         )
         self.assertListEqual(
+            [msg.model_dump() for msg in to_reserve],
             [
-                (block.type, block.id)
-                for block in to_compress[-1].get_content_blocks()
+                {
+                    "id": "multi-tool-msg",
+                    "created_at": AnyString(),
+                    "finished_at": None,
+                    "name": "Friday",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "id": "final-text",
+                            "type": "text",
+                            "text": "Both tools completed.",
+                        },
+                    ],
+                    "metadata": {},
+                    "usage": None,
+                },
+                {
+                    "id": "latest-user",
+                    "created_at": AnyString(),
+                    "finished_at": AnyString(),
+                    "name": "User",
+                    "role": "user",
+                    "content": [
+                        {
+                            "id": AnyString(),
+                            "type": "text",
+                            "text": "latest question",
+                        },
+                    ],
+                    "metadata": {},
+                    "usage": None,
+                },
             ],
-            [
-                ("tool_call", "tc1"),
-                ("tool_call", "tc2"),
-                ("tool_result", "tc1"),
-                ("tool_result", "tc2"),
-            ],
-        )
-        self.assertListEqual(
-            [msg.id for msg in to_reserve],
-            ["multi-tool-msg", "latest-user"],
-        )
-        self.assertListEqual(
-            [
-                (block.type, block.id)
-                for block in to_reserve[0].get_content_blocks()
-            ],
-            [("text", "final-text")],
         )
 
     async def test_context_compression(self) -> None:

--- a/tests/compress_context_test.py
+++ b/tests/compress_context_test.py
@@ -18,6 +18,8 @@ from agentscope.message import (
     AssistantMsg,
     TextBlock,
     ToolCallBlock,
+    ToolResultBlock,
+    ToolResultState,
     HintBlock,
     Msg,
 )
@@ -632,6 +634,97 @@ class ContextCompressionTest(IsolatedAsyncioTestCase):
                     "usage": None,
                 },
             ],
+        )
+
+    async def test_split_multi_tool_pairs_reaches_stable_boundary(
+        self,
+    ) -> None:
+        """The boundary is rechecked after moving an unmatched result."""
+        agent = Agent(
+            name="Friday",
+            system_prompt="",
+            model=MockModel(context_size=1_000),
+            state=AgentState(
+                session_id="multi-tool-compression",
+                context=[
+                    UserMsg("User", "old" * 80, id="old-user"),
+                    AssistantMsg(
+                        "Friday",
+                        [
+                            ToolCallBlock(
+                                id="tc1",
+                                name="first_tool",
+                                input=json.dumps({"value": "a" * 80}),
+                            ),
+                            ToolCallBlock(
+                                id="tc2",
+                                name="second_tool",
+                                input=json.dumps({"value": "b" * 80}),
+                            ),
+                            ToolResultBlock(
+                                id="tc1",
+                                name="first_tool",
+                                output=[
+                                    TextBlock(text="first result " * 8),
+                                ],
+                                state=ToolResultState.SUCCESS,
+                            ),
+                            ToolResultBlock(
+                                id="tc2",
+                                name="second_tool",
+                                output=[
+                                    TextBlock(text="second result " * 8),
+                                ],
+                                state=ToolResultState.SUCCESS,
+                            ),
+                            TextBlock(
+                                text="Both tools completed.",
+                                id="final-text",
+                            ),
+                        ],
+                        id="multi-tool-msg",
+                    ),
+                    UserMsg(
+                        "User",
+                        "latest question",
+                        id="latest-user",
+                    ),
+                ],
+            ),
+            toolkit=Toolkit(),
+        )
+
+        to_compress, to_reserve = await agent._split_context_for_compression(
+            to_reserved_tokens=86,
+            tools=[],
+        )
+
+        self.assertListEqual(
+            [msg.id for msg in to_compress],
+            ["old-user", "multi-tool-msg"],
+        )
+        self.assertListEqual(
+            [
+                (block.type, block.id)
+                for block in to_compress[-1].get_content_blocks()
+            ],
+            [
+                ("tool_call", "tc1"),
+                ("tool_call", "tc2"),
+                ("tool_result", "tc1"),
+                ("tool_result", "tc2"),
+            ],
+        )
+        self.assertListEqual(
+            [msg.id for msg in to_reserve],
+            ["multi-tool-msg", "latest-user"],
+        )
+        self.assertListEqual(
+            [
+                (block.type, block.id)
+                for block in to_reserve[0].get_content_blocks()
+            ],
+            [("text", "final-text")],
         )
 
     async def test_context_compression(self) -> None:


### PR DESCRIPTION
## AgentScope Version

2.0.4

## Problem

Context compression adjusts its block boundary once when the reserved suffix
contains a tool result without its matching tool call.

For an interleaved multi-tool batch such as:

```text
call1, call2, result1, result2
```

moving `result1` into the compressed side also moves `call2`, while `result2`
remains reserved. This creates a new split pair that is not checked again,
causing invalid provider requests.

## Solution

Recheck the reserved suffix after every boundary adjustment until no unmatched
tool results remain. This reaches a stable boundary while preserving the
existing block-level compression strategy.

## Changes

- Replace the one-pass tool-pair boundary adjustment with a fixed-point loop.
- Add a deterministic regression test with two tool calls followed by their
  two results.
- Verify that the complete multi-tool batch stays on the compressed side while
  later text remains reserved.

## Testing

- `pytest tests/compress_context_test.py::ContextCompressionTest::test_split_multi_tool_pairs_reaches_stable_boundary -vv`
- `pytest tests/compress_context_test.py tests/compress_tool_result_test.py tests/formatter_openai_chat_test.py tests/agent_basic_test.py -q`
  - 30 passed
- `pre-commit run --files src/agentscope/agent/_agent.py tests/compress_context_test.py`
  - all hooks passed
- Manual smoke test confirmed both call/result pairs remain together.

## Notes for Reviewer

Fixes #2090.

This is an internal correctness fix with no public API, dependency, or
documentation changes.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation is not required for this internal bug fix
- [x] Code is ready for review
