### PR TITLE
fix(formatter): content-addressed + atexit cleanup for unsupported media temp files (#2173)

### DIFF
--- a/src/agentscope/formatter/_formatter_base.py
+++ b/src/agentscope/formatter/_formatter_base.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 """The formatter module."""
+import atexit
 import base64
 import mimetypes
+import os
 import tempfile
 from abc import abstractmethod
 from fnmatch import fnmatch
@@ -17,6 +19,22 @@ from ..message import (
     URLSource,
     Base64Source,
 )
+
+_UNSUPPORTED_MEDIA_TEMP_FILES: set[str] = set()
+
+
+def _cleanup_unsupported_media_temp_files() -> None:
+    for path in list(_UNSUPPORTED_MEDIA_TEMP_FILES):
+        try:
+            if os.path.exists(path):
+                os.remove(path)
+        except OSError:
+            pass
+        finally:
+            _UNSUPPORTED_MEDIA_TEMP_FILES.discard(path)
+
+
+atexit.register(_cleanup_unsupported_media_temp_files)
 
 
 class FormatterBase(BaseModel):
@@ -141,21 +159,43 @@ class FormatterBase(BaseModel):
                     )
 
                 elif isinstance(block.source, Base64Source):
-                    # Have to save the base64 data locally
                     extension = mimetypes.guess_extension(
                         block.source.media_type,
                     )
-                    with tempfile.NamedTemporaryFile(
-                        suffix=extension,
-                        delete=False,
-                    ) as temp_file:
-                        decoded_data = base64.b64decode(block.source.data)
-                        temp_file.write(decoded_data)
-                        textual_output.append(
-                            f"<system-reminder>A(n) {main_type} file is "
-                            f"returned and saved locally at: {temp_file.name}."
-                            f"</system-reminder>",
-                        )
+                    decoded_data = base64.b64decode(block.source.data)
+                    stable_name = shortuuid.uuid(
+                        name=block.source.data,  # noqa: FBT003
+                    )
+                    tmp_dir = tempfile.gettempdir()
+                    candidate_ext = extension or ""
+                    stable_path = os.path.join(
+                        tmp_dir,
+                        f"as-unsup-{stable_name}{candidate_ext}",
+                    )
+                    if not os.path.exists(stable_path) or os.path.getsize(
+                        stable_path,
+                    ) != len(decoded_data):
+                        with tempfile.NamedTemporaryFile(
+                            suffix=candidate_ext,
+                            dir=tmp_dir,
+                            prefix="as-unsup-",
+                            delete=False,
+                        ) as temp_file:
+                            temp_file.write(decoded_data)
+                            written = temp_file.name
+                        try:
+                            os.replace(written, stable_path)
+                        except OSError:
+                            try:
+                                os.remove(written)
+                            except OSError:
+                                pass
+                    _UNSUPPORTED_MEDIA_TEMP_FILES.add(stable_path)
+                    textual_output.append(
+                        f"<system-reminder>A(n) {main_type} file is "
+                        f"returned and saved locally at: {stable_path}."
+                        f"</system-reminder>",
+                    )
 
         # Add system reminder tags if there is multimodal data to be promoted
         if multimodal_data:

--- a/src/agentscope/formatter/_formatter_base.py
+++ b/src/agentscope/formatter/_formatter_base.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 """The formatter module."""
+import atexit
 import base64
 import mimetypes
+import os
+import shutil
 import tempfile
 from abc import abstractmethod
 from fnmatch import fnmatch
@@ -17,6 +20,28 @@ from ..message import (
     URLSource,
     Base64Source,
 )
+
+_UNSUPPORTED_MEDIA_TEMP_DIR: str | None = None
+
+
+def _get_unsupported_media_temp_dir() -> str:
+    global _UNSUPPORTED_MEDIA_TEMP_DIR
+    if _UNSUPPORTED_MEDIA_TEMP_DIR is None:
+        temp_dir = tempfile.mkdtemp(prefix="agentscope-unsupported-media-")
+        os.chmod(temp_dir, 0o700)
+        _UNSUPPORTED_MEDIA_TEMP_DIR = temp_dir
+    return _UNSUPPORTED_MEDIA_TEMP_DIR
+
+
+def _cleanup_unsupported_media_temp_files() -> None:
+    global _UNSUPPORTED_MEDIA_TEMP_DIR
+    temp_dir = _UNSUPPORTED_MEDIA_TEMP_DIR
+    _UNSUPPORTED_MEDIA_TEMP_DIR = None
+    if temp_dir is not None:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+atexit.register(_cleanup_unsupported_media_temp_files)
 
 
 class FormatterBase(BaseModel):
@@ -141,21 +166,43 @@ class FormatterBase(BaseModel):
                     )
 
                 elif isinstance(block.source, Base64Source):
-                    # Have to save the base64 data locally
                     extension = mimetypes.guess_extension(
                         block.source.media_type,
                     )
-                    with tempfile.NamedTemporaryFile(
-                        suffix=extension,
-                        delete=False,
-                    ) as temp_file:
+                    stable_name = shortuuid.uuid(
+                        name=block.source.data,
+                    )
+                    tmp_dir = _get_unsupported_media_temp_dir()
+                    candidate_ext = extension or ""
+                    stable_path = os.path.join(
+                        tmp_dir,
+                        f"as-unsup-{stable_name}{candidate_ext}",
+                    )
+                    if not os.path.exists(stable_path):
                         decoded_data = base64.b64decode(block.source.data)
-                        temp_file.write(decoded_data)
-                        textual_output.append(
-                            f"<system-reminder>A(n) {main_type} file is "
-                            f"returned and saved locally at: {temp_file.name}."
-                            f"</system-reminder>",
-                        )
+                        written = ""
+                        try:
+                            with tempfile.NamedTemporaryFile(
+                                suffix=candidate_ext,
+                                dir=tmp_dir,
+                                prefix="staging-",
+                                delete=False,
+                            ) as temp_file:
+                                temp_file.write(decoded_data)
+                                written = temp_file.name
+                            os.replace(written, stable_path)
+                        except OSError:
+                            if written:
+                                try:
+                                    os.remove(written)
+                                except OSError:
+                                    pass
+                            raise
+                    textual_output.append(
+                        f"<system-reminder>A(n) {main_type} file is "
+                        f"returned and saved locally at: {stable_path}."
+                        f"</system-reminder>",
+                    )
 
         # Add system reminder tags if there is multimodal data to be promoted
         if multimodal_data:

--- a/tests/formatter_openai_chat_test.py
+++ b/tests/formatter_openai_chat_test.py
@@ -3,12 +3,24 @@
 OpenAIMultiAgentFormatter, following the reference test style with exact
 ground-truth comparisons.
 """
+import base64
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+from contextlib import ExitStack
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch
 
+import agentscope.formatter._formatter_base as formatter_base
 from agentscope.formatter import (
     OpenAIChatFormatter,
     OpenAIMultiAgentFormatter,
+)
+from agentscope.formatter._formatter_base import (
+    FormatterBase,
+    _cleanup_unsupported_media_temp_files,
 )
 from agentscope.message import (
     UserMsg,
@@ -770,3 +782,205 @@ class TestOpenAIFormatter(IsolatedAsyncioTestCase):
             ],
             res,
         )
+
+
+class _TextOnlyFormatter(FormatterBase):
+    """A formatter that accepts only ``text/plain``; everything else goes
+    through ``convert_tool_result_to_string``'s unsupported-media path."""
+
+    async def format(
+        self,
+        *args: object,
+        **kwargs: object,
+    ) -> list[dict]:  # pragma: no cover
+        return []
+
+
+class FormatterBaseUnsupportedMediaTest(IsolatedAsyncioTestCase):
+    """Unsupported-media Base64Source storage regressions (issue #2173)."""
+
+    def setUp(self) -> None:
+        """Seed a text-only formatter and two base64 fixtures."""
+        _cleanup_unsupported_media_temp_files()
+        self._fmt = _TextOnlyFormatter(input_types=["text/plain"])
+        self._png_bytes = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDRfakehdr"
+        self._png_b64 = base64.b64encode(self._png_bytes).decode("ascii")
+        self._mp3_bytes = b"ID3\x04\x00\x00\x00\x00\x00\x00fake mp3 payload"
+        self._mp3_b64 = base64.b64encode(self._mp3_bytes).decode("ascii")
+
+    def tearDown(self) -> None:
+        """Run the atexit hook so no temp files leak between tests."""
+        _cleanup_unsupported_media_temp_files()
+
+    @staticmethod
+    def _blocks(data: str, media_type: str) -> list[DataBlock]:
+        """Build one unsupported-media block."""
+        return [
+            DataBlock(
+                source=Base64Source(
+                    data=data,
+                    media_type=media_type,
+                ),
+            ),
+        ]
+
+    @staticmethod
+    def _saved_path(text: str) -> str:
+        """Extract the saved path from a formatter reminder."""
+        prefix = "saved locally at: "
+        start = text.index(prefix) + len(prefix)
+        return text[start : text.index(".</system-reminder>", start)]
+
+    def test_same_base64_yields_deterministic_path(self) -> None:
+        """Identical ``Base64Source`` bytes must produce identical output."""
+        blocks = self._blocks(self._png_b64, "image/png")
+        first, _ = self._fmt.convert_tool_result_to_string(blocks)
+        second, _ = self._fmt.convert_tool_result_to_string(blocks)
+        self.assertEqual(first, second)
+        self.assertIn("saved locally at:", first)
+
+    def test_written_file_contains_decoded_bytes(self) -> None:
+        """The process-owned temp file must store the decoded bytes."""
+        blocks = self._blocks(self._mp3_b64, "audio/mpeg")
+        text, _ = self._fmt.convert_tool_result_to_string(blocks)
+        path = self._saved_path(text)
+        self.assertTrue(os.path.isfile(path))
+        with open(path, "rb") as handle:
+            payload = handle.read()
+        self.assertEqual(payload, self._mp3_bytes)
+
+    def test_distinct_contents_yield_distinct_paths(self) -> None:
+        """Different payloads must use different stable paths."""
+        blocks_a = self._blocks(self._png_b64, "image/png")
+        blocks_b = self._blocks(self._mp3_b64, "audio/mpeg")
+        text_a, _ = self._fmt.convert_tool_result_to_string(blocks_a)
+        text_b, _ = self._fmt.convert_tool_result_to_string(blocks_b)
+        self.assertNotEqual(text_a, text_b)
+        self.assertNotEqual(
+            self._saved_path(text_a),
+            self._saved_path(text_b),
+        )
+
+    def test_cache_directory_is_private_and_cleaned(self) -> None:
+        """The cache must be process-private and removed during cleanup."""
+        blocks = self._blocks(self._png_b64, "image/png")
+        text, _ = self._fmt.convert_tool_result_to_string(blocks)
+        path = self._saved_path(text)
+        temp_dir = os.path.dirname(path)
+        if os.name != "nt":
+            self.assertEqual(
+                stat.S_IMODE(os.stat(temp_dir).st_mode),
+                0o700,
+            )
+        _cleanup_unsupported_media_temp_files()
+        self.assertFalse(os.path.exists(temp_dir))
+
+    def test_no_leaked_temp_file_per_call(self) -> None:
+        """Five consecutive runs must leave only one temp payload file."""
+        blocks = self._blocks(self._png_b64, "image/png")
+        text = ""
+        for _ in range(5):
+            text, _ = self._fmt.convert_tool_result_to_string(blocks)
+        temp_dir = os.path.dirname(self._saved_path(text))
+        self.assertEqual(len(os.listdir(temp_dir)), 1)
+
+    def test_cache_hit_skips_redundant_base64_decode(self) -> None:
+        """A stable cache hit must not decode the payload again."""
+        blocks = self._blocks(self._png_b64, "image/png")
+        first, _ = self._fmt.convert_tool_result_to_string(blocks)
+        with patch.object(
+            formatter_base.base64,
+            "b64decode",
+            side_effect=AssertionError("unexpected decode"),
+        ):
+            second, _ = self._fmt.convert_tool_result_to_string(blocks)
+        self.assertEqual(first, second)
+
+    def test_replace_failure_is_propagated_without_invalid_path(self) -> None:
+        """A failed atomic write must not return a missing target."""
+        blocks = self._blocks(self._png_b64, "image/png")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with (
+                patch(
+                    "agentscope.formatter._formatter_base."
+                    "_get_unsupported_media_temp_dir",
+                    return_value=temp_dir,
+                ),
+                patch.object(
+                    formatter_base.os,
+                    "replace",
+                    side_effect=OSError("replace failed"),
+                ),
+            ):
+                with self.assertRaisesRegex(OSError, "replace failed"):
+                    self._fmt.convert_tool_result_to_string(blocks)
+            self.assertEqual(os.listdir(temp_dir), [])
+
+    def test_worker_exit_does_not_remove_another_worker_file(self) -> None:
+        """Each process must clean only its own unsupported-media cache."""
+        script = """
+import base64
+import sys
+
+from agentscope.formatter._formatter_base import FormatterBase
+from agentscope.message import Base64Source, DataBlock
+
+
+class TextOnlyFormatter(FormatterBase):
+    async def format(self, *args, **kwargs):
+        return []
+
+
+payload = base64.b64encode(b"shared payload").decode("ascii")
+text, _ = TextOnlyFormatter().convert_tool_result_to_string(
+    [
+        DataBlock(
+            source=Base64Source(
+                data=payload,
+                media_type="image/png",
+            ),
+        ),
+    ],
+)
+path = text.split("saved locally at: ", 1)[1].split(
+    ".</system-reminder>",
+    1,
+)[0]
+print(path, flush=True)
+sys.stdin.readline()
+"""
+        with ExitStack() as stack:
+            workers = [
+                stack.enter_context(
+                    subprocess.Popen(
+                        [sys.executable, "-c", script],
+                        stdin=subprocess.PIPE,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        text=True,
+                    ),
+                )
+                for _ in range(2)
+            ]
+            paths: list[str] = []
+            try:
+                for worker in workers:
+                    self.assertIsNotNone(worker.stdout)
+                    paths.append(worker.stdout.readline().strip())
+                self.assertNotEqual(
+                    os.path.dirname(paths[0]),
+                    os.path.dirname(paths[1]),
+                )
+                self.assertTrue(all(os.path.isfile(path) for path in paths))
+
+                self.assertIsNotNone(workers[0].stdin)
+                workers[0].stdin.close()
+                self.assertEqual(workers[0].wait(timeout=20), 0)
+                self.assertFalse(os.path.exists(paths[0]))
+                self.assertTrue(os.path.isfile(paths[1]))
+            finally:
+                for worker in workers:
+                    if worker.poll() is None:
+                        self.assertIsNotNone(worker.stdin)
+                        worker.stdin.close()
+                        worker.wait(timeout=20)

--- a/tests/formatter_openai_chat_test.py
+++ b/tests/formatter_openai_chat_test.py
@@ -3,12 +3,20 @@
 OpenAIMultiAgentFormatter, following the reference test style with exact
 ground-truth comparisons.
 """
+import base64
+import os
+import tempfile
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch
 
 from agentscope.formatter import (
     OpenAIChatFormatter,
     OpenAIMultiAgentFormatter,
+)
+from agentscope.formatter._formatter_base import (
+    FormatterBase,
+    _UNSUPPORTED_MEDIA_TEMP_FILES,
+    _cleanup_unsupported_media_temp_files,
 )
 from agentscope.message import (
     UserMsg,
@@ -770,3 +778,136 @@ class TestOpenAIFormatter(IsolatedAsyncioTestCase):
             ],
             res,
         )
+
+
+class _TextOnlyFormatter(FormatterBase):
+    """A formatter that accepts only ``text/plain``; everything else goes
+    through ``convert_tool_result_to_string``'s unsupported-media path."""
+
+    async def format(
+        self,
+        *args: object,
+        **kwargs: object,
+    ) -> list[dict]:  # pragma: no cover
+        return []
+
+
+class FormatterBaseUnsupportedMediaTest(IsolatedAsyncioTestCase):
+    """Unsupported-media Base64Source storage regressions (issue #2173)."""
+
+    def setUp(self) -> None:
+        """Seed a text-only formatter, two base64 fixtures, and the
+        ``tmpdir`` snapshot used to detect temp-file leaks."""
+        self._fmt = _TextOnlyFormatter(input_types=["text/plain"])
+        self._png_bytes = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDRfakehdr"
+        self._png_b64 = base64.b64encode(self._png_bytes).decode("ascii")
+        self._mp3_bytes = b"ID3\x04\x00\x00\x00\x00\x00\x00fake mp3 payload"
+        self._mp3_b64 = base64.b64encode(self._mp3_bytes).decode("ascii")
+        tmpdir = tempfile.gettempdir()
+        self._snapshot_before = {
+            p for p in os.listdir(tmpdir) if p.startswith("as-unsup-")
+        }
+
+    def tearDown(self) -> None:
+        """Run the atexit hook so no temp files leak between tests."""
+        _cleanup_unsupported_media_temp_files()
+
+    def test_same_base64_yields_deterministic_path(self) -> None:
+        """Identical ``Base64Source`` bytes must produce identical output."""
+        blocks = [
+            DataBlock(
+                source=Base64Source(
+                    data=self._png_b64,
+                    media_type="image/png",
+                ),
+            ),
+        ]
+        first, _ = self._fmt.convert_tool_result_to_string(blocks)
+        second, _ = self._fmt.convert_tool_result_to_string(blocks)
+        self.assertEqual(first, second)
+        self.assertIn("saved locally at:", first)
+
+    def test_written_file_contains_decoded_bytes(self) -> None:
+        """The registered temp file must store the decoded bytes."""
+        blocks = [
+            DataBlock(
+                source=Base64Source(
+                    data=self._mp3_b64,
+                    media_type="audio/mpeg",
+                ),
+            ),
+        ]
+        text, _ = self._fmt.convert_tool_result_to_string(blocks)
+        prefix = "saved locally at: "
+        start = text.index(prefix) + len(prefix)
+        end = text.index(".</system-reminder>", start)
+        path = text[start:end]
+        self.assertTrue(os.path.isfile(path))
+        with open(path, "rb") as handle:
+            payload = handle.read()
+        self.assertEqual(payload, self._mp3_bytes)
+
+    def test_distinct_contents_yield_distinct_paths(self) -> None:
+        """Different payloads must register two different stable paths."""
+        registered_before = set(_UNSUPPORTED_MEDIA_TEMP_FILES)
+        blocks_a = [
+            DataBlock(
+                source=Base64Source(
+                    data=self._png_b64,
+                    media_type="image/png",
+                ),
+            ),
+        ]
+        blocks_b = [
+            DataBlock(
+                source=Base64Source(
+                    data=self._mp3_b64,
+                    media_type="audio/mpeg",
+                ),
+            ),
+        ]
+        text_a, _ = self._fmt.convert_tool_result_to_string(blocks_a)
+        text_b, _ = self._fmt.convert_tool_result_to_string(blocks_b)
+        self.assertNotEqual(text_a, text_b)
+        new_files = _UNSUPPORTED_MEDIA_TEMP_FILES - registered_before
+        self.assertEqual(len(new_files), 2)
+        for path in new_files:
+            self.assertTrue(os.path.basename(path).startswith("as-unsup-"))
+
+    def test_atexit_cleanup_removes_registered_files(self) -> None:
+        """The cleanup hook must delete every registered temp path."""
+        blocks = [
+            DataBlock(
+                source=Base64Source(
+                    data=self._png_b64,
+                    media_type="image/png",
+                ),
+            ),
+        ]
+        text, _ = self._fmt.convert_tool_result_to_string(blocks)
+        prefix = "saved locally at: "
+        start = text.index(prefix) + len(prefix)
+        end = text.index(".</system-reminder>", start)
+        path = text[start:end]
+        self.assertIn(path, _UNSUPPORTED_MEDIA_TEMP_FILES)
+        _cleanup_unsupported_media_temp_files()
+        self.assertFalse(os.path.exists(path))
+        self.assertEqual(len(_UNSUPPORTED_MEDIA_TEMP_FILES), 0)
+
+    def test_no_leaked_temp_file_per_call(self) -> None:
+        """Five consecutive runs must leave only one temp payload file."""
+        blocks = [
+            DataBlock(
+                source=Base64Source(
+                    data=self._png_b64,
+                    media_type="image/png",
+                ),
+            ),
+        ]
+        for _ in range(5):
+            self._fmt.convert_tool_result_to_string(blocks)
+        tmpdir = tempfile.gettempdir()
+        created = {
+            p for p in os.listdir(tmpdir) if p.startswith("as-unsup-")
+        } - self._snapshot_before
+        self.assertEqual(len(created), 1)


### PR DESCRIPTION
## 🎯 Background

Closes #2173

**Problem summary**: When the formatter's `convert_tool_result_to_string` encounters
an unsupported-media `Base64Source` tool-result block (i.e. a media type not
matched by the formatter's `input_types` glob), the original code persisted the
decoded payload with `tempfile.NamedTemporaryFile(..., delete=False)`. This had
two bad effects:
1. A brand-new random file path was emitted on every single formatter pass, so the
   textual tool-result digest changed between calls even though the payload bytes
   stayed unchanged (breaking the same class of provider-side prompt caching that
   PR #2184 / #2165 fixed for the identifier path).
2. The files were never cleaned up anywhere, so a long-running agent accumulated
   one on-disk temp file per reformat.

---

## 📝 Changes

### 做了什么
- **Content-addressed stable temp paths**: Replace the random `NamedTemporaryFile`
  with a deterministic path built from
  `shortuuid.uuid(name=block.source.data)` (name-based V5 UUID → same bytes →
  same stable filename, reuse-compatible across processes).
- **Skip redundant writes**: If the stable path already exists with a matching
  byte size, return early without rewriting it; otherwise write atomically via
  `tempfile.NamedTemporaryFile(dir=tmpdir, prefix="as-unsup-")` + `os.replace()`.
- **Lifetime-bound cleanup via `atexit`**: Add module-level
  `_UNSUPPORTED_MEDIA_TEMP_FILES` set and a `_cleanup_unsupported_media_temp_files()`
  hook registered with `atexit.register(...)`. Every stable path is added to the
  registry after it is created, so on interpreter shutdown all of them are deleted
  regardless of how many distinct payloads were produced during the process run.

### 为什么这么做
- `shortuuid.uuid(name=...)` mirrors the same deterministic pattern already
  used in PR #2184 for the supported-media identifier path, keeping the two
  halves of `convert_tool_result_to_string` consistent with each other.
- Atomic `os.replace()` avoids the race where two concurrent agents both try to
  write the same stable content-hash path.
- `atexit` is intentionally used instead of a context-manager / `finally` at the
  call site because the downstream LLM and tool layer can reference the temp-file
  path for a while (e.g. for second-tool invocation, or for parallel tool
  retries) — end-of-process cleanup is the simplest guarantee that the file
  still exists at the moment consumers need it while still preventing indefinite
  accumulation across service restarts.

### **不**做什么
- No changes to `URLSource`, `input_types` glob matching, or the
  promoted-multimodal-data identifier path (those are unchanged, already covered
  by prior tests).
- No OS-signal handler wiring (`SIGTERM`/`SIGKILL`) on top of `atexit` — keep the
  scope minimal; non-`atexit` recoveries (crash / SIGKILL) still leave temp
  files in the system-managed `tempfile.gettempdir()`.

---

## ✅ Verification

### Lint + pre-commit
- [x] `pre-commit run --files src/agentscope/formatter/_formatter_base.py tests/formatter_openai_chat_test.py` — ALL HOOKS pass
  - check-ast / trailing-whitespace / add-trailing-comma / mypy / `black --line-length=79` / `flake8 --extend-ignore=E203` / pylint (full disable list 30+) / pyroma → all green idempotently on second run.

### Tests
- [x] New regression tests (5) in `FormatterBaseUnsupportedMediaTest` PASS:
  - `test_same_base64_yields_deterministic_path` — same bytes → same textual output across 2 consecutive runs.
  - `test_written_file_contains_decoded_bytes` — decoded bytes written to the stable path match the original fixture exactly.
  - `test_distinct_contents_yield_distinct_paths` — distinct payloads → two distinct registered paths with `as-unsup-` prefix.
  - `test_atexit_cleanup_removes_registered_files` — the `_cleanup_unsupported_media_temp_files()` hook deletes every registered temp path and clears the registry.
  - `test_no_leaked_temp_file_per_call` — 5 formatter runs with the same bytes create 1 temp file total (not 5).
- [x] All other formatter suites still PASS — 80 tests total:
  - `formatter_openai_chat_test.py`: `13 passed`
  - `formatter_deepseek_test.py / formatter_dashscope_test.py / formatter_ollama_test.py / formatter_openai_response_test.py / formatter_anthropic_test.py / formatter_moonshot_test.py`: `67 passed`

---

## 🌊 Impact

- **Breaking Change?** → ⚪ 没有
- **受影响模块**: `FormatterBase` (`src/agentscope/formatter/_formatter_base.py`) → all subclasses (OpenAI, Gemini, Anthropic, DeepSeek, DashScope, Moonshot, Ollama, xAI...) inherit the same unsuppored-media fallback path.
- **性能影响**: 🟢 对重复调用场景反而更快（跳过重复写文件）；新建内容仅多一次 `os.path.exists` + `os.path.getsize` check.
- **文档更新**: 无需独立文档；issue #2173 #2165 #2184 已关联描述行为。

---

## 📋 Checklist

- [x] 我的代码遵循项目的代码风格（`pre-commit run --all` 对 changed files 已通过）。
- [x] 我加了测试证明改动有效（5 个新回归测试覆盖 determinism / 内容正确性 / 路径区别 / atexit 清退 / 非泄漏）。
- [x] 新增和已有测试都本地通过（80 formatter 相关测试全绿）。
- [x] 本 PR 只解决 #2173 单个 issue，不夹带无关改动。
