### PR TITLE
feat(moonshot): add Kimi K3 model support

### DIFF
--- a/src/agentscope/model/_moonshot/_model.py
+++ b/src/agentscope/model/_moonshot/_model.py
@@ -46,6 +46,16 @@ class MoonshotChatModel(ChatModelBase):
             ),
         )
 
+        reasoning_effort: Literal["low", "high", "max"] | None = Field(
+            default=None,
+            title="Reasoning Effort",
+            description=(
+                "The reasoning effort level for kimi-k3. "
+                "Supports 'low', 'high', and 'max' "
+                "(default 'max')."
+            ),
+        )
+
         temperature: float | None = Field(
             default=None,
             title="Temperature",
@@ -173,8 +183,13 @@ class MoonshotChatModel(ChatModelBase):
             "stream": self.stream,
         }
 
+        is_k3 = model_name == "kimi-k3"
+
         if self.parameters.max_tokens is not None:
-            kwargs["max_tokens"] = self.parameters.max_tokens
+            if is_k3:
+                kwargs["max_completion_tokens"] = self.parameters.max_tokens
+            else:
+                kwargs["max_tokens"] = self.parameters.max_tokens
 
         if self.parameters.temperature is not None:
             kwargs["temperature"] = self.parameters.temperature
@@ -184,12 +199,19 @@ class MoonshotChatModel(ChatModelBase):
 
         kwargs.update(generate_kwargs)
 
-        thinking_type = (
-            "enabled" if self.parameters.thinking_enable else "disabled"
-        )
-        kwargs.setdefault("extra_body", {})
-        kwargs["extra_body"].setdefault("thinking", {})
-        kwargs["extra_body"]["thinking"].setdefault("type", thinking_type)
+        if is_k3:
+            if self.parameters.reasoning_effort is not None:
+                kwargs["reasoning_effort"] = self.parameters.reasoning_effort
+        else:
+            thinking_type = (
+                "enabled" if self.parameters.thinking_enable else "disabled"
+            )
+            kwargs.setdefault("extra_body", {})
+            kwargs["extra_body"].setdefault("thinking", {})
+            kwargs["extra_body"]["thinking"].setdefault(
+                "type",
+                thinking_type,
+            )
 
         fmt_tools, fmt_tool_choice = self._format_tools(tools, tool_choice)
 

--- a/src/agentscope/model/_moonshot/_models/kimi-k2.6.yaml
+++ b/src/agentscope/model/_moonshot/_models/kimi-k2.6.yaml
@@ -25,3 +25,5 @@ output_size: 32768
 parameter_overrides:
   max_tokens:
     maximum: 32768
+  reasoning_effort:
+    hidden: true

--- a/src/agentscope/model/_moonshot/_models/kimi-k3.yaml
+++ b/src/agentscope/model/_moonshot/_models/kimi-k3.yaml
@@ -1,5 +1,5 @@
-name: kimi-k2.5
-label: Kimi K2.5
+name: kimi-k3
+label: Kimi K3
 status: active
 
 input_types:
@@ -9,16 +9,21 @@ input_types:
   - image/png
   - image/gif
   - image/webp
+  - video/mp4
+  - video/mpeg
+  - video/quicktime
+  - video/avi
+  - video/webm
 
 output_types:
   - text/plain
   - application/x-thinking
 
-context_size: 262144
-output_size: 65536
+context_size: 1048576
+output_size: 1048576
 
 parameter_overrides:
   max_tokens:
-    maximum: 65536
-  reasoning_effort:
+    maximum: 1048576
+  thinking_enable:
     hidden: true

--- a/src/agentscope/model/_moonshot/_models/moonshot-v1-128k.yaml
+++ b/src/agentscope/model/_moonshot/_models/moonshot-v1-128k.yaml
@@ -14,3 +14,5 @@ output_size: 131072
 parameter_overrides:
   max_tokens:
     maximum: 131072
+  reasoning_effort:
+    hidden: true

--- a/src/agentscope/model/_moonshot/_models/moonshot-v1-32k.yaml
+++ b/src/agentscope/model/_moonshot/_models/moonshot-v1-32k.yaml
@@ -14,3 +14,5 @@ output_size: 32768
 parameter_overrides:
   max_tokens:
     maximum: 32768
+  reasoning_effort:
+    hidden: true

--- a/src/agentscope/model/_moonshot/_models/moonshot-v1-8k.yaml
+++ b/src/agentscope/model/_moonshot/_models/moonshot-v1-8k.yaml
@@ -14,3 +14,5 @@ output_size: 8192
 parameter_overrides:
   max_tokens:
     maximum: 8192
+  reasoning_effort:
+    hidden: true


### PR DESCRIPTION
## AgentScope Version

2.0.4.post1

## Description

Add Kimi K3 model card and adapt the Moonshot chat model to K3's API contract: use `max_completion_tokens` instead of `max_tokens`, replace the K2.x `thinking` parameter with top-level `reasoning_effort`.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review