### PR TITLE
feat(webui): add scroll-to-bottom button

### DIFF
--- a/examples/web_ui/frontend/src/components/chat/ChatContent.tsx
+++ b/examples/web_ui/frontend/src/components/chat/ChatContent.tsx
@@ -1,10 +1,12 @@
 import type { ContentBlock, Msg, ToolCallBlock } from '@agentscope-ai/agentscope/message';
+import { ArrowDown } from 'lucide-react';
 import React from 'react';
-import { useRef, useEffect } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { EmptyMessage } from './Empty';
 import { MessageBubble } from '@/components/chat/MessageBubble';
 import { TextInput } from '@/components/chat/TextInput.tsx';
+import { Button } from '@/components/ui/button.tsx';
 import type { ReplyPhase } from '@/hooks/useMessages';
 import { cn } from '@/lib/utils';
 
@@ -58,6 +60,18 @@ const ChatContentComponent: React.FC<ChatContentProps> = ({
 	const scrollAreaRef = useRef<HTMLDivElement>(null);
 	const prevMsgCountRef = useRef<number>(0);
 	const wasNearBottomRef = useRef<boolean>(true);
+	const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+
+	const updateScrollState = useCallback(() => {
+		const scrollArea = scrollAreaRef.current;
+		if (!scrollArea) return;
+
+		const { scrollTop, scrollHeight, clientHeight } = scrollArea;
+		const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
+
+		wasNearBottomRef.current = distanceFromBottom <= 50;
+		setShowScrollToBottom(distanceFromBottom > 100);
+	}, []);
 
 	// Auto-scroll to bottom only if user is already near the bottom
 	useEffect(() => {
@@ -77,44 +91,65 @@ const ChatContentComponent: React.FC<ChatContentProps> = ({
 				top: scrollHeight,
 				behavior: 'smooth',
 			});
+		} else {
+			updateScrollState();
 		}
 
 		prevMsgCountRef.current = currentCount;
-	}, [msgs, phase]);
+	}, [msgs, phase, updateScrollState]);
 
 	// Track if user is near bottom whenever they scroll
 	useEffect(() => {
 		const scrollArea = scrollAreaRef.current;
 		if (!scrollArea) return;
 
-		const handleScroll = () => {
-			const { scrollTop, scrollHeight, clientHeight } = scrollArea;
-			wasNearBottomRef.current = scrollTop + clientHeight >= scrollHeight - 50;
-		};
-
-		scrollArea.addEventListener('scroll', handleScroll);
-		return () => scrollArea.removeEventListener('scroll', handleScroll);
-	}, []);
+		scrollArea.addEventListener('scroll', updateScrollState);
+		return () => scrollArea.removeEventListener('scroll', updateScrollState);
+	}, [updateScrollState]);
 
 	return (
 		<div className={cn('flex flex-col h-full w-full items-center p-2 gap-4', className)}>
-			<div
-				ref={scrollAreaRef}
-				className="flex-1 w-full max-w-full overflow-auto no-scrollbar overflow-x-hidden"
-			>
-				<div className="flex flex-col gap-4 size-full max-w-full">
-					{msgs.length > 0 ? (
-						msgs.map((message) => (
-							<MessageBubble
-								key={message.id}
-								message={message}
-								onUserConfirm={onUserConfirm}
-							/>
-						))
-					) : (
-						<EmptyMessage />
-					)}
+			<div className="relative flex-1 min-h-0 w-full max-w-full">
+				<div
+					ref={scrollAreaRef}
+					className="size-full overflow-auto no-scrollbar overflow-x-hidden"
+				>
+					<div className="flex flex-col gap-4 size-full max-w-full">
+						{msgs.length > 0 ? (
+							msgs.map((message) => (
+								<MessageBubble
+									key={message.id}
+									message={message}
+									onUserConfirm={onUserConfirm}
+								/>
+							))
+						) : (
+							<EmptyMessage />
+						)}
+					</div>
 				</div>
+				<Button
+					type="button"
+					variant="outline"
+					size="icon"
+					aria-label="Scroll to bottom"
+					aria-hidden={!showScrollToBottom}
+					tabIndex={showScrollToBottom ? 0 : -1}
+					className={cn(
+						'absolute bottom-4 left-1/2 z-10 -translate-x-1/2 rounded-full shadow-md transition-all duration-200',
+						showScrollToBottom
+							? 'translate-y-0 opacity-100'
+							: 'pointer-events-none translate-y-2 opacity-0',
+					)}
+					onClick={() =>
+						scrollAreaRef.current?.scrollTo({
+							top: scrollAreaRef.current.scrollHeight,
+							behavior: 'smooth',
+						})
+					}
+				>
+					<ArrowDown />
+				</Button>
 			</div>
 			{footerSlot ? <div className="w-full max-w-full shrink-0">{footerSlot}</div> : null}
 			<TextInput


### PR DESCRIPTION
## AgentScope Version

2.0.4.post1 (`main`)

## Description

Fixes #2096.

Long conversations previously had no quick way to return to the latest message after the user scrolled upward. This change adds an accessible floating scroll-to-bottom control to the chat message viewport.

### Changes

- Reuse the existing scroll-area state to track the distance from the bottom.
- Show the button only when the viewport is more than 100px from the bottom, while preserving the existing 50px auto-scroll threshold.
- Smoothly scroll to the full message height when the button is clicked.
- Fade and slide the button in and out to avoid flicker near the bottom.
- Place the button inside a relative message-area wrapper so it remains above, rather than overlapping, `footerSlot` and `TextInput`.
- Recompute visibility when messages grow without emitting a native scroll event.

This is an atomic WebUI-only change. It adds no dependency, public API change, migration, or documentation requirement.

### Validation

- `pnpm exec prettier --check frontend/src/components/chat/ChatContent.tsx`
- `.venv/Scripts/pre-commit run --files examples/web_ui/frontend/src/components/chat/ChatContent.tsx`
- `pnpm --filter frontend lint` (0 errors; 16 existing warnings in unrelated files)
- `pnpm --filter frontend build`
- Temporary Vitest/jsdom interaction harness: 4/4 cases passed for the 100px threshold, smooth-scroll call, content-growth recalculation, and footer/input layout ordering

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style (no docstrings were added)
- [x] Related documentation has been updated (not required; no public API or configuration changed)
- [x] Code is ready for review
