### PR TITLE
fix(agent): continue after thinking-only responses

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -1095,6 +1095,14 @@ class Agent:
             completed_response.usage,
         )
 
+        # A thinking-only response is an intermediate reasoning step rather
+        # than a user-visible final answer. Keep the ReAct loop running so the
+        # model can produce text, data, or a tool call on the next iteration.
+        has_only_thinking_blocks = bool(completed_response.content) and all(
+            isinstance(block, ThinkingBlock)
+            for block in completed_response.content
+        )
+
         # If no tool call is generated, return the final message directly
         if (
             completed_response.finished_reason != FinishedReason.INTERRUPTED
@@ -1102,6 +1110,7 @@ class Agent:
                 isinstance(_, ToolCallBlock)
                 for _ in completed_response.content
             )
+            and not has_only_thinking_blocks
         ):
             last_ctx = self._get_last_msg()
             final_usage = (

--- a/tests/agent_basic_test.py
+++ b/tests/agent_basic_test.py
@@ -17,7 +17,12 @@ from agentscope.permission import (
     PermissionBehavior,
     PermissionContext,
 )
-from agentscope.message import TextBlock, ToolCallBlock, UserMsg
+from agentscope.message import (
+    TextBlock,
+    ThinkingBlock,
+    ToolCallBlock,
+    UserMsg,
+)
 
 
 class MockSequentialTool(ToolBase):
@@ -562,6 +567,30 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
         ]
         context_dicts = [msg.model_dump() for msg in self.agent.state.context]
         self.assertListEqual(context_dicts, expected_context_after_reply)
+
+    async def test_thinking_only_response_continues_reasoning(self) -> None:
+        """A thinking-only response should not end with an empty reply."""
+        self.model.set_responses(
+            [
+                ChatResponse(
+                    content=[ThinkingBlock(thinking="Working on it")],
+                    is_last=True,
+                ),
+                ChatResponse(
+                    content=[TextBlock(text="Final answer")],
+                    is_last=True,
+                ),
+            ],
+        )
+
+        msg = await self.agent.reply(UserMsg(name="user", content="Think"))
+
+        self.assertEqual(self.model.cnt, 2)
+        self.assertEqual(msg.get_text_content(), "Final answer")
+        assistant_blocks = self.agent.state.context[-1].get_content_blocks()
+        self.assertEqual(len(assistant_blocks), 2)
+        self.assertIsInstance(assistant_blocks[0], ThinkingBlock)
+        self.assertIsInstance(assistant_blocks[1], TextBlock)
 
     async def test_streaming_sequential_tool_calls(self) -> None:
         """Test the streaming model inference with tool calls generated.

--- a/tests/agent_basic_test.py
+++ b/tests/agent_basic_test.py
@@ -585,12 +585,65 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
 
         msg = await self.agent.reply(UserMsg(name="user", content="Think"))
 
+        # The thinking-only turn must trigger a second reasoning round
         self.assertEqual(self.model.cnt, 2)
-        self.assertEqual(msg.get_text_content(), "Final answer")
-        assistant_blocks = self.agent.state.context[-1].get_content_blocks()
-        self.assertEqual(len(assistant_blocks), 2)
-        self.assertIsInstance(assistant_blocks[0], ThinkingBlock)
-        self.assertIsInstance(assistant_blocks[1], TextBlock)
+
+        # The final reply message only carries the visible text answer
+        self.assertDictEqual(
+            msg.model_dump(),
+            {
+                "id": AnyString(),
+                "created_at": AnyString(),
+                "finished_at": None,
+                "metadata": {},
+                "name": "Friday",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "text",
+                        "id": AnyString(),
+                        "text": "Final answer",
+                    },
+                ],
+                "usage": None,
+            },
+        )
+
+        # The context keeps the thinking block and the final answer in a
+        # single assistant message following the user turn
+        msg_base = self._get_msg_base()
+        expected_context = [
+            {
+                **msg_base,
+                "name": "user",
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "id": AnyString(),
+                        "text": "Think",
+                    },
+                ],
+                "finished_at": AnyString(),
+            },
+            {
+                **msg_base,
+                "content": [
+                    {
+                        "type": "thinking",
+                        "id": AnyString(),
+                        "thinking": "Working on it",
+                    },
+                    {
+                        "type": "text",
+                        "id": AnyString(),
+                        "text": "Final answer",
+                    },
+                ],
+            },
+        ]
+        context_dicts = [msg.model_dump() for msg in self.agent.state.context]
+        self.assertListEqual(context_dicts, expected_context)
 
     async def test_streaming_sequential_tool_calls(self) -> None:
         """Test the streaming model inference with tool calls generated.


### PR DESCRIPTION
## Summary

- keep the ReAct loop running when a model response contains only thinking blocks
- preserve the existing final-response behavior for text, data, and empty responses
- add a regression test covering a thinking-only turn followed by a visible answer

## Root cause

`Agent._reasoning_impl()` treated every completed response without a tool call as a final answer. For extended-thinking models, a response can contain only `ThinkingBlock` content, so the agent returned an empty user-visible reply instead of continuing to reason.

## Impact

Extended-thinking models can now proceed to the next ReAct iteration after an intermediate thinking-only response and produce a visible answer or tool call.

## Validation

- `python -m pytest tests/agent_basic_test.py tests/agent_interrupt_test.py tests/event_test.py tests/model_response_test.py tests/compress_context_test.py -q` (41 passed)
- `python -m pre_commit run --files src/agentscope/agent/_agent.py tests/agent_basic_test.py`

Fixes #1596
