### PR TITLE
fix(webui): open task panel on task updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,6 @@ pnpm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
+
+# PR tracker (local contribution workflow)
+.pr-tracker/

--- a/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
+++ b/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
@@ -402,7 +402,8 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 			return;
 		}
 		const tc = (view.session.state as Record<string, unknown>)?.tasks_context as
-			TaskContext | undefined;
+			| TaskContext
+			| undefined;
 		setTasksContext(tc ?? null);
 	}, [view]);
 
@@ -416,7 +417,8 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 			return;
 		}
 		const pc = (view.session.state as Record<string, unknown>)?.permission_context as
-			PermissionContext | undefined;
+			| PermissionContext
+			| undefined;
 		setPermissionContext(pc ?? null);
 	}, [view]);
 

--- a/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
+++ b/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
@@ -186,6 +186,7 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 	const [tasksContext, setTasksContext] = useState<TaskContext | null>(null);
 	const [permissionContext, setPermissionContext] = useState<PermissionContext | null>(null);
 	const [configPending, setConfigPending] = useState(false);
+	const planPanelDismissedRef = useRef(false);
 	// Dock layout: columns laid out left→right, each holding up to 2
 	// panels stacked top→bottom. Open order determines placement.
 	// Persisted so leaving and returning to /chat keeps the same panels.
@@ -194,6 +195,10 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 	useEffect(() => {
 		localStorage.setItem(PANEL_LAYOUT_KEY, JSON.stringify(panelLayout));
 	}, [panelLayout]);
+
+	useEffect(() => {
+		planPanelDismissedRef.current = false;
+	}, [agentId, sessionId]);
 
 	// When the viewport agent differs from the outer page's selected
 	// agent (i.e. user drilled into a team member), `refetchSessions`
@@ -217,7 +222,11 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 
 	const handleStateUpdated = useCallback((value: Record<string, unknown>) => {
 		if (value.tasks_context) {
-			setTasksContext(value.tasks_context as TaskContext);
+			const nextTasks = value.tasks_context as TaskContext;
+			setTasksContext(nextTasks);
+			if (nextTasks.tasks?.length && !planPanelDismissedRef.current) {
+				setPanelLayout((layout) => openPanelInLayout(layout, 'plan'));
+			}
 		}
 		if (value.permission_context) {
 			setPermissionContext(value.permission_context as PermissionContext);
@@ -254,15 +263,20 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 
 	// Toggle a panel open/closed from the top-bar buttons.
 	const togglePanel = useCallback((key: PanelKey) => {
-		setPanelLayout((layout) =>
-			layout.some((column) => column.includes(key))
-				? closePanelInLayout(layout, key)
-				: openPanelInLayout(layout, key),
-		);
+		setPanelLayout((layout) => {
+			const isOpen = layout.some((column) => column.includes(key));
+			if (isOpen && key === 'plan') {
+				planPanelDismissedRef.current = true;
+			}
+			return isOpen ? closePanelInLayout(layout, key) : openPanelInLayout(layout, key);
+		});
 	}, []);
 
 	// Close a panel (driven by the panel's own close button).
 	const closePanel = useCallback((key: PanelKey) => {
+		if (key === 'plan') {
+			planPanelDismissedRef.current = true;
+		}
 		setPanelLayout((layout) => closePanelInLayout(layout, key));
 	}, []);
 

--- a/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
+++ b/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
@@ -1,7 +1,7 @@
 import type { PermissionContext } from '@agentscope-ai/agentscope/permission';
 import type { TaskContext } from '@agentscope-ai/agentscope/state';
 import { BookText, ChevronDown, Database, ListTodo, PanelRight, ShieldCheck } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { ChatModelConfig, SessionKnowledgeConfig, TTSModelConfig } from '@/api';
 import { sessionApi } from '@/api';
@@ -143,13 +143,18 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 	const [credentialRefetchTrigger, setCredentialRefetchTrigger] = useState(0);
 	const [tasksContext, setTasksContext] = useState<TaskContext | null>(null);
 	const [permissionContext, setPermissionContext] = useState<PermissionContext | null>(null);
+	const userDismissedPanelRef = useRef(false);
 	// Dock layout: columns laid out left→right, each holding up to 2
 	// panels stacked top→bottom. Open order determines placement.
 	const [panelLayout, setPanelLayout] = useState<PanelKey[][]>([]);
 
 	const handleStateUpdated = useCallback((value: Record<string, unknown>) => {
 		if (value.tasks_context) {
-			setTasksContext(value.tasks_context as TaskContext);
+			const tc = value.tasks_context as TaskContext;
+			setTasksContext(tc);
+			if (tc.tasks?.length && !userDismissedPanelRef.current) {
+				setPanelLayout((layout) => openPanelInLayout(layout, 'plan'));
+			}
 		}
 		if (value.permission_context) {
 			setPermissionContext(value.permission_context as PermissionContext);
@@ -176,15 +181,21 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 
 	// Toggle a panel open/closed from the top-bar buttons.
 	const togglePanel = useCallback((key: PanelKey) => {
-		setPanelLayout((layout) =>
-			layout.some((column) => column.includes(key))
+		setPanelLayout((layout) => {
+			const willClose = layout.some((column) => column.includes(key));
+			if (willClose && key === 'plan') {
+				userDismissedPanelRef.current = true;
+			}
+			return willClose
 				? closePanelInLayout(layout, key)
-				: openPanelInLayout(layout, key),
-		);
+				: openPanelInLayout(layout, key);
+		});
 	}, []);
 
-	// Close a panel (driven by the panel's own close button).
 	const closePanel = useCallback((key: PanelKey) => {
+		if (key === 'plan') {
+			userDismissedPanelRef.current = true;
+		}
 		setPanelLayout((layout) => closePanelInLayout(layout, key));
 	}, []);
 
@@ -337,6 +348,7 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 	// before `view` repopulates — and an immediate send would post to
 	// a session whose backend config doesn't actually have that model.
 	useEffect(() => {
+		userDismissedPanelRef.current = false;
 		setSelectedModel(null);
 		setSelectedFallbackModel(null);
 		setSelectedTTSModel(null);

--- a/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
+++ b/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
@@ -186,9 +186,7 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 			if (willClose && key === 'plan') {
 				userDismissedPanelRef.current = true;
 			}
-			return willClose
-				? closePanelInLayout(layout, key)
-				: openPanelInLayout(layout, key);
+			return willClose ? closePanelInLayout(layout, key) : openPanelInLayout(layout, key);
 		});
 	}, []);
 
@@ -404,8 +402,7 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 			return;
 		}
 		const tc = (view.session.state as Record<string, unknown>)?.tasks_context as
-			| TaskContext
-			| undefined;
+			TaskContext | undefined;
 		setTasksContext(tc ?? null);
 	}, [view]);
 
@@ -419,8 +416,7 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 			return;
 		}
 		const pc = (view.session.state as Record<string, unknown>)?.permission_context as
-			| PermissionContext
-			| undefined;
+			PermissionContext | undefined;
 		setPermissionContext(pc ?? null);
 	}, [view]);
 

--- a/src/agentscope/app/middleware/_state_change_middleware.py
+++ b/src/agentscope/app/middleware/_state_change_middleware.py
@@ -6,12 +6,13 @@ event stream.
 Two kinds of change are detected:
 
 - **State change** — ``tasks_context`` or ``permission_context``
-  modified (detected via hash comparison). Checked both around each
-  tool call (``on_acting``, for incremental updates during a turn)
-  and around the whole reply (``on_reply``, to catch changes made
-  outside the tool-execution window — e.g. permission rules added
+  modified (detected via separate hash comparisons). Checked both
+  around each tool call (``on_acting``, for incremental updates during
+  a turn) and around the whole reply (``on_reply``, to catch changes
+  made outside the tool-execution window — e.g. permission rules added
   while handling a user confirmation). Pushes
-  ``CustomEvent(name="state_updated", value={...})``.
+  ``CustomEvent(name="state_updated", value={...})`` containing only
+  the fields that changed.
 - **Team change** — the tool that just ran is one of the team tools
   (``TeamCreate``, ``AgentCreate``, ``AgentInvite``, ``TeamDelete``).
   These tools directly mutate storage (``TeamRecord``,
@@ -68,8 +69,8 @@ class StateChangeMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
         self._session_id = session_id
 
     @staticmethod
-    def _state_hash(agent: Any) -> str:
-        """Compute a fast hash of the state fields we track.
+    def _state_hashes(agent: Any) -> tuple[str, str]:
+        """Compute separate hashes of the state fields we track.
 
         Only ``tasks_context`` and ``permission_context`` are included;
         ``context`` (the message history) is intentionally excluded
@@ -80,33 +81,48 @@ class StateChangeMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
             agent: The agent instance.
 
         Returns:
-            `str`: A hex digest that changes when the tracked fields
-            change.
+            `tuple[str, str]`: Hashes for ``tasks_context`` and
+            ``permission_context``, respectively.
         """
-        raw = (
-            agent.state.tasks_context.model_dump_json()
-            + agent.state.permission_context.model_dump_json()
+        return (
+            hashlib.md5(
+                agent.state.tasks_context.model_dump_json().encode(),
+            ).hexdigest(),
+            hashlib.md5(
+                agent.state.permission_context.model_dump_json().encode(),
+            ).hexdigest(),
         )
-        return hashlib.md5(raw.encode()).hexdigest()
 
-    async def _publish_state(self, agent: Any) -> None:
-        """Push a ``state_updated`` event with the current tracked state.
+    async def _publish_state_changes(
+        self,
+        agent: Any,
+        hashes_before: tuple[str, str],
+    ) -> None:
+        """Publish the tracked state fields that changed.
 
         Args:
             agent: The agent instance whose state to publish.
+            hashes_before (`tuple[str, str]`):
+                Tracked state hashes captured before execution.
         """
+        hashes_after = self._state_hashes(agent)
+        value = {}
+        if hashes_before[0] != hashes_after[0]:
+            value["tasks_context"] = agent.state.tasks_context.model_dump(
+                mode="json",
+            )
+        if hashes_before[1] != hashes_after[1]:
+            value[
+                "permission_context"
+            ] = agent.state.permission_context.model_dump(
+                mode="json",
+            )
+        if not value:
+            return
+
         event = CustomEvent(
             name="state_updated",
-            value={
-                "tasks_context": agent.state.tasks_context.model_dump(
-                    mode="json",
-                ),
-                "permission_context": (
-                    agent.state.permission_context.model_dump(
-                        mode="json",
-                    )
-                ),
-            },
+            value=value,
         )
         await publish_session_event(
             self._bus,
@@ -142,14 +158,12 @@ class StateChangeMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
         Yields:
             ``AgentEvent | Msg`` — unchanged from downstream.
         """
-        hash_before = self._state_hash(agent)
+        hashes_before = self._state_hashes(agent)
 
         async for item in next_handler(**input_kwargs):
             yield item
 
-        hash_after = self._state_hash(agent)
-        if hash_before != hash_after:
-            await self._publish_state(agent)
+        await self._publish_state_changes(agent, hashes_before)
 
     async def on_acting(
         self,
@@ -173,15 +187,13 @@ class StateChangeMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
         tool_call = input_kwargs.get("tool_call")
         tool_name = tool_call.name if tool_call else ""
 
-        hash_before = self._state_hash(agent)
+        hashes_before = self._state_hashes(agent)
 
         async for item in next_handler(**input_kwargs):
             yield item
 
         # Check 1: state fields changed?
-        hash_after = self._state_hash(agent)
-        if hash_before != hash_after:
-            await self._publish_state(agent)
+        await self._publish_state_changes(agent, hashes_before)
 
         # Check 2: team tool ran?
         if tool_name in _TEAM_TOOL_NAMES:

--- a/src/agentscope/app/middleware/_state_change_middleware.py
+++ b/src/agentscope/app/middleware/_state_change_middleware.py
@@ -87,7 +87,9 @@ class StateChangeMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
             hashlib.md5(perm_raw.encode()).hexdigest(),
         )
 
-    async def _publish_state(self, agent: Any, tasks_changed: bool, perm_changed: bool) -> None:
+    async def _publish_state(
+        self, agent: Any, tasks_changed: bool, perm_changed: bool
+    ) -> None:
         """Push a ``state_updated`` event with only the changed fields.
 
         Args:
@@ -101,10 +103,8 @@ class StateChangeMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
                 mode="json",
             )
         if perm_changed:
-            value["permission_context"] = (
-                agent.state.permission_context.model_dump(
-                    mode="json",
-                )
+            value["permission_context"] = agent.state.permission_context.model_dump(
+                mode="json",
             )
         if not value:
             return

--- a/src/agentscope/app/middleware/_state_change_middleware.py
+++ b/src/agentscope/app/middleware/_state_change_middleware.py
@@ -68,45 +68,49 @@ class StateChangeMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
         self._session_id = session_id
 
     @staticmethod
-    def _state_hash(agent: Any) -> str:
-        """Compute a fast hash of the state fields we track.
+    def _compute_hashes(agent: Any) -> tuple:
+        """Compute separate hashes for tasks_context and permission_context.
 
-        Only ``tasks_context`` and ``permission_context`` are included;
-        ``context`` (the message history) is intentionally excluded
-        because it changes on every reasoning step and is not what
-        this middleware cares about.
+        Returns a tuple of (tasks_hash, permission_hash) so callers can
+        detect which field changed independently.
 
         Args:
             agent: The agent instance.
 
         Returns:
-            `str`: A hex digest that changes when the tracked fields
-            change.
+            `tuple`: (tasks_hash, permission_hash) as hex digest strings.
         """
-        raw = (
-            agent.state.tasks_context.model_dump_json()
-            + agent.state.permission_context.model_dump_json()
+        tasks_raw = agent.state.tasks_context.model_dump_json()
+        perm_raw = agent.state.permission_context.model_dump_json()
+        return (
+            hashlib.md5(tasks_raw.encode()).hexdigest(),
+            hashlib.md5(perm_raw.encode()).hexdigest(),
         )
-        return hashlib.md5(raw.encode()).hexdigest()
 
-    async def _publish_state(self, agent: Any) -> None:
-        """Push a ``state_updated`` event with the current tracked state.
+    async def _publish_state(self, agent: Any, tasks_changed: bool, perm_changed: bool) -> None:
+        """Push a ``state_updated`` event with only the changed fields.
 
         Args:
             agent: The agent instance whose state to publish.
+            tasks_changed: Whether tasks_context changed.
+            perm_changed: Whether permission_context changed.
         """
+        value = {}
+        if tasks_changed:
+            value["tasks_context"] = agent.state.tasks_context.model_dump(
+                mode="json",
+            )
+        if perm_changed:
+            value["permission_context"] = (
+                agent.state.permission_context.model_dump(
+                    mode="json",
+                )
+            )
+        if not value:
+            return
         event = CustomEvent(
             name="state_updated",
-            value={
-                "tasks_context": agent.state.tasks_context.model_dump(
-                    mode="json",
-                ),
-                "permission_context": (
-                    agent.state.permission_context.model_dump(
-                        mode="json",
-                    )
-                ),
-            },
+            value=value,
         )
         await publish_session_event(
             self._bus,
@@ -142,14 +146,16 @@ class StateChangeMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
         Yields:
             ``AgentEvent | Msg`` — unchanged from downstream.
         """
-        hash_before = self._state_hash(agent)
+        tasks_hash_before, perm_hash_before = self._compute_hashes(agent)
 
         async for item in next_handler(**input_kwargs):
             yield item
 
-        hash_after = self._state_hash(agent)
-        if hash_before != hash_after:
-            await self._publish_state(agent)
+        tasks_hash_after, perm_hash_after = self._compute_hashes(agent)
+        tasks_changed = tasks_hash_before != tasks_hash_after
+        perm_changed = perm_hash_before != perm_hash_after
+        if tasks_changed or perm_changed:
+            await self._publish_state(agent, tasks_changed, perm_changed)
 
     async def on_acting(
         self,
@@ -173,15 +179,16 @@ class StateChangeMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
         tool_call = input_kwargs.get("tool_call")
         tool_name = tool_call.name if tool_call else ""
 
-        hash_before = self._state_hash(agent)
+        tasks_hash_before, perm_hash_before = self._compute_hashes(agent)
 
         async for item in next_handler(**input_kwargs):
             yield item
 
-        # Check 1: state fields changed?
-        hash_after = self._state_hash(agent)
-        if hash_before != hash_after:
-            await self._publish_state(agent)
+        tasks_hash_after, perm_hash_after = self._compute_hashes(agent)
+        tasks_changed = tasks_hash_before != tasks_hash_after
+        perm_changed = perm_hash_before != perm_hash_after
+        if tasks_changed or perm_changed:
+            await self._publish_state(agent, tasks_changed, perm_changed)
 
         # Check 2: team tool ran?
         if tool_name in _TEAM_TOOL_NAMES:

--- a/src/agentscope/app/middleware/_state_change_middleware.py
+++ b/src/agentscope/app/middleware/_state_change_middleware.py
@@ -88,7 +88,10 @@ class StateChangeMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
         )
 
     async def _publish_state(
-        self, agent: Any, tasks_changed: bool, perm_changed: bool
+        self,
+        agent: Any,
+        tasks_changed: bool,
+        perm_changed: bool,
     ) -> None:
         """Push a ``state_updated`` event with only the changed fields.
 

--- a/src/agentscope/app/middleware/_state_change_middleware.py
+++ b/src/agentscope/app/middleware/_state_change_middleware.py
@@ -25,6 +25,7 @@ event chain, because ``on_acting`` yields ``ToolChunk | ToolResponse``
 — not ``AgentEvent``. The SSE ``/stream`` endpoint picks them up from
 the bus like any other session event.
 """
+
 import hashlib
 from typing import Any, AsyncGenerator, Callable
 
@@ -106,8 +107,10 @@ class StateChangeMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
                 mode="json",
             )
         if perm_changed:
-            value["permission_context"] = agent.state.permission_context.model_dump(
-                mode="json",
+            value["permission_context"] = (
+                agent.state.permission_context.model_dump(
+                    mode="json",
+                )
             )
         if not value:
             return

--- a/src/agentscope/app/middleware/_state_change_middleware.py
+++ b/src/agentscope/app/middleware/_state_change_middleware.py
@@ -107,10 +107,10 @@ class StateChangeMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
                 mode="json",
             )
         if perm_changed:
-            value["permission_context"] = (
-                agent.state.permission_context.model_dump(
-                    mode="json",
-                )
+            value[
+                "permission_context"
+            ] = agent.state.permission_context.model_dump(
+                mode="json",
             )
         if not value:
             return

--- a/src/agentscope/event/_event.py
+++ b/src/agentscope/event/_event.py
@@ -513,7 +513,8 @@ class CustomEvent(EventBase):
             Identifies the kind of notification. Well-known values:
 
             - ``"state_updated"`` — agent state (tasks / permission)
-              changed during a tool call.
+              changed during a tool call. Its ``value`` is partial:
+              absent fields are unchanged.
             - ``"team_updated"`` — team membership changed (member
               added / team created or dissolved).
 

--- a/tests/service_state_change_middleware_test.py
+++ b/tests/service_state_change_middleware_test.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Tests for state-change event payloads."""
+from types import SimpleNamespace
+from typing import Any, AsyncGenerator, Callable
+from unittest import IsolatedAsyncioTestCase
+
+from agentscope.app.message_bus import InMemoryMessageBus
+from agentscope.app.message_bus._keys import MessageBusKeys
+from agentscope.app.middleware import StateChangeMiddleware
+from agentscope.permission import PermissionMode
+from agentscope.state import AgentState, Task
+
+
+async def _drain(generator: AsyncGenerator) -> list:
+    """Collect all values yielded by an async generator."""
+    return [item async for item in generator]
+
+
+class StateChangeMiddlewareTest(IsolatedAsyncioTestCase):
+    """Verify ``state_updated`` carries only changed fields."""
+
+    async def asyncSetUp(self) -> None:
+        """Create a fresh agent, bus, and middleware."""
+        self.bus = InMemoryMessageBus()
+        self.agent = SimpleNamespace(state=AgentState())
+        self.session_id = "session-id"
+        self.middleware = StateChangeMiddleware(
+            self.bus,
+            self.session_id,
+        )
+
+    async def _run_reply(self, mutate: Callable[[], None]) -> list[dict]:
+        """Run a reply handler and return its published events."""
+
+        async def next_handler(**_kwargs: Any) -> AsyncGenerator:
+            mutate()
+            yield "downstream"
+
+        output = await _drain(
+            self.middleware.on_reply(
+                self.agent,
+                {},
+                next_handler,
+            ),
+        )
+        self.assertEqual(output, ["downstream"])
+        entries = await self.bus.log_read(
+            MessageBusKeys.session_events(self.session_id),
+        )
+        return [payload for _, payload in entries]
+
+    async def test_task_change_omits_permission_context(self) -> None:
+        """A task-only update should not look like a permission update."""
+
+        def mutate() -> None:
+            self.agent.state.tasks_context.tasks.append(
+                Task(
+                    subject="Inspect logs",
+                    description="Find the root cause",
+                    metadata={},
+                ),
+            )
+
+        events = await self._run_reply(mutate)
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["name"], "state_updated")
+        self.assertIn("tasks_context", events[0]["value"])
+        self.assertNotIn("permission_context", events[0]["value"])
+
+    async def test_permission_change_omits_tasks_context(self) -> None:
+        """A permission-only update should not look like a task update."""
+
+        def mutate() -> None:
+            self.agent.state.permission_context.mode = PermissionMode.BYPASS
+
+        events = await self._run_reply(mutate)
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["name"], "state_updated")
+        self.assertIn("permission_context", events[0]["value"])
+        self.assertNotIn("tasks_context", events[0]["value"])
+
+    async def test_unchanged_state_publishes_nothing(self) -> None:
+        """A reply with no tracked change should not emit an event."""
+        events = await self._run_reply(lambda: None)
+
+        self.assertEqual(events, [])


### PR DESCRIPTION
## AgentScope Version

Current `main` at `41db2106`.

## Description

Fixes #2095.

Task and permission state previously shared one hash, so every
`state_updated` event carried both fields. The WebUI could not distinguish a
real task update from a permission-only update without duplicating backend
state comparison.

This PR:

- hashes task and permission contexts separately and publishes only changed
  fields;
- opens the plan panel when a non-empty task update arrives;
- preserves an explicit plan-panel close for the current agent/session;
- documents that `state_updated.value` is a partial payload.

## Verification

The new regression test fails on current `main` because task-only events
include `permission_context` and permission-only events include
`tasks_context`:

```text
2 failed, 1 passed
```

After the fix:

- `pytest -q tests/service_state_change_middleware_test.py` -> `3 passed`
- related in-memory message-bus suite -> `41 passed`
- file-scoped Pre-commit -> all hooks passed
- frontend Prettier -> passed
- frontend ESLint -> 0 errors, 2 pre-existing hook-dependency warnings
- `pnpm --filter frontend build` -> passed

## Impact

- No public API or persisted-state changes.
- Existing consumers already treat both state fields as optional.
- Permission-only updates no longer open the plan panel.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read `CONTRIBUTING.md`
- [x] Docstrings are in Google style
- [x] No separate documentation update is required
- [x] Code is ready for review
