### PR TITLE
fix(anthropic): preserve redacted_thinking blocks in message round-trip

### DIFF
--- a/src/agentscope/formatter/_anthropic_formatter.py
+++ b/src/agentscope/formatter/_anthropic_formatter.py
@@ -82,25 +82,44 @@ class _AnthropicFormatterBase(FormatterBase, ABC):
                         )
 
                 elif isinstance(block, ThinkingBlock):
-                    # Anthropic rejects thinking blocks without a valid
-                    # signature ("Invalid `signature` in `thinking` block").
-                    # ThinkingBlocks from other providers (OpenAI, DeepSeek,
-                    # ...) carry no signature, so drop them instead of
-                    # forwarding an empty one.
-                    signature = getattr(block, "signature", None)
-                    if signature:
+                    redacted_data = getattr(
+                        block,
+                        "redacted_thinking_data",
+                        None,
+                    )
+                    if redacted_data is not None:
                         content_blocks.append(
                             {
-                                "type": "thinking",
-                                "thinking": block.thinking,
-                                "signature": signature,
+                                "type": "redacted_thinking",
+                                "data": redacted_data,
                             },
                         )
                     else:
-                        logger.debug(
-                            "Dropping ThinkingBlock without signature; "
-                            "Anthropic requires a valid signature.",
+                        # Anthropic rejects thinking blocks without
+                        # a valid signature ("Invalid `signature`
+                        # in `thinking` block"). ThinkingBlocks from
+                        # other providers (OpenAI, DeepSeek, ...)
+                        # carry no signature, so drop them instead
+                        # of forwarding an empty one.
+                        signature = getattr(
+                            block,
+                            "signature",
+                            None,
                         )
+                        if signature:
+                            content_blocks.append(
+                                {
+                                    "type": "thinking",
+                                    "thinking": block.thinking,
+                                    "signature": signature,
+                                },
+                            )
+                        else:
+                            logger.debug(
+                                "Dropping ThinkingBlock without "
+                                "signature; Anthropic requires "
+                                "a valid signature.",
+                            )
 
                 elif isinstance(block, HintBlock):
                     if content_blocks:

--- a/src/agentscope/message/_block.py
+++ b/src/agentscope/message/_block.py
@@ -22,9 +22,17 @@ class TextBlock(BaseModel):
 class ThinkingBlock(BaseModel):
     """The thinking block.
 
-    Allows extra provider-specific fields (e.g. Anthropic's ``signature``)
-    via ``extra="allow"`` so that model implementations can pass
-    arbitrary metadata without subclassing.
+    Allows extra provider-specific fields (e.g. Anthropic's ``signature``,
+    ``redacted_thinking_data``) via ``extra="allow"`` so that model
+    implementations can pass arbitrary metadata without subclassing.
+
+    .. note::
+        Anthropic's ``redacted_thinking`` blocks are also stored as
+        ``ThinkingBlock`` instances with ``thinking=""`` and the
+        encrypted payload in the ``redacted_thinking_data`` extra
+        field. Callers filtering by ``type=="thinking"`` (e.g.
+        ``get_content_blocks``) will receive both visible and
+        redacted blocks.
     """
 
     model_config = ConfigDict(extra="allow")

--- a/src/agentscope/model/_anthropic/_model.py
+++ b/src/agentscope/model/_anthropic/_model.py
@@ -246,10 +246,29 @@ class AnthropicChatModel(ChatModelBase):
                 ):
                     thinking_block = ThinkingBlock(
                         thinking=content_block.thinking,
-                        signature=getattr(content_block, "signature", "")
+                        signature=getattr(
+                            content_block,
+                            "signature",
+                            "",
+                        )
                         or "",
                     )
                     content_blocks.append(thinking_block)
+
+                elif (
+                    hasattr(content_block, "type")
+                    and content_block.type == "redacted_thinking"
+                ):
+                    content_blocks.append(
+                        ThinkingBlock(
+                            thinking="",
+                            redacted_thinking_data=getattr(
+                                content_block,
+                                "data",
+                                "",
+                            ),
+                        ),
+                    )
 
                 elif (
                     hasattr(content_block, "type")
@@ -375,6 +394,17 @@ class AnthropicChatModel(ChatModelBase):
                         block_id=tool_block.id,
                         name=tool_block.name,
                         input="",
+                    )
+
+                elif event.content_block.type == "redacted_thinking":
+                    delta_res.append_thinking(
+                        "",
+                        block_id=_generate_id(),
+                        redacted_thinking_data=getattr(
+                            event.content_block,
+                            "data",
+                            "",
+                        ),
                     )
 
             elif event.type == "content_block_delta":

--- a/tests/formatter_anthropic_test.py
+++ b/tests/formatter_anthropic_test.py
@@ -371,6 +371,50 @@ class TestAnthropicFormatter(IsolatedAsyncioTestCase):
             res,
         )
 
+    async def test_chat_formatter_redacted_thinking_preserved(
+        self,
+    ) -> None:
+        """ThinkingBlock with redacted_thinking_data is formatted
+        as a redacted_thinking block."""
+        fmt = AnthropicChatFormatter()
+        msgs = [
+            AssistantMsg(
+                name="assistant",
+                content=[
+                    ThinkingBlock(
+                        thinking="visible",
+                        signature="sig_1",
+                    ),
+                    ThinkingBlock(
+                        thinking="",
+                        redacted_thinking_data="encrypted_abc",
+                    ),
+                    TextBlock(text="reply"),
+                ],
+            ),
+        ]
+        res = await fmt.format(msgs)
+        self.assertListEqual(
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "thinking",
+                            "thinking": "visible",
+                            "signature": "sig_1",
+                        },
+                        {
+                            "type": "redacted_thinking",
+                            "data": "encrypted_abc",
+                        },
+                        {"type": "text", "text": "reply"},
+                    ],
+                },
+            ],
+            res,
+        )
+
     async def test_chat_formatter_thinking_without_signature_dropped(
         self,
     ) -> None:

--- a/tests/model_anthropic_test.py
+++ b/tests/model_anthropic_test.py
@@ -195,6 +195,62 @@ class TestAnthropicNonStream(IsolatedAsyncioTestCase):
             ),
         )
 
+    @patch("anthropic.AsyncAnthropic")
+    async def test_redacted_thinking_response(
+        self,
+        mock_client_cls: MagicMock,
+    ) -> None:
+        """Non-stream redacted_thinking block is preserved."""
+        redacted = MagicMock()
+        redacted.type = "redacted_thinking"
+        redacted.data = "encrypted_data_abc"
+
+        thinking = MagicMock()
+        thinking.type = "thinking"
+        thinking.thinking = "visible thought"
+        thinking.signature = "sig_visible"
+
+        text = MagicMock()
+        text.type = "text"
+        text.text = "Answer"
+
+        resp = MagicMock()
+        resp.id = "msg-redacted"
+        resp.content = [thinking, redacted, text]
+        resp.usage = MagicMock()
+        resp.usage.input_tokens = 10
+        resp.usage.output_tokens = 5
+        resp.usage.cache_creation_input_tokens = 0
+        resp.usage.cache_read_input_tokens = 0
+
+        mock_create = AsyncMock(return_value=resp)
+        mock_client_cls.return_value.messages.create = mock_create
+
+        result = await self.model([])
+
+        self.assertEqual(
+            (result.is_last, result.content),
+            (
+                True,
+                [
+                    ThinkingBlock.model_construct(
+                        id=A,
+                        thinking="visible thought",
+                        signature="sig_visible",
+                    ),
+                    ThinkingBlock.model_construct(
+                        id=A,
+                        thinking="",
+                        redacted_thinking_data="encrypted_data_abc",
+                    ),
+                    TextBlock.model_construct(
+                        id=A,
+                        text="Answer",
+                    ),
+                ],
+            ),
+        )
+
 
 # ---------------------------------------------------------------------------
 # Streaming tests
@@ -231,8 +287,16 @@ class TestAnthropicStream(IsolatedAsyncioTestCase):
         msg_delta_usage = MagicMock()
         msg_delta_usage.output_tokens = 5
 
+        text_start = MagicMock()
+        text_start.type = "text"
+
         events = [
             _make_event("message_start", message=message),
+            _make_event(
+                "content_block_start",
+                index=0,
+                content_block=text_start,
+            ),
             _make_event("content_block_delta", index=0, delta=delta1),
             _make_event("content_block_delta", index=0, delta=delta2),
             _make_event(
@@ -286,10 +350,30 @@ class TestAnthropicStream(IsolatedAsyncioTestCase):
         text_delta.type = "text_delta"
         text_delta.text = "Result"
 
+        thinking_start = MagicMock()
+        thinking_start.type = "thinking"
+
+        text_start = MagicMock()
+        text_start.type = "text"
+
         events = [
             _make_event("message_start", message=message),
-            _make_event("content_block_delta", index=0, delta=thinking_delta),
+            _make_event(
+                "content_block_start",
+                index=0,
+                content_block=thinking_start,
+            ),
+            _make_event(
+                "content_block_delta",
+                index=0,
+                delta=thinking_delta,
+            ),
             _make_event("content_block_delta", index=0, delta=sig_delta),
+            _make_event(
+                "content_block_start",
+                index=1,
+                content_block=text_start,
+            ),
             _make_event("content_block_delta", index=1, delta=text_delta),
         ]
         mock_create = AsyncMock(
@@ -312,8 +396,6 @@ class TestAnthropicStream(IsolatedAsyncioTestCase):
                         ),
                     ],
                 ),
-                # ``signature_delta`` is emitted as its own delta chunk
-                # carrying the signature but no additional thinking text.
                 (
                     False,
                     [
@@ -334,6 +416,99 @@ class TestAnthropicStream(IsolatedAsyncioTestCase):
                             signature="sig_abc",
                         ),
                         TextBlock.model_construct(id=A, text="Result"),
+                    ],
+                ),
+            ],
+        )
+
+    @patch("anthropic.AsyncAnthropic")
+    async def test_stream_redacted_thinking(
+        self,
+        mock_client_cls: MagicMock,
+    ) -> None:
+        """Stream redacted_thinking block is emitted at
+        content_block_start."""
+        msg_usage = MagicMock()
+        msg_usage.input_tokens = 10
+        msg_usage.output_tokens = 0
+        msg_usage.cache_creation_input_tokens = 0
+        msg_usage.cache_read_input_tokens = 0
+
+        message = MagicMock()
+        message.id = "msg-r"
+        message.usage = msg_usage
+
+        redacted_block = MagicMock()
+        redacted_block.type = "redacted_thinking"
+        redacted_block.data = "encrypted_stream_data"
+
+        text_delta = MagicMock()
+        text_delta.type = "text_delta"
+        text_delta.text = "Result"
+
+        text_start = MagicMock()
+        text_start.type = "text"
+
+        events = [
+            _make_event("message_start", message=message),
+            _make_event(
+                "content_block_start",
+                index=0,
+                content_block=redacted_block,
+            ),
+            _make_event(
+                "content_block_start",
+                index=1,
+                content_block=text_start,
+            ),
+            _make_event(
+                "content_block_delta",
+                index=1,
+                delta=text_delta,
+            ),
+        ]
+        mock_create = AsyncMock(
+            return_value=_MockAsyncEventStream(events),
+        )
+        mock_client_cls.return_value.messages.create = mock_create
+
+        gen = await self.model([])
+        responses = [r async for r in gen]
+
+        self.assertListEqual(
+            [(r.is_last, r.content) for r in responses],
+            [
+                (
+                    False,
+                    [
+                        ThinkingBlock.model_construct(
+                            id=A,
+                            thinking="",
+                            redacted_thinking_data="encrypted_stream_data",
+                        ),
+                    ],
+                ),
+                (
+                    False,
+                    [
+                        TextBlock.model_construct(
+                            id=A,
+                            text="Result",
+                        ),
+                    ],
+                ),
+                (
+                    True,
+                    [
+                        ThinkingBlock.model_construct(
+                            id=A,
+                            thinking="",
+                            redacted_thinking_data="encrypted_stream_data",
+                        ),
+                        TextBlock.model_construct(
+                            id=A,
+                            text="Result",
+                        ),
                     ],
                 ),
             ],


### PR DESCRIPTION
## AgentScope Version

2.0.4.post1

## Description

Anthropic's extended thinking API may return `redacted_thinking` content blocks alongside regular `thinking` blocks. These blocks must be replayed byte-for-byte in subsequent API calls; any modification triggers an `InternalServerError`.

Previously, `redacted_thinking` blocks were silently dropped during both response parsing and message formatting, causing the API to reject follow-up requests.

Fixes #2135.

**Changes:**
- Parse `redacted_thinking` blocks into `ThinkingBlock` with encrypted payload stored in the `redacted_thinking_data` extra field (non-streaming and streaming)
- Reconstruct `{"type": "redacted_thinking", "data": ...}` in `AnthropicChatFormatter` when the extra field is present
- Use `is not None` check for defensive handling of edge cases
- Add unit tests covering parsing, streaming, and formatter round-trip

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review