### PR TITLE
fix(formatter): make unsupported-media Base64Source temp file path deterministic

### DIFF
--- a/src/agentscope/formatter/_formatter_base.py
+++ b/src/agentscope/formatter/_formatter_base.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 """The formatter module."""
 import base64
+import hashlib
 import mimetypes
+import os
 import tempfile
 from abc import abstractmethod
 from fnmatch import fnmatch
@@ -141,21 +143,32 @@ class FormatterBase(BaseModel):
                     )
 
                 elif isinstance(block.source, Base64Source):
-                    # Have to save the base64 data locally
+                    # Have to save the base64 data locally. Derive the path
+                    # from the block's own stable id so re-formatting the
+                    # same (unchanged) block is a pure function of its input
+                    # instead of minting a new random path (and a new file)
+                    # on every call; hash the id rather than embedding it
+                    # directly so the path stays confined to the temp
+                    # directory regardless of what the id contains.
                     extension = mimetypes.guess_extension(
                         block.source.media_type,
                     )
-                    with tempfile.NamedTemporaryFile(
-                        suffix=extension,
-                        delete=False,
-                    ) as temp_file:
+                    digest = hashlib.sha256(
+                        block.id.encode("utf-8"),
+                    ).hexdigest()
+                    temp_path = os.path.join(
+                        tempfile.gettempdir(),
+                        f"agentscope_{digest}{extension or ''}",
+                    )
+                    if not os.path.exists(temp_path):
                         decoded_data = base64.b64decode(block.source.data)
-                        temp_file.write(decoded_data)
-                        textual_output.append(
-                            f"<system-reminder>A(n) {main_type} file is "
-                            f"returned and saved locally at: {temp_file.name}."
-                            f"</system-reminder>",
-                        )
+                        with open(temp_path, "wb") as temp_file:
+                            temp_file.write(decoded_data)
+                    textual_output.append(
+                        f"<system-reminder>A(n) {main_type} file is "
+                        f"returned and saved locally at: {temp_path}."
+                        f"</system-reminder>",
+                    )
 
         # Add system reminder tags if there is multimodal data to be promoted
         if multimodal_data:

--- a/tests/formatter_openai_chat_test.py
+++ b/tests/formatter_openai_chat_test.py
@@ -3,6 +3,9 @@
 OpenAIMultiAgentFormatter, following the reference test style with exact
 ground-truth comparisons.
 """
+import base64
+import os
+import re
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch
 
@@ -348,6 +351,39 @@ class TestOpenAIFormatter(IsolatedAsyncioTestCase):
             ],
             res,
         )
+
+    async def test_convert_tool_result_base64_unsupported_media_is_det(
+        self,
+    ) -> None:
+        """Formatting the same tool-result DataBlock with an unsupported
+        Base64Source media type twice must reuse the same on-disk path
+        instead of writing a new temp file with a new random path on
+        every call."""
+        fmt = OpenAIChatFormatter()
+        block = DataBlock(
+            source=Base64Source(
+                data=self.image_b64,
+                media_type="application/pdf",
+            ),
+        )
+
+        first_text, _ = fmt.convert_tool_result_to_string([block])
+        second_text, _ = fmt.convert_tool_result_to_string([block])
+
+        self.assertEqual(first_text, second_text)
+
+        match = re.search(
+            r"saved locally at: (.+)\.</system-reminder>",
+            first_text,
+        )
+        self.assertIsNotNone(match)
+        path = match.group(1)
+        self.assertTrue(os.path.exists(path))
+        with open(path, "rb") as saved_file:
+            self.assertEqual(
+                saved_file.read(),
+                base64.b64decode(self.image_b64),
+            )
 
     async def test_chat_formatter_thinking_dropped(self) -> None:
         """ThinkingBlock is silently dropped by OpenAI formatter."""


### PR DESCRIPTION
## PR Title Format

`fix(formatter): make unsupported-media Base64Source temp file path deterministic`

## AgentScope Version

2.0.5 (HEAD `999f64d`)

## Description

**Root cause.** `FormatterBase.convert_tool_result_to_string` saves an unsupported-media-
type `Base64Source` tool result to a temp file so its path can be shown to the model
(`.../formatter/_formatter_base.py:145-159`). `format()` re-serializes the same, unchanged
message history on every LLM call in a conversation, so calling it twice on the same tool
result block should produce identical output. Instead, the branch uses
`tempfile.NamedTemporaryFile(suffix=extension, delete=False)`, which mints a brand-new file
at a brand-new random path on every call. This breaks two things: the text shown to the
model differs between calls for a block that never changed (defeating provider-side
prompt/prefix caching, the same non-determinism class fixed for the promoted-block
identifier path in #2165), and every generated file is left on disk with nothing anywhere
in the codebase to clean it up, so a long-running agent accumulates one new file per
reformat of the same unsupported-media tool result.

**The fix.** `DataBlock` already carries its own stable `id`
(`message/_block.py`, `default_factory=_generate_id`), set once at construction and
unchanged for the object's lifetime. Deriving the temp path from a sha256 hash of that id
(hashed rather than embedded directly, so the path stays confined to the temp directory
regardless of what the id contains) and only writing the file if it does not already exist
makes the output a pure function of the (unchanged) input, exactly mirroring #2165's
approach for the sibling identifier bug. Re-formatting the same block now reuses the same
path and does not rewrite the file, and formatting N distinct blocks across many turns
creates at most N files instead of one per `format()` call, bounding the leak by the number
of unique blocks ever formatted rather than by call count. Full active cleanup (deleting a
file once its block is provably no longer needed) is a separate, larger question with no
existing hook in this code to answer it, and this PR does not attempt it.

**Verification.** Reproduced in a clean `python:3.11-slim` Docker container, editable
install of this HEAD: calling `OpenAIChatFormatter().convert_tool_result_to_string()` twice
on an unchanged `DataBlock(source=Base64Source(..., media_type="application/pdf"))`
produced two different saved-locally-at paths and two files on disk before the fix; after
the fix, both calls return identical text and only one file exists, with content matching
the decoded base64 data. Added regression test
`test_convert_tool_result_base64_unsupported_media_is_det`
(`tests/formatter_openai_chat_test.py`), confirmed it fails on unfixed `main` (`AssertionError:
'...saved locally at: /tmp/tmpvrf8oo37.pdf...' != '...saved locally at: /tmp/tmp8d6daa2q.pdf...'`)
and passes on this branch. Ran the full formatter test suite (`formatter_openai_chat_test.py`,
`formatter_openai_response_test.py`, `formatter_dashscope_test.py`, `formatter_moonshot_test.py`,
`formatter_ollama_test.py`, `formatter_gemini_test.py`, `formatter_anthropic_test.py`,
`formatter_deepseek_test.py`, `formatter_xai_test.py`) in the same container: 101 passed. Ran
`pre-commit run --files src/agentscope/formatter/_formatter_base.py
tests/formatter_openai_chat_test.py` (check-ast, mypy, black, flake8, pylint, pyroma, etc.):
all hooks pass. Not verified: the project's full `pytest tests` (this change has no surface
outside the formatter module already covered above).

Fixes #2173

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the CONTRIBUTING.md
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated (no user-facing docs affected by this fix)
- [x] Code is ready for review
