### PR TITLE
feat(tool): complete PowerShell permission checks and rule matching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "aiofiles",
     "tree_sitter",
     "tree_sitter_bash",
+    "tree_sitter_pwsh",
     "jsonschema",
     # The IANA timezone database, which is absent on Windows and slim images
     "tzdata",

--- a/src/agentscope/tool/_builtin/_bash.py
+++ b/src/agentscope/tool/_builtin/_bash.py
@@ -2,9 +2,9 @@
 """The bash tool in agentscope."""
 import os
 from typing import AsyncGenerator, Any, List
-import re
 
 from ._bash_parser import BashCommandParser
+from ._wildcard_match import match_wildcard_pattern
 from .._base import ToolBase, ToolMiddlewareBase
 from .._constants import (
     DEFAULT_DANGEROUS_FILES,
@@ -421,74 +421,7 @@ easier to review tool calls and give permission.
             return True
 
         command = tool_input.get("command", "")
-
-        # Check if pattern is a prefix pattern (ends with :*)
-        if rule_content.endswith(":*"):
-            prefix = rule_content[:-2].strip()
-            return command.startswith(prefix + " ") or command == prefix
-
-        # Check if pattern has unescaped wildcards
-        def has_wildcards(pattern: str) -> bool:
-            """Check if pattern contains unescaped * wildcards."""
-            i = 0
-            while i < len(pattern):
-                if pattern[i] == "\\":
-                    i += 2  # Skip escaped character
-                elif pattern[i] == "*":
-                    return True
-                else:
-                    i += 1
-            return False
-
-        if not has_wildcards(rule_content):
-            # No wildcards, but may have escape sequences
-            # Convert escape sequences for matching
-            pattern = rule_content
-            pattern = pattern.replace("\\\\", "\x00BACKSLASH\x00")
-            pattern = pattern.replace("\\*", "*")
-            pattern = pattern.replace("\x00BACKSLASH\x00", "\\")
-            # Use substring matching with converted pattern
-            return pattern in command
-
-        # Convert wildcard pattern to regex with escape handling
-        # Use placeholders for escaped sequences
-        ESCAPED_STAR = "\x00ESCAPED_STAR\x00"
-        ESCAPED_BACKSLASH = "\x00ESCAPED_BACKSLASH\x00"
-
-        pattern = rule_content
-        # Replace \\ with placeholder
-        pattern = pattern.replace("\\\\", ESCAPED_BACKSLASH)
-        # Replace \* with placeholder
-        pattern = pattern.replace("\\*", ESCAPED_STAR)
-
-        # Manually escape regex special characters (except *)
-        # Don't use re.escape() as it escapes spaces too
-        special_chars = r".^$+?{}[]|()"
-        for char in special_chars:
-            pattern = pattern.replace(char, "\\" + char)
-
-        # Convert * to regex .* (match any characters)
-        pattern = pattern.replace("*", ".*")
-
-        # Restore escaped sequences
-        pattern = pattern.replace(ESCAPED_STAR, r"\*")
-        pattern = pattern.replace(ESCAPED_BACKSLASH, r"\\")
-
-        # Special optimization: "git *" should match both "git" and "git add"
-        # Pattern: if ends with .*, make it optional
-        if pattern.endswith(".*"):
-            base_pattern = pattern[:-2]  # Remove .*
-            # Try exact match first (handles trailing space)
-            base_pattern = base_pattern.rstrip()
-            if re.fullmatch(base_pattern, command):
-                return True
-
-        # Full regex match
-        try:
-            return bool(re.fullmatch(pattern, command))
-        except re.error:
-            # Invalid regex, fall back to substring matching
-            return rule_content.replace("*", "") in command
+        return match_wildcard_pattern(rule_content, command)
 
     async def generate_suggestions(
         self,

--- a/src/agentscope/tool/_builtin/_powershell.py
+++ b/src/agentscope/tool/_builtin/_powershell.py
@@ -3,9 +3,11 @@
 
 import base64
 import os
+import re
 from typing import AsyncGenerator, Any, List
 
 from ._backend import BackendBase, LocalBackend, _normalize_newlines
+from ._powershell_parser import PowerShellCommandParser
 from .._base import ToolBase, ToolMiddlewareBase
 from .._response import ToolChunk
 from ...message import TextBlock, ToolResultState
@@ -113,6 +115,7 @@ are easier for the user to review and authorize:
         self._cwd = os.fspath(cwd) if cwd is not None else None
         self._backend = backend or LocalBackend()
         self._executable: str | None = None
+        self._powershell_parser = PowerShellCommandParser()
 
     async def _resolve_executable(self) -> str:
         """Prefer PowerShell 6+ and cache the first available executable."""
@@ -136,34 +139,220 @@ are easier for the user to review and authorize:
                 self._executable = "powershell.exe"
         return self._executable
 
+    async def check_read_only(
+        self,
+        tool_input: dict[str, Any],
+    ) -> bool:
+        """Decide whether this PowerShell invocation is read-only.
+
+        Inspects the command and returns ``True`` for known-safe read-only
+        cmdlets (e.g. ``Get-ChildItem``, ``Test-Path``, ``ls``). The static
+        :attr:`is_read_only` class attribute remains ``False`` because
+        PowerShell can execute arbitrary commands; this method overrides
+        that with a per-invocation answer.
+        """
+        command = tool_input.get("command", "")
+        if not command:
+            return self.is_read_only
+        # Dynamic / unanalyzable structure cannot be proven read-only —
+        # e.g. ``Get-ChildItem $(Remove-Item -Recurse C:\\)``.
+        if self._powershell_parser.check_injection_risk(command):
+            return False
+        return self._powershell_parser.is_read_only_command(command)
+
     async def check_permissions(
         self,
         tool_input: dict[str, Any],
         context: PermissionContext,
     ) -> PermissionDecision:
-        """Ask the user to confirm every PowerShell command.
+        """Check permissions for PowerShell command execution.
 
-        PowerShell-specific command validation is intentionally outside this
-        implementation. Since no command is classified as safe, every
-        invocation prompts the user. This is a regular ASK that allow rules
-        and BYPASS mode may still override.
+        Implements Bash-style tiered checks:
+
+        0. Injection risk (bypass-immune safety ASK)
+        1. Read-only command auto-ALLOW
+        2. Dangerous command patterns (bypass-immune safety ASK)
+        3. PASSTHROUGH for the permission engine
+
+        Args:
+            tool_input (`dict[str, Any]`):
+                Tool input containing a ``command`` key.
+            context (`PermissionContext`):
+                Permission context with mode and rules.
+
+        Returns:
+            `PermissionDecision`:
+                ALLOW, ASK (possibly bypass-immune), or PASSTHROUGH.
         """
-        return PermissionDecision(
-            behavior=PermissionBehavior.ASK,
-            message="Execute PowerShell command",
-            decision_reason="PowerShell command validation is not enabled",
+        command = tool_input.get("command", "")
+        if not command:
+            return PermissionDecision(
+                behavior=PermissionBehavior.PASSTHROUGH,
+                message="Empty command",
+            )
+
+        injection_reason = self._powershell_parser.check_injection_risk(
+            command,
         )
+        if injection_reason:
+            return PermissionDecision(
+                behavior=PermissionBehavior.ASK,
+                message=f"Permission required: {injection_reason}",
+                decision_reason=(
+                    "Safety check: command contains dynamic expansion "
+                    "that cannot be statically analyzed"
+                ),
+                bypass_immune=True,
+            )
+
+        if self._powershell_parser.is_read_only_command(command):
+            return PermissionDecision(
+                behavior=PermissionBehavior.ALLOW,
+                message="Permission granted for read-only command",
+                decision_reason="Read-only command is allowed",
+            )
+
+        dangerous_pattern = self._powershell_parser.check_dangerous_command(
+            command,
+        )
+        if dangerous_pattern:
+            return PermissionDecision(
+                behavior=PermissionBehavior.ASK,
+                message=(
+                    "Permission required: Command contains dangerous "
+                    f"pattern: {dangerous_pattern}"
+                ),
+                decision_reason=(
+                    "Safety check: dangerous command pattern detected"
+                ),
+                bypass_immune=True,
+            )
+
+        return PermissionDecision(
+            behavior=PermissionBehavior.PASSTHROUGH,
+            message="PowerShell permission check passed",
+        )
+
+    async def match_rule(
+        self,
+        rule_content: str | None,
+        tool_input: dict[str, Any],
+    ) -> bool:
+        r"""Match PowerShell commands with Bash-compatible wildcards.
+
+        Pattern grammar matches Bash, with PowerShell-specific extras:
+
+        - Case-insensitive matching
+        - Alias normalization (``ls`` matches ``Get-ChildItem*``)
+        - ``:*`` prefix patterns, ``*`` wildcards, and substring match
+        - ``None`` rule content matches all invocations
+
+        Args:
+            rule_content (`str | None`):
+                Command pattern to match, or ``None`` for tool-name rules.
+            tool_input (`dict[str, Any]`):
+                Must contain a ``command`` key.
+
+        Returns:
+            `bool`:
+                ``True`` when the pattern matches the command.
+        """
+        if rule_content is None:
+            return True
+
+        command = tool_input.get("command", "")
+        command = self._powershell_parser.normalize_command_for_match(command)
+        pattern_source = self._powershell_parser.normalize_command_for_match(
+            rule_content,
+        )
+        command_cf = command.casefold()
+        rule_cf = pattern_source.casefold()
+
+        if rule_cf.endswith(":*"):
+            prefix = rule_cf[:-2].strip()
+            return command_cf.startswith(prefix + " ") or command_cf == prefix
+
+        def has_wildcards(pattern: str) -> bool:
+            """Check if pattern contains unescaped * wildcards."""
+            i = 0
+            while i < len(pattern):
+                if pattern[i] == "\\":
+                    i += 2
+                elif pattern[i] == "*":
+                    return True
+                else:
+                    i += 1
+            return False
+
+        if not has_wildcards(rule_cf):
+            pattern = rule_cf
+            pattern = pattern.replace("\\\\", "\x00BACKSLASH\x00")
+            pattern = pattern.replace("\\*", "*")
+            pattern = pattern.replace("\x00BACKSLASH\x00", "\\")
+            return pattern in command_cf
+
+        escaped_star = "\x00ESCAPED_STAR\x00"
+        escaped_backslash = "\x00ESCAPED_BACKSLASH\x00"
+
+        pattern = rule_cf
+        pattern = pattern.replace("\\\\", escaped_backslash)
+        pattern = pattern.replace("\\*", escaped_star)
+
+        special_chars = r".^$+?{}[]|()"
+        for char in special_chars:
+            pattern = pattern.replace(char, "\\" + char)
+
+        pattern = pattern.replace("*", ".*")
+        pattern = pattern.replace(escaped_star, r"\*")
+        pattern = pattern.replace(escaped_backslash, r"\\")
+
+        if pattern.endswith(".*"):
+            base_pattern = pattern[:-2].rstrip()
+            if re.fullmatch(base_pattern, command_cf):
+                return True
+
+        try:
+            return bool(re.fullmatch(pattern, command_cf))
+        except re.error:
+            return rule_cf.replace("*", "") in command_cf
 
     async def generate_suggestions(
         self,
         tool_input: dict[str, Any],
     ) -> List[PermissionRule]:
-        """Return no automatic allow-rule suggestions.
+        """Generate cmdlet prefix allow-rule suggestions.
 
-        A broad rule would weaken the conservative permission boundary before
-        PowerShell-specific command validation is available.
+        Produces rules such as ``Remove-Item:*`` from the command's
+        alias-normalized cmdlet names.
+
+        Args:
+            tool_input (`dict[str, Any]`):
+                Tool input containing a ``command`` key.
+
+        Returns:
+            `List[PermissionRule]`:
+                Suggested allow rules for the current command.
         """
-        return []
+        command = tool_input.get("command", "")
+        if not command:
+            return []
+
+        prefixes = self._powershell_parser.extract_command_prefixes(
+            command,
+            max_prefixes=5,
+        )
+        if not prefixes:
+            return []
+
+        return [
+            PermissionRule(
+                tool_name="PowerShell",
+                rule_content=f"{prefix}:*",
+                behavior=PermissionBehavior.ALLOW,
+                source="suggested",
+            )
+            for prefix in prefixes
+        ]
 
     async def call(  # type: ignore[override] # pylint: disable=unused-argument
         self,

--- a/src/agentscope/tool/_builtin/_powershell.py
+++ b/src/agentscope/tool/_builtin/_powershell.py
@@ -3,11 +3,11 @@
 
 import base64
 import os
-import re
 from typing import AsyncGenerator, Any, List
 
 from ._backend import BackendBase, LocalBackend, _normalize_newlines
 from ._powershell_parser import PowerShellCommandParser
+from ._wildcard_match import match_wildcard_pattern
 from .._base import ToolBase, ToolMiddlewareBase
 from .._response import ToolChunk
 from ...message import TextBlock, ToolResultState
@@ -244,7 +244,7 @@ are easier for the user to review and authorize:
 
         - Case-insensitive matching
         - Alias normalization (``ls`` matches ``Get-ChildItem*``)
-        - ``:*`` prefix patterns, ``*`` wildcards, and substring match
+        - ``:*`` prefix patterns require every pipeline segment to match
         - ``None`` rule content matches all invocations
 
         Args:
@@ -261,60 +261,25 @@ are easier for the user to review and authorize:
             return True
 
         command = tool_input.get("command", "")
-        command = self._powershell_parser.normalize_command_for_match(command)
-        pattern_source = self._powershell_parser.normalize_command_for_match(
+        rule_cf = self._powershell_parser.normalize_command_for_match(
             rule_content,
-        )
-        command_cf = command.casefold()
-        rule_cf = pattern_source.casefold()
+        ).casefold()
 
         if rule_cf.endswith(":*"):
-            prefix = rule_cf[:-2].strip()
-            return command_cf.startswith(prefix + " ") or command_cf == prefix
+            prefix = self._powershell_parser.normalize_cmdlet_name(
+                rule_cf[:-2].strip(),
+            ).casefold()
+            names = self._powershell_parser.extract_canonical_command_names(
+                command,
+            )
+            if not names:
+                return False
+            return all(name.casefold() == prefix for name in names)
 
-        def has_wildcards(pattern: str) -> bool:
-            """Check if pattern contains unescaped * wildcards."""
-            i = 0
-            while i < len(pattern):
-                if pattern[i] == "\\":
-                    i += 2
-                elif pattern[i] == "*":
-                    return True
-                else:
-                    i += 1
-            return False
-
-        if not has_wildcards(rule_cf):
-            pattern = rule_cf
-            pattern = pattern.replace("\\\\", "\x00BACKSLASH\x00")
-            pattern = pattern.replace("\\*", "*")
-            pattern = pattern.replace("\x00BACKSLASH\x00", "\\")
-            return pattern in command_cf
-
-        escaped_star = "\x00ESCAPED_STAR\x00"
-        escaped_backslash = "\x00ESCAPED_BACKSLASH\x00"
-
-        pattern = rule_cf
-        pattern = pattern.replace("\\\\", escaped_backslash)
-        pattern = pattern.replace("\\*", escaped_star)
-
-        special_chars = r".^$+?{}[]|()"
-        for char in special_chars:
-            pattern = pattern.replace(char, "\\" + char)
-
-        pattern = pattern.replace("*", ".*")
-        pattern = pattern.replace(escaped_star, r"\*")
-        pattern = pattern.replace(escaped_backslash, r"\\")
-
-        if pattern.endswith(".*"):
-            base_pattern = pattern[:-2].rstrip()
-            if re.fullmatch(base_pattern, command_cf):
-                return True
-
-        try:
-            return bool(re.fullmatch(pattern, command_cf))
-        except re.error:
-            return rule_cf.replace("*", "") in command_cf
+        command_cf = self._powershell_parser.normalize_command_for_match(
+            command,
+        ).casefold()
+        return match_wildcard_pattern(rule_cf, command_cf)
 
     async def generate_suggestions(
         self,

--- a/src/agentscope/tool/_builtin/_powershell_parser.py
+++ b/src/agentscope/tool/_builtin/_powershell_parser.py
@@ -1,0 +1,536 @@
+# -*- coding: utf-8 -*-
+"""PowerShell command parser using tree-sitter for permission checks.
+
+Mirrors :class:`BashCommandParser` method surface for PowerShell:
+- Read-only command classification
+- Dangerous command detection
+- Injection / unanalyzable structure detection
+- Command prefix extraction for allow-rule suggestions
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterator, List, Optional, Set
+
+import tree_sitter_pwsh as tspwsh
+from tree_sitter import Language, Node, Parser
+
+from .._constants import (
+    POWERSHELL_ALIASES,
+    POWERSHELL_DANGEROUS_COMMANDS,
+    POWERSHELL_INJECTION_NODE_TYPES,
+    POWERSHELL_READ_ONLY_COMMANDS,
+    POWERSHELL_READ_ONLY_VERB_PREFIXES,
+)
+
+
+class PowerShellCommandParser:
+    """Parse PowerShell commands using tree-sitter for safety checks."""
+
+    def __init__(self) -> None:
+        """Initialize the parser with the tree-sitter-pwsh language."""
+        self.parser = Parser(Language(tspwsh.language()))
+        self._alias_lookup = {
+            key.casefold(): value for key, value in POWERSHELL_ALIASES.items()
+        }
+        self._readonly_lookup = {
+            name.casefold(): name for name in POWERSHELL_READ_ONLY_COMMANDS
+        }
+        self._dangerous_lookup = {
+            name.casefold(): name for name in POWERSHELL_DANGEROUS_COMMANDS
+        }
+
+    def normalize_cmdlet_name(self, name: str) -> str:
+        """Resolve aliases to canonical cmdlet names (case-insensitive).
+
+        Args:
+            name (`str`):
+                Raw command name or alias from the source text.
+
+        Returns:
+            `str`:
+                Canonical cmdlet name when known, otherwise the original
+                name with PowerShell-style casing preserved when possible.
+        """
+        stripped = name.strip()
+        if not stripped:
+            return stripped
+        alias_target = self._alias_lookup.get(stripped.casefold())
+        if alias_target is not None:
+            return alias_target
+        readonly = self._readonly_lookup.get(stripped.casefold())
+        if readonly is not None:
+            return readonly
+        dangerous = self._dangerous_lookup.get(stripped.casefold())
+        if dangerous is not None:
+            return dangerous
+        return stripped
+
+    def normalize_command_for_match(self, command: str) -> str:
+        """Alias-normalize the leading cmdlet of each pipeline segment.
+
+        Used by permission rule matching so that ``Get-ChildItem*`` also
+        matches ``ls``.
+
+        Args:
+            command (`str`):
+                Raw PowerShell command text.
+
+        Returns:
+            `str`:
+                Command text with leading aliases expanded where practical.
+        """
+        if not command.strip():
+            return command
+
+        try:
+            tree = self.parser.parse(bytes(command, "utf8"))
+        except Exception:
+            return self._normalize_command_fallback(command)
+
+        replacements: list[tuple[int, int, str]] = []
+        for node in self._iter_nodes(tree.root_node):
+            if node.type != "command":
+                continue
+            name_node = self._command_name_node(node)
+            if name_node is None:
+                continue
+            raw = command[name_node.start_byte : name_node.end_byte]
+            canonical = self.normalize_cmdlet_name(raw)
+            if canonical != raw:
+                replacements.append(
+                    (name_node.start_byte, name_node.end_byte, canonical),
+                )
+
+        if not replacements:
+            return command
+
+        parts: list[str] = []
+        cursor = 0
+        for start, end, text in sorted(replacements):
+            parts.append(command[cursor:start])
+            parts.append(text)
+            cursor = end
+        parts.append(command[cursor:])
+        return "".join(parts)
+
+    def is_read_only_command(self, command: str) -> bool:
+        """Check whether a PowerShell command is read-only.
+
+        Pipelines and statement lists require every command segment to be
+        read-only. Script blocks, call operators, redirections, and
+        injection-risk structures are never treated as read-only.
+
+        Args:
+            command (`str`):
+                The PowerShell command string.
+
+        Returns:
+            `bool`:
+                ``True`` when the command is classified as read-only.
+        """
+        cmd = command.strip()
+        if not cmd:
+            return False
+
+        if self.check_injection_risk(cmd):
+            return False
+
+        try:
+            tree = self.parser.parse(bytes(cmd, "utf8"))
+            root = tree.root_node
+        except Exception:
+            return False
+
+        if self._has_error_nodes(root):
+            return False
+
+        if self._contains_node_types(
+            root,
+            {
+                "redirection",
+                "script_block_expression",
+                "script_block",
+                "command_invocation_operator",
+            },
+        ):
+            return False
+
+        commands = self._extract_command_nodes(root)
+        if not commands:
+            return False
+
+        for cmd_node in commands:
+            if not self._is_single_command_read_only(cmd, cmd_node):
+                return False
+        return True
+
+    def check_dangerous_command(self, command: str) -> Optional[str]:
+        """Detect dangerous PowerShell patterns that need an ASK.
+
+        Args:
+            command (`str`):
+                The PowerShell command to inspect.
+
+        Returns:
+            `Optional[str]`:
+                Matched dangerous pattern label, or ``None``.
+        """
+        cmd = command.strip()
+        if not cmd:
+            return None
+
+        try:
+            tree = self.parser.parse(bytes(cmd, "utf8"))
+            root = tree.root_node
+        except Exception:
+            return "unparseable PowerShell command"
+
+        # Prefer the more specific download-to-iex label when both apply.
+        download_pattern = self._check_download_to_iex(cmd, root)
+        if download_pattern:
+            return download_pattern
+
+        # Always-dangerous cmdlets (exact name match after alias normalize)
+        for cmd_node in self._extract_command_nodes(root):
+            name = self._command_name_text(cmd, cmd_node)
+            if not name:
+                continue
+            canonical = self.normalize_cmdlet_name(name)
+            folded = canonical.casefold()
+            if folded in self._dangerous_lookup:
+                return self._dangerous_lookup[folded]
+
+            params = self._command_parameters(cmd, cmd_node)
+            param_fold = {p.casefold() for p in params}
+
+            if folded == "remove-item" and (
+                "-recurse" in param_fold or "-force" in param_fold
+            ):
+                return "Remove-Item -Recurse/-Force"
+
+            if folded == "stop-process" and "-force" in param_fold:
+                return "Stop-Process -Force"
+
+            if folded == "set-itemproperty" and self._mentions_hklm(
+                cmd,
+                cmd_node,
+            ):
+                return "Set-ItemProperty HKLM:"
+
+        # Textual fallback for always-dangerous names that may appear
+        # oddly tokenized
+        normalized = " ".join(cmd.split())
+        for pattern in POWERSHELL_DANGEROUS_COMMANDS:
+            if re.search(
+                r"(?i)\b" + re.escape(pattern) + r"\b",
+                normalized,
+            ):
+                return pattern
+            alias_hit = self._alias_for_canonical(pattern)
+            for alias in alias_hit:
+                if re.search(
+                    r"(?i)\b" + re.escape(alias) + r"\b",
+                    normalized,
+                ):
+                    return pattern
+
+        return None
+
+    def check_injection_risk(self, command: str) -> Optional[str]:
+        """Detect structures that cannot be statically analyzed.
+
+        Args:
+            command (`str`):
+                The PowerShell command to inspect.
+
+        Returns:
+            `Optional[str]`:
+                Reason string when review is required, otherwise ``None``.
+        """
+        cmd = command.strip()
+        if not cmd:
+            return None
+
+        # Heuristics that do not require a clean AST
+        if re.search(r"(?i)(^|[\s|;])-EncodedCommand\b", cmd):
+            return (
+                "Command contains -EncodedCommand which cannot be "
+                "statically analyzed"
+            )
+        if self._has_backtick_obfuscation(cmd):
+            return (
+                "Command contains backtick obfuscation which cannot be "
+                "statically analyzed"
+            )
+        if self._has_string_built_cmdlet(cmd):
+            return (
+                "Command builds cmdlet names dynamically which cannot be "
+                "statically analyzed"
+            )
+
+        try:
+            tree = self.parser.parse(bytes(cmd, "utf8"))
+            root = tree.root_node
+        except Exception:
+            return "Command parsing failed, cannot verify safety"
+
+        if self._has_error_nodes(root):
+            return "Command parsing failed, cannot verify safety"
+
+        reason = self._walk_for_injection_nodes(root)
+        if reason:
+            return reason
+
+        # Call operator / dot-sourcing on dynamic targets
+        for cmd_node in self._extract_command_nodes(root):
+            if self._has_child_type(cmd_node, "command_invocation_operator"):
+                return (
+                    "Command contains call operator (&/.) which cannot be "
+                    "statically analyzed"
+                )
+            name = self._command_name_text(cmd, cmd_node)
+            if name and self.normalize_cmdlet_name(name).casefold() == (
+                "invoke-expression"
+            ):
+                return (
+                    "Command contains Invoke-Expression which cannot be "
+                    "statically analyzed"
+                )
+
+        return None
+
+    def extract_command_prefixes(
+        self,
+        command: str,
+        max_prefixes: int = 5,
+    ) -> List[str]:
+        """Extract cmdlet prefixes for allow-rule suggestions.
+
+        Returns canonical cmdlet names (alias-normalized). Read-only
+        cmdlets that auto-ALLOW are omitted, matching Bash's treatment of
+        safe commands.
+
+        Args:
+            command (`str`):
+                PowerShell command text (may include pipelines).
+            max_prefixes (`int`):
+                Maximum number of prefixes to return.
+
+        Returns:
+            `List[str]`:
+                Deduplicated cmdlet prefixes such as ``["Remove-Item"]``.
+        """
+        if not command or not command.strip():
+            return []
+
+        try:
+            tree = self.parser.parse(bytes(command, "utf8"))
+            root = tree.root_node
+        except Exception:
+            return []
+
+        prefixes: list[str] = []
+        seen: Set[str] = set()
+        for cmd_node in self._extract_command_nodes(root):
+            name = self._command_name_text(command, cmd_node)
+            if not name:
+                continue
+            canonical = self.normalize_cmdlet_name(name)
+            if self._is_readonly_cmdlet_name(canonical):
+                continue
+            key = canonical.casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            prefixes.append(canonical)
+            if len(prefixes) >= max_prefixes:
+                break
+        return prefixes
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _normalize_command_fallback(self, command: str) -> str:
+        """Token-based alias normalization when parsing fails."""
+        tokens = command.split(None, 1)
+        if not tokens:
+            return command
+        canonical = self.normalize_cmdlet_name(tokens[0])
+        if len(tokens) == 1:
+            return canonical
+        return f"{canonical} {tokens[1]}"
+
+    def _is_single_command_read_only(
+        self,
+        source: str,
+        cmd_node: Node,
+    ) -> bool:
+        """Classify one AST ``command`` node as read-only or not."""
+        if self._has_child_type(cmd_node, "command_invocation_operator"):
+            return False
+        if self._contains_node_types(
+            cmd_node,
+            {"script_block_expression", "script_block", "redirection"},
+        ):
+            return False
+
+        name = self._command_name_text(source, cmd_node)
+        if not name:
+            return False
+        return self._is_readonly_cmdlet_name(self.normalize_cmdlet_name(name))
+
+    def _is_readonly_cmdlet_name(self, name: str) -> bool:
+        """Return whether a canonical cmdlet name is read-only."""
+        folded = name.casefold()
+        if folded in self._readonly_lookup:
+            return True
+        for prefix in POWERSHELL_READ_ONLY_VERB_PREFIXES:
+            if folded.startswith(prefix.casefold()):
+                return True
+        return False
+
+    def _command_name_node(self, cmd_node: Node) -> Optional[Node]:
+        """Return the name node for a command AST node."""
+        for child in cmd_node.children:
+            if child.type in {"command_name", "command_name_expr"}:
+                return child
+        return None
+
+    def _command_name_text(self, source: str, cmd_node: Node) -> Optional[str]:
+        """Extract the command name text from a command node."""
+        name_node = self._command_name_node(cmd_node)
+        if name_node is None:
+            return None
+        return source[name_node.start_byte : name_node.end_byte].strip()
+
+    def _command_parameters(self, source: str, cmd_node: Node) -> list[str]:
+        """Collect ``command_parameter`` texts for a command node."""
+        params: list[str] = []
+        for node in self._iter_nodes(cmd_node):
+            if node.type == "command_parameter":
+                params.append(source[node.start_byte : node.end_byte])
+        return params
+
+    def _mentions_hklm(self, source: str, cmd_node: Node) -> bool:
+        """Return whether a command node references an HKLM path."""
+        text = source[cmd_node.start_byte : cmd_node.end_byte]
+        return bool(re.search(r"(?i)\bHKLM:", text))
+
+    def _check_download_to_iex(
+        self,
+        source: str,
+        root: Node,
+    ) -> Optional[str]:
+        """Detect download-to-iex patterns such as ``irm ... | iex``."""
+        normalized = " ".join(source.split())
+        if re.search(
+            r"(?i)\b(irm|iwr|Invoke-RestMethod|Invoke-WebRequest)\b.*"
+            r"\|\s*(iex|Invoke-Expression)\b",
+            normalized,
+        ):
+            return "download-to-iex"
+        if re.search(
+            r"(?i)\b(iex|Invoke-Expression)\b\s*\(.*\b"
+            r"(irm|iwr|Invoke-RestMethod|Invoke-WebRequest)\b",
+            normalized,
+        ):
+            return "download-to-iex"
+
+        # Also catch adjacent pipeline commands via AST
+        names = [
+            self.normalize_cmdlet_name(n).casefold()
+            for n in (
+                self._command_name_text(source, node)
+                for node in self._extract_command_nodes(root)
+            )
+            if n
+        ]
+        download = {
+            "invoke-restmethod",
+            "invoke-webrequest",
+        }
+        if any(n in download for n in names) and any(
+            n == "invoke-expression" for n in names
+        ):
+            return "download-to-iex"
+        return None
+
+    def _alias_for_canonical(self, canonical: str) -> list[str]:
+        """Return aliases that map to ``canonical``."""
+        target = canonical.casefold()
+        return [
+            alias
+            for alias, name in POWERSHELL_ALIASES.items()
+            if name.casefold() == target
+        ]
+
+    def _has_backtick_obfuscation(self, command: str) -> bool:
+        """Detect backtick-obfuscated command text."""
+        # e.g. Inv`oke-Expression or Get`-ChildItem
+        if re.search(r"[A-Za-z]`+[A-Za-z]", command):
+            return True
+        # Many backticks are a strong obfuscation signal
+        return command.count("`") >= 3
+
+    def _has_string_built_cmdlet(self, command: str) -> bool:
+        """Detect string-concatenated / expandable cmdlet names."""
+        # & ("Get-" + "ChildItem") or & "Get-$verb"
+        if re.search(
+            r"""(?i)&\s*[\(\"'].*(?:\+|\$)""",
+            command,
+        ):
+            return True
+        return bool(
+            re.search(
+                r"""(?i)\.\s*[\(\"'].*(?:\+|\$)""",
+                command,
+            ),
+        )
+
+    def _walk_for_injection_nodes(self, node: Node) -> Optional[str]:
+        """Walk the AST for injection-related node types."""
+        if node.type in POWERSHELL_INJECTION_NODE_TYPES:
+            return (
+                f"Command contains {node.type} which cannot be "
+                f"statically analyzed"
+            )
+        for child in node.children:
+            result = self._walk_for_injection_nodes(child)
+            if result:
+                return result
+        return None
+
+    def _extract_command_nodes(self, root: Node) -> list[Node]:
+        """Collect all ``command`` nodes under ``root``."""
+        return [
+            node for node in self._iter_nodes(root) if node.type == "command"
+        ]
+
+    def _contains_node_types(self, root: Node, types: Set[str]) -> bool:
+        """Return whether any descendant has a type in ``types``."""
+        for node in self._iter_nodes(root):
+            if node.type in types:
+                return True
+        return False
+
+    def _has_child_type(self, node: Node, node_type: str) -> bool:
+        """Return whether ``node`` has a direct child of ``node_type``."""
+        return any(child.type == node_type for child in node.children)
+
+    def _has_error_nodes(self, root: Node) -> bool:
+        """Return whether the tree contains ERROR / missing nodes."""
+        for node in self._iter_nodes(root):
+            if node.type == "ERROR" or node.is_error or node.is_missing:
+                return True
+        return False
+
+    def _iter_nodes(self, root: Node) -> Iterator[Node]:
+        """Yield ``root`` and all descendants depth-first."""
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            yield node
+            stack.extend(reversed(list(node.children)))

--- a/src/agentscope/tool/_builtin/_powershell_parser.py
+++ b/src/agentscope/tool/_builtin/_powershell_parser.py
@@ -11,17 +11,19 @@ Mirrors :class:`BashCommandParser` method surface for PowerShell:
 from __future__ import annotations
 
 import re
-from typing import Iterator, List, Optional, Set
+from typing import Iterator, List, Optional, Set, Tuple
 
 import tree_sitter_pwsh as tspwsh
-from tree_sitter import Language, Node, Parser
+from tree_sitter import Language, Node, Parser, Tree
 
 from .._constants import (
     POWERSHELL_ALIASES,
     POWERSHELL_DANGEROUS_COMMANDS,
     POWERSHELL_INJECTION_NODE_TYPES,
     POWERSHELL_READ_ONLY_COMMANDS,
-    POWERSHELL_READ_ONLY_VERB_PREFIXES,
+    POWERSHELL_REMOVE_ITEM_DANGEROUS_PARAMS,
+    POWERSHELL_SET_ITEM_PROPERTY_PATH_PARAMS,
+    POWERSHELL_STOP_PROCESS_DANGEROUS_PARAMS,
 )
 
 
@@ -40,6 +42,15 @@ class PowerShellCommandParser:
         self._dangerous_lookup = {
             name.casefold(): name for name in POWERSHELL_DANGEROUS_COMMANDS
         }
+        self._cache_key: str | None = None
+        self._cache_tree: Tree | None = None
+
+    def _parse(self, command: str) -> Tree:
+        """Parse ``command``, memoizing the tree for repeated checks."""
+        if self._cache_key != command or self._cache_tree is None:
+            self._cache_tree = self.parser.parse(bytes(command, "utf8"))
+            self._cache_key = command
+        return self._cache_tree
 
     def normalize_cmdlet_name(self, name: str) -> str:
         """Resolve aliases to canonical cmdlet names (case-insensitive).
@@ -84,11 +95,7 @@ class PowerShellCommandParser:
         if not command.strip():
             return command
 
-        try:
-            tree = self.parser.parse(bytes(command, "utf8"))
-        except Exception:
-            return self._normalize_command_fallback(command)
-
+        tree = self._parse(command)
         replacements: list[tuple[int, int, str]] = []
         for node in self._iter_nodes(tree.root_node):
             if node.type != "command":
@@ -115,6 +122,29 @@ class PowerShellCommandParser:
         parts.append(command[cursor:])
         return "".join(parts)
 
+    def extract_canonical_command_names(self, command: str) -> List[str]:
+        """Return alias-normalized cmdlet names for every command node.
+
+        Args:
+            command (`str`):
+                PowerShell command text.
+
+        Returns:
+            `List[str]`:
+                Canonical names in source order (may be empty on ERROR).
+        """
+        if not command.strip():
+            return []
+        tree = self._parse(command)
+        if self._has_error_nodes(tree.root_node):
+            return []
+        names: list[str] = []
+        for cmd_node in self._extract_command_nodes(tree.root_node):
+            raw = self._command_name_text(command, cmd_node)
+            if raw:
+                names.append(self.normalize_cmdlet_name(raw))
+        return names
+
     def is_read_only_command(self, command: str) -> bool:
         """Check whether a PowerShell command is read-only.
 
@@ -137,11 +167,8 @@ class PowerShellCommandParser:
         if self.check_injection_risk(cmd):
             return False
 
-        try:
-            tree = self.parser.parse(bytes(cmd, "utf8"))
-            root = tree.root_node
-        except Exception:
-            return False
+        tree = self._parse(cmd)
+        root = tree.root_node
 
         if self._has_error_nodes(root):
             return False
@@ -181,18 +208,13 @@ class PowerShellCommandParser:
         if not cmd:
             return None
 
-        try:
-            tree = self.parser.parse(bytes(cmd, "utf8"))
-            root = tree.root_node
-        except Exception:
-            return "unparseable PowerShell command"
+        tree = self._parse(cmd)
+        root = tree.root_node
 
-        # Prefer the more specific download-to-iex label when both apply.
         download_pattern = self._check_download_to_iex(cmd, root)
         if download_pattern:
             return download_pattern
 
-        # Always-dangerous cmdlets (exact name match after alias normalize)
         for cmd_node in self._extract_command_nodes(root):
             name = self._command_name_text(cmd, cmd_node)
             if not name:
@@ -202,39 +224,36 @@ class PowerShellCommandParser:
             if folded in self._dangerous_lookup:
                 return self._dangerous_lookup[folded]
 
-            params = self._command_parameters(cmd, cmd_node)
-            param_fold = {p.casefold() for p in params}
+            resolved = self._resolved_parameters(cmd, cmd_node)
 
-            if folded == "remove-item" and (
-                "-recurse" in param_fold or "-force" in param_fold
-            ):
+            if folded == "remove-item" and resolved & {
+                p.casefold() for p in POWERSHELL_REMOVE_ITEM_DANGEROUS_PARAMS
+            }:
                 return "Remove-Item -Recurse/-Force"
 
-            if folded == "stop-process" and "-force" in param_fold:
+            if folded == "stop-process" and "-force" in resolved:
                 return "Stop-Process -Force"
 
-            if folded == "set-itemproperty" and self._mentions_hklm(
-                cmd,
-                cmd_node,
-            ):
-                return "Set-ItemProperty HKLM:"
+            if folded == "set-itemproperty":
+                hklm = self._set_itemproperty_hklm_status(cmd, cmd_node)
+                if hklm == "hklm":
+                    return "Set-ItemProperty HKLM:"
 
-        # Textual fallback for always-dangerous names that may appear
-        # oddly tokenized
-        normalized = " ".join(cmd.split())
-        for pattern in POWERSHELL_DANGEROUS_COMMANDS:
-            if re.search(
-                r"(?i)\b" + re.escape(pattern) + r"\b",
-                normalized,
-            ):
-                return pattern
-            alias_hit = self._alias_for_canonical(pattern)
-            for alias in alias_hit:
+        # Textual fallback only when the AST is unusable.
+        if self._has_error_nodes(root):
+            normalized = " ".join(cmd.split())
+            for pattern in POWERSHELL_DANGEROUS_COMMANDS:
                 if re.search(
-                    r"(?i)\b" + re.escape(alias) + r"\b",
+                    r"(?i)\b" + re.escape(pattern) + r"\b",
                     normalized,
                 ):
                     return pattern
+                for alias in self._alias_for_canonical(pattern):
+                    if re.search(
+                        r"(?i)\b" + re.escape(alias) + r"\b",
+                        normalized,
+                    ):
+                        return pattern
 
         return None
 
@@ -253,8 +272,7 @@ class PowerShellCommandParser:
         if not cmd:
             return None
 
-        # Heuristics that do not require a clean AST
-        if re.search(r"(?i)(^|[\s|;])-EncodedCommand\b", cmd):
+        if self._has_encoded_command_flag(cmd):
             return (
                 "Command contains -EncodedCommand which cannot be "
                 "statically analyzed"
@@ -270,20 +288,19 @@ class PowerShellCommandParser:
                 "statically analyzed"
             )
 
-        try:
-            tree = self.parser.parse(bytes(cmd, "utf8"))
-            root = tree.root_node
-        except Exception:
-            return "Command parsing failed, cannot verify safety"
+        tree = self._parse(cmd)
+        root = tree.root_node
 
         if self._has_error_nodes(root):
             return "Command parsing failed, cannot verify safety"
 
-        reason = self._walk_for_injection_nodes(root)
-        if reason:
-            return reason
+        for node in self._iter_nodes(root):
+            if node.type in POWERSHELL_INJECTION_NODE_TYPES:
+                return (
+                    f"Command contains {node.type} which cannot be "
+                    f"statically analyzed"
+                )
 
-        # Call operator / dot-sourcing on dynamic targets
         for cmd_node in self._extract_command_nodes(root):
             if self._has_child_type(cmd_node, "command_invocation_operator"):
                 return (
@@ -291,13 +308,22 @@ class PowerShellCommandParser:
                     "statically analyzed"
                 )
             name = self._command_name_text(cmd, cmd_node)
-            if name and self.normalize_cmdlet_name(name).casefold() == (
-                "invoke-expression"
-            ):
+            if not name:
+                continue
+            canonical = self.normalize_cmdlet_name(name)
+            folded = canonical.casefold()
+            if folded == "invoke-expression":
                 return (
                     "Command contains Invoke-Expression which cannot be "
                     "statically analyzed"
                 )
+            if folded == "set-itemproperty":
+                status = self._set_itemproperty_hklm_status(cmd, cmd_node)
+                if status == "dynamic":
+                    return (
+                        "Command contains dynamic Set-ItemProperty -Path "
+                        "which cannot be statically analyzed"
+                    )
 
         return None
 
@@ -325,11 +351,8 @@ class PowerShellCommandParser:
         if not command or not command.strip():
             return []
 
-        try:
-            tree = self.parser.parse(bytes(command, "utf8"))
-            root = tree.root_node
-        except Exception:
-            return []
+        tree = self._parse(command)
+        root = tree.root_node
 
         prefixes: list[str] = []
         seen: Set[str] = set()
@@ -353,16 +376,6 @@ class PowerShellCommandParser:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _normalize_command_fallback(self, command: str) -> str:
-        """Token-based alias normalization when parsing fails."""
-        tokens = command.split(None, 1)
-        if not tokens:
-            return command
-        canonical = self.normalize_cmdlet_name(tokens[0])
-        if len(tokens) == 1:
-            return canonical
-        return f"{canonical} {tokens[1]}"
-
     def _is_single_command_read_only(
         self,
         source: str,
@@ -385,12 +398,9 @@ class PowerShellCommandParser:
     def _is_readonly_cmdlet_name(self, name: str) -> bool:
         """Return whether a canonical cmdlet name is read-only."""
         folded = name.casefold()
-        if folded in self._readonly_lookup:
-            return True
-        for prefix in POWERSHELL_READ_ONLY_VERB_PREFIXES:
-            if folded.startswith(prefix.casefold()):
-                return True
-        return False
+        if folded in self._dangerous_lookup:
+            return False
+        return folded in self._readonly_lookup
 
     def _command_name_node(self, cmd_node: Node) -> Optional[Node]:
         """Return the name node for a command AST node."""
@@ -406,56 +416,138 @@ class PowerShellCommandParser:
             return None
         return source[name_node.start_byte : name_node.end_byte].strip()
 
-    def _command_parameters(self, source: str, cmd_node: Node) -> list[str]:
-        """Collect ``command_parameter`` texts for a command node."""
-        params: list[str] = []
-        for node in self._iter_nodes(cmd_node):
-            if node.type == "command_parameter":
-                params.append(source[node.start_byte : node.end_byte])
-        return params
+    def _command_parameter_pairs(
+        self,
+        source: str,
+        cmd_node: Node,
+    ) -> list[Tuple[str, Optional[Node]]]:
+        """Return ``(raw_param, value_node)`` pairs for a command."""
+        elements = None
+        for child in cmd_node.children:
+            if child.type == "command_elements":
+                elements = child
+                break
+        if elements is None:
+            return []
 
-    def _mentions_hklm(self, source: str, cmd_node: Node) -> bool:
-        """Return whether a command node references an HKLM path."""
-        text = source[cmd_node.start_byte : cmd_node.end_byte]
-        return bool(re.search(r"(?i)\bHKLM:", text))
+        pairs: list[Tuple[str, Optional[Node]]] = []
+        kids = list(elements.children)
+        i = 0
+        while i < len(kids):
+            node = kids[i]
+            if node.type == "command_parameter":
+                raw = source[node.start_byte : node.end_byte]
+                value: Optional[Node] = None
+                j = i + 1
+                while j < len(kids) and kids[j].type == "command_argument_sep":
+                    j += 1
+                if j < len(kids) and kids[j].type != "command_parameter":
+                    value = kids[j]
+                    i = j
+                pairs.append((raw, value))
+            i += 1
+        return pairs
+
+    def _resolve_parameter_name(
+        self,
+        raw: str,
+        known: frozenset[str],
+    ) -> Optional[str]:
+        """Resolve a possibly abbreviated parameter against ``known``."""
+        folded = raw.casefold()
+        exact = [p for p in known if p.casefold() == folded]
+        if exact:
+            return exact[0]
+        matches = [p for p in known if p.casefold().startswith(folded)]
+        if len(matches) == 1:
+            return matches[0]
+        return None
+
+    def _resolved_parameters(
+        self,
+        source: str,
+        cmd_node: Node,
+    ) -> Set[str]:
+        """Resolve abbreviated switch names for dangerous-parameter checks."""
+        known = (
+            POWERSHELL_REMOVE_ITEM_DANGEROUS_PARAMS
+            | POWERSHELL_STOP_PROCESS_DANGEROUS_PARAMS
+            | POWERSHELL_SET_ITEM_PROPERTY_PATH_PARAMS
+        )
+        resolved: Set[str] = set()
+        for raw, _value in self._command_parameter_pairs(source, cmd_node):
+            canonical = self._resolve_parameter_name(raw, known)
+            if canonical is not None:
+                resolved.add(canonical.casefold())
+        return resolved
+
+    def _set_itemproperty_hklm_status(
+        self,
+        source: str,
+        cmd_node: Node,
+    ) -> Optional[str]:
+        """Classify Set-ItemProperty path: ``hklm``, ``dynamic``, or None."""
+        for raw, value in self._command_parameter_pairs(source, cmd_node):
+            resolved = self._resolve_parameter_name(
+                raw,
+                POWERSHELL_SET_ITEM_PROPERTY_PATH_PARAMS,
+            )
+            if resolved is None or value is None:
+                continue
+            if value.type == "variable" or self._contains_node_types(
+                value,
+                {"variable", "sub_expression", "expandable_string_literal"},
+            ):
+                return "dynamic"
+            text = source[value.start_byte : value.end_byte].strip("\"'")
+            if re.search(r"(?i)^HKLM:", text):
+                return "hklm"
+        return None
 
     def _check_download_to_iex(
         self,
         source: str,
         root: Node,
     ) -> Optional[str]:
-        """Detect download-to-iex patterns such as ``irm ... | iex``."""
-        normalized = " ".join(source.split())
-        if re.search(
-            r"(?i)\b(irm|iwr|Invoke-RestMethod|Invoke-WebRequest)\b.*"
-            r"\|\s*(iex|Invoke-Expression)\b",
-            normalized,
-        ):
-            return "download-to-iex"
-        if re.search(
-            r"(?i)\b(iex|Invoke-Expression)\b\s*\(.*\b"
-            r"(irm|iwr|Invoke-RestMethod|Invoke-WebRequest)\b",
-            normalized,
-        ):
-            return "download-to-iex"
+        """Detect adjacent download→iex pipelines via the AST only."""
+        download = {"invoke-restmethod", "invoke-webrequest"}
 
-        # Also catch adjacent pipeline commands via AST
-        names = [
-            self.normalize_cmdlet_name(n).casefold()
-            for n in (
-                self._command_name_text(source, node)
-                for node in self._extract_command_nodes(root)
-            )
-            if n
-        ]
-        download = {
-            "invoke-restmethod",
-            "invoke-webrequest",
-        }
-        if any(n in download for n in names) and any(
-            n == "invoke-expression" for n in names
-        ):
-            return "download-to-iex"
+        for node in self._iter_nodes(root):
+            if node.type != "pipeline_chain":
+                continue
+            commands = [c for c in node.children if c.type == "command"]
+            for left, right in zip(commands, commands[1:]):
+                left_name = self._command_name_text(source, left)
+                right_name = self._command_name_text(source, right)
+                if not left_name or not right_name:
+                    continue
+                if (
+                    self.normalize_cmdlet_name(left_name).casefold()
+                    in download
+                    and self.normalize_cmdlet_name(right_name).casefold()
+                    == "invoke-expression"
+                ):
+                    return "download-to-iex"
+
+        # iex (irm ...) — download nested under Invoke-Expression
+        for cmd_node in self._extract_command_nodes(root):
+            name = self._command_name_text(source, cmd_node)
+            if not name:
+                continue
+            if self.normalize_cmdlet_name(name).casefold() != (
+                "invoke-expression"
+            ):
+                continue
+            for nested in self._extract_command_nodes(cmd_node):
+                if nested is cmd_node:
+                    continue
+                nested_name = self._command_name_text(source, nested)
+                if (
+                    nested_name
+                    and self.normalize_cmdlet_name(nested_name).casefold()
+                    in download
+                ):
+                    return "download-to-iex"
         return None
 
     def _alias_for_canonical(self, canonical: str) -> list[str]:
@@ -467,17 +559,42 @@ class PowerShellCommandParser:
             if name.casefold() == target
         ]
 
+    def _has_encoded_command_flag(self, command: str) -> bool:
+        """Detect ``-EncodedCommand`` including unique abbreviations."""
+        # ``-en...`` is unique vs ``-ErrorAction`` (which needs ``-er...``).
+        for match in re.finditer(
+            r"(?i)(^|[\s|;])(-en[a-z]*)\b",
+            command,
+        ):
+            flag = match.group(2).lstrip("-").casefold()
+            if "encodedcommand".startswith(flag):
+                return True
+        # ``pwsh -e`` / ``powershell -e`` (CLI short form).
+        return bool(
+            re.search(
+                r"(?i)\b(pwsh|powershell)(\.exe)?(\s+\S+)*\s+-e\b",
+                command,
+            ),
+        )
+
+    def _strip_quoted_strings(self, command: str) -> str:
+        """Remove single- and double-quoted spans for heuristic scans."""
+        return re.sub(
+            r"'(?:[^']|'')*'|\"(?:[^\"`]|`.)*\"",
+            '""',
+            command,
+        )
+
     def _has_backtick_obfuscation(self, command: str) -> bool:
         """Detect backtick-obfuscated command text."""
+        unscanned = self._strip_quoted_strings(command)
         # e.g. Inv`oke-Expression or Get`-ChildItem
-        if re.search(r"[A-Za-z]`+[A-Za-z]", command):
+        if re.search(r"[A-Za-z]`+[A-Za-z]", unscanned):
             return True
-        # Many backticks are a strong obfuscation signal
-        return command.count("`") >= 3
+        return unscanned.count("`") >= 3
 
     def _has_string_built_cmdlet(self, command: str) -> bool:
         """Detect string-concatenated / expandable cmdlet names."""
-        # & ("Get-" + "ChildItem") or & "Get-$verb"
         if re.search(
             r"""(?i)&\s*[\(\"'].*(?:\+|\$)""",
             command,
@@ -489,19 +606,6 @@ class PowerShellCommandParser:
                 command,
             ),
         )
-
-    def _walk_for_injection_nodes(self, node: Node) -> Optional[str]:
-        """Walk the AST for injection-related node types."""
-        if node.type in POWERSHELL_INJECTION_NODE_TYPES:
-            return (
-                f"Command contains {node.type} which cannot be "
-                f"statically analyzed"
-            )
-        for child in node.children:
-            result = self._walk_for_injection_nodes(child)
-            if result:
-                return result
-        return None
 
     def _extract_command_nodes(self, root: Node) -> list[Node]:
         """Collect all ``command`` nodes under ``root``."""

--- a/src/agentscope/tool/_builtin/_wildcard_match.py
+++ b/src/agentscope/tool/_builtin/_wildcard_match.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""Shared wildcard permission-rule matching for shell tools."""
+
+from __future__ import annotations
+
+import re
+
+
+def match_wildcard_pattern(rule_content: str, command: str) -> bool:
+    """Match a command against Bash/PowerShell wildcard rule grammar.
+
+    Callers are responsible for any tool-specific preprocessing (alias
+    normalization, casefolding, pipeline splitting). This helper covers:
+
+    - ``:*`` prefix patterns (``git:*``)
+    - ``*`` wildcards with ``\\*`` / ``\\\\`` escapes
+    - substring match when the pattern has no unescaped ``*``
+
+    Args:
+        rule_content (`str`):
+            Preprocessed rule pattern (not ``None``).
+        command (`str`):
+            Preprocessed command text to match.
+
+    Returns:
+        `bool`:
+            ``True`` when ``command`` matches ``rule_content``.
+    """
+    if rule_content.endswith(":*"):
+        prefix = rule_content[:-2].strip()
+        return command.startswith(prefix + " ") or command == prefix
+
+    def has_wildcards(pattern: str) -> bool:
+        """Return whether ``pattern`` contains an unescaped ``*``."""
+        i = 0
+        while i < len(pattern):
+            if pattern[i] == "\\":
+                i += 2
+            elif pattern[i] == "*":
+                return True
+            else:
+                i += 1
+        return False
+
+    if not has_wildcards(rule_content):
+        pattern = rule_content
+        pattern = pattern.replace("\\\\", "\x00BACKSLASH\x00")
+        pattern = pattern.replace("\\*", "*")
+        pattern = pattern.replace("\x00BACKSLASH\x00", "\\")
+        return pattern in command
+
+    escaped_star = "\x00ESCAPED_STAR\x00"
+    escaped_backslash = "\x00ESCAPED_BACKSLASH\x00"
+
+    pattern = rule_content
+    pattern = pattern.replace("\\\\", escaped_backslash)
+    pattern = pattern.replace("\\*", escaped_star)
+
+    special_chars = r".^$+?{}[]|()"
+    for char in special_chars:
+        pattern = pattern.replace(char, "\\" + char)
+
+    pattern = pattern.replace("*", ".*")
+    pattern = pattern.replace(escaped_star, r"\*")
+    pattern = pattern.replace(escaped_backslash, r"\\")
+
+    if pattern.endswith(".*"):
+        base_pattern = pattern[:-2].rstrip()
+        if re.fullmatch(base_pattern, command):
+            return True
+
+    try:
+        return bool(re.fullmatch(pattern, command))
+    except re.error:
+        return rule_content.replace("*", "") in command

--- a/src/agentscope/tool/_constants.py
+++ b/src/agentscope/tool/_constants.py
@@ -108,3 +108,149 @@ DANGEROUS_NODE_TYPES = {
 #
 # Note: simple_expansion ($VAR) is handled separately with allowlist
 # for known-safe environment variables ($HOME, $PWD, etc.)
+
+
+POWERSHELL_ALIASES: dict[str, str] = {
+    "ls": "Get-ChildItem",
+    "dir": "Get-ChildItem",
+    "gci": "Get-ChildItem",
+    "cat": "Get-Content",
+    "gc": "Get-Content",
+    "type": "Get-Content",
+    "sls": "Select-String",
+    "select": "Select-Object",
+    "where": "Where-Object",
+    "?": "Where-Object",
+    "sort": "Sort-Object",
+    "measure": "Measure-Object",
+    "echo": "Write-Output",
+    "write": "Write-Output",
+    "cd": "Set-Location",
+    "chdir": "Set-Location",
+    "sl": "Set-Location",
+    "pwd": "Get-Location",
+    "gl": "Get-Location",
+    "rm": "Remove-Item",
+    "del": "Remove-Item",
+    "ri": "Remove-Item",
+    "rmdir": "Remove-Item",
+    "rd": "Remove-Item",
+    "ni": "New-Item",
+    "mi": "Move-Item",
+    "move": "Move-Item",
+    "cpi": "Copy-Item",
+    "copy": "Copy-Item",
+    "cp": "Copy-Item",
+    "ii": "Invoke-Item",
+    "iex": "Invoke-Expression",
+    "irm": "Invoke-RestMethod",
+    "iwr": "Invoke-WebRequest",
+    "curl": "Invoke-WebRequest",
+    "wget": "Invoke-WebRequest",
+    "kill": "Stop-Process",
+    "spps": "Stop-Process",
+    "gps": "Get-Process",
+    "ps": "Get-Process",
+    "ft": "Format-Table",
+    "fl": "Format-List",
+    "foreach": "ForEach-Object",
+    "%": "ForEach-Object",
+}
+# Built-in PowerShell alias map (lowercase key → canonical cmdlet name).
+# Used for read-only classification, dangerous-command checks, and
+# case-insensitive permission rule matching.
+
+
+POWERSHELL_READ_ONLY_COMMANDS: set[str] = {
+    "Get-Location",
+    "Get-Date",
+    "Get-Host",
+    "Get-Help",
+    "Get-Member",
+    "Get-Unique",
+    "Get-Variable",
+    "Get-Alias",
+    "Get-Command",
+    "Get-Module",
+    "Get-Process",
+    "Get-Service",
+    "Get-ChildItem",
+    "Get-Content",
+    "Get-Item",
+    "Get-ItemProperty",
+    "Get-Acl",
+    "Get-FileHash",
+    "Test-Path",
+    "Resolve-Path",
+    "Select-Object",
+    "Select-String",
+    "Where-Object",
+    "Sort-Object",
+    "Measure-Object",
+    "Format-Table",
+    "Format-List",
+    "Format-Wide",
+    "Format-Custom",
+    "ConvertTo-Json",
+    "ConvertFrom-Json",
+    "ConvertTo-Csv",
+    "ConvertFrom-Csv",
+    "ConvertTo-Xml",
+    "ConvertFrom-StringData",
+    "Out-String",
+    "Out-Null",
+    "Write-Output",
+    "Write-Host",
+    "Write-Verbose",
+    "Write-Debug",
+    "Write-Information",
+}
+# Cmdlets treated as read-only for auto-ALLOW / EXPLORE mode.
+# Verb prefixes such as Get- / Select- / Format- / ConvertTo- /
+# ConvertFrom- are handled separately in the PowerShell parser.
+
+
+POWERSHELL_READ_ONLY_VERB_PREFIXES: tuple[str, ...] = (
+    "Get-",
+    "Select-",
+    "Format-",
+    "ConvertTo-",
+    "ConvertFrom-",
+)
+# Verb prefixes that are generally read-only when the cmdlet has no
+# script block, call operator, or redirection.
+
+
+POWERSHELL_DANGEROUS_COMMANDS: list[str] = [
+    "Clear-Content",
+    "Clear-Item",
+    "Format-Volume",
+    "Invoke-Expression",
+    "Start-Process",
+    "Add-Type",
+    "Set-ExecutionPolicy",
+    "Set-MpPreference",
+    "Stop-Computer",
+    "Restart-Computer",
+    "Register-ScheduledTask",
+]
+# Dangerous PowerShell cmdlets that always require a bypass-immune ASK.
+# Parameter-sensitive patterns (Remove-Item -Recurse/-Force,
+# Stop-Process -Force, HKLM registry writes, download-to-iex) are
+# handled in the parser.
+
+
+POWERSHELL_INJECTION_NODE_TYPES: set[str] = {
+    "sub_expression",
+    "if_statement",
+    "while_statement",
+    "for_statement",
+    "foreach_statement",
+    "switch_statement",
+    "function_definition",
+    "filter_definition",
+    "trap_statement",
+}
+# AST node types that prevent static analysis of PowerShell commands.
+# Detecting these forces a non-read-only classification and a
+# bypass-immune safety ASK.

--- a/src/agentscope/tool/_constants.py
+++ b/src/agentscope/tool/_constants.py
@@ -110,7 +110,12 @@ DANGEROUS_NODE_TYPES = {
 # for known-safe environment variables ($HOME, $PWD, etc.)
 
 
+# Alias map from PowerShell 7.4 `Get-Alias` (built-in aliases). Includes
+# every built-in alias for names in POWERSHELL_DANGEROUS_COMMANDS so
+# incomplete coverage cannot skip a dangerous check. Unknown names are
+# never auto-allowed as read-only.
 POWERSHELL_ALIASES: dict[str, str] = {
+    # Read-oriented
     "ls": "Get-ChildItem",
     "dir": "Get-ChildItem",
     "gci": "Get-ChildItem",
@@ -125,16 +130,20 @@ POWERSHELL_ALIASES: dict[str, str] = {
     "measure": "Measure-Object",
     "echo": "Write-Output",
     "write": "Write-Output",
+    "pwd": "Get-Location",
+    "gl": "Get-Location",
+    "gps": "Get-Process",
+    "ps": "Get-Process",
+    "gsv": "Get-Service",
+    "ft": "Format-Table",
+    "fl": "Format-List",
+    "fw": "Format-Wide",
+    "foreach": "ForEach-Object",
+    "%": "ForEach-Object",
+    # Location / item mutation
     "cd": "Set-Location",
     "chdir": "Set-Location",
     "sl": "Set-Location",
-    "pwd": "Get-Location",
-    "gl": "Get-Location",
-    "rm": "Remove-Item",
-    "del": "Remove-Item",
-    "ri": "Remove-Item",
-    "rmdir": "Remove-Item",
-    "rd": "Remove-Item",
     "ni": "New-Item",
     "mi": "Move-Item",
     "move": "Move-Item",
@@ -142,23 +151,34 @@ POWERSHELL_ALIASES: dict[str, str] = {
     "copy": "Copy-Item",
     "cp": "Copy-Item",
     "ii": "Invoke-Item",
+    "rm": "Remove-Item",
+    "del": "Remove-Item",
+    "erase": "Remove-Item",
+    "ri": "Remove-Item",
+    "rmdir": "Remove-Item",
+    "rd": "Remove-Item",
+    # Dangerous cmdlets (complete built-in alias coverage)
+    "clc": "Clear-Content",
+    "cli": "Clear-Item",
+    "clp": "Clear-ItemProperty",
     "iex": "Invoke-Expression",
+    "icm": "Invoke-Command",
     "irm": "Invoke-RestMethod",
     "iwr": "Invoke-WebRequest",
     "curl": "Invoke-WebRequest",
     "wget": "Invoke-WebRequest",
-    "kill": "Stop-Process",
+    "saps": "Start-Process",
+    "start": "Start-Process",
+    "sasv": "Start-Service",
     "spps": "Stop-Process",
-    "gps": "Get-Process",
-    "ps": "Get-Process",
-    "ft": "Format-Table",
-    "fl": "Format-List",
-    "foreach": "ForEach-Object",
-    "%": "ForEach-Object",
+    "kill": "Stop-Process",
+    "spsv": "Stop-Service",
+    "sc": "Set-Content",
+    "si": "Set-Item",
+    "sp": "Set-ItemProperty",
+    "sv": "Set-Variable",
+    "set": "Set-Variable",
 }
-# Built-in PowerShell alias map (lowercase key → canonical cmdlet name).
-# Used for read-only classification, dangerous-command checks, and
-# case-insensitive permission rule matching.
 
 
 POWERSHELL_READ_ONLY_COMMANDS: set[str] = {
@@ -205,39 +225,45 @@ POWERSHELL_READ_ONLY_COMMANDS: set[str] = {
     "Write-Debug",
     "Write-Information",
 }
-# Cmdlets treated as read-only for auto-ALLOW / EXPLORE mode.
-# Verb prefixes such as Get- / Select- / Format- / ConvertTo- /
-# ConvertFrom- are handled separately in the PowerShell parser.
-
-
-POWERSHELL_READ_ONLY_VERB_PREFIXES: tuple[str, ...] = (
-    "Get-",
-    "Select-",
-    "Format-",
-    "ConvertTo-",
-    "ConvertFrom-",
-)
-# Verb prefixes that are generally read-only when the cmdlet has no
-# script block, call operator, or redirection.
+# Exact cmdlet names treated as read-only for auto-ALLOW / EXPLORE.
+# Unknown names are never assumed safe (no verb-prefix matching).
 
 
 POWERSHELL_DANGEROUS_COMMANDS: list[str] = [
     "Clear-Content",
     "Clear-Item",
+    "Clear-ItemProperty",
     "Format-Volume",
     "Invoke-Expression",
+    "Invoke-Command",
     "Start-Process",
+    "Start-Service",
     "Add-Type",
     "Set-ExecutionPolicy",
     "Set-MpPreference",
+    "Set-Service",
+    "New-Service",
     "Stop-Computer",
     "Restart-Computer",
+    "Stop-Service",
     "Register-ScheduledTask",
 ]
 # Dangerous PowerShell cmdlets that always require a bypass-immune ASK.
 # Parameter-sensitive patterns (Remove-Item -Recurse/-Force,
 # Stop-Process -Force, HKLM registry writes, download-to-iex) are
 # handled in the parser.
+
+
+# Parameter sets used for unique-prefix resolution (PowerShell abbrevs).
+POWERSHELL_REMOVE_ITEM_DANGEROUS_PARAMS: frozenset[str] = frozenset(
+    {"-Recurse", "-Force"},
+)
+POWERSHELL_STOP_PROCESS_DANGEROUS_PARAMS: frozenset[str] = frozenset(
+    {"-Force"},
+)
+POWERSHELL_SET_ITEM_PROPERTY_PATH_PARAMS: frozenset[str] = frozenset(
+    {"-Path", "-LiteralPath"},
+)
 
 
 POWERSHELL_INJECTION_NODE_TYPES: set[str] = {

--- a/tests/builtin_powershell_test.py
+++ b/tests/builtin_powershell_test.py
@@ -13,10 +13,10 @@ from agentscope.tool import ExecResult, LocalBackend, PowerShell
 
 
 class PowerShellInterfaceTest(IsolatedAsyncioTestCase):
-    """Test the public PowerShell interface and conservative permissions."""
+    """Test the public PowerShell interface and permission hooks."""
 
-    async def test_public_interface_is_conservative(self) -> None:
-        """Expose the command schema without auto-allowing any command."""
+    async def test_public_interface_and_read_only_allow(self) -> None:
+        """Expose the command schema and auto-allow read-only cmdlets."""
         backend = LocalBackend()
         tool = PowerShell(cwd="workspace", backend=backend)
 
@@ -37,15 +37,133 @@ class PowerShellInterfaceTest(IsolatedAsyncioTestCase):
             PermissionContext(),
         )
         self.assertEqual(
-            decision.behavior,
-            PermissionBehavior.ASK,
+            {
+                "behavior": decision.behavior,
+                "bypass_immune": decision.bypass_immune,
+                "decision_reason": decision.decision_reason,
+            },
+            {
+                "behavior": PermissionBehavior.ALLOW,
+                "bypass_immune": False,
+                "decision_reason": "Read-only command is allowed",
+            },
         )
-        self.assertFalse(decision.bypass_immune)
+        self.assertTrue(
+            await tool.check_read_only({"command": "Get-ChildItem"}),
+        )
+        self.assertTrue(await tool.check_read_only({"command": "ls"}))
+        self.assertFalse(
+            await tool.check_read_only({"command": "Remove-Item ./x"}),
+        )
+
+        suggestions = await tool.generate_suggestions(
+            {"command": "Remove-Item ./tmp"},
+        )
         self.assertEqual(
-            await tool.generate_suggestions(
-                {"command": "Get-Location"},
+            [
+                {
+                    "tool_name": rule.tool_name,
+                    "rule_content": rule.rule_content,
+                    "behavior": rule.behavior,
+                    "source": rule.source,
+                }
+                for rule in suggestions
+            ],
+            [
+                {
+                    "tool_name": "PowerShell",
+                    "rule_content": "Remove-Item:*",
+                    "behavior": PermissionBehavior.ALLOW,
+                    "source": "suggested",
+                },
+            ],
+        )
+
+
+class PowerShellPermissionTest(IsolatedAsyncioTestCase):
+    """Test PowerShell permission tiers and rule matching."""
+
+    async def asyncSetUp(self) -> None:
+        """Create a PowerShell tool for permission tests."""
+        self.tool = PowerShell(backend=LocalBackend())
+
+    async def test_dangerous_commands_are_bypass_immune_ask(self) -> None:
+        """Dangerous patterns return bypass-immune ASK decisions."""
+        decision = await self.tool.check_permissions(
+            {"command": "Remove-Item -Recurse -Force ./tmp"},
+            PermissionContext(),
+        )
+        self.assertEqual(
+            {
+                "behavior": decision.behavior,
+                "bypass_immune": decision.bypass_immune,
+            },
+            {
+                "behavior": PermissionBehavior.ASK,
+                "bypass_immune": True,
+            },
+        )
+        self.assertIn("Remove-Item", decision.message)
+
+    async def test_injection_is_bypass_immune_ask(self) -> None:
+        """Injection risk returns a bypass-immune ASK."""
+        decision = await self.tool.check_permissions(
+            {"command": "iex '1'"},
+            PermissionContext(),
+        )
+        self.assertEqual(
+            {
+                "behavior": decision.behavior,
+                "bypass_immune": decision.bypass_immune,
+            },
+            {
+                "behavior": PermissionBehavior.ASK,
+                "bypass_immune": True,
+            },
+        )
+
+    async def test_mutating_non_dangerous_is_passthrough(self) -> None:
+        """Ordinary mutating commands fall through to the engine."""
+        decision = await self.tool.check_permissions(
+            {"command": "New-Item -ItemType File -Path a.txt"},
+            PermissionContext(),
+        )
+        self.assertEqual(
+            decision.behavior,
+            PermissionBehavior.PASSTHROUGH,
+        )
+
+    async def test_match_rule_wildcard_and_alias(self) -> None:
+        """Content rules match with wildcards, case, and aliases."""
+        self.assertTrue(
+            await self.tool.match_rule(
+                "Remove-Item*",
+                {"command": "Remove-Item ./tmp"},
             ),
-            [],
+        )
+        self.assertTrue(
+            await self.tool.match_rule(
+                "Get-ChildItem*",
+                {"command": "ls"},
+            ),
+        )
+        self.assertTrue(
+            await self.tool.match_rule(
+                "get-childitem:*",
+                {"command": "Get-ChildItem -Path ."},
+            ),
+        )
+        self.assertTrue(
+            await self.tool.match_rule(
+                None,
+                {"command": "anything"},
+            ),
+        )
+        self.assertFalse(
+            await self.tool.match_rule(
+                "Remove-Item*",
+                {"command": "Get-ChildItem"},
+            ),
         )
 
 

--- a/tests/builtin_powershell_test.py
+++ b/tests/builtin_powershell_test.py
@@ -155,6 +155,18 @@ class PowerShellPermissionTest(IsolatedAsyncioTestCase):
         )
         self.assertTrue(
             await self.tool.match_rule(
+                "rm:*",
+                {"command": "rm ./tmp"},
+            ),
+        )
+        self.assertTrue(
+            await self.tool.match_rule(
+                "rm:*",
+                {"command": "Remove-Item ./tmp"},
+            ),
+        )
+        self.assertTrue(
+            await self.tool.match_rule(
                 None,
                 {"command": "anything"},
             ),
@@ -163,6 +175,63 @@ class PowerShellPermissionTest(IsolatedAsyncioTestCase):
             await self.tool.match_rule(
                 "Remove-Item*",
                 {"command": "Get-ChildItem"},
+            ),
+        )
+        self.assertFalse(
+            await self.tool.match_rule(
+                "Get-ChildItem:*",
+                {"command": "Get-ChildItem | Remove-Item"},
+            ),
+        )
+        self.assertFalse(
+            await self.tool.match_rule(
+                "Get-Content:*",
+                {"command": "Get-Content a.txt | Set-Content b.txt"},
+            ),
+        )
+
+    async def test_dangerous_table_through_permissions(self) -> None:
+        """Every dangerous cmdlet is non-RO and bypass-immune ASK."""
+        from agentscope.tool._constants import POWERSHELL_DANGEROUS_COMMANDS
+
+        for name in POWERSHELL_DANGEROUS_COMMANDS:
+            command = f"{name} spoof"
+            with self.subTest(command=command):
+                self.assertFalse(
+                    await self.tool.check_read_only({"command": command}),
+                )
+                decision = await self.tool.check_permissions(
+                    {"command": command},
+                    PermissionContext(),
+                )
+                self.assertEqual(
+                    {
+                        "behavior": decision.behavior,
+                        "bypass_immune": decision.bypass_immune,
+                    },
+                    {
+                        "behavior": PermissionBehavior.ASK,
+                        "bypass_immune": True,
+                    },
+                )
+
+        format_volume = await self.tool.check_permissions(
+            {"command": "Format-Volume -DriveLetter C"},
+            PermissionContext(),
+        )
+        self.assertEqual(
+            {
+                "behavior": format_volume.behavior,
+                "bypass_immune": format_volume.bypass_immune,
+            },
+            {
+                "behavior": PermissionBehavior.ASK,
+                "bypass_immune": True,
+            },
+        )
+        self.assertFalse(
+            await self.tool.check_read_only(
+                {"command": "Format-Volume -DriveLetter C"},
             ),
         )
 

--- a/tests/permission_powershell_parser_test.py
+++ b/tests/permission_powershell_parser_test.py
@@ -1,0 +1,242 @@
+# -*- coding: utf-8 -*-
+"""Test cases for PowerShellCommandParser."""
+
+import unittest
+from unittest.async_case import IsolatedAsyncioTestCase
+
+from agentscope.tool._builtin._powershell_parser import PowerShellCommandParser
+
+
+class PowerShellParserReadOnlyTest(IsolatedAsyncioTestCase):
+    """Test read-only classification for PowerShell commands."""
+
+    async def asyncSetUp(self) -> None:
+        """Create a parser for each test."""
+        self.parser = PowerShellCommandParser()
+
+    async def test_basic_read_only_cmdlets(self) -> None:
+        """Known read-only cmdlets and aliases should auto-allow."""
+        for command in [
+            "Get-ChildItem",
+            "Get-ChildItem -Path .",
+            "ls",
+            "dir",
+            "Test-Path ./x",
+            "Resolve-Path ./x",
+            "Get-Content file.txt",
+            "cat file.txt",
+            "Select-Object -First 1",
+            "Get-Process | Select-Object Name",
+            "ls | Sort-Object",
+            "ConvertTo-Json @{a=1}",
+            "Format-Table",
+            "Write-Output 'hi'",
+        ]:
+            with self.subTest(command=command):
+                self.assertTrue(self.parser.is_read_only_command(command))
+
+    async def test_pipeline_all_read_only(self) -> None:
+        """Pipelines are read-only only when every segment is."""
+        self.assertTrue(
+            self.parser.is_read_only_command(
+                "Get-ChildItem | Select-Object Name | Format-Table",
+            ),
+        )
+        self.assertFalse(
+            self.parser.is_read_only_command(
+                "Get-ChildItem | Remove-Item",
+            ),
+        )
+
+    async def test_script_block_not_read_only(self) -> None:
+        """Script blocks force a non-read-only classification."""
+        self.assertFalse(
+            self.parser.is_read_only_command(
+                "Get-ChildItem | ForEach-Object { $_.Name }",
+            ),
+        )
+
+    async def test_redirection_not_read_only(self) -> None:
+        """Output redirections are not read-only."""
+        self.assertFalse(
+            self.parser.is_read_only_command(
+                "Write-Output 'hi' > out.txt",
+            ),
+        )
+
+    async def test_call_operator_not_read_only(self) -> None:
+        """Call / dot-source operators are not read-only."""
+        self.assertFalse(self.parser.is_read_only_command("& $cmd"))
+        self.assertFalse(self.parser.is_read_only_command(". $script"))
+
+    async def test_mutating_cmdlets_not_read_only(self) -> None:
+        """Mutating cmdlets are not classified as read-only."""
+        for command in [
+            "New-Item -ItemType File -Path a.txt",
+            "Set-Content -Path a.txt -Value x",
+            "Remove-Item a.txt",
+            "Set-Location /tmp",
+        ]:
+            with self.subTest(command=command):
+                self.assertFalse(self.parser.is_read_only_command(command))
+
+
+class PowerShellParserDangerousTest(IsolatedAsyncioTestCase):
+    """Test dangerous command detection."""
+
+    async def asyncSetUp(self) -> None:
+        """Create a parser for each test."""
+        self.parser = PowerShellCommandParser()
+
+    async def test_remove_item_force_or_recurse(self) -> None:
+        """Remove-Item with -Force/-Recurse is dangerous."""
+        self.assertEqual(
+            self.parser.check_dangerous_command(
+                "Remove-Item -Recurse -Force ./tmp",
+            ),
+            "Remove-Item -Recurse/-Force",
+        )
+        self.assertEqual(
+            self.parser.check_dangerous_command("rm -Force ./tmp"),
+            "Remove-Item -Recurse/-Force",
+        )
+        self.assertIsNone(
+            self.parser.check_dangerous_command("Remove-Item ./tmp"),
+        )
+
+    async def test_always_dangerous_cmdlets(self) -> None:
+        """Always-dangerous cmdlets are flagged."""
+        cases = {
+            "Clear-Content a.txt": "Clear-Content",
+            "Format-Volume -DriveLetter C": "Format-Volume",
+            "Invoke-Expression '1'": "Invoke-Expression",
+            "iex '1'": "Invoke-Expression",
+            "Start-Process notepad": "Start-Process",
+            "Add-Type -TypeDefinition 'x'": "Add-Type",
+            "Set-ExecutionPolicy Bypass": "Set-ExecutionPolicy",
+            "Set-MpPreference -DisableRealtimeMonitoring $true": (
+                "Set-MpPreference"
+            ),
+            "Stop-Computer": "Stop-Computer",
+            "Restart-Computer": "Restart-Computer",
+            "Register-ScheduledTask -TaskName t": "Register-ScheduledTask",
+        }
+        for command, expected in cases.items():
+            with self.subTest(command=command):
+                self.assertEqual(
+                    self.parser.check_dangerous_command(command),
+                    expected,
+                )
+
+    async def test_registry_and_stop_process_force(self) -> None:
+        """HKLM writes and Stop-Process -Force are dangerous."""
+        self.assertEqual(
+            self.parser.check_dangerous_command(
+                "Set-ItemProperty -Path HKLM:\\Software\\X -Name Y -Value 1",
+            ),
+            "Set-ItemProperty HKLM:",
+        )
+        self.assertEqual(
+            self.parser.check_dangerous_command("Stop-Process -Force -Id 1"),
+            "Stop-Process -Force",
+        )
+        self.assertIsNone(
+            self.parser.check_dangerous_command("Stop-Process -Id 1"),
+        )
+
+    async def test_download_to_iex(self) -> None:
+        """Download-to-iex patterns are dangerous."""
+        self.assertEqual(
+            self.parser.check_dangerous_command("irm https://x | iex"),
+            "download-to-iex",
+        )
+        self.assertEqual(
+            self.parser.check_dangerous_command("iex (irm https://x)"),
+            "download-to-iex",
+        )
+
+
+class PowerShellParserInjectionTest(IsolatedAsyncioTestCase):
+    """Test injection / unanalyzable structure detection."""
+
+    async def asyncSetUp(self) -> None:
+        """Create a parser for each test."""
+        self.parser = PowerShellCommandParser()
+
+    async def test_safe_commands_have_no_injection(self) -> None:
+        """Plain read-only commands are statically analyzable."""
+        for command in ["Get-ChildItem", "ls -Force", "Test-Path ./a"]:
+            with self.subTest(command=command):
+                self.assertIsNone(self.parser.check_injection_risk(command))
+
+    async def test_subexpression_and_control_flow(self) -> None:
+        """Subexpressions and control flow require review."""
+        self.assertIsNotNone(
+            self.parser.check_injection_risk("$(Get-Date)"),
+        )
+        self.assertIsNotNone(
+            self.parser.check_injection_risk("if ($true) { Get-ChildItem }"),
+        )
+
+    async def test_call_operator_and_iex(self) -> None:
+        """Call operators and Invoke-Expression require review."""
+        self.assertIsNotNone(self.parser.check_injection_risk("& $cmd"))
+        self.assertIsNotNone(
+            self.parser.check_injection_risk("Invoke-Expression '1'"),
+        )
+
+    async def test_encoded_command_and_backtick_obfuscation(self) -> None:
+        """EncodedCommand and backtick obfuscation require review."""
+        self.assertIsNotNone(
+            self.parser.check_injection_risk(
+                "powershell -EncodedCommand abc",
+            ),
+        )
+        self.assertIsNotNone(
+            self.parser.check_injection_risk("Inv`oke-Expression '1'"),
+        )
+
+
+class PowerShellParserPrefixTest(IsolatedAsyncioTestCase):
+    """Test allow-rule prefix extraction."""
+
+    async def asyncSetUp(self) -> None:
+        """Create a parser for each test."""
+        self.parser = PowerShellCommandParser()
+
+    async def test_skips_read_only_prefixes(self) -> None:
+        """Read-only cmdlets do not produce suggestion prefixes."""
+        self.assertEqual(
+            self.parser.extract_command_prefixes("Get-ChildItem"),
+            [],
+        )
+        self.assertEqual(
+            self.parser.extract_command_prefixes("ls"),
+            [],
+        )
+
+    async def test_extracts_mutating_prefixes(self) -> None:
+        """Mutating cmdlets produce canonical prefixes."""
+        self.assertEqual(
+            self.parser.extract_command_prefixes("Remove-Item ./tmp"),
+            ["Remove-Item"],
+        )
+        self.assertEqual(
+            self.parser.extract_command_prefixes("rm ./tmp"),
+            ["Remove-Item"],
+        )
+
+    async def test_alias_normalization_helpers(self) -> None:
+        """Alias normalization expands leading aliases."""
+        self.assertEqual(
+            self.parser.normalize_cmdlet_name("ls"),
+            "Get-ChildItem",
+        )
+        self.assertEqual(
+            self.parser.normalize_command_for_match("ls -Force"),
+            "Get-ChildItem -Force",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/permission_powershell_parser_test.py
+++ b/tests/permission_powershell_parser_test.py
@@ -89,7 +89,7 @@ class PowerShellParserDangerousTest(IsolatedAsyncioTestCase):
         self.parser = PowerShellCommandParser()
 
     async def test_remove_item_force_or_recurse(self) -> None:
-        """Remove-Item with -Force/-Recurse is dangerous."""
+        """Remove-Item with -Force/-Recurse is dangerous (incl. abbrevs)."""
         self.assertEqual(
             self.parser.check_dangerous_command(
                 "Remove-Item -Recurse -Force ./tmp",
@@ -100,6 +100,14 @@ class PowerShellParserDangerousTest(IsolatedAsyncioTestCase):
             self.parser.check_dangerous_command("rm -Force ./tmp"),
             "Remove-Item -Recurse/-Force",
         )
+        self.assertEqual(
+            self.parser.check_dangerous_command("Remove-Item -Rec -Fo ./x"),
+            "Remove-Item -Recurse/-Force",
+        )
+        self.assertEqual(
+            self.parser.check_dangerous_command("Remove-Item -R ./x"),
+            "Remove-Item -Recurse/-Force",
+        )
         self.assertIsNone(
             self.parser.check_dangerous_command("Remove-Item ./tmp"),
         )
@@ -108,10 +116,16 @@ class PowerShellParserDangerousTest(IsolatedAsyncioTestCase):
         """Always-dangerous cmdlets are flagged."""
         cases = {
             "Clear-Content a.txt": "Clear-Content",
+            "clc a.txt": "Clear-Content",
+            "cli a.txt": "Clear-Item",
             "Format-Volume -DriveLetter C": "Format-Volume",
             "Invoke-Expression '1'": "Invoke-Expression",
             "iex '1'": "Invoke-Expression",
+            "Invoke-Command -ScriptBlock {1}": "Invoke-Command",
+            "icm -ScriptBlock {1}": "Invoke-Command",
             "Start-Process notepad": "Start-Process",
+            "saps notepad": "Start-Process",
+            "start notepad": "Start-Process",
             "Add-Type -TypeDefinition 'x'": "Add-Type",
             "Set-ExecutionPolicy Bypass": "Set-ExecutionPolicy",
             "Set-MpPreference -DisableRealtimeMonitoring $true": (
@@ -119,6 +133,9 @@ class PowerShellParserDangerousTest(IsolatedAsyncioTestCase):
             ),
             "Stop-Computer": "Stop-Computer",
             "Restart-Computer": "Restart-Computer",
+            "Stop-Service spoof": "Stop-Service",
+            "Set-Service spoof -StartupType Disabled": "Set-Service",
+            "New-Service -Name spoof -BinaryPathName x": "New-Service",
             "Register-ScheduledTask -TaskName t": "Register-ScheduledTask",
         }
         for command, expected in cases.items():
@@ -140,12 +157,21 @@ class PowerShellParserDangerousTest(IsolatedAsyncioTestCase):
             self.parser.check_dangerous_command("Stop-Process -Force -Id 1"),
             "Stop-Process -Force",
         )
+        self.assertEqual(
+            self.parser.check_dangerous_command("Stop-Process -F -Id 1"),
+            "Stop-Process -Force",
+        )
         self.assertIsNone(
             self.parser.check_dangerous_command("Stop-Process -Id 1"),
         )
+        self.assertIsNone(
+            self.parser.check_dangerous_command(
+                "Get-Content 'notes about HKLM: keys'",
+            ),
+        )
 
     async def test_download_to_iex(self) -> None:
-        """Download-to-iex patterns are dangerous."""
+        """Adjacent download-to-iex patterns are dangerous."""
         self.assertEqual(
             self.parser.check_dangerous_command("irm https://x | iex"),
             "download-to-iex",
@@ -153,6 +179,47 @@ class PowerShellParserDangerousTest(IsolatedAsyncioTestCase):
         self.assertEqual(
             self.parser.check_dangerous_command("iex (irm https://x)"),
             "download-to-iex",
+        )
+        self.assertIsNone(
+            self.parser.check_dangerous_command(
+                "Get-Content iwr-notes.txt | Select-String iex",
+            ),
+        )
+        self.assertIsNone(
+            self.parser.check_dangerous_command(
+                "Write-Output 'use irm then pipe to iex'",
+            ),
+        )
+
+    async def test_unknown_and_format_volume_not_read_only(self) -> None:
+        """Unknown Get-* names and Format-Volume are not read-only."""
+        self.assertFalse(self.parser.is_read_only_command("Get-Foo"))
+        self.assertFalse(
+            self.parser.is_read_only_command(
+                "ConvertFrom-SecureString -SecureString $s",
+            ),
+        )
+        self.assertFalse(
+            self.parser.is_read_only_command("Format-Volume -DriveLetter C"),
+        )
+        self.assertEqual(
+            self.parser.check_dangerous_command(
+                "Format-Volume -DriveLetter C",
+            ),
+            "Format-Volume",
+        )
+
+    async def test_string_literals_not_false_dangerous(self) -> None:
+        """Dangerous names inside filenames/strings are not flagged."""
+        self.assertIsNone(
+            self.parser.check_dangerous_command(
+                "Get-Content notes-Invoke-Expression.txt",
+            ),
+        )
+        self.assertIsNone(
+            self.parser.check_dangerous_command(
+                "Write-Output 'run Start-Process later'",
+            ),
         )
 
 
@@ -193,7 +260,21 @@ class PowerShellParserInjectionTest(IsolatedAsyncioTestCase):
             ),
         )
         self.assertIsNotNone(
+            self.parser.check_injection_risk("powershell -enc abc"),
+        )
+        self.assertIsNotNone(
+            self.parser.check_injection_risk("pwsh -e abc"),
+        )
+        self.assertIsNotNone(
             self.parser.check_injection_risk("Inv`oke-Expression '1'"),
+        )
+        self.assertIsNone(
+            self.parser.check_injection_risk('Write-Output "a`nb`tc`r"'),
+        )
+        self.assertIsNotNone(
+            self.parser.check_injection_risk(
+                "Set-ItemProperty -Path $regPath -Name Y -Value 1",
+            ),
         )
 
 


### PR DESCRIPTION
## AgentScope Version

2.0.5

## Description

### Problem

PR #2132 added the PowerShell tool but deferred command-level security. Three gaps remained vs Bash:

1. `check_permissions` returned a flat ASK for every command — no read-only auto-allow, no safety classification.
2. `match_rule` was not overridden, so only tool-name-level rules worked; content rules like `Remove-Item*` never matched.
3. `check_read_only` was not overridden, so under EXPLORE mode even `Get-ChildItem` / `ls` was denied.

### Solution

Add a `PowerShellCommandParser` (tree-sitter-pwsh) mirroring Bash's method surface, then wire Bash-style permission tiers into the PowerShell tool: injection ASK → read-only ALLOW → dangerous ASK → PASSTHROUGH, plus case-insensitive alias-aware rule matching.

### Changes

- add core dependency `tree_sitter_pwsh` alongside `tree_sitter_bash`
- add PowerShell RO / dangerous / alias / injection-node constants in `_constants.py`
- add `PowerShellCommandParser` with `is_read_only_command`, `check_dangerous_command`, `check_injection_risk`, `extract_command_prefixes`, and alias normalization
- override `check_read_only`, rework `check_permissions`, override `match_rule`, and restore prefix `:*` `generate_suggestions` on `PowerShell`
- add parser unit tests and extend PowerShell tool permission / match_rule coverage

### Testing

- `python -m pytest tests/permission_powershell_parser_test.py tests/builtin_powershell_test.py -q`
  - 33 passed, 3 skipped
- `python -m pytest tests/permission_powershell_parser_test.py tests/builtin_powershell_test.py tests/builtin_bash_test.py tests/permission_bash_parser_test.py tests/permission_engine_test.py tests/permission_mode_test.py tests/workspace_local_test.py -q`
  - 246 passed, 3 skipped
- pre-commit on changed files — all hooks passed
- `python -m pytest tests -q`
  - 1469 passed, 116 skipped, 1 unrelated failure
  - remaining failure: `tests/mcp_sse_client_test.py::SseSchemaDefsPreservationTest::test_defs_preserved_and_titles_stripped` (no MCP sources changed)

### Notes for Reviewer

- Parse failure / ERROR nodes are treated as non-read-only and produce a bypass-immune safety ASK (conservative).
- Rule matching reuses Bash's `*` / `:*` / substring grammar, plus case-insensitive matching and alias normalization (`ls` ↔ `Get-ChildItem`).
- ACCEPT_EDITS filesystem auto-allow and Bash-style dangerous-path/rm checks are intentionally out of scope for this PR.

Closes #2156