### PR TITLE
fix(webui): recover from stalled chat runs

### DIFF
--- a/examples/web_ui/frontend/src/api/session.ts
+++ b/examples/web_ui/frontend/src/api/session.ts
@@ -16,6 +16,28 @@ export interface MessagesResponse {
 	has_more: boolean;
 }
 
+/** The server emits heartbeats every 30s; allow two missed frames plus jitter. */
+const SSE_HEARTBEAT_TIMEOUT_MS = 90_000;
+
+async function readStreamChunk(
+	reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			reader.read(),
+			new Promise<never>((_, reject) => {
+				timeout = setTimeout(
+					() => reject(new Error('Session event stream heartbeat timed out.')),
+					SSE_HEARTBEAT_TIMEOUT_MS,
+				);
+			}),
+		]);
+	} finally {
+		if (timeout !== undefined) clearTimeout(timeout);
+	}
+}
+
 export const sessionApi = {
 	list: (agentId: string) => client.get<SessionListResponse>('/sessions/', { agent_id: agentId }),
 
@@ -55,7 +77,8 @@ export const sessionApi = {
 	 * Opens a long-lived ``GET /sessions/{sid}/stream`` connection and
 	 * yields each ``AgentEvent`` as it arrives. The connection stays
 	 * open until the caller aborts via the ``signal`` or closes the
-	 * generator.
+	 * generator. If no event or heartbeat bytes arrive for 90 seconds,
+	 * the generator throws so the UI can leave its streaming state.
 	 *
 	 * Uses fetch-based SSE (not native ``EventSource``) so the
 	 * ``X-User-ID`` custom header is sent.
@@ -74,6 +97,7 @@ export const sessionApi = {
 			method: 'GET',
 			params: { agent_id: agentId },
 			signal,
+			silent: true,
 		});
 
 		const reader = res.body!.getReader();
@@ -82,7 +106,7 @@ export const sessionApi = {
 
 		try {
 			while (true) {
-				const { done, value } = await reader.read();
+				const { done, value } = await readStreamChunk(reader);
 				if (done) break;
 
 				buffer += decoder.decode(value, { stream: true });
@@ -98,6 +122,9 @@ export const sessionApi = {
 					// (used for heartbeats).
 				}
 			}
+		} catch (error) {
+			await reader.cancel().catch(() => undefined);
+			throw error;
 		} finally {
 			reader.releaseLock();
 		}

--- a/examples/web_ui/frontend/src/hooks/useMessages.ts
+++ b/examples/web_ui/frontend/src/hooks/useMessages.ts
@@ -12,6 +12,8 @@ import { appendEvent, AssistantMsg, UserMsg } from '@agentscope-ai/agentscope/me
 import type { Msg, ContentBlock } from '@agentscope-ai/agentscope/message';
 import type { ToolCallBlock } from '@agentscope-ai/agentscope/message';
 import { useState, useCallback, useRef, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 
 import { sessionApi } from '@/api';
 import { chatApi } from '@/api';
@@ -94,7 +96,8 @@ const INTERRUPT_TIMEOUT_MS = 10_000;
  *
  * ``phase`` is driven by event content, not HTTP lifecycle: it moves
  * to ``streaming`` on ``ReplyStartEvent`` and back to ``idle`` on
- * ``ReplyEndEvent``. Calling ``interrupt()`` moves it to
+ * ``ReplyEndEvent`` or a service-level ``chat_run_error``. Calling
+ * ``interrupt()`` moves it to
  * ``interrupting`` until the terminating ``ReplyEndEvent`` arrives (or
  * a 10s safety timeout fires).
  *
@@ -124,6 +127,7 @@ export function useMessages(
 		onStateUpdated?: (value: Record<string, unknown>) => void;
 	},
 ) {
+	const { t } = useTranslation();
 	const [msgs, setMsgs] = useState<Msg[]>([]);
 	const [loading, setLoading] = useState(false);
 	const [phase, setPhase] = useState<ReplyPhase>('idle');
@@ -147,6 +151,27 @@ export function useMessages(
 	}, []);
 
 	const audioManager = useAudioManager();
+	const reportReplyFailure = useCallback(
+		(message: string, offerRefresh = false) => {
+			const failure = new Error(message);
+			clearInterruptTimer();
+			audioManager?.stopLivePlayback();
+			currentReplyRef.current = null;
+			setPhase('idle');
+			setError(failure);
+			if (offerRefresh) {
+				toast.error(message, {
+					action: {
+						label: t('chat.refresh'),
+						onClick: () => window.location.reload(),
+					},
+				});
+			} else {
+				toast.error(message);
+			}
+		},
+		[audioManager, clearInterruptTimer, t],
+	);
 
 	const optionsRef = useRef(options);
 	useEffect(() => {
@@ -167,7 +192,9 @@ export function useMessages(
 			// reply content — route them to callbacks and skip appendEvent.
 			if (event.type === EventType.CUSTOM) {
 				const custom = event as CustomEvent;
-				if (custom.name === 'team_updated') {
+				if (custom.name === 'chat_run_error') {
+					reportReplyFailure(t('chat.runFailed'));
+				} else if (custom.name === 'team_updated') {
 					optionsRef.current?.onTeamUpdated?.();
 				} else if (custom.name === 'state_updated' && custom.value) {
 					optionsRef.current?.onStateUpdated?.(custom.value as Record<string, unknown>);
@@ -189,6 +216,7 @@ export function useMessages(
 			}
 			if (event.type === EventType.REPLY_START) {
 				audioManager?.stopAllPlayback();
+				setError(null);
 				const e = event as ReplyStartEvent;
 				const msg = AssistantMsg({ id: e.reply_id, name: e.name, content: [] });
 				msgsRef.current = [...msgsRef.current, msg];
@@ -231,7 +259,7 @@ export function useMessages(
 
 			scheduleUpdate();
 		},
-		[scheduleUpdate, audioManager, clearInterruptTimer],
+		[scheduleUpdate, audioManager, clearInterruptTimer, reportReplyFailure, t],
 	);
 
 	// ── Lifecycle: fetch history + open SSE stream ──────────────────
@@ -293,9 +321,12 @@ export function useMessages(
 					if (cancelled) break;
 					processEvent(event);
 				}
+				if (!cancelled) {
+					reportReplyFailure(t('chat.connectionLost'), true);
+				}
 			} catch (e) {
 				if ((e as Error).name !== 'AbortError' && !cancelled) {
-					setError(e as Error);
+					reportReplyFailure(t('chat.connectionLost'), true);
 				}
 			}
 		})();
@@ -306,7 +337,16 @@ export function useMessages(
 			abortRef.current = null;
 			clearInterruptTimer();
 		};
-	}, [agentId, sessionId, scheduleUpdate, processEvent, audioManager, clearInterruptTimer]);
+	}, [
+		agentId,
+		sessionId,
+		scheduleUpdate,
+		processEvent,
+		audioManager,
+		clearInterruptTimer,
+		reportReplyFailure,
+		t,
+	]);
 
 	/**
 	 * Send a user message. Appends the message to the local list

--- a/examples/web_ui/frontend/src/i18n/locales/en.json
+++ b/examples/web_ui/frontend/src/i18n/locales/en.json
@@ -133,6 +133,11 @@
 		"newSession": "New Session",
 		"noSessions": "No sessions yet",
 		"greeting": "Where should we start?",
+		"noMessages": "No Messages Yet",
+		"noMessagesDesc": "Start your conversation by sending a message",
+		"runFailed": "Model response failed. Check the server logs and try again.",
+		"connectionLost": "Connection to the model service was lost. Refresh to reconnect.",
+		"refresh": "Refresh",
 		"agent": {
 			"selectPlaceholder": "Select an agent",
 			"emptyTitle": "No agents",

--- a/examples/web_ui/frontend/src/i18n/locales/zh.json
+++ b/examples/web_ui/frontend/src/i18n/locales/zh.json
@@ -133,6 +133,11 @@
 		"newSession": "新会话",
 		"noSessions": "暂无会话",
 		"greeting": "我们从哪儿开始？",
+		"noMessages": "暂无消息",
+		"noMessagesDesc": "发送一条消息开始新的对话",
+		"runFailed": "模型响应失败。请检查服务器日志后重试。",
+		"connectionLost": "与模型服务的连接已断开，请刷新页面后重试。",
+		"refresh": "刷新",
 		"agent": {
 			"selectPlaceholder": "选择 Agent",
 			"emptyTitle": "暂无 Agent",

--- a/src/agentscope/app/_service/_chat.py
+++ b/src/agentscope/app/_service/_chat.py
@@ -45,6 +45,7 @@ from ..._logging import logger
 from ...agent import Agent, ModelConfig
 from ...event import (
     AgentEvent,
+    CustomEvent,
     ReplyStartEvent,
     ReplyEndEvent,
     ReplyFinishedReason,
@@ -55,6 +56,9 @@ from ...event import (
 from ._errors import _classify_error
 from ...message import AssistantMsg, Msg, ToolCallState
 from ...permission import AdditionalWorkingDirectory
+
+
+_CHAT_RUN_ERROR_EVENT = "chat_run_error"
 
 
 class ChatService:
@@ -186,8 +190,9 @@ class ChatService:
         (:meth:`MessageBus.session_run`); events are simultaneously
         persisted to the replay log and fanned out on the live channel
         via :meth:`MessageBus.session_publish_event`. Exceptions are
-        logged and swallowed so a single failed fire does not tear
-        down its trigger (HTTP request task, wakeup dispatcher, …).
+        logged and reported to session subscribers with a generic error
+        event, then swallowed so a single failed fire does not tear down
+        its trigger (HTTP request task, wakeup dispatcher, …).
 
         Args:
             user_id (`str`):
@@ -222,6 +227,21 @@ class ChatService:
                 agent_id,
                 str(e),
             )
+            try:
+                error_event = CustomEvent(
+                    name=_CHAT_RUN_ERROR_EVENT,
+                    value={},
+                )
+                await publish_session_event(
+                    self._message_bus,
+                    session_id,
+                    error_event.model_dump(mode="json"),
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to publish chat run error for session_id=%s.",
+                    session_id,
+                )
 
     async def interrupt(
         self,

--- a/src/agentscope/event/_event.py
+++ b/src/agentscope/event/_event.py
@@ -516,6 +516,8 @@ class CustomEvent(EventBase):
               changed during a tool call.
             - ``"team_updated"`` — team membership changed (member
               added / team created or dissolved).
+            - ``"chat_run_error"`` — a service-level chat run failure;
+              details remain in server logs.
 
         value (`dict`):
             Arbitrary JSON-serializable payload whose schema depends

--- a/tests/service_chat_error_test.py
+++ b/tests/service_chat_error_test.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for service-level chat run failures."""
+from unittest.async_case import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock, patch
+
+from agentscope.app._service import ChatService
+from agentscope.app.message_bus import InMemoryMessageBus, MessageBusKeys
+
+
+class ChatServiceErrorTest(IsolatedAsyncioTestCase):
+    """Chat failures must terminate the WebUI reply state."""
+
+    async def test_run_failure_publishes_generic_error_event(self) -> None:
+        """Unhandled run errors notify subscribers without leaking details."""
+        bus = InMemoryMessageBus()
+        service = ChatService(
+            storage=MagicMock(),
+            workspace_manager=MagicMock(),
+            scheduler_manager=MagicMock(),
+            background_task_manager=MagicMock(),
+            message_bus=bus,
+            resource_access_service=MagicMock(),
+        )
+
+        with patch.object(
+            service,
+            "_run_impl",
+            side_effect=RuntimeError("private provider failure"),
+        ):
+            async with bus:
+                await service.run("user-1", "session-1", "agent-1")
+                entries = await bus.log_read(
+                    MessageBusKeys.session_events("session-1"),
+                )
+
+        self.assertEqual(len(entries), 1)
+        event = entries[0][1]
+        self.assertEqual(event["type"], "CUSTOM")
+        self.assertEqual(event["name"], "chat_run_error")
+        self.assertEqual(event["value"], {})
+        self.assertNotIn("private provider failure", str(event))


### PR DESCRIPTION
## Summary

- publish a generic `chat_run_error` session event when an unhandled chat service failure is logged and swallowed
- reset the WebUI reply phase and show a localized error without exposing provider exception details
- treat 90 seconds without SSE data or heartbeat bytes as a lost connection and offer a refresh action

The heartbeat timeout follows the server endpoint contract (one comment frame every 30 seconds); it does not impose a timeout on model inference while the service remains responsive.

## Validation

- `pytest tests/service_chat_error_test.py tests/service_agent_interrupt_test.py tests/service_message_bus_test.py -q` (`32 passed`)
- changed-file pre-commit: Black, mypy, flake8, pylint, pyroma, JSON and secret checks
- `pnpm --filter frontend build`
- `pnpm --filter frontend lint` (0 errors; 16 existing warnings in unrelated files)
- Prettier check on changed frontend files

Fixes #2110.