### PR TITLE
docs(tool): fix docstring formatting errors

### DIFF
--- a/src/agentscope/tool/_tool_group.py
+++ b/src/agentscope/tool/_tool_group.py
@@ -51,7 +51,7 @@ class ToolGroup:
         """Initialize the tool group.
 
         Args:
-            name (`Literal["basic"] | str):
+            name (`Literal["basic"] | str`):
                 The name of the tool group.
             description (`str | None`):
                 The description of the tool group.

--- a/src/agentscope/tool/_toolkit.py
+++ b/src/agentscope/tool/_toolkit.py
@@ -178,8 +178,8 @@ class Toolkit:
         .. note:: The preset keyword arguments is removed from the JSON
          schema, and the extended model is applied if it is set.
 
-         Args:
-             groups (`list[str] | None`, optional):
+        Args:
+            groups (`list[str] | None`, optional):
                 A list of group names to filter the tool function. The "basic"
                 group will always be included regardless of the filter. If not
                 provided, only the "basic" group will be included.
@@ -401,7 +401,7 @@ class Toolkit:
                 provided, only the "basic" group will be included.
 
         Returns:
-            `dict[str, Skill]`
+            `dict[str, Skill]`:
                 A dictionary of skill name and their corresponding Skill
                 objects.
         """

--- a/src/agentscope/tool/_utils.py
+++ b/src/agentscope/tool/_utils.py
@@ -73,7 +73,7 @@ def _extract_input_schema(
     """Extract input schema from the tool function's docstring
 
     Args:
-        tool_func (`ToolFunction`):
+        tool_func (`Callable`):
             The tool function to extract the JSON schema from.
         include_var_positional (`bool`):
             Whether to include variable positional arguments in the JSON


### PR DESCRIPTION
## Summary

Fixes four small docstring/Sphinx rendering defects in the stable `tool/` module. Documentation-only changes — no logic or public API is affected.

- `_utils.py`: `_extract_input_schema` documented `tool_func` as `` `ToolFunction` `` (an undefined type); corrected to `` `Callable` `` to match the signature.
- `_toolkit.py`: `get_tool_schemas` had its `Args:` block indented one extra space, nesting it under the preceding `.. note::` directive; dedented so it renders as a proper Args section.
- `_toolkit.py`: `_get_available_skills` `Returns:` type `` `dict[str, Skill]` `` was missing the trailing colon required by the Google/Sphinx docstring format; added it.
- `_tool_group.py`: the `name` parameter type `` (`Literal["basic"] | str) `` was missing its closing backtick; added it.

## Test plan

- [x] `python -m py_compile` on the three changed files passes.
- [x] `git diff --check` reports no whitespace errors.
- [ ] Docs build renders the corrected Args/Returns sections.