### PR TITLE
fix(tool): use backend mtime for file cache validation

### DIFF
--- a/src/agentscope/state/_state.py
+++ b/src/agentscope/state/_state.py
@@ -20,6 +20,13 @@ from ..message import (
 from ..permission import PermissionContext
 
 
+class _UseHostMtime:
+    """Sentinel indicating that the host filesystem should be inspected."""
+
+
+_USE_HOST_MTIME = _UseHostMtime()
+
+
 class ReadCacheEntry(BaseModel):
     """The read file cache."""
 
@@ -43,45 +50,74 @@ class ToolContext(BaseModel):
     """The names of the activated tool groups, each group contains a set of
     tools."""
 
-    async def get_cache(self, file_path: str) -> ReadCacheEntry | None:
+    async def get_cache(
+        self,
+        file_path: str,
+        mtime: float | None | _UseHostMtime = _USE_HOST_MTIME,
+    ) -> ReadCacheEntry | None:
         """Get cached file content if still valid.
 
         Args:
-            file_path: The absolute path of the file.
+            file_path (`str`):
+                The absolute path of the file.
+            mtime (`float | None`, optional):
+                Modification time obtained from the filesystem that owns the
+                file. When omitted, the host filesystem is inspected for
+                backward compatibility. An explicit ``None`` means the
+                modification time could not be determined, so the cache is
+                treated as invalid.
 
         Returns:
-            The cached entry if valid, otherwise None.
+            `ReadCacheEntry | None`:
+                The cached entry if valid, otherwise None.
         """
 
         # Find the cache entry
         for entry in self.read_file_cache:
             if entry.file_path == file_path:
                 # Check if cache is still valid
-                try:
-                    updated_at = await aiofiles.os.path.getmtime(file_path)
-                    if updated_at == entry.updated_at:
-                        return entry
-                    else:
-                        # Cache is outdated, remove it
-                        self.read_file_cache.remove(entry)
-                        return None
-                except Exception:
-                    # File might not exist anymore
+                if isinstance(mtime, _UseHostMtime):
+                    try:
+                        mtime = await aiofiles.os.path.getmtime(file_path)
+                    except Exception:
+                        mtime = None
+
+                if mtime is None or mtime != entry.updated_at:
+                    # File might no longer exist, be unverifiable, or have
+                    # changed since it was read.
                     self.read_file_cache.remove(entry)
                     return None
+                return entry
         return None
 
-    async def cache_file(self, file_path: str, lines: list[str]) -> None:
+    async def cache_file(
+        self,
+        file_path: str,
+        lines: list[str],
+        mtime: float | None | _UseHostMtime = _USE_HOST_MTIME,
+    ) -> None:
         """Cache file content with LRU eviction.
 
         Args:
-            file_path: The absolute path of the file.
-            lines: The lines of the file content.
+            file_path (`str`):
+                The absolute path of the file.
+            lines (`list[str]`):
+                The lines of the file content.
+            mtime (`float | None`, optional):
+                Modification time obtained from the filesystem that owns the
+                file. When omitted, the host filesystem is inspected for
+                backward compatibility. An explicit ``None`` means the
+                modification time could not be determined and caching is
+                skipped.
         """
-        try:
-            updated_at = await aiofiles.os.path.getmtime(file_path)
-        except Exception:
-            # Cannot get mtime, skip caching
+        if isinstance(mtime, _UseHostMtime):
+            try:
+                mtime = await aiofiles.os.path.getmtime(file_path)
+            except Exception:
+                mtime = None
+
+        if mtime is None:
+            # Cannot validate the entry later, so do not cache it.
             return
 
         # Calculate size in KB
@@ -113,7 +149,7 @@ class ToolContext(BaseModel):
         self.read_file_cache.append(
             ReadCacheEntry(
                 lines=lines,
-                updated_at=updated_at,
+                updated_at=mtime,
                 bytes=new_entry_bytes,
                 file_path=file_path,
             ),

--- a/src/agentscope/tool/_builtin/_edit.py
+++ b/src/agentscope/tool/_builtin/_edit.py
@@ -295,7 +295,11 @@ Usage:
 
         content = None
         if _agent_state is not None:
-            cache = await _agent_state.tool_context.get_cache(file_path)
+            mtime = await self._backend.stat_mtime(file_path)
+            cache = await _agent_state.tool_context.get_cache(
+                file_path,
+                mtime=mtime,
+            )
             if cache is None:
                 # Haven't read this file before
                 return ToolChunk(

--- a/src/agentscope/tool/_builtin/_read.py
+++ b/src/agentscope/tool/_builtin/_read.py
@@ -225,8 +225,13 @@ Usage:
         try:
             # Read file content via backend
             lines = None
+            mtime = None
             if _agent_state is not None:
-                cache = await _agent_state.tool_context.get_cache(file_path)
+                mtime = await self._backend.stat_mtime(file_path)
+                cache = await _agent_state.tool_context.get_cache(
+                    file_path,
+                    mtime=mtime,
+                )
                 if cache is not None:
                     lines = cache.lines
 
@@ -244,6 +249,7 @@ Usage:
                     await _agent_state.tool_context.cache_file(
                         file_path=file_path,
                         lines=lines,
+                        mtime=mtime,
                     )
 
             # Apply offset and limit (offset is 1-based)

--- a/src/agentscope/tool/_builtin/_write.py
+++ b/src/agentscope/tool/_builtin/_write.py
@@ -248,7 +248,11 @@ Usage:
             await self._backend.file_exists(file_path)
             and _agent_state is not None
         ):
-            cache = await _agent_state.tool_context.get_cache(file_path)
+            mtime = await self._backend.stat_mtime(file_path)
+            cache = await _agent_state.tool_context.get_cache(
+                file_path,
+                mtime=mtime,
+            )
             if cache is None:
                 return ToolChunk(
                     content=[

--- a/tests/builtin_file_cache_backend_test.py
+++ b/tests/builtin_file_cache_backend_test.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+"""Backend-aware cache tests for the builtin file tools."""
+
+import os
+from unittest.async_case import IsolatedAsyncioTestCase
+
+from agentscope.state import AgentState
+from agentscope.tool import Edit, Read, Write
+from agentscope.tool._builtin._backend import BackendBase, ExecResult
+
+
+class _RemoteMemoryBackend(BackendBase):
+    """A backend whose files are not visible to the host filesystem."""
+
+    def __init__(self) -> None:
+        """Initialize the in-memory files and modification times."""
+        self.files: dict[str, bytes] = {}
+        self.mtimes: dict[str, float] = {}
+        self.stat_available = True
+
+    async def exec_shell(
+        self,
+        command: list[str],
+        *,
+        cwd: str | None = None,
+        timeout: float | None = None,
+    ) -> ExecResult:
+        """Return success for directory creation used by ``Write``."""
+        return ExecResult(exit_code=0, stdout=b"", stderr=b"")
+
+    async def read_file(self, path: str) -> bytes:
+        """Read a file from the backend-only store."""
+        return self.files[path]
+
+    async def write_file(self, path: str, data: bytes) -> None:
+        """Write a file and advance its backend modification time."""
+        self.files[path] = data
+        self.mtimes[path] = self.mtimes.get(path, 0.0) + 1.0
+
+    async def file_exists(self, path: str) -> bool:
+        """Check whether a backend-only file exists."""
+        return path in self.files
+
+    async def is_dir(self, path: str) -> bool:
+        """The test backend stores files only."""
+        return False
+
+    async def stat_mtime(self, path: str) -> float | None:
+        """Return the backend mtime when stat is available."""
+        if not self.stat_available:
+            return None
+        return self.mtimes.get(path)
+
+
+class BackendAwareFileCacheTest(IsolatedAsyncioTestCase):
+    """Exercise cache behavior for files that only a backend can access."""
+
+    async def asyncSetUp(self) -> None:
+        """Create stateful tools backed by an isolated remote-style store."""
+        self.backend = _RemoteMemoryBackend()
+        self.read_tool = Read(backend=self.backend)
+        self.edit_tool = Edit(backend=self.backend)
+        self.write_tool = Write(backend=self.backend)
+        self.state = AgentState()
+        self.file_path = "/workspace/test.txt"
+        await self.backend.write_file(self.file_path, b"alpha\n")
+        self.assertFalse(os.path.exists(self.file_path))
+
+    async def _read_file(self) -> None:
+        """Read the backend-only file and assert the tool call succeeds."""
+        chunk = await self.read_tool(
+            file_path=self.file_path,
+            _agent_state=self.state,
+        )
+        self.assertEqual(chunk.state.value, "running")
+
+    async def test_read_caches_backend_only_file(self) -> None:
+        """Read should cache a path that the host cannot stat."""
+        await self._read_file()
+
+        self.assertEqual(len(self.state.tool_context.read_file_cache), 1)
+        self.assertEqual(
+            self.state.tool_context.read_file_cache[0].file_path,
+            self.file_path,
+        )
+
+    async def test_edit_after_read(self) -> None:
+        """Edit should accept a backend-only file after Read."""
+        await self._read_file()
+
+        chunk = await self.edit_tool(
+            file_path=self.file_path,
+            old_string="alpha",
+            new_string="beta",
+            _agent_state=self.state,
+        )
+
+        self.assertEqual(chunk.state.value, "running")
+        self.assertEqual(
+            await self.backend.read_file(self.file_path),
+            b"beta\n",
+        )
+
+    async def test_edit_without_read_is_rejected(self) -> None:
+        """A backend-only file should still require a preceding Read."""
+        chunk = await self.edit_tool(
+            file_path=self.file_path,
+            old_string="alpha",
+            new_string="beta",
+            _agent_state=self.state,
+        )
+
+        self.assertEqual(chunk.state.value, "error")
+        self.assertIn("must first read", chunk.content[0].text)
+
+    async def test_write_after_read(self) -> None:
+        """Write should accept a backend-only file after Read."""
+        await self._read_file()
+
+        chunk = await self.write_tool(
+            file_path=self.file_path,
+            content="beta\n",
+            _agent_state=self.state,
+        )
+
+        self.assertEqual(chunk.state.value, "running")
+        self.assertEqual(
+            await self.backend.read_file(self.file_path),
+            b"beta\n",
+        )
+
+    async def test_write_without_read_is_rejected(self) -> None:
+        """A backend-only existing file should require a preceding Read."""
+        chunk = await self.write_tool(
+            file_path=self.file_path,
+            content="beta\n",
+            _agent_state=self.state,
+        )
+
+        self.assertEqual(chunk.state.value, "error")
+        self.assertIn("has not been read yet", chunk.content[0].text)
+
+    async def test_backend_change_invalidates_cache(self) -> None:
+        """An mtime change in the backend should invalidate cached content."""
+        await self._read_file()
+        await self.backend.write_file(self.file_path, b"changed externally\n")
+
+        chunk = await self.edit_tool(
+            file_path=self.file_path,
+            old_string="alpha",
+            new_string="beta",
+            _agent_state=self.state,
+        )
+
+        self.assertEqual(chunk.state.value, "error")
+        self.assertIn("must first read", chunk.content[0].text)
+        self.assertEqual(self.state.tool_context.read_file_cache, [])
+
+    async def test_unavailable_backend_mtime_invalidates_cache(self) -> None:
+        """An unverifiable cache entry should not authorize an edit."""
+        await self._read_file()
+        self.backend.stat_available = False
+
+        chunk = await self.edit_tool(
+            file_path=self.file_path,
+            old_string="alpha",
+            new_string="beta",
+            _agent_state=self.state,
+        )
+
+        self.assertEqual(chunk.state.value, "error")
+        self.assertIn("must first read", chunk.content[0].text)
+        self.assertEqual(self.state.tool_context.read_file_cache, [])
+
+    async def test_agent_state_remains_serializable(self) -> None:
+        """Backend-aware caching must not store the backend in agent state."""
+        await self._read_file()
+
+        serialized = self.state.model_dump_json()
+        restored = AgentState.model_validate_json(serialized)
+
+        self.assertEqual(
+            restored.tool_context.read_file_cache[0].file_path,
+            self.file_path,
+        )


### PR DESCRIPTION
## PR Title Format

`fix(tool): use backend mtime for file cache validation`

## AgentScope Version

`2.0.4.post1`

## Description

Fixes #2084.

The builtin Read tool could read files through a Docker or remote workspace backend, but the subsequent Edit or Write call still failed with a "must first read" error. The file cache was validating workspace paths with the host filesystem's `getmtime()`, where those paths do not exist.

This change:

- validates the cache with the filesystem backend's `stat_mtime()`;
- passes the mtime result at call time without storing the backend in `ToolContext`;
- keeps the existing host-filesystem fallback for callers that omit `mtime`;
- treats an explicit `mtime=None` as unverifiable and does not reuse the cache;
- adds regression tests using a non-local backend whose files are not visible to the host filesystem.

This overlaps with #2092, but explicitly distinguishes an omitted mtime from a backend that returns `None`, so an unverifiable cache entry is not trusted.

Testing performed:

- `pre-commit run --all-files` passed.
- Windows/Python 3.12: 72 passed, 2 skipped.
- Linux/Python 3.11 against the final commit: 82 relevant tests passed.
- Broader Linux suite excluding the two Docker image-building test files: 1295 passed, 55 skipped, and 300 subtests passed.
- A real DockerBackend verification passed for Read → Edit, Read → Write, unread-file rejection, external mtime invalidation, AgentState serialization, and workspace teardown.

The repository's Docker workspace test suites require rebuilding an image from external resources unavailable on the test server, so the affected behavior was verified separately against a real DockerBackend.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation is not required because this is an internal cache fix with no public API or user-facing documentation changes
- [x] Code is ready for review