### PR TITLE
fix(workspace): isolate local workspaces by user

### DIFF
--- a/src/agentscope/app/workspace_manager/_local_workspace_manager.py
+++ b/src/agentscope/app/workspace_manager/_local_workspace_manager.py
@@ -2,6 +2,7 @@
 """The local workspace manager."""
 
 import asyncio
+import hashlib
 import os
 import time
 
@@ -15,10 +16,9 @@ from ._base import WorkspaceManagerBase, IsolationPolicy
 class LocalWorkspaceManager(WorkspaceManagerBase):
     """Manages LocalWorkspace instances with TTL-based lazy lifecycle.
 
-    Workspaces are keyed by ``workspace_id`` in the cache. On cache miss
-    the manager reconstructs the workspace from ``basedir/agent_id`` — the
-    workdir is deterministic for local workspaces so no storage lookup is
-    needed.
+    Workspaces are scoped by ``(user_id, workspace_id)`` in both the cache
+    and the filesystem. This keeps explicit workspace identifiers useful
+    for same-user team sharing without making them cross-user bearer keys.
     """
 
     def __init__(
@@ -34,8 +34,8 @@ class LocalWorkspaceManager(WorkspaceManagerBase):
 
         Args:
             basedir (`str`):
-                Root directory under which per-agent workdir are
-                created.
+                Root directory under which user/workspace-scoped workdirs
+                are created.
             isolation (`IsolationPolicy`, defaults to `PER_AGENT`):
                 Isolation grain for :meth:`assign_workspace_id`. See
                 :class:`DockerWorkspaceManager` for semantics.
@@ -50,10 +50,33 @@ class LocalWorkspaceManager(WorkspaceManagerBase):
         self._default_mcps = default_mcps or []
         self._skill_paths = skill_paths or []
         self._ttl = ttl
-        # workspace_id → (workspace, last_access_monotonic)
-        self._cache: dict[str, tuple[LocalWorkspace, float]] = {}
+        # (user_id, workspace_id) -> (workspace, last_access_monotonic)
+        self._cache: dict[
+            tuple[str, str],
+            tuple[LocalWorkspace, float],
+        ] = {}
         self._lock = asyncio.Lock()
         super().__init__(isolation=isolation)
+
+    @staticmethod
+    def _path_component(value: str) -> str:
+        """Return a filesystem-safe, opaque component for an identifier."""
+        return hashlib.blake2b(
+            value.encode("utf-8"),
+            digest_size=16,
+        ).hexdigest()
+
+    def _workdir_for(self, user_id: str, workspace_id: str) -> str:
+        """Resolve a workdir scoped to one user and workspace.
+
+        Legacy ``basedir/agent_id`` directories are intentionally ignored:
+        they contain no ownership metadata and cannot be migrated safely.
+        """
+        return os.path.join(
+            self._basedir,
+            self._path_component(user_id),
+            self._path_component(workspace_id),
+        )
 
     def _pop_expired(self, now: float) -> list[LocalWorkspace]:
         """Pop every cache entry whose last-access exceeds ``ttl``.
@@ -62,10 +85,10 @@ class LocalWorkspaceManager(WorkspaceManagerBase):
         *outside* the manager lock so a slow ``close()`` does not stall
         unrelated ``get_workspace`` callers.
         """
-        expired_ids = [
-            wid for wid, (_, ts) in self._cache.items() if now - ts > self._ttl
+        expired_keys = [
+            key for key, (_, ts) in self._cache.items() if now - ts > self._ttl
         ]
-        return [self._cache.pop(wid)[0] for wid in expired_ids]
+        return [self._cache.pop(key)[0] for key in expired_keys]
 
     async def get_workspace(
         self,
@@ -82,26 +105,25 @@ class LocalWorkspaceManager(WorkspaceManagerBase):
         collects expired entries; expired entries are then closed in
         parallel *outside* the lock; on a miss a second acquisition
         runs ``initialize()`` while holding the lock so two concurrent
-        cache misses for the same ``workspace_id`` cannot create two
-        workspaces.
+        cache misses for the same user and ``workspace_id`` cannot create
+        two workspaces.
         """
-        del user_id  # accepted for interface parity; not used here
-
         if workspace_id is None:
             workspace_id = self.assign_workspace_id(
-                user_id="",
+                user_id=user_id,
                 agent_id=agent_id,
-                session_id="",
+                session_id=session_id,
             )
+        cache_key = (user_id, workspace_id)
 
         # Phase 1: cache hit + collect expired.
         async with self._lock:
             now = time.monotonic()
             expired = self._pop_expired(now)
-            cached = self._cache.get(workspace_id)
+            cached = self._cache.get(cache_key)
             if cached is not None:
                 ws, _ = cached
-                self._cache[workspace_id] = (ws, now)
+                self._cache[cache_key] = (ws, now)
                 hit: LocalWorkspace | None = ws
             else:
                 hit = None
@@ -118,17 +140,17 @@ class LocalWorkspaceManager(WorkspaceManagerBase):
             return hit
 
         # Phase 3: build under the lock to prevent two concurrent
-        # get_workspace(workspace_id=X) calls from creating two
-        # workspaces for the same id.
+        # calls for the same user/workspace pair from creating two
+        # workspaces.
         async with self._lock:
-            cached = self._cache.get(workspace_id)
+            cached = self._cache.get(cache_key)
             if cached is not None:
                 ws, _ = cached
-                self._cache[workspace_id] = (ws, time.monotonic())
+                self._cache[cache_key] = (ws, time.monotonic())
                 return ws
 
-            # Workdir is deterministic for local workspaces — no storage needed
-            workdir = os.path.join(self._basedir, agent_id)
+            # Workdir is deterministic; no storage lookup is needed.
+            workdir = self._workdir_for(user_id, workspace_id)
             ws = LocalWorkspace(
                 workspace_id=workspace_id,
                 workdir=workdir,
@@ -136,7 +158,7 @@ class LocalWorkspaceManager(WorkspaceManagerBase):
                 skill_paths=self._skill_paths,
             )
             await ws.initialize()
-            self._cache[workspace_id] = (ws, time.monotonic())
+            self._cache[cache_key] = (ws, time.monotonic())
             return ws
 
     @deprecated(
@@ -150,35 +172,30 @@ class LocalWorkspaceManager(WorkspaceManagerBase):
         agent_id: str,
         session_id: str,
     ) -> LocalWorkspace:
-        """Create a new workspace for the given agent and return it.
+        """Return the isolated workspace for the given agent.
 
         .. deprecated::
             Use :meth:`get_workspace` with ``workspace_id=None`` — it
             falls back to :meth:`assign_workspace_id` under the
             manager's isolation policy and reuses the cache path.
         """
-        del user_id, session_id  # accepted for interface parity
-
-        workdir = os.path.join(self._basedir, agent_id)
-        os.makedirs(workdir, exist_ok=True)
-        ws = LocalWorkspace(
-            workdir=workdir,
-            default_mcps=self._default_mcps,
-            skill_paths=self._skill_paths,
+        return await self.get_workspace(
+            user_id=user_id,
+            agent_id=agent_id,
+            session_id=session_id,
         )
-        await ws.initialize()
-        async with self._lock:
-            self._cache[ws.workspace_id] = (ws, time.monotonic())
-        return ws
 
     async def close(self, workspace_id: str) -> None:
-        """Close and evict a single workspace from the cache."""
+        """Close and evict every user-scoped entry for a workspace id."""
         async with self._lock:
-            entry = self._cache.pop(workspace_id, None)
-        if entry is None:
+            keys = [key for key in self._cache if key[1] == workspace_id]
+            entries = [self._cache.pop(key) for key in keys]
+        if not entries:
             return
-        ws, _ = entry
-        await self._safe_close(ws)
+        await asyncio.gather(
+            *(self._safe_close(ws) for ws, _ in entries),
+            return_exceptions=True,
+        )
 
     async def close_all(self) -> None:
         """Close every cached workspace in parallel.

--- a/tests/workspace_manager_local_test.py
+++ b/tests/workspace_manager_local_test.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Security and lifecycle tests for LocalWorkspaceManager."""
+
+import asyncio
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.async_case import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+from agentscope.app.workspace_manager import (
+    IsolationPolicy,
+    LocalWorkspaceManager,
+)
+
+
+class _FakeWorkspace:
+    """Workspace double used by manager tests."""
+
+    created: list["_FakeWorkspace"] = []
+
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        self.workspace_id = str(kwargs.get("workspace_id") or "new-id")
+        self.initialized = False
+        self.closed = False
+        _FakeWorkspace.created.append(self)
+
+    async def initialize(self) -> None:
+        """Mark the workspace initialized."""
+        await asyncio.sleep(0)
+        Path(str(self.kwargs["workdir"])).mkdir(
+            parents=True,
+            exist_ok=True,
+        )
+        self.initialized = True
+
+    async def close(self) -> None:
+        """Mark the workspace closed."""
+        self.closed = True
+
+
+class TestLocalWorkspaceManager(IsolatedAsyncioTestCase):
+    """Validate user isolation, cache behavior, and path safety."""
+
+    async def asyncSetUp(self) -> None:
+        """Patch LocalWorkspace and allocate a temporary base directory."""
+        _FakeWorkspace.created.clear()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.workspace_patch = patch(
+            "agentscope.app.workspace_manager."
+            "_local_workspace_manager.LocalWorkspace",
+            _FakeWorkspace,
+        )
+        self.workspace_patch.start()
+
+    async def asyncTearDown(self) -> None:
+        """Undo patches and remove the temporary directory."""
+        self.workspace_patch.stop()
+        self.temp_dir.cleanup()
+
+    async def test_shared_agent_is_isolated_between_users(self) -> None:
+        """A shared agent must not share its implicit local workspace."""
+        manager = LocalWorkspaceManager(self.temp_dir.name)
+
+        owner = await manager.get_workspace(
+            "owner",
+            "shared-agent",
+            "owner-session",
+        )
+        viewer = await manager.get_workspace(
+            "viewer",
+            "shared-agent",
+            "viewer-session",
+        )
+
+        self.assertIsNot(owner, viewer)
+        self.assertNotEqual(owner.workspace_id, viewer.workspace_id)
+        self.assertNotEqual(owner.kwargs["workdir"], viewer.kwargs["workdir"])
+        self.assertEqual(len(_FakeWorkspace.created), 2)
+
+        owner_secret = Path(str(owner.kwargs["workdir"])) / "secret.txt"
+        owner_secret.write_text("owner only", encoding="utf-8")
+        viewer_secret = Path(str(viewer.kwargs["workdir"])) / "secret.txt"
+        self.assertFalse(viewer_secret.exists())
+
+    async def test_explicit_workspace_id_is_user_scoped(self) -> None:
+        """An explicit id is not a bearer key across user boundaries."""
+        manager = LocalWorkspaceManager(self.temp_dir.name)
+
+        owner = await manager.get_workspace(
+            "owner",
+            "shared-agent",
+            "s1",
+            "shared-workspace",
+        )
+        viewer = await manager.get_workspace(
+            "viewer",
+            "shared-agent",
+            "s2",
+            "shared-workspace",
+        )
+
+        self.assertIsNot(owner, viewer)
+        self.assertNotEqual(owner.kwargs["workdir"], viewer.kwargs["workdir"])
+        self.assertIn(("owner", "shared-workspace"), manager._cache)
+        self.assertIn(("viewer", "shared-workspace"), manager._cache)
+
+    async def test_same_user_can_share_workspace_across_agents(self) -> None:
+        """Team agents for one user can intentionally share one id."""
+        manager = LocalWorkspaceManager(self.temp_dir.name)
+
+        leader = await manager.get_workspace(
+            "user",
+            "leader",
+            "s1",
+            "team-workspace",
+        )
+        member = await manager.get_workspace(
+            "user",
+            "member",
+            "s2",
+            "team-workspace",
+        )
+
+        self.assertIs(leader, member)
+        self.assertEqual(len(_FakeWorkspace.created), 1)
+
+    async def test_missing_workspace_id_uses_real_scope_values(self) -> None:
+        """Fallback id assignment receives the caller's full scope."""
+        manager = LocalWorkspaceManager(
+            self.temp_dir.name,
+            isolation=IsolationPolicy.PER_SESSION,
+        )
+
+        with patch.object(
+            manager,
+            "assign_workspace_id",
+            return_value="generated-workspace",
+        ) as assign_workspace_id:
+            workspace = await manager.get_workspace(
+                "user",
+                "agent",
+                "session",
+            )
+
+        assign_workspace_id.assert_called_once_with(
+            user_id="user",
+            agent_id="agent",
+            session_id="session",
+        )
+        self.assertEqual(workspace.workspace_id, "generated-workspace")
+
+    async def test_identifiers_cannot_escape_basedir(self) -> None:
+        """Hostile identifiers are hashed before entering a local path."""
+        manager = LocalWorkspaceManager(self.temp_dir.name)
+
+        workspace = await manager.get_workspace(
+            "../../other-user",
+            "ignored-agent",
+            "session",
+            "../outside/workspace",
+        )
+
+        basedir = Path(self.temp_dir.name).resolve()
+        workdir = Path(str(workspace.kwargs["workdir"])).resolve()
+        self.assertEqual(os.path.commonpath((basedir, workdir)), str(basedir))
+        relative = workdir.relative_to(basedir)
+        self.assertEqual(len(relative.parts), 2)
+        for component in relative.parts:
+            self.assertRegex(component, r"^[0-9a-f]{32}$")
+
+    async def test_deprecated_create_workspace_keeps_user_isolation(
+        self,
+    ) -> None:
+        """The compatibility API delegates to the isolated code path."""
+        manager = LocalWorkspaceManager(self.temp_dir.name)
+
+        owner = await manager.create_workspace("owner", "agent", "s1")
+        viewer = await manager.create_workspace("viewer", "agent", "s2")
+
+        self.assertIsNot(owner, viewer)
+        self.assertNotEqual(owner.kwargs["workdir"], viewer.kwargs["workdir"])
+
+    async def test_ttl_eviction_handles_scoped_cache_keys(self) -> None:
+        """TTL eviction closes entries after the cache key migration."""
+        manager = LocalWorkspaceManager(self.temp_dir.name, ttl=-1)
+        expired = await manager.get_workspace("u1", "a", "s", "old")
+
+        active = await manager.get_workspace("u2", "a", "s", "new")
+
+        self.assertTrue(expired.closed)
+        self.assertFalse(active.closed)
+        self.assertNotIn(("u1", "old"), manager._cache)
+        self.assertIn(("u2", "new"), manager._cache)
+
+    async def test_close_evicts_all_scopes_for_workspace_id(self) -> None:
+        """The legacy close signature handles every matching tuple key."""
+        manager = LocalWorkspaceManager(self.temp_dir.name)
+        first = await manager.get_workspace("u1", "a", "s", "shared")
+        second = await manager.get_workspace("u2", "a", "s", "shared")
+        remaining = await manager.get_workspace("u1", "a", "s", "other")
+
+        await manager.close("shared")
+
+        self.assertTrue(first.closed)
+        self.assertTrue(second.closed)
+        self.assertFalse(remaining.closed)
+        self.assertNotIn(("u1", "shared"), manager._cache)
+        self.assertNotIn(("u2", "shared"), manager._cache)
+        self.assertIn(("u1", "other"), manager._cache)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## AgentScope Version

2.0.4.post1

## Description

Fixes #2107.

`LocalWorkspaceManager` accepted `user_id` but did not enforce it as an isolation boundary:

- the cache was keyed only by `workspace_id`;
- the persistent workdir was always `<basedir>/<agent_id>`;
- the fallback workspace ID calculation discarded the real user and session values.

As a result, two users opening the same shared agent could receive different logical workspace IDs while still reading and writing the same physical directory. A shared explicit workspace ID could also return the same cached object across users.

### Changes

- Scope cache entries by `(user_id, workspace_id)`.
- Derive filesystem-safe persistent paths from hashed user and workspace IDs.
- Forward the real user, agent, and session values to `assign_workspace_id`.
- Preserve intentional same-user workspace sharing across team agents.
- Route deprecated `create_workspace` calls through the isolated code path.
- Adapt TTL eviction and `close(workspace_id)` to tuple cache keys.
- Add focused tests for implicit and explicit IDs, same-user sharing, path safety, lifecycle compatibility, and TTL behavior.

### Security Scope

This PR fixes unintended cache and workdir aliasing performed by `LocalWorkspaceManager`. It does not turn `LocalWorkspace` into an OS-level sandbox for mutually untrusted users. Deployments requiring isolation from arbitrary host Bash/Read access should use a sandbox-backed workspace.

### Migration

The new layout is:

```text
<basedir>/<hash(user_id)>/<hash(workspace_id)>
```

Legacy `<basedir>/<agent_id>` directories are intentionally not adopted automatically because they contain no ownership metadata. Existing data remains untouched and requires an explicit administrator-provided ownership mapping for migration.

## Validation

- `.venv/Scripts/python.exe -m pytest tests/workspace_manager_local_test.py -q`: 8 passed
- `.venv/Scripts/python.exe -m pytest tests/workspace_local_test.py -q`: 18 passed
- `.venv/Scripts/python.exe -m pre_commit run --files src/agentscope/app/workspace_manager/_local_workspace_manager.py tests/workspace_manager_local_test.py`: passed
- Real `LocalWorkspace` integration reproduction:
  - distinct workspace IDs: true
  - same workdir: false
  - viewer can see owner secret: false

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the CONTRIBUTING.md
- [x] Docstrings are in Google style
- [x] Related documentation has been considered; no public API or docs-repository update is required
- [x] Code is ready for review
