### PR TITLE
fix(tool): preserve error state in tool responses

### DIFF
--- a/src/agentscope/tool/_response.py
+++ b/src/agentscope/tool/_response.py
@@ -135,9 +135,15 @@ class ToolResponse(BaseModel):
         # worse.
         if chunk.state == ToolResultState.ERROR:
             self.state = ToolResultState.ERROR
-        elif chunk.state == "interrupted":
+        elif (
+            self.state != ToolResultState.ERROR
+            and chunk.state == ToolResultState.INTERRUPTED
+        ):
             self.state = ToolResultState.INTERRUPTED
-        elif chunk.state == ToolResultState.DENIED:
+        elif (
+            self.state != ToolResultState.ERROR
+            and chunk.state == ToolResultState.DENIED
+        ):
             self.state = ToolResultState.DENIED
 
         self.metadata.update(chunk.metadata)


### PR DESCRIPTION
## AgentScope Version

2.0.5 (current `main` at `999f64d`)

## Description

`ToolResponse.append_chunk()` could replace an existing `ERROR` state with a later `INTERRUPTED` or `DENIED` chunk, even though the method documents that failure state should be preserved.

This change:

- keeps `ToolResultState.ERROR` sticky once any chunk reports an error
- retains the existing last-terminal-state behavior when no error has occurred
- uses `ToolResultState.INTERRUPTED` instead of comparing against a string literal
- adds regression coverage for both error-to-interrupted and error-to-denied sequences

Closes #2177.

## Testing

- `.venv/Scripts/python.exe -m pytest tests/tool_response_test.py tests/toolkit_test.py -q`
  - 17 passed, 2 subtests passed
- `.venv/Scripts/pre-commit.exe run --all-files`
  - all hooks passed
- `.venv/Scripts/python.exe -m pytest tests -q` with localhost excluded from the machine proxy
  - 1297 passed, 268 skipped, 33 subtests passed
  - 1 unrelated Windows locale failure remains in `AsyncSQLAlchemyStorageAutoMigrateTest`: Alembic explicitly reads its UTF-8 `alembic.ini` with the system GBK locale

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Documentation update is not required because this only corrects internal state aggregation behavior
- [x] Code is ready for review