### PR TITLE
Add Atlas Cloud chat model support

### DIFF
--- a/src/agentscope/credential/__init__.py
+++ b/src/agentscope/credential/__init__.py
@@ -3,6 +3,7 @@
 
 from ._base import CredentialBase
 from ._anthropic import AnthropicCredential
+from ._atlascloud import AtlasCloudCredential
 from ._dashscope import DashScopeCredential
 from ._deepseek import DeepSeekCredential
 from ._gemini import GeminiCredential
@@ -16,6 +17,7 @@ from ._factory import CredentialFactory
 __all__ = [
     "CredentialBase",
     "AnthropicCredential",
+    "AtlasCloudCredential",
     "DashScopeCredential",
     "DeepSeekCredential",
     "GeminiCredential",

--- a/src/agentscope/credential/_atlascloud.py
+++ b/src/agentscope/credential/_atlascloud.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""The Atlas Cloud credential."""
+from typing import Literal, Type, TYPE_CHECKING
+
+from pydantic import ConfigDict, Field, SecretStr
+
+from ._base import CredentialBase
+
+if TYPE_CHECKING:
+    from ..model import ChatModelBase
+
+_ATLASCLOUD_BASE_URL = "https://api.atlascloud.ai/v1"
+
+
+class AtlasCloudCredential(CredentialBase):
+    """The Atlas Cloud credential model."""
+
+    model_config = ConfigDict(
+        title="Atlas Cloud API",
+    )
+
+    type: Literal["atlascloud_credential"] = "atlascloud_credential"
+    """The credential type."""
+
+    api_key: SecretStr = Field(
+        description="The Atlas Cloud API key.",
+    )
+    """The API key."""
+
+    base_url: str = Field(
+        default=_ATLASCLOUD_BASE_URL,
+        description="The Atlas Cloud OpenAI-compatible API base URL.",
+    )
+    """The Atlas Cloud OpenAI-compatible API base URL."""
+
+    organization: str | None = Field(
+        default=None,
+        exclude=True,
+        description="Unused compatibility field for OpenAI-compatible clients.",
+    )
+    """Compatibility field consumed by the OpenAI chat client."""
+
+    @classmethod
+    def get_chat_model_class(cls) -> Type["ChatModelBase"]:
+        """Return the AtlasCloudChatModel class."""
+        from ..model import AtlasCloudChatModel
+
+        return AtlasCloudChatModel

--- a/src/agentscope/credential/_factory.py
+++ b/src/agentscope/credential/_factory.py
@@ -5,6 +5,7 @@ from typing import Annotated, Type, Union, get_args, get_type_hints
 from pydantic import TypeAdapter, Field
 
 from ._anthropic import AnthropicCredential
+from ._atlascloud import AtlasCloudCredential
 from ._dashscope import DashScopeCredential
 from ._deepseek import DeepSeekCredential
 from ._gemini import GeminiCredential
@@ -35,6 +36,7 @@ class CredentialFactory:
 
     _classes: list[Type[CredentialBase]] = [
         AnthropicCredential,
+        AtlasCloudCredential,
         DashScopeCredential,
         DeepSeekCredential,
         GeminiCredential,

--- a/src/agentscope/model/__init__.py
+++ b/src/agentscope/model/__init__.py
@@ -6,6 +6,7 @@ from ._model_card import ModelCard
 from ._model_response import ChatResponse, StructuredResponse, FinishedReason
 from ._model_usage import ChatUsage
 from ._anthropic import AnthropicChatModel
+from ._atlascloud import AtlasCloudChatModel
 from ._dashscope import DashScopeChatModel
 from ._deepseek import DeepSeekChatModel
 from ._gemini import GeminiChatModel
@@ -23,6 +24,7 @@ __all__ = [
     "ModelCard",
     "StructuredResponse",
     "AnthropicChatModel",
+    "AtlasCloudChatModel",
     "DashScopeChatModel",
     "DeepSeekChatModel",
     "GeminiChatModel",

--- a/src/agentscope/model/_atlascloud/__init__.py
+++ b/src/agentscope/model/_atlascloud/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+"""The Atlas Cloud LLM API modules."""
+
+from ._model import AtlasCloudCredential, AtlasCloudChatModel
+
+__all__ = [
+    "AtlasCloudCredential",
+    "AtlasCloudChatModel",
+]

--- a/src/agentscope/model/_atlascloud/_model.py
+++ b/src/agentscope/model/_atlascloud/_model.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""The Atlas Cloud chat model implementation."""
+from typing import Any, Literal
+
+from ...credential import AtlasCloudCredential
+from .._openai_chat import OpenAIChatModel
+
+
+class AtlasCloudChatModel(OpenAIChatModel):
+    """Atlas Cloud chat model using the OpenAI-compatible API surface."""
+
+    type: Literal["atlascloud_chat"] = "atlascloud_chat"
+    """The type of the chat model."""
+
+    def __init__(
+        self,
+        credential: AtlasCloudCredential,
+        model: str = "qwen/qwen3.5-flash",
+        parameters: "OpenAIChatModel.Parameters | None" = None,
+        stream: bool = True,
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
+        context_size: int = 1_000_000,
+        client_kwargs: dict[str, Any] | None = None,
+        extra_body: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize the Atlas Cloud chat model.
+
+        Args:
+            credential (`AtlasCloudCredential`):
+                The Atlas Cloud credential used to authenticate API calls.
+            model (`str`, defaults to `"qwen/qwen3.5-flash"`):
+                The Atlas Cloud model id.
+            parameters (`OpenAIChatModel.Parameters | None`, defaults to \
+            `None`):
+                The OpenAI-compatible Chat API parameters.
+            stream (`bool`, defaults to `True`):
+                Whether to enable streaming output.
+            max_retries (`int`, defaults to `3`):
+                The maximum number of retries for the API.
+            retry_delay (`float`, defaults to `1.0`):
+                Seconds to sleep between retry attempts.
+            context_size (`int`, defaults to `1_000_000`):
+                The model context size used for context compression.
+            client_kwargs (`dict[str, Any] | None`, defaults to `None`):
+                Extra keyword arguments forwarded to ``openai.AsyncClient``.
+            extra_body (`dict[str, Any] | None`, defaults to `None`):
+                Additional request body fields forwarded to Atlas Cloud.
+        """
+        super().__init__(
+            credential=credential,
+            model=model,
+            parameters=parameters,
+            stream=stream,
+            max_retries=max_retries,
+            retry_delay=retry_delay,
+            context_size=context_size,
+            client_kwargs=client_kwargs,
+            extra_body=extra_body,
+        )

--- a/src/agentscope/model/_atlascloud/_models/deepseek-ai-deepseek-v4-pro.yaml
+++ b/src/agentscope/model/_atlascloud/_models/deepseek-ai-deepseek-v4-pro.yaml
@@ -1,0 +1,20 @@
+name: deepseek-ai/deepseek-v4-pro
+label: DeepSeek V4 Pro
+status: active
+
+input_types:
+  - text/plain
+  - application/x-thinking
+
+output_types:
+  - text/plain
+  - application/x-thinking
+
+context_size: 1048576
+output_size: 393216
+
+parameter_overrides:
+  max_tokens:
+    maximum: 393216
+  voice:
+    hidden: true

--- a/src/agentscope/model/_atlascloud/_models/qwen-qwen3.5-flash.yaml
+++ b/src/agentscope/model/_atlascloud/_models/qwen-qwen3.5-flash.yaml
@@ -1,0 +1,22 @@
+name: qwen/qwen3.5-flash
+label: Qwen3.5 Flash
+status: active
+
+input_types:
+  - text/plain
+
+output_types:
+  - text/plain
+
+context_size: 1000000
+output_size: 67072
+
+parameter_overrides:
+  max_tokens:
+    maximum: 67072
+  thinking_enable:
+    hidden: true
+  reasoning_effort:
+    hidden: true
+  voice:
+    hidden: true

--- a/tests/model_atlascloud_test.py
+++ b/tests/model_atlascloud_test.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for AtlasCloudChatModel."""
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from agentscope.credential import AtlasCloudCredential, CredentialFactory
+from agentscope.model import AtlasCloudChatModel
+
+
+class TestAtlasCloudModel(IsolatedAsyncioTestCase):
+    """Tests for Atlas Cloud credential and chat model wiring."""
+
+    def test_credential_factory_and_model_cards(self) -> None:
+        """Atlas Cloud is available through credentials and model cards."""
+        credential = CredentialFactory.from_dict(
+            {
+                "type": "atlascloud_credential",
+                "api_key": "test",
+            },
+        )
+
+        self.assertIsInstance(credential, AtlasCloudCredential)
+        self.assertEqual(
+            credential.base_url,
+            "https://api.atlascloud.ai/v1",
+        )
+        self.assertIs(
+            AtlasCloudCredential.get_chat_model_class(),
+            AtlasCloudChatModel,
+        )
+        self.assertIn(
+            "qwen/qwen3.5-flash",
+            [card.name for card in AtlasCloudChatModel.list_models()],
+        )
+
+    @patch("openai.AsyncClient")
+    async def test_uses_atlascloud_openai_compatible_client(
+        self,
+        mock_client_cls: MagicMock,
+    ) -> None:
+        """Atlas Cloud forwards requests through the OpenAI-compatible path."""
+        message = MagicMock()
+        message.content = "ok"
+        message.reasoning_content = None
+        message.reasoning = None
+        message.audio = None
+        message.tool_calls = None
+
+        choice = MagicMock()
+        choice.message = message
+
+        response = MagicMock()
+        response.id = "atlascloud-1"
+        response.choices = [choice]
+        response.usage.prompt_tokens = 1
+        response.usage.completion_tokens = 1
+        response.usage.prompt_tokens_details = None
+
+        mock_create = AsyncMock(return_value=response)
+        mock_client_cls.return_value.chat.completions.create = mock_create
+
+        model = AtlasCloudChatModel(
+            credential=AtlasCloudCredential(api_key="test"),
+            stream=False,
+        )
+
+        result = await model([])
+
+        self.assertEqual(result.id, "atlascloud-1")
+        mock_client_cls.assert_called_once()
+        self.assertEqual(
+            mock_client_cls.call_args.kwargs["base_url"],
+            "https://api.atlascloud.ai/v1",
+        )
+        self.assertEqual(
+            mock_create.call_args.kwargs["model"],
+            "qwen/qwen3.5-flash",
+        )


### PR DESCRIPTION
## Summary
- add `AtlasCloudCredential` with the Atlas Cloud OpenAI-compatible base URL
- add `AtlasCloudChatModel` by reusing AgentScope's OpenAI Chat Completions implementation
- add live-verified Atlas Cloud model cards for `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`
- cover credential factory/model card/client wiring with focused tests

## Validation
- `git diff --check`
- `python3 -m py_compile src/agentscope/credential/_atlascloud.py src/agentscope/model/_atlascloud/_model.py src/agentscope/credential/__init__.py src/agentscope/credential/_factory.py src/agentscope/model/__init__.py tests/model_atlascloud_test.py`
- `UV_PROJECT_ENVIRONMENT=.venv312 /Users/zby/.local/bin/uv run --python 3.12 python -m unittest tests/model_atlascloud_test.py`
- `UV_PROJECT_ENVIRONMENT=.venv312 /Users/zby/.local/bin/uv run --python 3.12 --with ruff ruff check src/agentscope/credential/_atlascloud.py src/agentscope/credential/__init__.py src/agentscope/credential/_factory.py src/agentscope/model/_atlascloud src/agentscope/model/__init__.py tests/model_atlascloud_test.py`
- Atlas Cloud live model catalog check returned 118 models and confirmed `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`

No README changes.
