### PR TITLE
fix(agent): avoid duplicate external tool start event

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -719,9 +719,12 @@ class Agent:
             call_block = last_msg.content[index]
             assert isinstance(call_block, ToolCallBlock)
 
-            # An ALLOWED call was already running, so its START was already
-            # emitted — skip it here (checked before flipping to FINISHED).
-            if call_block.state != ToolCallState.ALLOWED:
+            # ALLOWED calls are running and SUBMITTED external calls are
+            # awaiting their result; both already emitted START.
+            if call_block.state not in (
+                ToolCallState.ALLOWED,
+                ToolCallState.SUBMITTED,
+            ):
                 yield ToolResultStartEvent(
                     reply_id=self.state.reply_id,
                     tool_call_id=last_msg.content[index].id,

--- a/tests/agent_interrupt_test.py
+++ b/tests/agent_interrupt_test.py
@@ -20,6 +20,7 @@ from utils import AnyString, MockModel
 from agentscope.agent import Agent, InjectionConfig
 from agentscope.event import (
     ReplyEndEvent,
+    ToolResultStartEvent,
     UserInterruptEvent,
 )
 from agentscope.message import (
@@ -742,7 +743,7 @@ class AgentInterruptEventTest(IsolatedAsyncioTestCase):
         agent: Agent,
         model: MockModel,
         pending_tool_calls: list[ToolCallBlock],
-    ) -> None:
+    ) -> list[Any]:
         """Drive one reply that yields the given tool calls so the reply
         parks in either ASKING or SUBMITTED state."""
         model.set_responses(
@@ -758,10 +759,12 @@ class AgentInterruptEventTest(IsolatedAsyncioTestCase):
                 ],
             ],
         )
-        async for _ in agent.reply_stream(
+        events = []
+        async for event in agent.reply_stream(
             UserMsg(name="user", content="Hi"),
         ):
-            pass
+            events.append(event)
+        return events
 
     async def test_interrupt_event_on_idle_agent_is_noop(self) -> None:
         """No parked HITL → ``UserInterruptEvent`` yields nothing and
@@ -839,7 +842,7 @@ class AgentInterruptEventTest(IsolatedAsyncioTestCase):
         """Parked in SUBMITTED: ``UserInterruptEvent`` patches the same
         way (``str`` output)."""
         agent, model = self._make_agent([_ExternalConcurrentTool()])
-        await self._park_with(
+        parked_events = await self._park_with(
             agent,
             model,
             [
@@ -859,6 +862,13 @@ class AgentInterruptEventTest(IsolatedAsyncioTestCase):
         ):
             events.append(evt)
 
+        self.assertEqual(
+            sum(
+                isinstance(evt, ToolResultStartEvent)
+                for evt in [*parked_events, *events]
+            ),
+            1,
+        )
         _assert_interrupted_end(self, events, reply_id, session_id)
 
         context_dicts = [


### PR DESCRIPTION
Fixes #2166

## AgentScope Version

2.0.5 (current `main`)

## Problem and root cause

External tools emit `ToolResultStartEvent` when they are allowed, then transition from `ALLOWED` to `SUBMITTED` while awaiting external execution. Interruption cleanup only recognized `ALLOWED` as already started, so a parked `SUBMITTED` call received a second START event.

## Changes

- Treat both `ALLOWED` and `SUBMITTED` unfinished tool calls as already started during interruption cleanup.
- Add a regression test that combines the parked and interruption event streams and asserts exactly one START for the external tool call.
- Preserve the existing START-before-terminal behavior for calls that are still awaiting confirmation.

## User impact

Consumers of the event stream now receive one balanced tool-result lifecycle for interrupted external tools instead of duplicate START events.

## Validation

- `.venv/bin/pre-commit run --all-files` — passed (AST, YAML/XML/TOML/JSON, mypy, black, flake8, pylint, Pyroma, and remaining hooks)
- `.venv/bin/python -m pytest tests/agent_interrupt_test.py -q` — 9 passed
- `.venv/bin/python -m pytest tests/agent_*_test.py -q` — 38 passed
- `.venv/bin/python -m pytest tests -q` — collection blocked by unrelated optional test dependencies not installed locally (`fakeredis`, `boto3`, `mem0`, and `sqlalchemy`); no test failures were observed

## Compatibility and risk

No public API changes. The change only suppresses a duplicate event for the existing `SUBMITTED` lifecycle state; terminal interruption events and stored tool results are unchanged. Risk is low and covered by the full agent test group.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the contributing guide
- [x] Docstrings remain in Google style
- [x] No user-facing documentation change is required
- [x] Code is ready for review
