### PR TITLE
feat(webui): increase textarea max rows + show shift-enter hint (#2096, #2098)

### DIFF
--- a/examples/web_ui/frontend/src/components/chat/TextInput.tsx
+++ b/examples/web_ui/frontend/src/components/chat/TextInput.tsx
@@ -91,8 +91,8 @@ const COLLAPSED_HEIGHT_PX = 52;
  * height would leave dead space under the caret instead of centring the line.
  */
 const TEXTAREA_PADDING_Y_PX = (COLLAPSED_HEIGHT_PX - LINE_HEIGHT_PX) / 2;
-/** Growth stops after six lines of text; the textarea scrolls beyond that. */
-const MAX_HEIGHT_PX = LINE_HEIGHT_PX * 6 + TEXTAREA_PADDING_Y_PX * 2;
+/** Growth stops after 12 lines of text; the textarea scrolls beyond that. */
+const MAX_HEIGHT_PX = LINE_HEIGHT_PX * 12 + TEXTAREA_PADDING_Y_PX * 2;
 /** Horizontal padding of the textarea, mirrored by the overlay and the ghost. */
 const TEXTAREA_PADDING_X_PX = 12;
 
@@ -506,6 +506,12 @@ export const TextInput = forwardRef<TextInputRef, TextInputProps>(
 						</div>
 					</div>
 				</div>
+				<p className="mt-1 px-4 text-xs text-muted-foreground/70 flex items-center gap-1">
+					<Kbd>Shift</Kbd>
+					<span>+</span>
+					<Kbd>Enter</Kbd>
+					<span>— {t('textInput.newLineHint')}</span>
+				</p>
 			</div>
 		);
 	},

--- a/examples/web_ui/frontend/src/i18n/locales/en.json
+++ b/examples/web_ui/frontend/src/i18n/locales/en.json
@@ -92,7 +92,8 @@
 		"attachNotSupported": "This model does not support file attachments",
 		"send": "Send",
 		"stop": "Stop generating",
-		"stopping": "Stopping ..."
+		"stopping": "Stopping ...",
+		"newLineHint": "Shift + Enter for new line"
 	},
 	"confirmCard": {
 		"toConfirm": "to confirm",

--- a/examples/web_ui/frontend/src/i18n/locales/zh.json
+++ b/examples/web_ui/frontend/src/i18n/locales/zh.json
@@ -92,7 +92,8 @@
 		"attachNotSupported": "当前模型不支持文件附件",
 		"send": "发送",
 		"stop": "停止生成",
-		"stopping": "停止中 ..."
+		"stopping": "停止中 ...",
+		"newLineHint": "Shift + Enter 换行"
 	},
 	"confirmCard": {
 		"toConfirm": "确认",


### PR DESCRIPTION
## Summary

Closes #2096 and closes #2098 — two chat-page UX improvements from the #2094 Help Wanted tracking issue.

* **(1) Textarea max visible rows doubled to 12** — bumping the previous 6-line cap lets users compose longer prompts without the input collapsing into a tiny scrollable slot. Growth behaviour, collapsed height and line-height remain unchanged.
* **(2) Shift+Enter hint placed under the input** — a small muted `Kbd` helper sits right below the input field so first-time users discover multi-line editing instead of accidentally sending a short message. The string is localised via the new `textInput.newLineHint` key in both en/zh locales.
* The implicit **scroll-to-bottom button** (`MessageScrollerButton`) already provided by the shared scroller component still works automatically when the user scrolls up; this PR keeps that behaviour intact and focuses on the two tracked #2094 sub-tasks.

## Test plan

* [x] `npx prettier --check examples/web_ui/frontend/src/components/chat/TextInput.tsx examples/web_ui/frontend/src/i18n/locales/en.json examples/web_ui/frontend/src/i18n/locales/zh.json` passes.
* [x] Verifying visually: when a user types 10+ lines of text the input grows visibly past the old 6-line cap and only starts scrolling at line 12.
* [x] New `textInput.newLineHint` i18n keys are defined for both English and Chinese locales.
