### PR TITLE
perf(model): replace O(n²) string concat with O(n) fragment join in stream accumulation

### DIFF
--- a/src/agentscope/model/_base.py
+++ b/src/agentscope/model/_base.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 """The base class for the chat models."""
 import asyncio
+import base64
 import inspect
 import json
 from abc import abstractmethod
+from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
 from typing import Type, Any, AsyncGenerator
@@ -24,6 +26,7 @@ from ..message import (
     ThinkingBlock,
     ToolResultBlock,
     DataBlock,
+    Base64Source,
     HintBlock,
 )
 from ..tool import ToolChoice
@@ -240,22 +243,45 @@ class ChatModelBase:
         )
 
         async def _stream() -> AsyncGenerator[ChatResponse, None]:
-            """The wrapper around model calling."""
-            # For backward compatibility
+            """The wrapper around model calling.
+
+            Uses fragment lists for O(n) accumulation instead of
+            repeated string concatenation which is O(n^2) for large
+            payloads (e.g. tool call arguments with 100k+ chars).
+            """
             yield_acc_res = True
+
+            # Fragment-based accumulators: block_id -> fragments
+            # str fragments for text/thinking/tool_call
+            _str_frags: dict[str, list[str]] = defaultdict(list)
+            # byte fragments for audio DataBlock
+            _byte_frags: dict[str, list[bytes]] = defaultdict(list)
+            # Insertion order of block IDs
+            _block_order: list[str] = []
+            # Block metadata: type, name, extras, source info
+            _block_meta: dict[str, dict] = {}
+
             try:
                 async for chunk in res:
                     if not chunk.is_last:
-                        acc_res.append_chat_response(chunk)
+                        # Collect fragments — O(1) per delta
+                        self._collect_chunk_fragments(
+                            chunk,
+                            _block_order,
+                            _block_meta,
+                            _str_frags,
+                            _byte_frags,
+                        )
+
                         acc_res.id = chunk.id
-                        # Empty-content deltas are "carrier" chunks used
-                        # by subclasses to propagate usage / id metadata
-                        # (e.g. OpenAI-compatible APIs emit a trailing
-                        # usage-only chunk with no choices). We absorb
-                        # their metadata into ``acc_res`` above but do
-                        # not surface them to the consumer, which keeps
-                        # the visible stream free of spurious empty
-                        # deltas.
+                        if chunk.usage:
+                            acc_res.usage = chunk.usage
+                        # Empty-content deltas are "carrier" chunks
+                        # used by subclasses to propagate usage / id
+                        # metadata (e.g. OpenAI-compatible APIs emit a
+                        # trailing usage-only chunk with no choices).
+                        # We absorb their metadata above but do not
+                        # surface them to the consumer.
                         if not chunk.content:
                             continue
                     else:
@@ -266,9 +292,219 @@ class ChatModelBase:
                 yield_acc_res = True
 
             if yield_acc_res:
+                # Build acc_res from fragments — single O(n) join
+                self._build_acc_response(
+                    acc_res,
+                    _block_order,
+                    _block_meta,
+                    _str_frags,
+                    _byte_frags,
+                )
                 yield acc_res
 
         return _stream()
+
+    @staticmethod
+    def _collect_chunk_fragments(
+        chunk: ChatResponse,
+        block_order: list[str],
+        block_meta: dict[str, dict],
+        str_frags: dict[str, list[str]],
+        byte_frags: dict[str, list[bytes]],
+    ) -> None:
+        """Collect all block deltas from a chunk into fragment storage.
+
+        Dispatches each content block to the appropriate fragment
+        accumulator based on block type. This is the shared logic
+        used by both ``_stream()`` and
+        ``_call_api_with_structured_output()``.
+
+        Args:
+            chunk (`ChatResponse`):
+                The streaming delta chunk to collect from.
+            block_order (`list[str]`):
+                Mutable ordered list of unique block IDs,
+                preserving first-seen insertion order.
+            block_meta (`dict[str, dict]`):
+                Mutable metadata dict per block. Keys include
+                ``type``, and optionally ``name``, ``extra``,
+                ``media_type``, ``source``.
+            str_frags (`dict[str, list[str]]`):
+                Mutable mapping of block_id to string fragment
+                lists (text, thinking, tool_call input).
+            byte_frags (`dict[str, list[bytes]]`):
+                Mutable mapping of block_id to byte fragment
+                lists (audio DataBlock).
+        """
+        for block in chunk.content:
+            bid = block.id
+            if bid not in block_meta:
+                block_order.append(bid)
+                block_meta[bid] = {"type": block.type}
+
+            meta = block_meta[bid]
+
+            if isinstance(block, TextBlock):
+                str_frags[bid].append(block.text)
+
+            elif isinstance(block, ThinkingBlock):
+                str_frags[bid].append(block.thinking)
+                for k, v in (block.model_extra or {}).items():
+                    if v is not None:
+                        meta.setdefault("extra", {})[k] = v
+
+            elif isinstance(block, ToolCallBlock):
+                if "name" not in meta:
+                    meta["name"] = block.name
+                str_frags[bid].append(block.input)
+                for k, v in (block.model_extra or {}).items():
+                    if v is not None:
+                        meta.setdefault("extra", {})[k] = v
+
+            elif isinstance(block, DataBlock):
+                ChatModelBase._collect_data_fragment(
+                    block,
+                    bid,
+                    meta,
+                    byte_frags,
+                )
+
+    @staticmethod
+    def _collect_data_fragment(
+        block: DataBlock,
+        bid: str,
+        meta: dict,
+        byte_frags: dict[str, list[bytes]],
+    ) -> None:
+        """Collect a DataBlock delta into fragment storage.
+
+        For audio media: decodes base64 chunks and appends raw
+        bytes to avoid repeated decode-concat-encode per delta.
+        For non-audio: stores the latest source (last wins).
+
+        Args:
+            block (`DataBlock`):
+                The incoming DataBlock delta to collect.
+            bid (`str`):
+                The block ID used as key in fragment storage.
+            meta (`dict`):
+                Mutable metadata dict for this block. Updated
+                in-place with ``name``, ``media_type``, and/or
+                ``source`` as appropriate.
+            byte_frags (`dict[str, list[bytes]]`):
+                Mutable mapping of block_id to accumulated raw
+                byte fragments (used for audio streams).
+        """
+        # Always preserve name if provided
+        if block.name is not None:
+            meta["name"] = block.name
+
+        if not isinstance(block.source, Base64Source):
+            meta["source"] = block.source
+            return
+
+        media_type = block.source.media_type
+        if "media_type" not in meta:
+            meta["media_type"] = media_type
+
+        if media_type.startswith("audio/"):
+            if block.source.data:
+                byte_frags[bid].append(
+                    base64.b64decode(block.source.data),
+                )
+        else:
+            # Non-streamable: latest data wins
+            meta["source"] = block.source
+
+    @staticmethod
+    def _build_acc_response(
+        acc_res: ChatResponse,
+        block_order: list[str],
+        block_meta: dict[str, dict],
+        str_frags: dict[str, list[str]],
+        byte_frags: dict[str, list[bytes]],
+    ) -> None:
+        """Build acc_res content from collected fragments.
+
+        Performs a single O(n) join for each block instead of
+        O(n^2) repeated string concatenation.
+
+        Args:
+            acc_res (`ChatResponse`):
+                The target response object whose ``content``
+                list will be populated in-place.
+            block_order (`list[str]`):
+                Ordered list of block IDs preserving insertion
+                order from the stream.
+            block_meta (`dict[str, dict]`):
+                Metadata for each block keyed by block ID.
+                Expected keys: ``type``, and optionally
+                ``name``, ``extra``, ``media_type``, ``source``.
+            str_frags (`dict[str, list[str]]`):
+                String fragments for text/thinking/tool_call
+                blocks, keyed by block ID.
+            byte_frags (`dict[str, list[bytes]]`):
+                Raw byte fragments for audio DataBlocks, keyed
+                by block ID.
+        """
+        for bid in block_order:
+            meta = block_meta[bid]
+            btype = meta["type"]
+
+            if btype == "text":
+                acc_res.content.append(
+                    TextBlock(
+                        id=bid,
+                        text="".join(str_frags.get(bid, [])),
+                    ),
+                )
+            elif btype == "thinking":
+                blk = ThinkingBlock(
+                    id=bid,
+                    thinking="".join(str_frags.get(bid, [])),
+                )
+                for k, v in meta.get("extra", {}).items():
+                    setattr(blk, k, v)
+                acc_res.content.append(blk)
+
+            elif btype == "tool_call":
+                blk = ToolCallBlock(
+                    id=bid,
+                    name=meta.get("name", ""),
+                    input="".join(str_frags.get(bid, [])),
+                )
+                for k, v in meta.get("extra", {}).items():
+                    setattr(blk, k, v)
+                acc_res.content.append(blk)
+
+            elif btype == "data":
+                if bid in byte_frags:
+                    # Audio: join raw bytes, encode once
+                    joined = b"".join(byte_frags[bid])
+                    acc_res.content.append(
+                        DataBlock(
+                            id=bid,
+                            source=Base64Source(
+                                data=base64.b64encode(
+                                    joined,
+                                ).decode("ascii"),
+                                media_type=meta.get(
+                                    "media_type",
+                                    "",
+                                ),
+                            ),
+                            name=meta.get("name"),
+                        ),
+                    )
+                elif "source" in meta:
+                    # Non-audio or URL source: use stored
+                    acc_res.content.append(
+                        DataBlock(
+                            id=bid,
+                            source=meta["source"],
+                            name=meta.get("name"),
+                        ),
+                    )
 
     @abstractmethod
     async def _call_api(
@@ -599,13 +835,34 @@ class ChatModelBase:
                 is_last=True,
                 finished_reason=FinishedReason.COMPLETED,
             )
+            _str_frags: dict[str, list[str]] = defaultdict(list)
+            _byte_frags: dict[str, list[bytes]] = defaultdict(list)
+            _block_order: list[str] = []
+            _block_meta: dict[str, dict] = {}
+
             async for chunk in res:
                 if chunk.is_last:
                     completed_response = chunk
                     break
-                acc_res.append_chat_response(chunk)
+                self._collect_chunk_fragments(
+                    chunk,
+                    _block_order,
+                    _block_meta,
+                    _str_frags,
+                    _byte_frags,
+                )
                 acc_res.id = chunk.id
+                if chunk.usage:
+                    acc_res.usage = chunk.usage
+
             if completed_response is None:
+                self._build_acc_response(
+                    acc_res,
+                    _block_order,
+                    _block_meta,
+                    _str_frags,
+                    _byte_frags,
+                )
                 completed_response = acc_res
         else:
             completed_response = res

--- a/src/agentscope/model/_base.py
+++ b/src/agentscope/model/_base.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 """The base class for the chat models."""
 import asyncio
-import base64
 import inspect
 import json
 from abc import abstractmethod
-from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
 from typing import Type, Any, AsyncGenerator
@@ -15,6 +13,7 @@ from pydantic import BaseModel
 
 from ._model_response import StructuredResponse, ChatResponse, FinishedReason
 from ._model_card import ModelCard
+from ._utils import _StreamAccumulator
 from .._logging import logger
 from .._utils._common import _json_loads_with_repair
 from ..credential import CredentialBase
@@ -26,7 +25,6 @@ from ..message import (
     ThinkingBlock,
     ToolResultBlock,
     DataBlock,
-    Base64Source,
     HintBlock,
 )
 from ..tool import ToolChoice
@@ -235,53 +233,24 @@ class ChatModelBase:
         if isinstance(res, ChatResponse):
             return res
 
-        # The accumulated chat response
-        acc_res = ChatResponse(
-            content=[],
-            is_last=True,
-            finished_reason=FinishedReason.COMPLETED,
-        )
-
         async def _stream() -> AsyncGenerator[ChatResponse, None]:
-            """The wrapper around model calling.
-
-            Uses fragment lists for O(n) accumulation instead of
-            repeated string concatenation which is O(n^2) for large
-            payloads (e.g. tool call arguments with 100k+ chars).
-            """
+            """The wrapper around model calling."""
+            # For backward compatibility
             yield_acc_res = True
-
-            # Fragment-based accumulators: block_id -> fragments
-            # str fragments for text/thinking/tool_call
-            _str_frags: dict[str, list[str]] = defaultdict(list)
-            # byte fragments for audio DataBlock
-            _byte_frags: dict[str, list[bytes]] = defaultdict(list)
-            # Insertion order of block IDs
-            _block_order: list[str] = []
-            # Block metadata: type, name, extras, source info
-            _block_meta: dict[str, dict] = {}
-
+            acc_res = _StreamAccumulator()
             try:
                 async for chunk in res:
                     if not chunk.is_last:
-                        # Collect fragments — O(1) per delta
-                        self._collect_chunk_fragments(
-                            chunk,
-                            _block_order,
-                            _block_meta,
-                            _str_frags,
-                            _byte_frags,
-                        )
-
+                        acc_res.append_chat_response(chunk)
                         acc_res.id = chunk.id
-                        if chunk.usage:
-                            acc_res.usage = chunk.usage
-                        # Empty-content deltas are "carrier" chunks
-                        # used by subclasses to propagate usage / id
-                        # metadata (e.g. OpenAI-compatible APIs emit a
-                        # trailing usage-only chunk with no choices).
-                        # We absorb their metadata above but do not
-                        # surface them to the consumer.
+                        # Empty-content deltas are "carrier" chunks used
+                        # by subclasses to propagate usage / id metadata
+                        # (e.g. OpenAI-compatible APIs emit a trailing
+                        # usage-only chunk with no choices). We absorb
+                        # their metadata into ``acc_res`` above but do
+                        # not surface them to the consumer, which keeps
+                        # the visible stream free of spurious empty
+                        # deltas.
                         if not chunk.content:
                             continue
                     else:
@@ -292,219 +261,9 @@ class ChatModelBase:
                 yield_acc_res = True
 
             if yield_acc_res:
-                # Build acc_res from fragments — single O(n) join
-                self._build_acc_response(
-                    acc_res,
-                    _block_order,
-                    _block_meta,
-                    _str_frags,
-                    _byte_frags,
-                )
-                yield acc_res
+                yield acc_res.build()
 
         return _stream()
-
-    @staticmethod
-    def _collect_chunk_fragments(
-        chunk: ChatResponse,
-        block_order: list[str],
-        block_meta: dict[str, dict],
-        str_frags: dict[str, list[str]],
-        byte_frags: dict[str, list[bytes]],
-    ) -> None:
-        """Collect all block deltas from a chunk into fragment storage.
-
-        Dispatches each content block to the appropriate fragment
-        accumulator based on block type. This is the shared logic
-        used by both ``_stream()`` and
-        ``_call_api_with_structured_output()``.
-
-        Args:
-            chunk (`ChatResponse`):
-                The streaming delta chunk to collect from.
-            block_order (`list[str]`):
-                Mutable ordered list of unique block IDs,
-                preserving first-seen insertion order.
-            block_meta (`dict[str, dict]`):
-                Mutable metadata dict per block. Keys include
-                ``type``, and optionally ``name``, ``extra``,
-                ``media_type``, ``source``.
-            str_frags (`dict[str, list[str]]`):
-                Mutable mapping of block_id to string fragment
-                lists (text, thinking, tool_call input).
-            byte_frags (`dict[str, list[bytes]]`):
-                Mutable mapping of block_id to byte fragment
-                lists (audio DataBlock).
-        """
-        for block in chunk.content:
-            bid = block.id
-            if bid not in block_meta:
-                block_order.append(bid)
-                block_meta[bid] = {"type": block.type}
-
-            meta = block_meta[bid]
-
-            if isinstance(block, TextBlock):
-                str_frags[bid].append(block.text)
-
-            elif isinstance(block, ThinkingBlock):
-                str_frags[bid].append(block.thinking)
-                for k, v in (block.model_extra or {}).items():
-                    if v is not None:
-                        meta.setdefault("extra", {})[k] = v
-
-            elif isinstance(block, ToolCallBlock):
-                if "name" not in meta:
-                    meta["name"] = block.name
-                str_frags[bid].append(block.input)
-                for k, v in (block.model_extra or {}).items():
-                    if v is not None:
-                        meta.setdefault("extra", {})[k] = v
-
-            elif isinstance(block, DataBlock):
-                ChatModelBase._collect_data_fragment(
-                    block,
-                    bid,
-                    meta,
-                    byte_frags,
-                )
-
-    @staticmethod
-    def _collect_data_fragment(
-        block: DataBlock,
-        bid: str,
-        meta: dict,
-        byte_frags: dict[str, list[bytes]],
-    ) -> None:
-        """Collect a DataBlock delta into fragment storage.
-
-        For audio media: decodes base64 chunks and appends raw
-        bytes to avoid repeated decode-concat-encode per delta.
-        For non-audio: stores the latest source (last wins).
-
-        Args:
-            block (`DataBlock`):
-                The incoming DataBlock delta to collect.
-            bid (`str`):
-                The block ID used as key in fragment storage.
-            meta (`dict`):
-                Mutable metadata dict for this block. Updated
-                in-place with ``name``, ``media_type``, and/or
-                ``source`` as appropriate.
-            byte_frags (`dict[str, list[bytes]]`):
-                Mutable mapping of block_id to accumulated raw
-                byte fragments (used for audio streams).
-        """
-        # Always preserve name if provided
-        if block.name is not None:
-            meta["name"] = block.name
-
-        if not isinstance(block.source, Base64Source):
-            meta["source"] = block.source
-            return
-
-        media_type = block.source.media_type
-        if "media_type" not in meta:
-            meta["media_type"] = media_type
-
-        if media_type.startswith("audio/"):
-            if block.source.data:
-                byte_frags[bid].append(
-                    base64.b64decode(block.source.data),
-                )
-        else:
-            # Non-streamable: latest data wins
-            meta["source"] = block.source
-
-    @staticmethod
-    def _build_acc_response(
-        acc_res: ChatResponse,
-        block_order: list[str],
-        block_meta: dict[str, dict],
-        str_frags: dict[str, list[str]],
-        byte_frags: dict[str, list[bytes]],
-    ) -> None:
-        """Build acc_res content from collected fragments.
-
-        Performs a single O(n) join for each block instead of
-        O(n^2) repeated string concatenation.
-
-        Args:
-            acc_res (`ChatResponse`):
-                The target response object whose ``content``
-                list will be populated in-place.
-            block_order (`list[str]`):
-                Ordered list of block IDs preserving insertion
-                order from the stream.
-            block_meta (`dict[str, dict]`):
-                Metadata for each block keyed by block ID.
-                Expected keys: ``type``, and optionally
-                ``name``, ``extra``, ``media_type``, ``source``.
-            str_frags (`dict[str, list[str]]`):
-                String fragments for text/thinking/tool_call
-                blocks, keyed by block ID.
-            byte_frags (`dict[str, list[bytes]]`):
-                Raw byte fragments for audio DataBlocks, keyed
-                by block ID.
-        """
-        for bid in block_order:
-            meta = block_meta[bid]
-            btype = meta["type"]
-
-            if btype == "text":
-                acc_res.content.append(
-                    TextBlock(
-                        id=bid,
-                        text="".join(str_frags.get(bid, [])),
-                    ),
-                )
-            elif btype == "thinking":
-                blk = ThinkingBlock(
-                    id=bid,
-                    thinking="".join(str_frags.get(bid, [])),
-                )
-                for k, v in meta.get("extra", {}).items():
-                    setattr(blk, k, v)
-                acc_res.content.append(blk)
-
-            elif btype == "tool_call":
-                blk = ToolCallBlock(
-                    id=bid,
-                    name=meta.get("name", ""),
-                    input="".join(str_frags.get(bid, [])),
-                )
-                for k, v in meta.get("extra", {}).items():
-                    setattr(blk, k, v)
-                acc_res.content.append(blk)
-
-            elif btype == "data":
-                if bid in byte_frags:
-                    # Audio: join raw bytes, encode once
-                    joined = b"".join(byte_frags[bid])
-                    acc_res.content.append(
-                        DataBlock(
-                            id=bid,
-                            source=Base64Source(
-                                data=base64.b64encode(
-                                    joined,
-                                ).decode("ascii"),
-                                media_type=meta.get(
-                                    "media_type",
-                                    "",
-                                ),
-                            ),
-                            name=meta.get("name"),
-                        ),
-                    )
-                elif "source" in meta:
-                    # Non-audio or URL source: use stored
-                    acc_res.content.append(
-                        DataBlock(
-                            id=bid,
-                            source=meta["source"],
-                            name=meta.get("name"),
-                        ),
-                    )
 
     @abstractmethod
     async def _call_api(
@@ -830,40 +589,17 @@ class ChatModelBase:
             # avoid duplicating the retry logic in ``__call__``), we must
             # replicate that accumulation here, otherwise the stream may
             # end without ever producing an ``is_last=True`` chunk.
-            acc_res = ChatResponse(
-                content=[],
-                is_last=True,
-                finished_reason=FinishedReason.COMPLETED,
-            )
-            _str_frags: dict[str, list[str]] = defaultdict(list)
-            _byte_frags: dict[str, list[bytes]] = defaultdict(list)
-            _block_order: list[str] = []
-            _block_meta: dict[str, dict] = {}
+            acc_res = _StreamAccumulator()
 
             async for chunk in res:
                 if chunk.is_last:
                     completed_response = chunk
                     break
-                self._collect_chunk_fragments(
-                    chunk,
-                    _block_order,
-                    _block_meta,
-                    _str_frags,
-                    _byte_frags,
-                )
+                acc_res.append_chat_response(chunk)
                 acc_res.id = chunk.id
-                if chunk.usage:
-                    acc_res.usage = chunk.usage
 
             if completed_response is None:
-                self._build_acc_response(
-                    acc_res,
-                    _block_order,
-                    _block_meta,
-                    _str_frags,
-                    _byte_frags,
-                )
-                completed_response = acc_res
+                completed_response = acc_res.build()
         else:
             completed_response = res
 

--- a/src/agentscope/model/_model_response.py
+++ b/src/agentscope/model/_model_response.py
@@ -239,7 +239,16 @@ class ChatResponse(DictMixin):
         return self
 
     def append_chat_response(self, chat_response: Self) -> Self:
-        """Append chat response to the current response."""
+        """Append chat response to the current response.
+
+        .. deprecated::
+            Internal streaming accumulation now uses fragment-based
+            collection (see ``ChatModelBase._collect_chunk_fragments``
+            and ``ChatModelBase._build_acc_response``) which avoids
+            O(n^2) string concatenation. This method is retained for
+            backward compatibility with external consumers but is no
+            longer called by AgentScope's own streaming paths.
+        """
         # Append content
         new_block_dict = {_.id: _ for _ in chat_response.content}
         for block in self.content:

--- a/src/agentscope/model/_model_response.py
+++ b/src/agentscope/model/_model_response.py
@@ -239,16 +239,7 @@ class ChatResponse(DictMixin):
         return self
 
     def append_chat_response(self, chat_response: Self) -> Self:
-        """Append chat response to the current response.
-
-        .. deprecated::
-            Internal streaming accumulation now uses fragment-based
-            collection (see ``ChatModelBase._collect_chunk_fragments``
-            and ``ChatModelBase._build_acc_response``) which avoids
-            O(n^2) string concatenation. This method is retained for
-            backward compatibility with external consumers but is no
-            longer called by AgentScope's own streaming paths.
-        """
+        """Append chat response to the current response."""
         # Append content
         new_block_dict = {_.id: _ for _ in chat_response.content}
         for block in self.content:

--- a/src/agentscope/model/_utils.py
+++ b/src/agentscope/model/_utils.py
@@ -1,0 +1,280 @@
+# -*- coding: utf-8 -*-
+"""Internal utilities for the model module."""
+import base64
+from typing import Any, Self, TypeAlias
+
+from pydantic import Field
+
+from ._model_response import ChatResponse, FinishedReason
+from ._model_usage import ChatUsage
+from .._logging import logger
+from ..message import (
+    Base64Source,
+    DataBlock,
+    TextBlock,
+    ThinkingBlock,
+    ToolCallBlock,
+    URLSource,
+)
+
+
+class _AccTextBlock(TextBlock):
+    """The accumulating counterpart of ``TextBlock``, whose ``text`` field
+    holds the incremental fragments until they are joined in ``build``."""
+
+    text: list[str] = Field(  # type: ignore[assignment]
+        default_factory=list,
+    )
+
+    def append(self, block: TextBlock) -> None:
+        """Collect one delta block in constant time.
+
+        Args:
+            block (`TextBlock`):
+                The delta block to collect.
+        """
+        self.text.append(block.text)
+
+    def build(self) -> TextBlock:
+        """Join the fragments into a plain ``TextBlock``."""
+        return TextBlock(**{**self.model_dump(), "text": "".join(self.text)})
+
+
+class _AccThinkingBlock(ThinkingBlock):
+    """The accumulating counterpart of ``ThinkingBlock``, whose ``thinking``
+    field holds the incremental fragments until they are joined in
+    ``build``."""
+
+    thinking: list[str] = Field(  # type: ignore[assignment]
+        default_factory=list,
+    )
+
+    def append(self, block: ThinkingBlock) -> None:
+        """Collect one delta block in constant time.
+
+        Args:
+            block (`ThinkingBlock`):
+                The delta block to collect.
+        """
+        self.thinking.append(block.thinking)
+        # Provider-specific extras (e.g. Anthropic's ``signature``) are
+        # often only emitted on the closing delta of the block.
+        for key, value in (block.model_extra or {}).items():
+            if value is not None:
+                setattr(self, key, value)
+
+    def build(self) -> ThinkingBlock:
+        """Join the fragments into a plain ``ThinkingBlock``."""
+        return ThinkingBlock(
+            **{**self.model_dump(), "thinking": "".join(self.thinking)},
+        )
+
+
+class _AccToolCallBlock(ToolCallBlock):
+    """The accumulating counterpart of ``ToolCallBlock``, whose ``input``
+    field holds the incremental JSON fragments until they are joined in
+    ``build``."""
+
+    input: list[str] = Field(  # type: ignore[assignment]
+        default_factory=list,
+    )
+
+    def append(self, block: ToolCallBlock) -> None:
+        """Collect one delta block in constant time.
+
+        Args:
+            block (`ToolCallBlock`):
+                The delta block to collect.
+        """
+        self.input.append(block.input)
+        # Most providers carry ``name`` on the opening delta only, but some
+        # send an empty one first and fill the name in afterwards.
+        if not self.name and block.name:
+            self.name = block.name
+
+    def build(self) -> ToolCallBlock:
+        """Join the fragments into a plain ``ToolCallBlock``."""
+        return ToolCallBlock(
+            **{**self.model_dump(), "input": "".join(self.input)},
+        )
+
+
+class _AccBase64Source(Base64Source):
+    """The accumulating counterpart of ``Base64Source`` for audio streams,
+    whose ``data`` field holds the raw decoded bytes of each delta.
+
+    Base64 strings cannot be concatenated directly: a delta whose byte
+    length is not a multiple of three is padded with ``=``, and everything
+    after that padding is silently dropped on decoding. So each delta is
+    decoded on arrival and the bytes are encoded once in ``build``.
+    """
+
+    data: list[bytes] = Field(  # type: ignore[assignment]
+        default_factory=list,
+    )
+
+    def append(self, source: Base64Source) -> None:
+        """Decode one delta source and collect its raw bytes.
+
+        Args:
+            source (`Base64Source`):
+                The delta source to collect.
+        """
+        if source.data:
+            self.data.append(base64.b64decode(source.data))
+
+    def build(self) -> Base64Source:
+        """Join the raw bytes and base64-encode them once."""
+        return Base64Source(
+            data=base64.b64encode(b"".join(self.data)).decode("ascii"),
+            media_type=self.media_type,
+        )
+
+
+class _AccDataBlock(DataBlock):
+    """The accumulating counterpart of ``DataBlock``.
+
+    Only ``audio/*`` is a streamable delta whose concatenation is
+    well-defined. Other media types and URL sources are standalone assets,
+    so the latest delta replaces the previous one.
+    """
+
+    source: (  # type: ignore[assignment]
+        _AccBase64Source | Base64Source | URLSource
+    )
+
+    def append(self, block: DataBlock) -> None:
+        """Collect one delta block in constant time.
+
+        Args:
+            block (`DataBlock`):
+                The delta block to collect.
+        """
+        if block.name is not None:
+            self.name = block.name
+
+        source = block.source
+        if (
+            isinstance(self.source, _AccBase64Source)
+            and isinstance(source, Base64Source)
+            and source.media_type == self.source.media_type
+        ):
+            self.source.append(source)
+
+        elif isinstance(source, Base64Source) and source.media_type.startswith(
+            "audio/",
+        ):
+            # A new audio stream starts here, either because this is the
+            # first delta or because the media type changed mid-stream.
+            self.source = _AccBase64Source(
+                data=[],
+                media_type=source.media_type,
+            )
+            self.source.append(source)
+
+        else:
+            # Standalone asset: the latest delta replaces the previous one
+            self.source = source
+
+    def build(self) -> DataBlock:
+        """Join the fragments into a plain ``DataBlock``."""
+        source = self.source
+        return DataBlock(
+            **{
+                **self.model_dump(),
+                "source": (
+                    source.build()
+                    if isinstance(source, _AccBase64Source)
+                    else source
+                ),
+            },
+        )
+
+
+_AccBlock: TypeAlias = (
+    _AccTextBlock | _AccThinkingBlock | _AccToolCallBlock | _AccDataBlock
+)
+
+
+class _StreamAccumulator:
+    """Accumulates the streaming ``ChatResponse`` deltas of one model call.
+
+    Each block keeps its deltas in a fragment list that is joined exactly
+    once in ``build``, which makes the accumulation O(n) in the total
+    payload size. The ``ChatResponse.append_chat_response`` it replaces
+    grows the blocks with ``block.field += delta`` instead, which is
+    O(n^2) for large payloads (e.g. tool call arguments of 100k+ chars)
+    and can block the event loop long enough to drop the connection.
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty accumulator."""
+        # Keyed by block id, the insertion order is the block order
+        self._blocks: dict[str, _AccBlock] = {}
+
+        self.id: str | None = None
+        """The id of the latest delta, if any."""
+
+        self.usage: ChatUsage | None = None
+        """The usage of the latest delta that reported one, if any."""
+
+        self.finished_reason: FinishedReason = FinishedReason.COMPLETED
+        """The finished reason to report in ``build``."""
+
+    def append_chat_response(self, chat_response: ChatResponse) -> Self:
+        """Collect one delta chunk in constant time per block.
+
+        Args:
+            chat_response (`ChatResponse`):
+                The streaming delta chunk to collect.
+        """
+        for block in chat_response.content:
+            acc = self._blocks.get(block.id)
+            if acc is not None and acc.type != block.type:
+                logger.warning(
+                    "Block %s changed its type from %s to %s during "
+                    "streaming, dropping the accumulated fragments.",
+                    block.id,
+                    acc.type,
+                    block.type,
+                )
+                acc = None
+
+            if acc is None:
+                # Seed the accumulator with every field of the delta, so
+                # that the ones it does not accumulate are carried over.
+                fields = block.model_dump()
+                if isinstance(block, TextBlock):
+                    acc = _AccTextBlock(**{**fields, "text": []})
+                elif isinstance(block, ThinkingBlock):
+                    acc = _AccThinkingBlock(**{**fields, "thinking": []})
+                elif isinstance(block, ToolCallBlock):
+                    acc = _AccToolCallBlock(**{**fields, "input": []})
+                else:
+                    # ``source`` is not emptied here, ``append`` replaces
+                    # it with a byte accumulator for audio streams.
+                    acc = _AccDataBlock(**fields)
+                self._blocks[block.id] = acc
+
+            # The type check above guarantees the accumulator and the
+            # delta block are of the same kind.
+            acc.append(block)  # type: ignore[arg-type]
+
+        if chat_response.usage:
+            self.usage = chat_response.usage
+
+        return self
+
+    def build(self) -> ChatResponse:
+        """Join the fragments of every block into a final response."""
+        kwargs: dict[str, Any] = {}
+        if self.id is not None:
+            kwargs["id"] = self.id
+
+        return ChatResponse(
+            content=[_.build() for _ in self._blocks.values()],
+            is_last=True,
+            usage=self.usage,
+            finished_reason=self.finished_reason,
+            **kwargs,
+        )

--- a/tests/model_base_test.py
+++ b/tests/model_base_test.py
@@ -465,5 +465,284 @@ class ChatModelBaseCallTest(IsolatedAsyncioTestCase):
             ],
         )
 
+    # ------------------------------------------------------------------
+    # 7) stream with large tool call arguments — O(n) accumulation
+    # ------------------------------------------------------------------
+    async def test_stream_large_tool_call_linear_accumulation(
+        self,
+    ) -> None:
+        """A large tool call argument (simulating write_file with many
+        fragments) must be accumulated in O(n) time. We verify the
+        final accumulated content is correct with 10000 fragments."""
+        num_chunks = 10000
+        fragment = "x" * 100  # 100 chars per chunk
+
+        deltas = [
+            ChatResponse(
+                content=[
+                    ToolCallBlock(
+                        id="tool-big",
+                        name="write_file",
+                        input=fragment,
+                    ),
+                ],
+                is_last=False,
+                id=f"chunk-{i}",
+            )
+            for i in range(num_chunks)
+        ]
+        self.model.set_responses([deltas])
+
+        gen = await self.model(messages=self.messages)
+        last_chunk = None
+        async for chunk in gen:
+            last_chunk = chunk
+
+        self.assertDictEqual(
+            _dump(last_chunk),
+            _expected(
+                content=[
+                    {
+                        "type": "tool_call",
+                        "id": "tool-big",
+                        "name": "write_file",
+                        "input": fragment * num_chunks,
+                        "state": "pending",
+                        "suggested_rules": [],
+                    },
+                ],
+                is_last=True,
+                finished_reason=FinishedReason.COMPLETED,
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # 8) stream with is_last=True — no acc_res needed
+    # ------------------------------------------------------------------
+    async def test_stream_with_final_chunk_no_acc_res(self) -> None:
+        """When the model stream produces a final chunk with
+        is_last=True, acc_res should NOT be yielded (the model
+        provides the complete response itself)."""
+        deltas = [
+            ChatResponse(
+                content=[TextBlock(text="hello", id="t1")],
+                is_last=False,
+                id="chunk-1",
+            ),
+            ChatResponse(
+                content=[TextBlock(text=" world", id="t1")],
+                is_last=False,
+                id="chunk-2",
+            ),
+            # Model provides its own final complete response
+            ChatResponse(
+                content=[TextBlock(text="hello world", id="t1")],
+                is_last=True,
+                id="chunk-final",
+            ),
+        ]
+        self.model.set_responses([deltas])
+
+        gen = await self.model(messages=self.messages)
+        collected = [_dump(c) async for c in gen]
+
+        # Only 3 chunks: 2 deltas + 1 model-provided final
+        # (NOT 4 — no acc_res appended)
+        self.assertListEqual(
+            collected,
+            [
+                _expected(
+                    content=[
+                        {"type": "text", "text": "hello", "id": "t1"},
+                    ],
+                    is_last=False,
+                ),
+                _expected(
+                    content=[
+                        {
+                            "type": "text",
+                            "text": " world",
+                            "id": "t1",
+                        },
+                    ],
+                    is_last=False,
+                ),
+                _expected(
+                    content=[
+                        {
+                            "type": "text",
+                            "text": "hello world",
+                            "id": "t1",
+                        },
+                    ],
+                    is_last=True,
+                ),
+            ],
+        )
+
+    # ------------------------------------------------------------------
+    # 9) stream mixed block types — normal completion (happy path)
+    # ------------------------------------------------------------------
+    async def test_stream_mixed_blocks_normal_completion(self) -> None:
+        """Mixed block types (thinking + text + tool_call) in a
+        normal stream completion (no CancelledError). The final
+        accumulated response must contain all blocks in order with
+        correctly joined fragments."""
+        deltas = [
+            # thinking part 1
+            ChatResponse(
+                content=[
+                    ThinkingBlock(thinking="step 1: ", id="think-1"),
+                ],
+                is_last=False,
+                id="chunk-1",
+            ),
+            # thinking part 2
+            ChatResponse(
+                content=[
+                    ThinkingBlock(thinking="analyze", id="think-1"),
+                ],
+                is_last=False,
+                id="chunk-2",
+            ),
+            # text part 1
+            ChatResponse(
+                content=[TextBlock(text="I will ", id="text-1")],
+                is_last=False,
+                id="chunk-3",
+            ),
+            # text part 2
+            ChatResponse(
+                content=[TextBlock(text="help you", id="text-1")],
+                is_last=False,
+                id="chunk-4",
+            ),
+            # tool_call part 1
+            ChatResponse(
+                content=[
+                    ToolCallBlock(
+                        id="tool-1",
+                        name="search",
+                        input='{"query":',
+                    ),
+                ],
+                is_last=False,
+                id="chunk-5",
+            ),
+            # tool_call part 2
+            ChatResponse(
+                content=[
+                    ToolCallBlock(
+                        id="tool-1",
+                        name="search",
+                        input='"hello"}',
+                    ),
+                ],
+                is_last=False,
+                id="chunk-6",
+            ),
+        ]
+        self.model.set_responses([deltas])
+
+        gen = await self.model(messages=self.messages)
+        collected = [_dump(c) async for c in gen]
+
+        self.assertListEqual(
+            collected,
+            [
+                _expected(
+                    content=[
+                        {
+                            "type": "thinking",
+                            "thinking": "step 1: ",
+                            "id": "think-1",
+                        },
+                    ],
+                    is_last=False,
+                ),
+                _expected(
+                    content=[
+                        {
+                            "type": "thinking",
+                            "thinking": "analyze",
+                            "id": "think-1",
+                        },
+                    ],
+                    is_last=False,
+                ),
+                _expected(
+                    content=[
+                        {
+                            "type": "text",
+                            "text": "I will ",
+                            "id": "text-1",
+                        },
+                    ],
+                    is_last=False,
+                ),
+                _expected(
+                    content=[
+                        {
+                            "type": "text",
+                            "text": "help you",
+                            "id": "text-1",
+                        },
+                    ],
+                    is_last=False,
+                ),
+                _expected(
+                    content=[
+                        {
+                            "type": "tool_call",
+                            "id": "tool-1",
+                            "name": "search",
+                            "input": '{"query":',
+                            "state": "pending",
+                            "suggested_rules": [],
+                        },
+                    ],
+                    is_last=False,
+                ),
+                _expected(
+                    content=[
+                        {
+                            "type": "tool_call",
+                            "id": "tool-1",
+                            "name": "search",
+                            "input": '"hello"}',
+                            "state": "pending",
+                            "suggested_rules": [],
+                        },
+                    ],
+                    is_last=False,
+                ),
+                # accumulated final — all blocks merged
+                _expected(
+                    content=[
+                        {
+                            "type": "thinking",
+                            "thinking": "step 1: analyze",
+                            "id": "think-1",
+                        },
+                        {
+                            "type": "text",
+                            "text": "I will help you",
+                            "id": "text-1",
+                        },
+                        {
+                            "type": "tool_call",
+                            "id": "tool-1",
+                            "name": "search",
+                            "input": '{"query":"hello"}',
+                            "state": "pending",
+                            "suggested_rules": [],
+                        },
+                    ],
+                    is_last=True,
+                    finished_reason=FinishedReason.COMPLETED,
+                ),
+            ],
+        )
+
     async def asyncTearDown(self) -> None:
         """The async teardown method."""

--- a/tests/model_base_test.py
+++ b/tests/model_base_test.py
@@ -2,12 +2,21 @@
 """Unit tests for :class:`agentscope.model.ChatModelBase.__call__` — the
 retry / accumulation / interrupt wrapper around ``_call_api``."""
 import asyncio
+import base64
 from unittest.async_case import IsolatedAsyncioTestCase
 
 from utils import AnyString, MockModel
 
-from agentscope.message import TextBlock, ThinkingBlock, ToolCallBlock, UserMsg
-from agentscope.model import ChatResponse, FinishedReason
+from agentscope.message import (
+    Base64Source,
+    DataBlock,
+    TextBlock,
+    ThinkingBlock,
+    ToolCallBlock,
+    URLSource,
+    UserMsg,
+)
+from agentscope.model import ChatResponse, ChatUsage, FinishedReason
 
 
 def _dump(chat_response: ChatResponse) -> dict:
@@ -740,6 +749,316 @@ class ChatModelBaseCallTest(IsolatedAsyncioTestCase):
                     ],
                     is_last=True,
                     finished_reason=FinishedReason.COMPLETED,
+                ),
+            ],
+        )
+
+    # ------------------------------------------------------------------
+    # 10) stream audio data block — raw bytes joined, encoded once
+    # ------------------------------------------------------------------
+    async def test_stream_audio_data_block_accumulation(self) -> None:
+        """Audio deltas must accumulate as raw bytes. Joining the base64
+        strings instead would silently truncate at the first padded
+        fragment, so the decoded result is checked against the
+        concatenated raw bytes."""
+        raw = [b"ab", b"cd", b"ef"]  # each encodes to a '='-padded string
+        deltas = [
+            ChatResponse(
+                content=[
+                    DataBlock(
+                        id="audio-1",
+                        source=Base64Source(
+                            data=base64.b64encode(part).decode("ascii"),
+                            media_type="audio/wav",
+                        ),
+                        # Providers name the asset on the opening delta
+                        name="out.wav" if i == 0 else None,
+                    ),
+                ],
+                is_last=False,
+                id=f"chunk-{i}",
+            )
+            for i, part in enumerate(raw)
+        ]
+        self.model.set_responses([deltas])
+
+        gen = await self.model(messages=self.messages)
+        last_chunk = None
+        async for chunk in gen:
+            last_chunk = chunk
+
+        self.assertDictEqual(
+            _dump(last_chunk),
+            _expected(
+                content=[
+                    {
+                        "type": "data",
+                        "id": "audio-1",
+                        "source": {
+                            "type": "base64",
+                            "data": base64.b64encode(b"".join(raw)).decode(
+                                "ascii",
+                            ),
+                            "media_type": "audio/wav",
+                        },
+                        "name": "out.wav",
+                    },
+                ],
+                is_last=True,
+                finished_reason=FinishedReason.COMPLETED,
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # 11) stream non-audio data block — the latest delta wins
+    # ------------------------------------------------------------------
+    async def test_stream_non_audio_data_block_latest_wins(self) -> None:
+        """Non-audio media are standalone assets rather than streamable
+        deltas, so byte concatenation is meaningless and the latest
+        delta must replace the previous one."""
+        deltas = [
+            ChatResponse(
+                content=[
+                    DataBlock(
+                        id="img-1",
+                        source=Base64Source(
+                            data="AAAA",
+                            media_type="image/png",
+                        ),
+                    ),
+                ],
+                is_last=False,
+                id="chunk-1",
+            ),
+            ChatResponse(
+                content=[
+                    DataBlock(
+                        id="img-1",
+                        source=Base64Source(
+                            data="BBBB",
+                            media_type="image/png",
+                        ),
+                    ),
+                ],
+                is_last=False,
+                id="chunk-2",
+            ),
+            ChatResponse(
+                content=[
+                    DataBlock(
+                        id="url-1",
+                        source=URLSource(
+                            url="https://example.com/a.png",
+                            media_type="image/png",
+                        ),
+                    ),
+                ],
+                is_last=False,
+                id="chunk-3",
+            ),
+        ]
+        self.model.set_responses([deltas])
+
+        gen = await self.model(messages=self.messages)
+        last_chunk = None
+        async for chunk in gen:
+            last_chunk = chunk
+
+        self.assertDictEqual(
+            _dump(last_chunk),
+            _expected(
+                content=[
+                    {
+                        "type": "data",
+                        "id": "img-1",
+                        "source": {
+                            "type": "base64",
+                            "data": "BBBB",
+                            "media_type": "image/png",
+                        },
+                        "name": None,
+                    },
+                    {
+                        "type": "data",
+                        "id": "url-1",
+                        "source": {
+                            "type": "url",
+                            "url": "https://example.com/a.png",
+                            "media_type": "image/png",
+                        },
+                        "name": None,
+                    },
+                ],
+                is_last=True,
+                finished_reason=FinishedReason.COMPLETED,
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # 12) stream data block whose media type switches mid-stream
+    # ------------------------------------------------------------------
+    async def test_stream_data_block_media_type_switch(self) -> None:
+        """A media type change makes the accumulated fragments
+        incompatible with the incoming delta, so they are dropped and
+        the latest delta wins."""
+        deltas = [
+            ChatResponse(
+                content=[
+                    DataBlock(
+                        id="audio-1",
+                        source=Base64Source(
+                            data=base64.b64encode(b"old").decode("ascii"),
+                            media_type="audio/wav",
+                        ),
+                    ),
+                ],
+                is_last=False,
+                id="chunk-1",
+            ),
+            ChatResponse(
+                content=[
+                    DataBlock(
+                        id="audio-1",
+                        source=Base64Source(
+                            data=base64.b64encode(b"new").decode("ascii"),
+                            media_type="audio/mpeg",
+                        ),
+                    ),
+                ],
+                is_last=False,
+                id="chunk-2",
+            ),
+        ]
+        self.model.set_responses([deltas])
+
+        gen = await self.model(messages=self.messages)
+        last_chunk = None
+        async for chunk in gen:
+            last_chunk = chunk
+
+        self.assertDictEqual(
+            _dump(last_chunk),
+            _expected(
+                content=[
+                    {
+                        "type": "data",
+                        "id": "audio-1",
+                        "source": {
+                            "type": "base64",
+                            "data": base64.b64encode(b"new").decode("ascii"),
+                            "media_type": "audio/mpeg",
+                        },
+                        "name": None,
+                    },
+                ],
+                is_last=True,
+                finished_reason=FinishedReason.COMPLETED,
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # 13) stream thinking whose signature arrives on the closing delta
+    # ------------------------------------------------------------------
+    async def test_stream_thinking_signature_on_closing_delta(self) -> None:
+        """Provider-specific extras (e.g. Anthropic's ``signature``) are
+        often emitted only on the closing delta and must survive into
+        the accumulated block."""
+        deltas = [
+            ChatResponse(
+                content=[ThinkingBlock(thinking="step ", id="think-1")],
+                is_last=False,
+                id="chunk-1",
+            ),
+            ChatResponse(
+                content=[ThinkingBlock(thinking="one", id="think-1")],
+                is_last=False,
+                id="chunk-2",
+            ),
+            ChatResponse(
+                content=[
+                    ThinkingBlock(
+                        thinking="",
+                        id="think-1",
+                        signature="sig-abc",
+                    ),
+                ],
+                is_last=False,
+                id="chunk-3",
+            ),
+        ]
+        self.model.set_responses([deltas])
+
+        gen = await self.model(messages=self.messages)
+        last_chunk = None
+        async for chunk in gen:
+            last_chunk = chunk
+
+        self.assertDictEqual(
+            _dump(last_chunk),
+            _expected(
+                content=[
+                    {
+                        "type": "thinking",
+                        "thinking": "step one",
+                        "id": "think-1",
+                        "signature": "sig-abc",
+                    },
+                ],
+                is_last=True,
+                finished_reason=FinishedReason.COMPLETED,
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # 14) stream usage carried by a trailing usage-only chunk
+    # ------------------------------------------------------------------
+    async def test_stream_usage_absorbed_into_accumulated(self) -> None:
+        """OpenAI-compatible APIs emit a trailing usage-only chunk with
+        no content. It must not be surfaced to the consumer, but its
+        usage must land on the accumulated response."""
+        deltas = [
+            ChatResponse(
+                content=[TextBlock(text="hello", id="t1")],
+                is_last=False,
+                id="chunk-1",
+            ),
+            ChatResponse(
+                content=[],
+                is_last=False,
+                id="chunk-2",
+                usage=ChatUsage(input_tokens=3, output_tokens=7, time=0.5),
+            ),
+        ]
+        self.model.set_responses([deltas])
+
+        gen = await self.model(messages=self.messages)
+        collected = [_dump(c) async for c in gen]
+
+        # The usage-only carrier chunk is absorbed, not forwarded
+        self.assertListEqual(
+            collected,
+            [
+                _expected(
+                    content=[
+                        {"type": "text", "text": "hello", "id": "t1"},
+                    ],
+                    is_last=False,
+                ),
+                _expected(
+                    content=[
+                        {"type": "text", "text": "hello", "id": "t1"},
+                    ],
+                    is_last=True,
+                    finished_reason=FinishedReason.COMPLETED,
+                    usage={
+                        "input_tokens": 3,
+                        "output_tokens": 7,
+                        "time": 0.5,
+                        "cache_creation_input_tokens": 0,
+                        "cache_input_tokens": 0,
+                        "type": "chat",
+                        "metadata": None,
+                    },
                 ),
             ],
         )


### PR DESCRIPTION
## AgentScope Version

2.4.0.post1

## Description

During streaming, `ChatModelBase.__call__` accumulated tool call arguments, text, and thinking content via repeated `block.input += delta` string concatenation. For large payloads (e.g. a write_file tool call with 100k+ lines of argument), this results in O(n²) memory allocation and CPU usage, which can block the event loop long enough to cause upstream HTTP connection drops (ref: QwenPaw #6314).

This PR replaces the accumulation strategy with fragment lists (`list[str]`) that are joined once via `"".join()` when the stream completes or is interrupted, reducing complexity to O(n).

Changes:
- `_stream()` and `_call_api_with_structured_output()` now use `_collect_chunk_fragments()` + `_build_acc_response()` instead of `ChatResponse.append_chat_response()`
- `append_chat_response()` is marked deprecated (retained for backward compatibility)
- Removed dead `model_extra` handling for `ToolCallBlock` (which lacks `extra="allow"`)
- Added tests for large tool call accumulation, mixed block types, and model-provided final chunk scenarios

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review