### PR TITLE
fix(webui): recover failed agent replies

### DIFF
--- a/examples/web_ui/frontend/src/hooks/useMessages.ts
+++ b/examples/web_ui/frontend/src/hooks/useMessages.ts
@@ -1,4 +1,4 @@
-import { EventType } from '@agentscope-ai/agentscope/event';
+import { EventType, ReplyFinishedReason } from '@agentscope-ai/agentscope/event';
 import type {
 	AgentEvent,
 	CustomEvent,
@@ -56,6 +56,15 @@ const hitlKey = (e: { worker_session_id: string; reply_id: string }) =>
 	`${e.worker_session_id}:${e.reply_id}`;
 
 /**
+ * Finalize an in-memory reply when the server cannot emit REPLY_END.
+ * This client-local stamp is not persisted and will not survive a refresh.
+ */
+const finishMessage = (msg: Msg, reason: ReplyFinishedReason, finishedAt: string) => {
+	if (!msg.finished_at) msg.finished_at = finishedAt;
+	msg.finished_reason = reason;
+};
+
+/**
  * Lifecycle phase of the reply currently owned by this session.
  *
  * - ``idle`` — no in-flight reply; the send button is enabled.
@@ -72,7 +81,7 @@ const hitlKey = (e: { worker_session_id: string; reply_id: string }) =>
  */
 export type ReplyPhase = 'idle' | 'streaming' | 'interrupting';
 
-/** Safety fallback: force phase back to idle if REPLY_END is not seen. */
+/** Safety fallback: terminate locally if REPLY_END is not seen. */
 const INTERRUPT_TIMEOUT_MS = 10_000;
 
 /**
@@ -160,6 +169,19 @@ export function useMessages(
 		});
 	}, []);
 
+	const finalizeCurrentReply = useCallback(
+		(reason: ReplyFinishedReason) => {
+			if (currentReplyRef.current) {
+				finishMessage(currentReplyRef.current, reason, new Date().toISOString());
+			}
+			currentReplyRef.current = null;
+			clearInterruptTimer();
+			setPhase('idle');
+			scheduleUpdate();
+		},
+		[clearInterruptTimer, scheduleUpdate],
+	);
+
 	/** Apply a single AgentEvent to the in-progress reply. */
 	const processEvent = useCallback(
 		(event: AgentEvent) => {
@@ -199,9 +221,9 @@ export function useMessages(
 				if (currentReplyRef.current) {
 					appendEvent(currentReplyRef.current, event);
 				}
+				currentReplyRef.current = null;
 				clearInterruptTimer();
 				setPhase('idle');
-				currentReplyRef.current = null;
 			} else if (currentReplyRef.current) {
 				appendEvent(currentReplyRef.current, event);
 			}
@@ -268,12 +290,17 @@ export function useMessages(
 				const tail = messages[messages.length - 1];
 				if (is_running || hasPendingToolCall(tail)) {
 					setPhase('streaming');
-					if (hasPendingToolCall(tail)) {
+					if (tail?.role === 'assistant' && !tail.finished_at) {
 						// Prime the ref so continuation events (which
 						// arrive without a fresh REPLY_START) apply to
 						// the right msg.
 						currentReplyRef.current = tail ?? null;
 					}
+				} else if (tail?.role === 'assistant' && !tail.finished_at) {
+					// The server is idle, so an unfinished non-HITL tail can only
+					// be left by a worker/process failure that could not emit its
+					// terminal event.
+					finishMessage(tail, ReplyFinishedReason.ERROR, new Date().toISOString());
 				}
 				scheduleUpdate();
 			} catch (e) {
@@ -293,8 +320,13 @@ export function useMessages(
 					if (cancelled) break;
 					processEvent(event);
 				}
+				if (!cancelled) {
+					finalizeCurrentReply(ReplyFinishedReason.ERROR);
+					setError(new Error('Session event stream closed unexpectedly.'));
+				}
 			} catch (e) {
 				if ((e as Error).name !== 'AbortError' && !cancelled) {
+					finalizeCurrentReply(ReplyFinishedReason.ERROR);
 					setError(e as Error);
 				}
 			}
@@ -306,7 +338,15 @@ export function useMessages(
 			abortRef.current = null;
 			clearInterruptTimer();
 		};
-	}, [agentId, sessionId, scheduleUpdate, processEvent, audioManager, clearInterruptTimer]);
+	}, [
+		agentId,
+		sessionId,
+		scheduleUpdate,
+		processEvent,
+		audioManager,
+		clearInterruptTimer,
+		finalizeCurrentReply,
+	]);
 
 	/**
 	 * Send a user message. Appends the message to the local list
@@ -412,16 +452,15 @@ export function useMessages(
 		clearInterruptTimer();
 		interruptTimerRef.current = setTimeout(() => {
 			interruptTimerRef.current = null;
-			setPhase((prev) => (prev === 'interrupting' ? 'idle' : prev));
+			finalizeCurrentReply(ReplyFinishedReason.INTERRUPTED);
 		}, INTERRUPT_TIMEOUT_MS);
 		try {
 			await sessionApi.interrupt(sessionId, agentId);
 		} catch (e) {
-			clearInterruptTimer();
-			setPhase((prev) => (prev === 'interrupting' ? 'idle' : prev));
+			finalizeCurrentReply(ReplyFinishedReason.ERROR);
 			setError(e as Error);
 		}
-	}, [agentId, sessionId, clearInterruptTimer]);
+	}, [agentId, sessionId, clearInterruptTimer, finalizeCurrentReply]);
 
 	/**
 	 * Confirm or deny a tool call that a *team member* is awaiting,

--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -56,11 +56,11 @@ from ..event import (
     DataBlockDeltaEvent,
     DataBlockEndEvent,
     ExceedMaxItersEvent,
-    ReplyFinishedReason,
     UserInterruptEvent,
     HintBlockEvent,
 )
 from ..exception import AgentOrientedException
+from ..types import ReplyFinishedReason
 from ..model import (
     ChatResponse,
     ChatUsage,
@@ -741,6 +741,7 @@ class Agent:
         """Core reply logic."""
 
         end_event: ReplyEndEvent | None = None
+        reply_active = False
         try:
             # Dispatch the unified inputs by type into the legacy local
             # variables
@@ -785,6 +786,7 @@ class Agent:
             #  - if event is None and agent is not waiting for an event
             # ===================================================================
             is_awaiting = await self._check_incoming_event(event)
+            reply_active = is_awaiting
 
             # ===================================================================
             # Step 2: Handling agent event if applicable
@@ -799,6 +801,7 @@ class Agent:
                 # Update the context with the incoming message and state
                 self.state.reply_id = _generate_id()
                 self.state.cur_iter = 0
+                reply_active = True
 
                 yield ReplyStartEvent(
                     session_id=self.state.session_id,
@@ -968,6 +971,18 @@ class Agent:
 
             if self.react_config.interruption_raise_cancelled_error:
                 raise
+
+        except Exception:
+            # Preserve the exception for callers and logs, but close an
+            # already-started reply first so streaming consumers do not wait
+            # forever for a terminal event.
+            if reply_active:
+                end_event = ReplyEndEvent(
+                    session_id=self.state.session_id,
+                    reply_id=self.state.reply_id,
+                    finished_reason=ReplyFinishedReason.ERROR,
+                )
+            raise
 
         finally:
             if end_event is not None:

--- a/src/agentscope/app/middleware/_protocol/_agui.py
+++ b/src/agentscope/app/middleware/_protocol/_agui.py
@@ -33,6 +33,7 @@ from ....event import (
     ToolResultTextDeltaEvent,
     UserConfirmResultEvent,
 )
+from ....types import ReplyFinishedReason
 
 if TYPE_CHECKING:
     from ag_ui.core.events import BaseEvent as AGUIBaseEvent
@@ -99,6 +100,11 @@ class AGUIProtocolMiddleware(ProtocolMiddlewareBase):
             )
 
         if isinstance(event, ReplyEndEvent):
+            if event.finished_reason == ReplyFinishedReason.ERROR:
+                return AGUIRunErrorEvent(
+                    message="Agent reply failed",
+                    code="agent_reply_error",
+                )
             return AGUIRunFinishedEvent(
                 thread_id=event.session_id,
                 run_id=event.reply_id,

--- a/tests/agent_reply_error_test.py
+++ b/tests/agent_reply_error_test.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for terminal reply events on agent failures."""
+from unittest.async_case import IsolatedAsyncioTestCase
+
+from utils import MockModel
+
+from agentscope.agent import Agent
+from agentscope.event import ReplyEndEvent, ReplyStartEvent
+from agentscope.message import AssistantMsg, UserMsg
+from agentscope.tool import Toolkit
+from agentscope.types import ReplyFinishedReason
+
+
+class AgentReplyErrorTest(IsolatedAsyncioTestCase):
+    """Ensure a started reply always reaches a terminal event."""
+
+    async def test_model_error_emits_reply_end_before_propagating(
+        self,
+    ) -> None:
+        """A model failure must terminate the live reply before surfacing."""
+        model = MockModel()
+        model.max_retries = 0
+        model.set_responses([RuntimeError("model backend unavailable")])
+        agent = Agent(
+            name="Friday",
+            system_prompt="You are a helpful assistant.",
+            model=model,
+            toolkit=Toolkit(),
+        )
+
+        events = []
+        with self.assertRaisesRegex(RuntimeError, "model backend unavailable"):
+            async for event in agent.reply_stream(
+                UserMsg(name="user", content="Hello"),
+            ):
+                events.append(event)
+
+        self.assertEqual(
+            len([e for e in events if isinstance(e, ReplyStartEvent)]),
+            1,
+        )
+        end_events = [e for e in events if isinstance(e, ReplyEndEvent)]
+        self.assertEqual(len(end_events), 1)
+        self.assertEqual(
+            end_events[0].finished_reason,
+            ReplyFinishedReason.ERROR,
+        )
+
+        reply = AssistantMsg(
+            id=end_events[0].reply_id,
+            name="Friday",
+            content=[],
+        )
+        reply.append_event(end_events[0])
+        self.assertEqual(reply.finished_at, end_events[0].created_at)
+        self.assertEqual(reply.finished_reason, ReplyFinishedReason.ERROR)

--- a/tests/agui_protocol_test.py
+++ b/tests/agui_protocol_test.py
@@ -222,6 +222,19 @@ class AGUIProtocolLifecycleTest(IsolatedAsyncioTestCase):
         self.assertEqual(result["threadId"], "sess_1")
         self.assertEqual(result["runId"], "reply_1")
 
+    async def test_error_reply_end_to_run_error(self) -> None:
+        """Test failed ReplyEndEvent -> RUN_ERROR."""
+        event = ReplyEndEvent(
+            session_id="sess_1",
+            reply_id="reply_1",
+            finished_reason=ReplyFinishedReason.ERROR,
+        )
+        result = self.mw._convert_to_protocol(event)
+
+        self.assertEqual(result["type"], "RUN_ERROR")
+        self.assertEqual(result["message"], "Agent reply failed")
+        self.assertEqual(result["code"], "agent_reply_error")
+
     async def test_exceed_max_iters_to_run_error(self) -> None:
         """Test ExceedMaxItersEvent -> RUN_ERROR."""
         event = ExceedMaxItersEvent(


### PR DESCRIPTION
## Summary

- emit a terminal `ReplyEndEvent(finished_reason=ReplyFinishedReason.ERROR)` when an active agent reply fails, while preserving the original exception behavior
- map errored reply termination to AG-UI `RUN_ERROR`
- finalize unfinished WebUI messages locally when the event stream fails or closes, the server reports an idle unfinished tail, or Stop fallback handling is triggered
- use the SDK 0.0.14 first-class `Msg.finished_reason` field for client-local recovery

## Root cause

When model or runtime execution raised inside `Agent._reply_impl()`, direct consumers of `agent.reply_stream()` received the exception without a matching terminal event. Those consumers could remain in a streaming state indefinitely. The WebUI also needed a client-side fallback for cases where the server process or event stream disappears before any terminal event can arrive.

This branch is rebased onto current `main` and keeps the error model introduced by #2133: `ReplyFinishedReason`, `Msg.finished_reason`, and `Msg.error`. It does not add metadata-based reason plumbing or duplicate `MessageBubble` error rendering.

## Validation

- 47 targeted Python tests passed, covering agent reply failures, message aggregation, AG-UI mapping, error classification, and interruption
- changed-file pre-commit checks passed, including AST, mypy, Black, Flake8, Pylint, and Pyroma
- WebUI production build passed against `@agentscope-ai/agentscope` 0.0.14
- ESLint completed with 0 errors (16 existing warnings outside the changed code)
- `git diff --check` passed

Fixes #2110