### PR TITLE
fix(webui): streaming-phase stall watchdog + SSE-error phase reset (#2110)

### DIFF
--- a/examples/web_ui/frontend/src/hooks/useMessages.ts
+++ b/examples/web_ui/frontend/src/hooks/useMessages.ts
@@ -76,6 +76,21 @@ export type ReplyPhase = 'idle' | 'streaming' | 'interrupting';
 const INTERRUPT_TIMEOUT_MS = 10_000;
 
 /**
+ * Maximum silence window during an in-flight ``streaming`` reply. When the
+ * backend produces no ``AgentEvent`` for this many milliseconds while a reply
+ * is still open (unhandled LLM exception, crashed worker process, dropped
+ * network packet on the SSE connection), the frontend falls back to ``idle``
+ * and surfaces a descriptive error so the spinner / Stop button do not stick
+ * indefinitely (issue #2110).
+ *
+ * The value is intentionally generous at 45 s because long tool calls (e.g.
+ * web search, code sandbox, or a slow LLM ``n`` parameter run) are legitimately
+ * silent for 10 s – 30 s. Short values would false-positive stall-detect
+ * running requests.
+ */
+const STALL_TIMEOUT_MS = 45_000;
+
+/**
  * Manages messages for a single ``(agentId, sessionId)`` pair.
  *
  * Event delivery has two independent channels:
@@ -138,6 +153,10 @@ export function useMessages(
 	// Timer that reverts ``interrupting`` back to ``idle`` if the
 	// terminating REPLY_END never arrives (dropped SSE frame, etc.).
 	const interruptTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	// Timer that reverts ``streaming`` back to ``idle`` when the backend stops
+	// emitting AgentEvent for STALL_TIMEOUT_MS (crashed worker, LLM exception
+	// that escaped the event pipeline, silent TCP drop on the SSE socket).
+	const stallTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	const clearInterruptTimer = useCallback(() => {
 		if (interruptTimerRef.current !== null) {
@@ -145,6 +164,29 @@ export function useMessages(
 			interruptTimerRef.current = null;
 		}
 	}, []);
+
+	const clearStallTimer = useCallback(() => {
+		if (stallTimerRef.current !== null) {
+			clearTimeout(stallTimerRef.current);
+			stallTimerRef.current = null;
+		}
+	}, []);
+
+	/** (Re)start the stall timer — only meaningful while streaming. */
+	const restartStallTimer = useCallback(() => {
+		clearStallTimer();
+		stallTimerRef.current = setTimeout(() => {
+			stallTimerRef.current = null;
+			setPhase((prev) => (prev === 'streaming' ? 'idle' : prev));
+			setError(
+				new Error(
+					`The backend stopped producing events for ${STALL_TIMEOUT_MS / 1000}s`
+						+ ' during this chat run (crashed worker or LLM exception).'
+						+ ' Please retry your message.',
+				),
+			);
+		}, STALL_TIMEOUT_MS);
+	}, [clearStallTimer]);
 
 	const audioManager = useAudioManager();
 
@@ -185,6 +227,7 @@ export function useMessages(
 					const v = custom.value as { worker_session_id: string; reply_id: string };
 					setSubagentHitl((prev) => prev.filter((x) => hitlKey(x) !== hitlKey(v)));
 				}
+				restartStallTimer();
 				return;
 			}
 			if (event.type === EventType.REPLY_START) {
@@ -195,15 +238,18 @@ export function useMessages(
 				currentReplyRef.current = msg;
 				clearInterruptTimer();
 				setPhase('streaming');
+				restartStallTimer();
 			} else if (event.type === EventType.REPLY_END) {
 				if (currentReplyRef.current) {
 					appendEvent(currentReplyRef.current, event);
 				}
 				clearInterruptTimer();
+				clearStallTimer();
 				setPhase('idle');
 				currentReplyRef.current = null;
 			} else if (currentReplyRef.current) {
 				appendEvent(currentReplyRef.current, event);
+				restartStallTimer();
 			}
 
 			// Route streaming audio DataBlocks to the audio manager. They still
@@ -231,7 +277,13 @@ export function useMessages(
 
 			scheduleUpdate();
 		},
-		[scheduleUpdate, audioManager, clearInterruptTimer],
+		[
+			scheduleUpdate,
+			audioManager,
+			clearInterruptTimer,
+			clearStallTimer,
+			restartStallTimer,
+		],
 	);
 
 	// ── Lifecycle: fetch history + open SSE stream ──────────────────
@@ -241,6 +293,7 @@ export function useMessages(
 		setMsgs([]);
 		setError(null);
 		clearInterruptTimer();
+		clearStallTimer();
 		setPhase('idle');
 		setSubagentHitl([]);
 		audioManager?.disposeAll();
@@ -268,6 +321,7 @@ export function useMessages(
 				const tail = messages[messages.length - 1];
 				if (is_running || hasPendingToolCall(tail)) {
 					setPhase('streaming');
+					restartStallTimer();
 					if (hasPendingToolCall(tail)) {
 						// Prime the ref so continuation events (which
 						// arrive without a fresh REPLY_START) apply to
@@ -295,6 +349,11 @@ export function useMessages(
 				}
 			} catch (e) {
 				if ((e as Error).name !== 'AbortError' && !cancelled) {
+					// The SSE stream disconnected unexpectedly — do not
+					// leave the UI stuck on streaming/spinner even if
+					// the backend never emitted a REPLY_END.
+					clearStallTimer();
+					setPhase((prev) => (prev === 'streaming' ? 'idle' : prev));
 					setError(e as Error);
 				}
 			}
@@ -305,8 +364,18 @@ export function useMessages(
 			controller.abort();
 			abortRef.current = null;
 			clearInterruptTimer();
+			clearStallTimer();
 		};
-	}, [agentId, sessionId, scheduleUpdate, processEvent, audioManager, clearInterruptTimer]);
+	}, [
+		agentId,
+		sessionId,
+		scheduleUpdate,
+		processEvent,
+		audioManager,
+		clearInterruptTimer,
+		clearStallTimer,
+		restartStallTimer,
+	]);
 
 	/**
 	 * Send a user message. Appends the message to the local list
@@ -410,6 +479,7 @@ export function useMessages(
 		// click) leave the phase alone.
 		setPhase((prev) => (prev === 'streaming' ? 'interrupting' : prev));
 		clearInterruptTimer();
+		clearStallTimer();
 		interruptTimerRef.current = setTimeout(() => {
 			interruptTimerRef.current = null;
 			setPhase((prev) => (prev === 'interrupting' ? 'idle' : prev));
@@ -421,7 +491,7 @@ export function useMessages(
 			setPhase((prev) => (prev === 'interrupting' ? 'idle' : prev));
 			setError(e as Error);
 		}
-	}, [agentId, sessionId, clearInterruptTimer]);
+	}, [agentId, sessionId, clearInterruptTimer, clearStallTimer]);
 
 	/**
 	 * Confirm or deny a tool call that a *team member* is awaiting,

--- a/examples/web_ui/frontend/src/hooks/useMessages.ts
+++ b/examples/web_ui/frontend/src/hooks/useMessages.ts
@@ -180,9 +180,9 @@ export function useMessages(
 			setPhase((prev) => (prev === 'streaming' ? 'idle' : prev));
 			setError(
 				new Error(
-					`The backend stopped producing events for ${STALL_TIMEOUT_MS / 1000}s`
-						+ ' during this chat run (crashed worker or LLM exception).'
-						+ ' Please retry your message.',
+					`The backend stopped producing events for ${STALL_TIMEOUT_MS / 1000}s` +
+						' during this chat run (crashed worker or LLM exception).' +
+						' Please retry your message.',
 				),
 			);
 		}, STALL_TIMEOUT_MS);
@@ -277,13 +277,7 @@ export function useMessages(
 
 			scheduleUpdate();
 		},
-		[
-			scheduleUpdate,
-			audioManager,
-			clearInterruptTimer,
-			clearStallTimer,
-			restartStallTimer,
-		],
+		[scheduleUpdate, audioManager, clearInterruptTimer, clearStallTimer, restartStallTimer],
 	);
 
 	// ── Lifecycle: fetch history + open SSE stream ──────────────────


### PR DESCRIPTION
## 🎯 Background

Closes #2110

**Problem summary**: When the backend LLM / worker crashes with an unhandled
exception mid-run, or the SSE connection silently drops a TCP packet on a
long-silent tool call, the WebUI session remains in
`phase: 'streaming'` **forever**:
- Reply phase only transitions to `streaming` on `ReplyStartEvent` and back to
  `idle` on `ReplyEndEvent` (driven 100 % by event content; SSE socket-level
  disconnects don't touch the phase).
- A crashed worker never emits `ReplyEndEvent` because the exception escapes
  the event pipeline before the terminal frame is produced.
- Result for the user: the spinner and Stop button stick on the text input
  permanently, and no descriptive error surfaces. The only workaround is a
  full browser reload.

A **10 s safety fallback** already existed for the `interrupting` sub-phase
(when the user has already clicked Stop), but there was **no equivalent guard
at all** for the main `streaming` sub-phase where the user is still waiting
patiently and 90 % of the bug actually manifests.

---

## 📝 Changes

### 做了什么
- **新增 `STALL_TIMEOUT_MS = 45_000`** streaming stall guard. If the SSE
  event-stream does not deliver any `AgentEvent` for 45 s while the reply is
  still declared `streaming`, the hook automatically:
  1. Clears `phase` back to `'idle'` so the spinner / Stop button disappear.
  2. Sets a descriptive `Error` explaining "backend stopped producing events
     for 45 s during this chat run (crashed worker or LLM exception). Please
     retry your message." so the user understands what happened and the
     standard error toast surfaces it.
- **Reset the stall timer on every received event**, not just on REPLY_START.
  Long but healthy tool calls (web search / code sandbox / slow `n`-parameter
  LLMs) produce intermittent progress events (DATA_BLOCK_DELTA, TOOL_* frames,
  CUSTOM service notifications) and therefore never trip the guard; truly
  silent runs (uncaught exception, process crash) are what trips it.
- **Unexpected SSE disconnect no longer leaves the spinner on**: the `catch`
  branch that handles `streamEvents()` generator exceptions (non-`AbortError`,
  non-cancelled) now explicitly runs `clearStallTimer()` and resets phase to
  `'idle'` — the SSE reader's `done`-completion path (backend graceful close)
  stays untouched so as not to double-transition a run that is already ended
  normally via REPLY_END.
- **Bootstrap history streaming recovery**: When
  `GET /messages` reports `is_running=true` at page-load time (existing
  behaviour: priming the phase to `streaming` so the interrupt button is
  immediately accessible), the stall timer is now *also* armed, because this
  was the exact scenario where a user refreshed the page while their worker
  had already died — the UI would be stuck on "Stop" forever, with zero
  mechanism to recover.
- **`interrupt()` clears the stall timer** alongside the existing
  interrupt-timer clear — the two guards never fight; interrupt's own 10 s
  fallback (deliberately shorter than `STALL_TIMEOUT_MS`) is authoritative
  once the user has clicked Stop.
- `clearStallTimer()` is called on every cleanup path (hook `return` teardown,
  REPLY_END completion, effect run re-entry when agentId/sessionId change),
  so stale timers from previous runs never fire against a fresh phase.

### 为什么这么做
- **Event-siloed phase machine vs. partial failure**: The existing design is
  correct in the happy path — phases track event content, not HTTP lifecycle,
  because two fully-independent channels (REST history + SSE deltas) carry
  information. But this split means *any* breakage in the content channel
  silently deadlocks the phase; a wall-clock fallback is the standard
  watchdog pattern for content-driven state machines.
- **45 s, not 10 s / 30 s**: 45 s is intentionally conservative. Slow
  external tool calls (Google search, Python sandbox running unit tests, a
  cold-start LLM endpoint with large `n`) legitimately produce zero events
  for 20–30 s. Short values like 20 s would false-positive and annoy users
  with fake "crashed" errors. 45 s is double the interrupt fallback, so the
  user's explicit "Stop" always wins before the watchdog.
- **No new deps / no new components**: everything is internal to
  `useMessages` so there is zero new API surface and zero risk of affecting
  other hooks.

### **不**做什么
- No backend-side fix (e.g. finally guard around the worker run coroutine
  ensuring `ReplyEndEvent` always fires). That would be a complementary
  server-side fix, but issue #2110 is explicitly filed as a **WebUI** bug
  ("spinner永不停止"), so frontend watchdog is the scoped fix. Adding the
  backend finally-block would be done in a *separate* PR (single-task single-PR
  rule).
- No automatic chat-retry on stall — if the last 45 s of run state is unknown
  we cannot safely replay the POST; surfacing the error and letting the user
  retry is the correct UX.
- No `SIGTERM`/socket-level heartbeat protocol changes to SSE frames. The
  backend already emits `:` comment heartbeats via the existing `; comment`
  frames; this PR focuses on *content-side* stall (events stop but heartbeats
  still flow because the proxy TCP layer is alive). Adding heartbeat parsing
  to the stall timer is out of scope.

---

## ✅ Verification

### TypeScript
- [x] `npm run build` → `tsc -b` + `vite build` **PASS** — zero TypeScript
  diagnostics for the changed file and the whole frontend project.

### Lint
- [x] `npm run lint` targeted at the modified file:
  `./node_modules/.bin/eslint src/hooks/useMessages.ts` → **PASS / no
  violations**.
- Plugin mix includes `eslint-plugin-react-hooks` — no
  `exhaustive-deps`/`rules-of-hooks` violations on the new callbacks
  (`clearStallTimer`, `restartStallTimer`, `interrupt`, `processEvent`,
  `useEffect` deps arrays — all added new refs are explicitly listed).

### Manual review of edge cases
- **Normal run** → REPLY_START arms timer, every delta event restarts it,
  REPLY_END clears it → no error, phase tracks events exactly as before.
- **Crash after REPLY_START and no further events** → timer fires once at
  45 s → phase `streaming → idle` and descriptive error set once. Repeat
  fire is impossible because `setTimeout` fires exactly once, and the firing
  path clears `stallTimerRef`.
- **Crash at page load** with `is_running=true` from history → stall timer is
  armed on effect entry via `restartStallTimer()` after the `setPhase('streaming')`
  call; 45 s later UI clears.
- **SSE reader throws (`fetch` failed mid-stream, TCP RST)** → `catch` path
  (non-`AbortError`, non-`cancelled`) runs `clearStallTimer()`,
  `setPhase(prev => streaming → idle)`, `setError(e as Error)` → spinner gone
  + network error shown instead of silently hanging.
- **User clicks Stop mid-stream** → `interrupt()` clears stall timer, arms
  the existing 10 s interrupt fallback. Both timers coexist with disjoint
  phases (stall only fires while `phase === 'streaming'`; interrupt fallback
  only fires while `phase === 'interrupting'`) so they cannot conflict.
- **Agent/session changes mid-stream** → `useEffect` return runs
  `clearStallTimer()` along with `clearInterruptTimer()`; stale timers from
  the previous (session, agent) pair cannot leak into the next hook run.
- **HITL-parked reply on page load** (`hasPendingToolCall(tail)` is true):
  arming the stall timer here is correct — a pending tool call has an
  "external execution" provider that should push events at some point. If the
  external process died with the tool still pending, a 45 s watchdog is the
  right escape hatch.

---

## 🌊 Impact

- **Breaking Change?** → ⚪ 没有
- **受影响模块**: `useMessages` hook (single file) → only the WebUI chat
  viewport; the Python SDK, REST API layer, SSE backend, persisted Msg
  storage, all sibling pages (credentials, knowledge base, schedule,
  setup guide), audio streaming manager, HITL cards, and task panel are
  untouched.
- **性能影响**: 🟢 Negligible. One additional `setTimeout` / `clearTimeout`
  pair per in-flight event (typical runs = dozens of events, not thousands);
  `setTimeout` is O(1) and sleeps on the browser scheduler.
- **文档更新**: 无需独立文档 — issue #2110 is the descriptive change note.

---

## 📋 Checklist

- [x] My code follows the project's frontend code style (tsc + eslint both green on targeted run).
- [x] No new TypeScript violations project-wide.
- [x] All five failure paths from issue #2110 are handled: mid-stream LLM exception, worker crash, silent SSE content-drop, post-reload recovery of `is_running=true`, and unexpected generator error in the stream reader.
- [x] Normal happy path is byte-for-byte equivalent except for the timer bookkeeping that never fires when events keep flowing.
- [x] This PR addresses only issue #2110 — no unrelated changes bundled.
