### PR TITLE
fix(webui): scroll newly loaded sessions to bottom

### DIFF
--- a/examples/web_ui/frontend/src/components/chat/ChatContent.tsx
+++ b/examples/web_ui/frontend/src/components/chat/ChatContent.tsx
@@ -65,21 +65,18 @@ const ChatContentComponent: React.FC<ChatContentProps> = ({
 		const prevCount = prevMsgCountRef.current;
 
 		const isActive = phase !== 'idle';
-		const shouldCheck =
+		const isInitialLoad = prevCount === 0 && currentCount > 0;
+		const hasRelevantUpdate =
 			(currentCount > prevCount && prevCount > 0) || (isActive && prevCount > 0);
+		const shouldScroll = isInitialLoad || (hasRelevantUpdate && wasNearBottomRef.current);
 
-		if (shouldCheck && scrollAreaRef.current) {
+		if (shouldScroll && scrollAreaRef.current) {
 			const { scrollHeight } = scrollAreaRef.current;
 
-			// Check if user was near bottom before content changed
-			const isNearBottom = wasNearBottomRef.current;
-
-			if (isNearBottom) {
-				scrollAreaRef.current.scrollTo({
-					top: scrollHeight,
-					behavior: 'smooth',
-				});
-			}
+			scrollAreaRef.current.scrollTo({
+				top: scrollHeight,
+				behavior: 'smooth',
+			});
 		}
 
 		prevMsgCountRef.current = currentCount;


### PR DESCRIPTION
## Summary

- scroll to the latest message when a session first loads a non-empty history
- preserve the existing near-bottom guard for later messages and active streaming updates
- keep the fix scoped to `ChatContent.tsx` without adding dependencies or changing component APIs

## Root cause

The auto-scroll effect only considered message growth when `prevMsgCountRef.current` was already greater than zero. On the first persisted-history load, the previous count is zero, so the effect skipped scrolling entirely.

## Validation

- `pnpm exec prettier --check frontend/src/components/chat/ChatContent.tsx`
- `pnpm --filter frontend lint` (0 errors; 16 existing warnings also present on `main`)
- `pnpm --filter frontend build`
- local decision-matrix assertions for empty, initial-load, later-growth, and active-update cases (6/6 passed)

Fixes #2097