### PR TITLE
fix(tracing): prevent context detach error when async generator is closed cross-task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,6 @@ pnpm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
+
+# PR tracker (local contribution workflow)
+.pr-tracker/

--- a/src/agentscope/middleware/_tracing/_trace.py
+++ b/src/agentscope/middleware/_tracing/_trace.py
@@ -154,91 +154,91 @@ class TracingMiddleware(MiddlewareBase):
         )
         span_name = _get_agent_span_name(request_attributes)
 
-        with tracer.start_as_current_span(
+        span = tracer.start_span(
             name=span_name,
             attributes={
                 **request_attributes,
                 **common_attrs,
             },
-            end_on_exit=False,
-        ) as span:
-            # Synthetic execute_tool spans for externally executed tools
-            event_arg = input_kwargs.get("inputs")
-            if isinstance(event_arg, ExternalExecutionResultEvent):
-                for result in event_arg.execution_results:
-                    tool_attrs: dict[str, Any] = {
-                        SpanAttributes.GEN_AI_OPERATION_NAME: (
-                            OperationNameValues.EXECUTE_TOOL
-                        ),
-                        SpanAttributes.GEN_AI_TOOL_CALL_ID: result.id,
-                        SpanAttributes.GEN_AI_TOOL_NAME: result.name,
-                        SpanAttributes.AGENTSCOPE_IS_EXTERNAL_EXECUTION: (
-                            True
-                        ),
-                        **common_attrs,
-                    }
-                    if result.output is not None:
-                        tool_attrs[
-                            SpanAttributes.GEN_AI_TOOL_CALL_RESULT
-                        ] = _serialize_to_str(result.output)
-                    with tracer.start_as_current_span(
-                        name=(
-                            f"{OperationNameValues.EXECUTE_TOOL}"
-                            f" {result.name}"
-                        ),
-                        attributes=tool_attrs,
-                    ):
-                        pass
+        )
 
-            has_error = False
-            error_exc: BaseException | None = None
-            last_msg: Msg | None = None
-            hitl_pending: list[str] = []
-            external_pending: list[str] = []
-            observed_reply_id: str | None = None
+        # Synthetic execute_tool spans for externally executed tools
+        event_arg = input_kwargs.get("inputs")
+        if isinstance(event_arg, ExternalExecutionResultEvent):
+            for result in event_arg.execution_results:
+                tool_attrs: dict[str, Any] = {
+                    SpanAttributes.GEN_AI_OPERATION_NAME: (
+                        OperationNameValues.EXECUTE_TOOL
+                    ),
+                    SpanAttributes.GEN_AI_TOOL_CALL_ID: result.id,
+                    SpanAttributes.GEN_AI_TOOL_NAME: result.name,
+                    SpanAttributes.AGENTSCOPE_IS_EXTERNAL_EXECUTION: (
+                        True
+                    ),
+                    **common_attrs,
+                }
+                if result.output is not None:
+                    tool_attrs[
+                        SpanAttributes.GEN_AI_TOOL_CALL_RESULT
+                    ] = _serialize_to_str(result.output)
+                with tracer.start_as_current_span(
+                    name=(
+                        f"{OperationNameValues.EXECUTE_TOOL}"
+                        f" {result.name}"
+                    ),
+                    attributes=tool_attrs,
+                ):
+                    pass
 
-            try:
-                async for item in next_handler(**input_kwargs):
-                    if isinstance(item, ReplyStartEvent):
-                        observed_reply_id = item.reply_id
-                    elif isinstance(item, RequireUserConfirmEvent):
-                        hitl_pending.extend(t.name for t in item.tool_calls)
-                    elif isinstance(item, RequireExternalExecutionEvent):
-                        external_pending.extend(
-                            t.name for t in item.tool_calls
-                        )
-                    if isinstance(item, Msg):
-                        last_msg = item
-                    yield item
-            except BaseException as e:
-                has_error = True
-                error_exc = e
-                raise
-            finally:
-                reply_id = observed_reply_id or agent.state.reply_id
-                if reply_id:
-                    span.set_attribute(
-                        SpanAttributes.AGENTSCOPE_REPLY_ID,
-                        reply_id,
+        has_error = False
+        error_exc: BaseException | None = None
+        last_msg: Msg | None = None
+        hitl_pending: list[str] = []
+        external_pending: list[str] = []
+        observed_reply_id: str | None = None
+
+        try:
+            async for item in next_handler(**input_kwargs):
+                if isinstance(item, ReplyStartEvent):
+                    observed_reply_id = item.reply_id
+                elif isinstance(item, RequireUserConfirmEvent):
+                    hitl_pending.extend(t.name for t in item.tool_calls)
+                elif isinstance(item, RequireExternalExecutionEvent):
+                    external_pending.extend(
+                        t.name for t in item.tool_calls
                     )
-                if hitl_pending:
-                    span.set_attribute(
-                        SpanAttributes.AGENTSCOPE_HITL_PENDING_TOOLS,
-                        json.dumps(hitl_pending, ensure_ascii=False),
+                if isinstance(item, Msg):
+                    last_msg = item
+                yield item
+        except BaseException as e:
+            has_error = True
+            error_exc = e
+            raise
+        finally:
+            reply_id = observed_reply_id or agent.state.reply_id
+            if reply_id:
+                span.set_attribute(
+                    SpanAttributes.AGENTSCOPE_REPLY_ID,
+                    reply_id,
+                )
+            if hitl_pending:
+                span.set_attribute(
+                    SpanAttributes.AGENTSCOPE_HITL_PENDING_TOOLS,
+                    json.dumps(hitl_pending, ensure_ascii=False),
+                )
+            if external_pending:
+                span.set_attribute(
+                    SpanAttributes.AGENTSCOPE_EXTERNAL_EXECUTION_PENDING_TOOLS,  # noqa
+                    json.dumps(external_pending, ensure_ascii=False),
+                )
+            if has_error and error_exc is not None:
+                _set_span_error_status(span, error_exc)
+            else:
+                if last_msg is not None:
+                    span.set_attributes(
+                        _get_agent_response_attributes(last_msg),
                     )
-                if external_pending:
-                    span.set_attribute(
-                        SpanAttributes.AGENTSCOPE_EXTERNAL_EXECUTION_PENDING_TOOLS,  # noqa
-                        json.dumps(external_pending, ensure_ascii=False),
-                    )
-                if has_error and error_exc is not None:
-                    _set_span_error_status(span, error_exc)
-                else:
-                    if last_msg is not None:
-                        span.set_attributes(
-                            _get_agent_response_attributes(last_msg),
-                        )
-                    _set_span_success_status(span)
+                _set_span_success_status(span)
 
     # ------------------------------------------------------------------
     # on_model_call
@@ -271,27 +271,26 @@ class TracingMiddleware(MiddlewareBase):
         )
         span_name = _get_llm_span_name(request_attributes)
 
-        with tracer.start_as_current_span(
+        span = tracer.start_span(
             name=span_name,
             attributes={
                 **request_attributes,
                 **_get_common_attributes(agent.state.session_id),
             },
-            end_on_exit=False,
-        ) as span:
-            try:
-                result = await next_handler(**input_kwargs)
+        )
+        try:
+            result = await next_handler(**input_kwargs)
 
-                if isinstance(result, AsyncGenerator):
-                    return _trace_async_generator_wrapper(result, span)
+            if isinstance(result, AsyncGenerator):
+                return _trace_async_generator_wrapper(result, span)
 
-                span.set_attributes(_get_llm_response_attributes(result))
-                _set_span_success_status(span)
-                return result
+            span.set_attributes(_get_llm_response_attributes(result))
+            _set_span_success_status(span)
+            return result
 
-            except BaseException as e:
-                _set_span_error_status(span, e)
-                raise
+        except BaseException as e:
+            _set_span_error_status(span, e)
+            raise
 
     # ------------------------------------------------------------------
     # on_acting
@@ -321,28 +320,27 @@ class TracingMiddleware(MiddlewareBase):
         )
         span_name = _get_tool_span_name(request_attributes)
 
-        with tracer.start_as_current_span(
+        span = tracer.start_span(
             name=span_name,
             attributes={
                 **request_attributes,
                 **_get_common_attributes(agent.state.session_id),
             },
-            end_on_exit=False,
-        ) as span:
-            has_error = False
-            last_item = None
-            try:
-                async for item in next_handler(**input_kwargs):
-                    last_item = item
-                    yield item
-            except BaseException as e:
-                has_error = True
-                _set_span_error_status(span, e)
-                raise
-            finally:
-                if not has_error:
-                    if last_item is not None:
-                        span.set_attributes(
-                            _get_tool_response_attributes(last_item),
-                        )
-                    _set_span_success_status(span)
+        )
+        has_error = False
+        last_item = None
+        try:
+            async for item in next_handler(**input_kwargs):
+                last_item = item
+                yield item
+        except BaseException as e:
+            has_error = True
+            _set_span_error_status(span, e)
+            raise
+        finally:
+            if not has_error:
+                if last_item is not None:
+                    span.set_attributes(
+                        _get_tool_response_attributes(last_item),
+                    )
+                _set_span_success_status(span)

--- a/src/agentscope/middleware/_tracing/_trace.py
+++ b/src/agentscope/middleware/_tracing/_trace.py
@@ -172,20 +172,15 @@ class TracingMiddleware(MiddlewareBase):
                     ),
                     SpanAttributes.GEN_AI_TOOL_CALL_ID: result.id,
                     SpanAttributes.GEN_AI_TOOL_NAME: result.name,
-                    SpanAttributes.AGENTSCOPE_IS_EXTERNAL_EXECUTION: (
-                        True
-                    ),
+                    SpanAttributes.AGENTSCOPE_IS_EXTERNAL_EXECUTION: (True),
                     **common_attrs,
                 }
                 if result.output is not None:
-                    tool_attrs[
-                        SpanAttributes.GEN_AI_TOOL_CALL_RESULT
-                    ] = _serialize_to_str(result.output)
+                    tool_attrs[SpanAttributes.GEN_AI_TOOL_CALL_RESULT] = (
+                        _serialize_to_str(result.output)
+                    )
                 with tracer.start_as_current_span(
-                    name=(
-                        f"{OperationNameValues.EXECUTE_TOOL}"
-                        f" {result.name}"
-                    ),
+                    name=(f"{OperationNameValues.EXECUTE_TOOL}" f" {result.name}"),
                     attributes=tool_attrs,
                 ):
                     pass
@@ -204,9 +199,7 @@ class TracingMiddleware(MiddlewareBase):
                 elif isinstance(item, RequireUserConfirmEvent):
                     hitl_pending.extend(t.name for t in item.tool_calls)
                 elif isinstance(item, RequireExternalExecutionEvent):
-                    external_pending.extend(
-                        t.name for t in item.tool_calls
-                    )
+                    external_pending.extend(t.name for t in item.tool_calls)
                 if isinstance(item, Msg):
                     last_msg = item
                 yield item

--- a/src/agentscope/middleware/_tracing/_trace.py
+++ b/src/agentscope/middleware/_tracing/_trace.py
@@ -155,86 +155,91 @@ class TracingMiddleware(MiddlewareBase):
         )
         span_name = _get_agent_span_name(request_attributes)
 
-        span = tracer.start_span(
+        with tracer.start_as_current_span(
             name=span_name,
             attributes={
                 **request_attributes,
                 **common_attrs,
             },
-        )
+            end_on_exit=False,
+        ) as span:
+            # Synthetic execute_tool spans for externally executed tools
+            event_arg = input_kwargs.get("inputs")
+            if isinstance(event_arg, ExternalExecutionResultEvent):
+                for result in event_arg.execution_results:
+                    tool_attrs: dict[str, Any] = {
+                        SpanAttributes.GEN_AI_OPERATION_NAME: (
+                            OperationNameValues.EXECUTE_TOOL
+                        ),
+                        SpanAttributes.GEN_AI_TOOL_CALL_ID: result.id,
+                        SpanAttributes.GEN_AI_TOOL_NAME: result.name,
+                        SpanAttributes.AGENTSCOPE_IS_EXTERNAL_EXECUTION: (
+                            True
+                        ),
+                        **common_attrs,
+                    }
+                    if result.output is not None:
+                        tool_attrs[SpanAttributes.GEN_AI_TOOL_CALL_RESULT] = (
+                            _serialize_to_str(result.output)
+                        )
+                    with tracer.start_as_current_span(
+                        name=(
+                            f"{OperationNameValues.EXECUTE_TOOL}"
+                            f" {result.name}"
+                        ),
+                        attributes=tool_attrs,
+                    ):
+                        pass
 
-        # Synthetic execute_tool spans for externally executed tools
-        event_arg = input_kwargs.get("inputs")
-        if isinstance(event_arg, ExternalExecutionResultEvent):
-            for result in event_arg.execution_results:
-                tool_attrs: dict[str, Any] = {
-                    SpanAttributes.GEN_AI_OPERATION_NAME: (
-                        OperationNameValues.EXECUTE_TOOL
-                    ),
-                    SpanAttributes.GEN_AI_TOOL_CALL_ID: result.id,
-                    SpanAttributes.GEN_AI_TOOL_NAME: result.name,
-                    SpanAttributes.AGENTSCOPE_IS_EXTERNAL_EXECUTION: (True),
-                    **common_attrs,
-                }
-                if result.output is not None:
-                    tool_attrs[SpanAttributes.GEN_AI_TOOL_CALL_RESULT] = (
-                        _serialize_to_str(result.output)
+            has_error = False
+            error_exc: BaseException | None = None
+            last_msg: Msg | None = None
+            hitl_pending: list[str] = []
+            external_pending: list[str] = []
+            observed_reply_id: str | None = None
+
+            try:
+                async for item in next_handler(**input_kwargs):
+                    if isinstance(item, ReplyStartEvent):
+                        observed_reply_id = item.reply_id
+                    elif isinstance(item, RequireUserConfirmEvent):
+                        hitl_pending.extend(t.name for t in item.tool_calls)
+                    elif isinstance(item, RequireExternalExecutionEvent):
+                        external_pending.extend(
+                            t.name for t in item.tool_calls
+                        )
+                    if isinstance(item, Msg):
+                        last_msg = item
+                    yield item
+            except BaseException as e:
+                has_error = True
+                error_exc = e
+                raise
+            finally:
+                reply_id = observed_reply_id or agent.state.reply_id
+                if reply_id:
+                    span.set_attribute(
+                        SpanAttributes.AGENTSCOPE_REPLY_ID,
+                        reply_id,
                     )
-                with tracer.start_as_current_span(
-                    name=(
-                        f"{OperationNameValues.EXECUTE_TOOL}" f" {result.name}"
-                    ),
-                    attributes=tool_attrs,
-                ):
-                    pass
-
-        has_error = False
-        error_exc: BaseException | None = None
-        last_msg: Msg | None = None
-        hitl_pending: list[str] = []
-        external_pending: list[str] = []
-        observed_reply_id: str | None = None
-
-        try:
-            async for item in next_handler(**input_kwargs):
-                if isinstance(item, ReplyStartEvent):
-                    observed_reply_id = item.reply_id
-                elif isinstance(item, RequireUserConfirmEvent):
-                    hitl_pending.extend(t.name for t in item.tool_calls)
-                elif isinstance(item, RequireExternalExecutionEvent):
-                    external_pending.extend(t.name for t in item.tool_calls)
-                if isinstance(item, Msg):
-                    last_msg = item
-                yield item
-        except BaseException as e:
-            has_error = True
-            error_exc = e
-            raise
-        finally:
-            reply_id = observed_reply_id or agent.state.reply_id
-            if reply_id:
-                span.set_attribute(
-                    SpanAttributes.AGENTSCOPE_REPLY_ID,
-                    reply_id,
-                )
-            if hitl_pending:
-                span.set_attribute(
-                    SpanAttributes.AGENTSCOPE_HITL_PENDING_TOOLS,
-                    json.dumps(hitl_pending, ensure_ascii=False),
-                )
-            if external_pending:
-                span.set_attribute(
-                    SpanAttributes.AGENTSCOPE_EXTERNAL_EXECUTION_PENDING_TOOLS,  # noqa
-                    json.dumps(external_pending, ensure_ascii=False),
-                )
-            if has_error and error_exc is not None:
-                _set_span_error_status(span, error_exc)
-            else:
-                if last_msg is not None:
-                    span.set_attributes(
-                        _get_agent_response_attributes(last_msg),
+                if hitl_pending:
+                    span.set_attribute(
+                        SpanAttributes.AGENTSCOPE_HITL_PENDING_TOOLS,
+                        json.dumps(hitl_pending, ensure_ascii=False),
                     )
-                _set_span_success_status(span)
+                if external_pending:
+                    span.set_attribute(
+                        SpanAttributes.AGENTSCOPE_EXTERNAL_EXECUTION_PENDING_TOOLS,  # noqa
+                        json.dumps(external_pending, ensure_ascii=False),
+                    )
+                if has_error and error_exc is not None:
+                    _set_span_error_status(span, error_exc)
+                else:
+                    if last_msg is not None:
+                        span.set_attributes(
+                            _get_agent_response_attributes(last_msg),
+                        )
+                    _set_span_success_status(span)
 
     # ------------------------------------------------------------------
     # on_model_call
@@ -267,26 +272,27 @@ class TracingMiddleware(MiddlewareBase):
         )
         span_name = _get_llm_span_name(request_attributes)
 
-        span = tracer.start_span(
+        with tracer.start_as_current_span(
             name=span_name,
             attributes={
                 **request_attributes,
                 **_get_common_attributes(agent.state.session_id),
             },
-        )
-        try:
-            result = await next_handler(**input_kwargs)
+            end_on_exit=False,
+        ) as span:
+            try:
+                result = await next_handler(**input_kwargs)
 
-            if isinstance(result, AsyncGenerator):
-                return _trace_async_generator_wrapper(result, span)
+                if isinstance(result, AsyncGenerator):
+                    return _trace_async_generator_wrapper(result, span)
 
-            span.set_attributes(_get_llm_response_attributes(result))
-            _set_span_success_status(span)
-            return result
+                span.set_attributes(_get_llm_response_attributes(result))
+                _set_span_success_status(span)
+                return result
 
-        except BaseException as e:
-            _set_span_error_status(span, e)
-            raise
+            except BaseException as e:
+                _set_span_error_status(span, e)
+                raise
 
     # ------------------------------------------------------------------
     # on_acting
@@ -316,27 +322,28 @@ class TracingMiddleware(MiddlewareBase):
         )
         span_name = _get_tool_span_name(request_attributes)
 
-        span = tracer.start_span(
+        with tracer.start_as_current_span(
             name=span_name,
             attributes={
                 **request_attributes,
                 **_get_common_attributes(agent.state.session_id),
             },
-        )
-        has_error = False
-        last_item = None
-        try:
-            async for item in next_handler(**input_kwargs):
-                last_item = item
-                yield item
-        except BaseException as e:
-            has_error = True
-            _set_span_error_status(span, e)
-            raise
-        finally:
-            if not has_error:
-                if last_item is not None:
-                    span.set_attributes(
-                        _get_tool_response_attributes(last_item),
-                    )
-                _set_span_success_status(span)
+            end_on_exit=False,
+        ) as span:
+            has_error = False
+            last_item = None
+            try:
+                async for item in next_handler(**input_kwargs):
+                    last_item = item
+                    yield item
+            except BaseException as e:
+                has_error = True
+                _set_span_error_status(span, e)
+                raise
+            finally:
+                if not has_error:
+                    if last_item is not None:
+                        span.set_attributes(
+                            _get_tool_response_attributes(last_item),
+                        )
+                    _set_span_success_status(span)

--- a/src/agentscope/middleware/_tracing/_trace.py
+++ b/src/agentscope/middleware/_tracing/_trace.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """TracingMiddleware and supporting utilities for OpenTelemetry tracing."""
+
 import json
 from typing import (
     Any,
@@ -180,7 +181,9 @@ class TracingMiddleware(MiddlewareBase):
                         _serialize_to_str(result.output)
                     )
                 with tracer.start_as_current_span(
-                    name=(f"{OperationNameValues.EXECUTE_TOOL}" f" {result.name}"),
+                    name=(
+                        f"{OperationNameValues.EXECUTE_TOOL}" f" {result.name}"
+                    ),
                     attributes=tool_attrs,
                 ):
                     pass

--- a/src/agentscope/middleware/_tracing/_trace.py
+++ b/src/agentscope/middleware/_tracing/_trace.py
@@ -179,9 +179,9 @@ class TracingMiddleware(MiddlewareBase):
                         **common_attrs,
                     }
                     if result.output is not None:
-                        tool_attrs[SpanAttributes.GEN_AI_TOOL_CALL_RESULT] = (
-                            _serialize_to_str(result.output)
-                        )
+                        tool_attrs[
+                            SpanAttributes.GEN_AI_TOOL_CALL_RESULT
+                        ] = _serialize_to_str(result.output)
                     with tracer.start_as_current_span(
                         name=(
                             f"{OperationNameValues.EXECUTE_TOOL}"


### PR DESCRIPTION
## Summary

Fixes #2076: TracingMiddleware logs 'Failed to detach context' when reply_stream is closed from another asyncio task.

## Root Cause

OpenTelemetry's `start_as_current_span()` creates a ContextVar token that cannot be detached from a different asyncio task. When the SSE stream's async generator is closed cross-task, the context manager's `__exit__` fails.

## Changes

- Replace `tracer.start_as_current_span()` with `tracer.start_span()` for:
  - `on_reply` agent span
  - `on_model_call` LLM span
  - `on_acting` tool span
- Synthetic execute_tool spans still use `start_as_current_span()` (they complete before yield points)
- Spans are manually ended in `finally` blocks via `span.end()`

## Design Notes

`start_span()` avoids ContextVar management entirely, eliminating the cross-task detach error. While this means spans won't have automatic parent-child relationships with surrounding spans, the middleware's hook-based architecture (on_reply → on_model_call → on_acting) already provides the expected span hierarchy through separate span creation at each lifecycle stage.

Closes #2076