### PR TITLE
feat(webui): load older messages on scroll to top

### DIFF
--- a/examples/web_ui/frontend/src/components/chat/ChatContent.tsx
+++ b/examples/web_ui/frontend/src/components/chat/ChatContent.tsx
@@ -1,14 +1,17 @@
 import type { ContentBlock, Msg, ToolCallBlock } from '@agentscope-ai/agentscope/message';
 import { ArrowDown } from 'lucide-react';
 import React from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import { EmptyMessage } from './Empty';
 import { MessageBubble } from '@/components/chat/MessageBubble';
 import { TextInput } from '@/components/chat/TextInput.tsx';
 import { Button } from '@/components/ui/button.tsx';
+import { Spinner } from '@/components/ui/spinner';
 import type { ReplyPhase } from '@/hooks/useMessages';
 import { cn } from '@/lib/utils';
+
+const LOAD_MORE_THRESHOLD_PX = 100;
 
 interface ChatContentProps {
 	msgs: Msg[];
@@ -19,6 +22,9 @@ interface ChatContentProps {
 	 */
 	phase: ReplyPhase;
 	disabled: boolean;
+	hasMore: boolean;
+	loadingMore: boolean;
+	onLoadMore: () => Promise<boolean>;
 	onSend: (content: ContentBlock[]) => void;
 	onUserConfirm: (
 		toolCall: ToolCallBlock,
@@ -48,6 +54,9 @@ const ChatContentComponent: React.FC<ChatContentProps> = ({
 	msgs,
 	phase,
 	disabled,
+	hasMore,
+	loadingMore,
+	onLoadMore,
 	onSend,
 	onUserConfirm,
 	autoComplete,
@@ -59,7 +68,14 @@ const ChatContentComponent: React.FC<ChatContentProps> = ({
 }) => {
 	const scrollAreaRef = useRef<HTMLDivElement>(null);
 	const prevMsgCountRef = useRef<number>(0);
+	const prevFirstMsgIdRef = useRef<string | undefined>(undefined);
 	const wasNearBottomRef = useRef<boolean>(true);
+	const lastScrollTopRef = useRef<number>(0);
+	const pendingPrependRef = useRef<{
+		firstMessageId: string;
+		scrollHeight: number;
+		scrollTop: number;
+	} | null>(null);
 	const [showScrollToBottom, setShowScrollToBottom] = useState(false);
 
 	const updateScrollState = useCallback(() => {
@@ -73,15 +89,42 @@ const ChatContentComponent: React.FC<ChatContentProps> = ({
 		setShowScrollToBottom(distanceFromBottom > 100);
 	}, []);
 
+	// Restore the viewport after older messages are prepended.
+	useLayoutEffect(() => {
+		if (msgs.length === 0) {
+			pendingPrependRef.current = null;
+			lastScrollTopRef.current = 0;
+			return;
+		}
+
+		const pending = pendingPrependRef.current;
+		const scrollArea = scrollAreaRef.current;
+		if (!pending || !scrollArea || msgs[0]?.id === pending.firstMessageId) return;
+
+		const heightDelta = scrollArea.scrollHeight - pending.scrollHeight;
+		const nextScrollTop = pending.scrollTop + heightDelta;
+		lastScrollTopRef.current = nextScrollTop;
+		scrollArea.scrollTop = nextScrollTop;
+		pendingPrependRef.current = null;
+		updateScrollState();
+	}, [msgs, updateScrollState]);
+
 	// Auto-scroll to bottom only if user is already near the bottom
 	useEffect(() => {
 		const currentCount = msgs.length;
 		const prevCount = prevMsgCountRef.current;
+		const firstMsgId = msgs[0]?.id;
+		const prependedMessages =
+			prevCount > 0 &&
+			currentCount > prevCount &&
+			prevFirstMsgIdRef.current !== undefined &&
+			firstMsgId !== prevFirstMsgIdRef.current;
 
 		const isActive = phase !== 'idle';
 		const isInitialLoad = prevCount === 0 && currentCount > 0;
 		const hasRelevantUpdate =
-			(currentCount > prevCount && prevCount > 0) || (isActive && prevCount > 0);
+			!prependedMessages &&
+			((currentCount > prevCount && prevCount > 0) || (isActive && prevCount > 0));
 		const shouldScroll = isInitialLoad || (hasRelevantUpdate && wasNearBottomRef.current);
 
 		if (shouldScroll && scrollAreaRef.current) {
@@ -96,16 +139,45 @@ const ChatContentComponent: React.FC<ChatContentProps> = ({
 		}
 
 		prevMsgCountRef.current = currentCount;
+		prevFirstMsgIdRef.current = firstMsgId;
 	}, [msgs, phase, updateScrollState]);
 
-	// Track if user is near bottom whenever they scroll
+	// Track the scroll direction and load older messages near the top.
 	useEffect(() => {
 		const scrollArea = scrollAreaRef.current;
 		if (!scrollArea) return;
 
-		scrollArea.addEventListener('scroll', updateScrollState);
-		return () => scrollArea.removeEventListener('scroll', updateScrollState);
-	}, [updateScrollState]);
+		const handleScroll = () => {
+			const { scrollTop, scrollHeight } = scrollArea;
+
+			const wasScrollingUp = scrollTop < lastScrollTopRef.current;
+			lastScrollTopRef.current = scrollTop;
+			updateScrollState();
+			const firstMessageId = msgs[0]?.id;
+			if (
+				!wasScrollingUp ||
+				scrollTop >= LOAD_MORE_THRESHOLD_PX ||
+				!firstMessageId ||
+				!hasMore ||
+				loadingMore ||
+				pendingPrependRef.current
+			) {
+				return;
+			}
+
+			pendingPrependRef.current = {
+				firstMessageId,
+				scrollHeight,
+				scrollTop,
+			};
+			void onLoadMore().then((loaded) => {
+				if (!loaded) pendingPrependRef.current = null;
+			});
+		};
+
+		scrollArea.addEventListener('scroll', handleScroll);
+		return () => scrollArea.removeEventListener('scroll', handleScroll);
+	}, [hasMore, loadingMore, msgs, onLoadMore, updateScrollState]);
 
 	return (
 		<div className={cn('flex flex-col h-full w-full items-center p-2 gap-4', className)}>
@@ -128,6 +200,15 @@ const ChatContentComponent: React.FC<ChatContentProps> = ({
 						)}
 					</div>
 				</div>
+				{loadingMore ? (
+					<div
+						role="status"
+						aria-label="Loading older messages"
+						className="pointer-events-none absolute inset-x-0 top-0 z-10 flex h-8 items-center justify-center"
+					>
+						<Spinner className="text-muted-foreground" />
+					</div>
+				) : null}
 				<Button
 					type="button"
 					variant="outline"

--- a/examples/web_ui/frontend/src/hooks/useMessages.ts
+++ b/examples/web_ui/frontend/src/hooks/useMessages.ts
@@ -101,8 +101,8 @@ const INTERRUPT_TIMEOUT_MS = 10_000;
  * @param agentId - The agent whose session to subscribe. ``null`` to
  *   skip.
  * @param sessionId - The session to subscribe. ``null`` to skip.
- * @returns Object with ``msgs``, ``loading``, ``phase``, ``error``,
- *   ``send``, ``onUserConfirm``, and ``abort``.
+ * @returns Object with message state, pagination controls, reply
+ *   lifecycle state, and chat actions.
  */
 export function useMessages(
 	agentId: string | null,
@@ -126,6 +126,8 @@ export function useMessages(
 ) {
 	const [msgs, setMsgs] = useState<Msg[]>([]);
 	const [loading, setLoading] = useState(false);
+	const [hasMore, setHasMore] = useState(false);
+	const [loadingMore, setLoadingMore] = useState(false);
 	const [phase, setPhase] = useState<ReplyPhase>('idle');
 	const [error, setError] = useState<Error | null>(null);
 	// Pending subagent HITL cards projected onto this (leader) session.
@@ -135,6 +137,9 @@ export function useMessages(
 	const currentReplyRef = useRef<Msg | null>(null);
 	const abortRef = useRef<AbortController | null>(null);
 	const rafRef = useRef<number | null>(null);
+	const hasMoreRef = useRef(false);
+	const loadingMoreRef = useRef(false);
+	const paginationGenerationRef = useRef(0);
 	// Timer that reverts ``interrupting`` back to ``idle`` if the
 	// terminating REPLY_END never arrives (dropped SSE frame, etc.).
 	const interruptTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -236,9 +241,14 @@ export function useMessages(
 
 	// ── Lifecycle: fetch history + open SSE stream ──────────────────
 	useEffect(() => {
+		paginationGenerationRef.current += 1;
 		msgsRef.current = [];
 		currentReplyRef.current = null;
+		hasMoreRef.current = false;
+		loadingMoreRef.current = false;
 		setMsgs([]);
+		setHasMore(false);
+		setLoadingMore(false);
 		setError(null);
 		clearInterruptTimer();
 		setPhase('idle');
@@ -255,9 +265,14 @@ export function useMessages(
 			// 1. Fetch persisted history
 			setLoading(true);
 			try {
-				const { messages, is_running } = await sessionApi.messages(sessionId, agentId);
+				const { messages, is_running, has_more } = await sessionApi.messages(
+					sessionId,
+					agentId,
+				);
 				if (cancelled) return;
 				msgsRef.current = messages;
+				hasMoreRef.current = has_more;
+				setHasMore(has_more);
 				// If a reply is in flight (running on a worker) OR the
 				// tail msg is parked on a pending tool_call (awaiting
 				// user confirmation / external execution), initialise the
@@ -302,11 +317,61 @@ export function useMessages(
 
 		return () => {
 			cancelled = true;
+			paginationGenerationRef.current += 1;
 			controller.abort();
 			abortRef.current = null;
 			clearInterruptTimer();
 		};
 	}, [agentId, sessionId, scheduleUpdate, processEvent, audioManager, clearInterruptTimer]);
+
+	/** Fetch and prepend the next page of messages before the oldest one. */
+	const loadMore = useCallback(async (): Promise<boolean> => {
+		if (!agentId || !sessionId || !hasMoreRef.current || loadingMoreRef.current) {
+			return false;
+		}
+
+		const oldestMsgId = msgsRef.current[0]?.id;
+		if (!oldestMsgId) {
+			hasMoreRef.current = false;
+			setHasMore(false);
+			return false;
+		}
+
+		loadingMoreRef.current = true;
+		setLoadingMore(true);
+		const generation = paginationGenerationRef.current;
+
+		try {
+			const { messages, has_more } = await sessionApi.messages(sessionId, agentId, {
+				before: oldestMsgId,
+			});
+
+			if (generation !== paginationGenerationRef.current) {
+				return false;
+			}
+
+			const existingIds = new Set(msgsRef.current.map((msg) => msg.id));
+			const olderMessages = messages.filter((msg) => !existingIds.has(msg.id));
+			hasMoreRef.current = has_more;
+			setHasMore(has_more);
+
+			if (olderMessages.length === 0) return false;
+
+			msgsRef.current = [...olderMessages, ...msgsRef.current];
+			setMsgs([...msgsRef.current]);
+			return true;
+		} catch (e) {
+			if (generation === paginationGenerationRef.current) {
+				setError(e as Error);
+			}
+			return false;
+		} finally {
+			if (generation === paginationGenerationRef.current) {
+				loadingMoreRef.current = false;
+				setLoadingMore(false);
+			}
+		}
+	}, [agentId, sessionId]);
 
 	/**
 	 * Send a user message. Appends the message to the local list
@@ -479,6 +544,9 @@ export function useMessages(
 	return {
 		msgs,
 		loading,
+		hasMore,
+		loadingMore,
+		loadMore,
 		phase,
 		error,
 		send,

--- a/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
+++ b/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
@@ -156,11 +156,21 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 		}
 	}, []);
 
-	const { msgs, phase, send, onUserConfirm, onSubagentConfirm, subagentHitl, interrupt } =
-		useMessages(agentId, sessionId, {
-			onTeamUpdated: handleTeamUpdated,
-			onStateUpdated: handleStateUpdated,
-		});
+	const {
+		msgs,
+		hasMore,
+		loadingMore,
+		loadMore,
+		phase,
+		send,
+		onUserConfirm,
+		onSubagentConfirm,
+		subagentHitl,
+		interrupt,
+	} = useMessages(agentId, sessionId, {
+		onTeamUpdated: handleTeamUpdated,
+		onStateUpdated: handleStateUpdated,
+	});
 	const {
 		mcps,
 		loading: mcpsLoading,
@@ -617,6 +627,9 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 									msgs={msgs}
 									phase={phase}
 									disabled={selectedModel === null}
+									hasMore={hasMore}
+									loadingMore={loadingMore}
+									onLoadMore={loadMore}
 									onSend={send}
 									onUserConfirm={onUserConfirm}
 									onInterrupt={interrupt}


### PR DESCRIPTION
## AgentScope Version

2.0.4.post1

## Description

Fixes #2099

The Web UI previously loaded only the latest message page and ignored the
`has_more` cursor returned by the sessions API. Long conversations therefore
had no way to reveal earlier messages.

This PR:

- tracks `has_more` and exposes guarded `loadMore`/`loadingMore` state from
  `useMessages`
- requests older messages with the current oldest message ID as the `before`
  cursor, deduplicates the response, and discards stale requests after session
  changes
- loads the next page when the user scrolls upward within 100 px of the top
- restores the viewport from the prepended content height delta without letting
  the loading indicator affect the calculation
- integrates pagination with the existing initial/live auto-scroll and
  scroll-to-bottom behavior

There are no public API changes or new dependencies.

### Latest update

- Rebased the branch onto `main` at `30ca3ef3` and resolved the
  `ChatContent.tsx` conflict with the scroll-to-bottom work from #2106.
- Consolidated top-pagination and bottom-distance tracking in the same scroll
  listener so both behaviors remain consistent.
- Kept the pagination spinner out of normal layout flow so it cannot skew the
  prepend height delta or cause a second viewport jump when loading completes.
- Distinguished prepended history from newly appended live messages so the
  existing auto-scroll behavior cannot override viewport restoration.

The updated head is `c53562c7` and the PR is mergeable.

### Validation

- `npm run lint`
- `npm run build` (TypeScript project build and Vite production build)
- Vite development server browser smoke test (`HTTP 200`, no console errors)
- GitHub Actions: Web UI, pre-commit, PR title, and Python tests on Ubuntu,
  Windows, and macOS all pass

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style (not applicable to this frontend-only change)
- [x] Related documentation has been updated (not required; no public API or configuration changes)
- [x] Code is ready for review
