### PR TITLE
fix(app): serialize concurrent session updates

### DIFF
--- a/src/agentscope/app/_router/_session.py
+++ b/src/agentscope/app/_router/_session.py
@@ -431,6 +431,7 @@ async def update_session(
     user_id: str = Depends(get_current_user_id),
     storage: StorageBase = Depends(get_storage),
     access: ResourceAccessService = Depends(get_resource_access_service),
+    message_bus: MessageBus = Depends(get_message_bus),
 ) -> SessionRecord:
     """Update the model configuration of an existing session.
 
@@ -440,6 +441,7 @@ async def update_session(
         user_id (`str`): Injected authenticated user ID.
         storage (`StorageBase`): Injected storage backend.
         access (`ResourceAccessService`): Injected access service.
+        message_bus (`MessageBus`): Injected message bus.
 
     Returns:
         `SessionRecord`: The full session record after the update.
@@ -448,56 +450,70 @@ async def update_session(
         `HTTPException`: 404 if the session does not exist, or if the
             referenced credential / KB is not visible to the caller.
     """
-    existing = await storage.get_session(user_id, agent_id, session_id)
-    if existing is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Session '{session_id}' not found.",
+    async with message_bus.acquire_lock(
+        MessageBusKeys.session_update_lock(session_id),
+    ):
+        existing = await storage.get_session(user_id, agent_id, session_id)
+        if existing is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Session '{session_id}' not found.",
+            )
+
+        await _ensure_credential_exists(
+            access,
+            user_id,
+            body.chat_model_config,
+        )
+        await _ensure_credential_exists(
+            access,
+            user_id,
+            body.fallback_chat_model_config,
+        )
+        await _ensure_credential_exists(
+            access,
+            user_id,
+            body.tts_model_config,
+        )
+        await _ensure_knowledge_bases_exist(
+            access,
+            user_id,
+            body.knowledge_config,
         )
 
-    await _ensure_credential_exists(access, user_id, body.chat_model_config)
-    await _ensure_credential_exists(
-        access,
-        user_id,
-        body.fallback_chat_model_config,
-    )
-    await _ensure_credential_exists(access, user_id, body.tts_model_config)
-    await _ensure_knowledge_bases_exist(
-        access,
-        user_id,
-        body.knowledge_config,
-    )
+        updated_state = existing.state
+        if body.permission_mode is not None:
+            updated_ctx = existing.state.permission_context.model_copy(
+                update={"mode": body.permission_mode},
+            )
 
-    updated_state = existing.state
-    if body.permission_mode is not None:
-        updated_ctx = existing.state.permission_context.model_copy(
-            update={"mode": body.permission_mode},
+            updated_state = existing.state.model_copy(
+                update={
+                    "permission_context": updated_ctx,
+                },
+            )
+
+        # PATCH semantics: only fields explicitly present in the request body
+        # are applied. ``exclude_unset=True`` lets clients distinguish "leave
+        # unchanged" (omit) from "clear" (send ``null``) — required for
+        # clearing ``fallback_chat_model_config``.
+        config_updates = body.model_dump(
+            exclude_unset=True,
+            exclude={"permission_mode"},
         )
 
-        updated_state = existing.state.model_copy(
-            update={
-                "permission_context": updated_ctx,
-            },
+        return await storage.upsert_session(
+            user_id=user_id,
+            agent_id=agent_id,
+            config=SessionConfig.model_validate(
+                {
+                    **existing.config.model_dump(mode="json"),
+                    **config_updates,
+                },
+            ),
+            state=updated_state,
+            session_id=session_id,
         )
-
-    # PATCH semantics: only fields explicitly present in the request body are
-    # applied. ``exclude_unset=True`` lets clients distinguish "leave
-    # unchanged" (omit) from "clear" (send ``null``) — required for clearing
-    # ``fallback_chat_model_config``.
-    config_updates = body.model_dump(
-        exclude_unset=True,
-        exclude={"permission_mode"},
-    )
-
-    return await storage.upsert_session(
-        user_id=user_id,
-        agent_id=agent_id,
-        config=SessionConfig.model_validate(
-            {**existing.config.model_dump(mode="json"), **config_updates},
-        ),
-        state=updated_state,
-        session_id=session_id,
-    )
 
 
 # ----------------------------------------------------------------------

--- a/src/agentscope/app/message_bus/_keys.py
+++ b/src/agentscope/app/message_bus/_keys.py
@@ -134,6 +134,17 @@ class MessageBusKeys:
         return cls._SESSION_LOCK.format(sid=session_id)
 
     # ------------------------------------------------------------------
+    # Session update lock
+    # ------------------------------------------------------------------
+
+    _SESSION_UPDATE_LOCK = "agentscope:session:update-lock:{sid}"
+
+    @classmethod
+    def session_update_lock(cls, session_id: str) -> str:
+        """Per-session lock for atomic read-merge-write updates."""
+        return cls._SESSION_UPDATE_LOCK.format(sid=session_id)
+
+    # ------------------------------------------------------------------
     # Session inbox
     # ------------------------------------------------------------------
 

--- a/tests/session_router_test.py
+++ b/tests/session_router_test.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+"""Tests for the session router."""
+import asyncio
+from unittest import IsolatedAsyncioTestCase
+
+from agentscope.app._router._schema import UpdateSessionRequest
+from agentscope.app._router._session import update_session
+from agentscope.app.message_bus import InMemoryMessageBus
+from agentscope.app.storage import SessionConfig, SessionRecord
+from agentscope.permission import PermissionMode
+from agentscope.state import AgentState
+
+
+class _RacingStorage:
+    """Minimal storage double that exposes stale concurrent reads."""
+
+    def __init__(self) -> None:
+        """Initialize a session and controls for the first read."""
+        self.session = SessionRecord(
+            id="session-1",
+            user_id="user-1",
+            agent_id="agent-1",
+            config=SessionConfig(
+                workspace_id="workspace-1",
+                name="original",
+            ),
+            state=AgentState(session_id="session-1"),
+        )
+        self.first_read = asyncio.Event()
+        self.release_first_read = asyncio.Event()
+        self.read_count = 0
+
+    async def get_session(
+        self,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> SessionRecord:
+        """Return a snapshot, pausing the first reader.
+
+        Args:
+            user_id (`str`):
+                Session owner ID.
+            agent_id (`str`):
+                Session agent ID.
+            session_id (`str`):
+                Session ID.
+
+        Returns:
+            `SessionRecord`:
+                A detached snapshot of the current session.
+        """
+        del user_id, agent_id, session_id
+        snapshot = self.session.model_copy(deep=True)
+        self.read_count += 1
+        if self.read_count == 1:
+            self.first_read.set()
+            await self.release_first_read.wait()
+        return snapshot
+
+    async def upsert_session(
+        self,
+        user_id: str,
+        agent_id: str,
+        config: SessionConfig,
+        state: AgentState,
+        session_id: str,
+    ) -> SessionRecord:
+        """Replace the stored config and state.
+
+        Args:
+            user_id (`str`):
+                Session owner ID.
+            agent_id (`str`):
+                Session agent ID.
+            config (`SessionConfig`):
+                Replacement session configuration.
+            state (`AgentState`):
+                Replacement session state.
+            session_id (`str`):
+                Session ID.
+
+        Returns:
+            `SessionRecord`:
+                A detached snapshot of the updated session.
+        """
+        del user_id, agent_id, session_id
+        self.session = self.session.model_copy(
+            update={
+                "config": config,
+                "state": state,
+            },
+            deep=True,
+        )
+        return self.session.model_copy(deep=True)
+
+
+class TestUpdateSession(IsolatedAsyncioTestCase):
+    """Concurrent update behavior for the session PATCH route."""
+
+    async def test_concurrent_updates_preserve_disjoint_fields(self) -> None:
+        """Two concurrent PATCH requests preserve both field updates."""
+        storage = _RacingStorage()
+        message_bus = InMemoryMessageBus()
+        access = object()
+        expected = storage.session.model_copy(deep=True)
+
+        rename_task = asyncio.create_task(
+            update_session(
+                session_id="session-1",
+                body=UpdateSessionRequest(name="renamed"),
+                agent_id="agent-1",
+                user_id="user-1",
+                storage=storage,
+                access=access,
+                message_bus=message_bus,
+            ),
+        )
+        await storage.first_read.wait()
+
+        permission_task = asyncio.create_task(
+            update_session(
+                session_id="session-1",
+                body=UpdateSessionRequest(
+                    permission_mode=PermissionMode.BYPASS,
+                ),
+                agent_id="agent-1",
+                user_id="user-1",
+                storage=storage,
+                access=access,
+                message_bus=message_bus,
+            ),
+        )
+        await asyncio.sleep(0)
+        storage.release_first_read.set()
+
+        await asyncio.gather(rename_task, permission_task)
+
+        expected.config.name = "renamed"
+        expected.state.permission_context.mode = PermissionMode.BYPASS
+        self.assertEqual(
+            storage.session.model_dump(),
+            expected.model_dump(),
+        )


### PR DESCRIPTION
## AgentScope Version

2.0.5

## Description

Fixes #2172

Concurrent session PATCH requests could read the same snapshot and overwrite each other's changes during the read-merge-write sequence.

This change:

- adds a dedicated per-session update lock key
- serializes the complete PATCH read, validation, merge, and write sequence
- keeps the update lock separate from the chat-run lock
- adds a deterministic regression test covering concurrent updates to disjoint fields

## Testing

- `.venv/bin/python -m pytest tests/session_router_test.py tests/in_memory_message_bus_test.py tests/service_message_bus_test.py -q` (69 passed)
- `.venv/bin/pre-commit run --files src/agentscope/app/_router/_session.py src/agentscope/app/message_bus/_keys.py tests/session_router_test.py`

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the CONTRIBUTING.md
- [x] Docstrings are in Google style
- [x] Related documentation is not required for this internal concurrency fix
- [x] Code is ready for review