### PR TITLE
chore(version): bump version to 2.0.5 and reorganize optional dependencies

### DIFF
--- a/examples/long_term_memory/mem0/README.md
+++ b/examples/long_term_memory/mem0/README.md
@@ -20,7 +20,7 @@ the alternative shown inline (look for the
 
 ```bash
 # mem0 is an optional AgentScope dependency — pull it via the extra:
-pip install "agentscope[mem0]"      # resolves to mem0ai>=2.0.0,<3.0.0
+pip install "agentscope[memory-mem0]"      # resolves to mem0ai>=2.0.0,<3.0.0
 # (equivalent to `pip install agentscope mem0ai>=2.0.0,<3.0.0`)
 
 export DASHSCOPE_API_KEY=sk-...     # OSS path

--- a/examples/long_term_memory/reme/README.md
+++ b/examples/long_term_memory/reme/README.md
@@ -27,7 +27,7 @@ see below.
 
 ```bash
 # reme-ai is an optional AgentScope dependency — pull it via the extra:
-pip install "agentscope[reme]"
+pip install "agentscope[memory-reme]"
 # (equivalent to `pip install agentscope reme-ai`)
 
 export DASHSCOPE_API_KEY=sk-...

--- a/examples/long_term_memory/reme/reme_demo.py
+++ b/examples/long_term_memory/reme/reme_demo.py
@@ -38,7 +38,7 @@ and embedding model — so the only credential needed is a DashScope key.
 Starts each run from a clean workspace so the demo is reproducible.
 
 Requires:
-    pip install "agentscope[reme]"
+    pip install "agentscope[memory-reme]"
     export DASHSCOPE_API_KEY=sk-...
 """
 import asyncio

--- a/examples/rag/README.md
+++ b/examples/rag/README.md
@@ -25,9 +25,9 @@ To use a local persistent Milvus Lite vector store instead of the
 in-memory Qdrant store, install the optional extra:
 
 ```bash
-uv pip install "agentscope[milvuslite]"
+uv pip install "agentscope[vdb-milvus]"
 # Or from source (repo root)
-uv pip install -e ".[milvuslite]"
+uv pip install -e ".[vdb-milvus]"
 ```
 
 Then replace the vector store construction in `index_and_search.py`
@@ -47,9 +47,9 @@ store and wants to avoid maintaining a separate vector database — install
 the optional extra:
 
 ```bash
-uv pip install "agentscope[mongodb]"
+uv pip install "agentscope[vdb-mongodb]"
 # Or from source (repo root)
-uv pip install -e ".[mongodb]"
+uv pip install -e ".[vdb-mongodb]"
 ```
 
 **Prerequisites**
@@ -119,9 +119,9 @@ To use Elasticsearch as the vector backend, install the optional async
 client extra:
 
 ```bash
-uv pip install "agentscope[elasticsearch]"
+uv pip install "agentscope[vdb-elasticsearch]"
 # Or from source (repo root)
-uv pip install -e ".[elasticsearch]"
+uv pip install -e ".[vdb-elasticsearch]"
 ```
 
 **Prerequisites**
@@ -230,7 +230,7 @@ store = ElasticsearchStore(
 
 | | Qdrant (default) | Milvus Lite | MongoDB | Elasticsearch |
 | --- | --- | --- | --- | --- |
-| Install extra | `agentscope[rag]` | `agentscope[milvuslite]` | `agentscope[mongodb]` | `agentscope[elasticsearch]` |
+| Install extra | `agentscope[rag]` | `agentscope[vdb-milvus]` | `agentscope[vdb-mongodb]` | `agentscope[vdb-elasticsearch]` |
 | External service | No | No | Yes | Yes |
 | Persistence | No (`:memory:`) | Yes (local `.db`) | Yes (server) | Yes (server) |
 | Best for | Quick start / tests | Local dev with persistence | Teams already on MongoDB | Teams already on Elastic or needing distributed kNN search |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,13 +49,13 @@ dependencies = [
 
 [project.optional-dependencies]
 # ------------ Model APIs ------------
-gemini = ["google-genai"]
-ollama = ["ollama>=0.5.4"]
-xai = ["xai-sdk"]
+model-gemini = ["google-genai"]
+model-ollama = ["ollama>=0.5.4"]
+model-xai = ["xai-sdk"]
 models = [
-    "agentscope[ollama]",
-    "agentscope[gemini]",
-    "agentscope[xai]",
+    "agentscope[model-gemini]",
+    "agentscope[model-ollama]",
+    "agentscope[model-xai]",
 ]
 # ------------ Service ------------
 service = [
@@ -64,34 +64,47 @@ service = [
     "apscheduler",
     "ag-ui-protocol>=0.1.10",
 ]
-# ------------ Storage ------------
-storage = [
-    "redis",
-]
-# ------------ SQL storage ------------
+# ------------ Storage backends ------------
+storage-redis = ["redis"]
 # Async SQLAlchemy 2.0 + Alembic. The concrete driver
 # (aiosqlite / asyncpg / aiomysql / asyncmy) is left to the user
 # so the extra stays lightweight.
-sql = [
+storage-sql = [
     "sqlalchemy[asyncio]>=2.0",
     "alembic>=1.13",
 ]
-# ------------ Workspace -----------
-k8s = ["kubernetes-asyncio"]
+# S3-compatible blob store
+storage-s3 = ["aioboto3"]
+# ------------ Workspace (sandbox backends) ------------
+workspace-docker = ["aiodocker"]
+workspace-e2b = ["e2b"]
+workspace-daytona = ["daytona"]
+workspace-k8s = ["kubernetes-asyncio"]
+workspace-opensandbox = ["opensandbox"]
 workspace = [
-    "aiodocker",
-    "e2b",
-    "agentscope[k8s]",
-    "daytona",
-    "opensandbox",
+    "agentscope[workspace-docker]",
+    "agentscope[workspace-e2b]",
+    "agentscope[workspace-daytona]",
+    "agentscope[workspace-k8s]",
+    "agentscope[workspace-opensandbox]",
 ]
 # ------------ Tools ------------
+# Ships the ``rg`` binary for the builtin Grep tool on LocalWorkspace
+# (remote sandboxes install ripgrep inside the sandbox instead).
 tools = [
     "ripgrep",
 ]
+# ------------ Vector stores ------------
+vdb-qdrant = ["qdrant-client"]
+vdb-milvus = [
+    "pymilvus>=2.4.0",
+    "milvus-lite>=3.1.0",
+]
+vdb-mongodb = ["pymongo>=4.7"]
+vdb-elasticsearch = ["elasticsearch[async]>=8.12"]
 # ------------ RAG ------------
+# Document parsers; pick a vector store via the vdb-* extras.
 rag = [
-    "qdrant-client",
     "pypdf",
     "python-pptx",
     "python-docx",
@@ -99,24 +112,6 @@ rag = [
     "xlrd>=2.0",
     "pandas",
 ]
-milvuslite = [
-    "pymilvus>=2.4.0",
-    "milvus-lite>=3.1.0",
-]
-# ------------ MongoDB vector store ------------
-mongodb = [
-    "pymongo>=4.7",
-]
-# ------------ Elasticsearch vector store ------------
-elasticsearch = [
-    "elasticsearch[async]>=8.12",
-]
-
-# ------------ S3-compatible blob store ------------
-s3 = [
-    "aioboto3",
-]
-
 # ------------ Long-term memory ------------
 # Required by `agentscope.middleware._longterm_memory.Mem0Middleware`.
 # Pinned to mem0 v2.x because the middleware targets that
@@ -125,24 +120,43 @@ s3 = [
 # v3 phased pipeline in `_add_to_vector_store`. Running on mem0 1.x
 # wouldn't crash but the 2-tier add fallback degenerates into a
 # wasted LLM call.
-mem0 = ["mem0ai>=2.0.0"]
+memory-mem0 = ["mem0ai>=2.0.0"]
 # Required by `agentscope.middleware._longterm_memory.ReMeMiddleware`.
-reme = ["reme-ai>=0.4.0.6"]
+memory-reme = ["reme-ai>=0.4.0.6"]
+memory = [
+    "agentscope[memory-mem0]",
+    "agentscope[memory-reme]",
+]
+# ------------ Deprecated aliases ------------
+# Kept for backward compatibility; will be removed in a future
+# major release. Use the prefixed names instead.
+gemini = ["agentscope[model-gemini]"]
+ollama = ["agentscope[model-ollama]"]
+xai = ["agentscope[model-xai]"]
+storage = ["agentscope[storage-redis]"]
+sql = ["agentscope[storage-sql]"]
+s3 = ["agentscope[storage-s3]"]
+k8s = ["agentscope[workspace-k8s]"]
+milvuslite = ["agentscope[vdb-milvus]"]
+mongodb = ["agentscope[vdb-mongodb]"]
+elasticsearch = ["agentscope[vdb-elasticsearch]"]
+mem0 = ["agentscope[memory-mem0]"]
+reme = ["agentscope[memory-reme]"]
 # ------------ Full ------------
 full = [
     "agentscope[models]",
     "agentscope[service]",
-    "agentscope[storage]",
-    "agentscope[sql]",
+    "agentscope[storage-redis]",
+    "agentscope[storage-sql]",
+    "agentscope[storage-s3]",
     "agentscope[workspace]",
     "agentscope[tools]",
     "agentscope[rag]",
-    "agentscope[milvuslite]",
-    "agentscope[mongodb]",
-    "agentscope[elasticsearch]",
-    "agentscope[s3]",
-    "agentscope[mem0]",
-    "agentscope[reme]",
+    "agentscope[vdb-qdrant]",
+    "agentscope[vdb-milvus]",
+    "agentscope[vdb-mongodb]",
+    "agentscope[vdb-elasticsearch]",
+    "agentscope[memory]",
 ]
 
 # ------------ Development ------------
@@ -158,11 +172,9 @@ dev = [
     "fakeredis",
     # SQL backend tests — SQLite via aiosqlite so no server is needed.
     "aiosqlite",
-    # S3-backend testing — moto[server] spins up an in-process S3, the
-    # store-under-test (`S3BlobStore`) uses aioboto3, and boto3 is the
-    # sync client the test fixtures use to seed/verify buckets.
+    # S3-backend testing — moto[server] spins up an in-process S3
+    # (aioboto3 comes via full→storage-s3), boto3 seeds/verifies buckets.
     "moto[server,s3]",
-    "aioboto3",
     "boto3",
     # RAG parser tests — used to generate PDF fixtures in-memory
     "reportlab",

--- a/src/agentscope/_version.py
+++ b/src/agentscope/_version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """The version of agentscope."""
 
-__version__ = "2.0.4.post1"
+__version__ = "2.0.5"

--- a/src/agentscope/middleware/_longterm_memory/_reme/_middleware.py
+++ b/src/agentscope/middleware/_longterm_memory/_reme/_middleware.py
@@ -242,7 +242,7 @@ class ReMeMiddleware(MiddlewareBase):
         except ImportError as e:  # pragma: no cover - import guard
             raise ImportError(
                 "ReMeMiddleware requires the `reme-ai` package. Install "
-                'it with `pip install "agentscope[reme]"` (or '
+                'it with `pip install "agentscope[memory-reme]"` (or '
                 "`pip install reme-ai`).",
             ) from e
 

--- a/src/agentscope/rag/_vdb/_elasticsearch.py
+++ b/src/agentscope/rag/_vdb/_elasticsearch.py
@@ -27,7 +27,7 @@ class ElasticsearchStore(VectorStoreBase):
     dynamic mappings.
 
     .. note:: Requires the official async Elasticsearch client. Install it
-        with ``pip install agentscope[elasticsearch]``.
+        with ``pip install agentscope[vdb-elasticsearch]``.
     """
 
     def __init__(

--- a/src/agentscope/rag/_vdb/_milvus_lite.py
+++ b/src/agentscope/rag/_vdb/_milvus_lite.py
@@ -32,7 +32,7 @@ class MilvusLiteStore(VectorStoreBase):
     field used for flat equality filtering.
 
     .. note:: Install optional dependencies with
-        ``pip install agentscope[milvuslite]``.
+        ``pip install agentscope[vdb-milvus]``.
 
     .. code-block:: python
 

--- a/src/agentscope/rag/_vdb/_mongodb.py
+++ b/src/agentscope/rag/_vdb/_mongodb.py
@@ -39,7 +39,7 @@ class MongoDBStore(VectorStoreBase):
 
     .. note:: Requires ``pymongo`` with ``AsyncMongoClient`` support
         (``pymongo>=4.7``).  Install with
-        ``pip install agentscope[mongodb]``.
+        ``pip install agentscope[vdb-mongodb]``.
 
     .. note:: Fields used in :meth:`search` ``metadata_filter`` must be
         declared in ``filter_fields`` at construction time so they are

--- a/src/agentscope/rag/_vdb/_qdrant.py
+++ b/src/agentscope/rag/_vdb/_qdrant.py
@@ -37,7 +37,7 @@ class QdrantStore(VectorStoreBase):
     retrieval.
 
     .. note:: The ``qdrant-client`` package is required. Install it
-        with ``pip install qdrant-client``.
+        with ``pip install agentscope[vdb-qdrant]``.
 
     .. code-block:: python
 


### PR DESCRIPTION
## Description

1. Bump the Python package version from `2.0.4.post1` to `2.0.5`.
2. Reorganize `[project.optional-dependencies]` into a consistent two-tier scheme:
   - **Fine-grained per-backend extras with subsystem prefixes**: `model-*` (gemini/ollama/xai), `storage-*` (redis/sql/s3), `workspace-*` (docker/e2b/daytona/k8s/opensandbox), `vdb-*` (qdrant/milvus/mongodb/elasticsearch), `memory-*` (mem0/reme)
   - **Capability aggregates**: `models`, `workspace`, `rag` (document parsers only now — pick a vector store via `vdb-*`), `memory`, `full`
   - All previously published extra names (`storage`, `sql`, `s3`, `k8s`, `milvuslite`, `mongodb`, `elasticsearch`, `mem0`, `reme`, `gemini`, `ollama`, `xai`) are kept as **deprecated aliases** pointing at the new prefixed names, so existing installs keep working; slated for removal in the next major release
   - Dropped duplicate `aioboto3` from `dev` (already included via `full` → `storage-s3`)
   - Install hints in docstrings and example READMEs updated to the new names

## Checklist

- [x] Version updated in `src/agentscope/_version.py`
- [x] `pre-commit run --all-files` passes
- [x] All extra self-references validated (setuptools + uv resolve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
