### PR TITLE
fix(model): auto-retry without tool_choice for thinking-model 400s (#1608)

### DIFF
--- a/src/agentscope/model/_openai_chat/_model.py
+++ b/src/agentscope/model/_openai_chat/_model.py
@@ -267,7 +267,7 @@ class OpenAIChatModel(ChatModelBase):
             kwargs["stream_options"] = {"include_usage": True}
 
         start_datetime = datetime.now()
-        response = await self.client.chat.completions.create(**kwargs)
+        response = await self._safe_chat_completions_create(kwargs)
 
         audio_cfg = kwargs.get("audio")
         audio_fmt = (
@@ -585,6 +585,69 @@ class OpenAIChatModel(ChatModelBase):
                 tool_choice=ToolChoice(mode="auto"),
                 **kwargs,
             )
+
+    async def _safe_chat_completions_create(
+        self,
+        kwargs: dict[str, Any],
+    ) -> Any:
+        """Call ``self.client.chat.completions.create`` with a tool_choice
+        fallback.
+
+        Some OpenAI-compatible providers (DeepSeek thinking-mode models,
+        reasoning variants of qwen-plus, certain Groq partitions, etc.)
+        reject the ``tool_choice`` parameter outright, even values such
+        as ``"auto"`` that would otherwise be a no-op.  When the
+        underlying call raises ``openai.BadRequestError`` and the error
+        message mentions ``tool_choice``, this helper drops
+        ``kwargs["tool_choice"]`` and retries once.
+
+        ``tool_choice`` is the only parameter this helper can suppress
+        on retry: a different ``BadRequestError`` is re-raised without
+        retrying so unrelated provider regressions continue to be
+        visible as soon as possible.
+
+        Args:
+            kwargs: Positional kwargs forwarded verbatim (after any
+                retry-time mutation) to
+                ``self.client.chat.completions.create``.
+
+        Returns:
+            The raw completion object (non-stream mode) or the async
+            stream object (stream mode) returned by the client.
+        """
+        import openai
+
+        first_error: Exception | None = None
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                return await self.client.chat.completions.create(**kwargs)
+            except openai.BadRequestError as exc:
+                if (
+                    "tool_choice" in str(exc)
+                    and "tool_choice" in kwargs
+                    and attempt < 2
+                ):
+                    first_error = exc
+                    fallback = {
+                        k: v for k, v in kwargs.items() if k != "tool_choice"
+                    }
+                    warnings.warn(
+                        "tool_choice parameter rejected by provider "
+                        f"({exc}); retrying without tool_choice "
+                        "(model still receives tool definitions, only "
+                        "the selection hint is dropped).",
+                        stacklevel=3,
+                    )
+                    kwargs = fallback
+                    continue
+                if first_error is not None:
+                    # Preserve the original traceback so operators can
+                    # still see exactly which argument the provider
+                    # rejected in the first place.
+                    raise first_error from exc
+                raise
 
     def _format_tools(
         self,

--- a/tests/model_openai_chat_test.py
+++ b/tests/model_openai_chat_test.py
@@ -23,6 +23,7 @@ from agentscope.message import (
     ThinkingBlock,
     DataBlock,
     Base64Source,
+    UserMsg,
 )
 from agentscope.model import OpenAIChatModel
 from agentscope.credential import OpenAICredential
@@ -834,3 +835,181 @@ class TestOpenAIChatFormatTools(unittest.TestCase):
         fmt_tools, fmt_choice = self.model._format_tools(_FT_TOOLS, None)
         self.assertEqual(fmt_tools, _FT_TOOLS)
         self.assertIsNone(fmt_choice)
+
+
+def _bad_request_error(message: str) -> Exception:
+    """Build a minimal ``openai.BadRequestError``-compatible exception.
+
+    The real SDK error is a thin subclass of ``APIError`` with a body +
+    status code; for tests we only need ``str(exc)`` to contain the
+    provided ``message`` and for ``isinstance(exc, openai.BadRequestError)``
+    to be True, both of which this factory guarantees by importing
+    from an installed ``openai`` SDK (shipped as a core dependency).
+    """
+    from openai import BadRequestError  # type: ignore[import-not-found]
+
+    return BadRequestError(
+        message=message,
+        response=MagicMock(status_code=400),
+        body={"error": {"message": message}},
+    )
+
+
+class TestToolChoiceRejectionFallback(IsolatedAsyncioTestCase):
+    """Exercise ``_safe_chat_completions_create`` tool_choice retry loop."""
+
+    def setUp(self) -> None:
+        self.model = _make_model(stream=False)
+        self.mock_client = MagicMock()
+        self.model.client = self.mock_client
+
+    async def test_400_tool_choice_rejection_retries_without_param(
+        self,
+    ) -> None:
+        """On ``BadRequestError`` mentioning ``tool_choice`` the helper
+        drops the ``tool_choice`` kwarg and retries exactly once."""
+        calls = []
+        good_response = _mock_completion(text="ok")
+
+        async def create_side_effect(**kwargs: Any) -> Any:
+            calls.append(dict(kwargs))
+            if "tool_choice" in kwargs:
+                raise _bad_request_error(
+                    "deepseek-reasoner does not support this tool_choice",
+                )
+            return good_response
+
+        self.mock_client.chat.completions.create = AsyncMock(
+            side_effect=create_side_effect,
+        )
+
+        with self.assertWarns(UserWarning):
+            result = await self.model._safe_chat_completions_create(
+                {
+                    "model": "gpt-4o",
+                    "messages": [{"role": "user", "content": "Hi"}],
+                    "tools": _FT_TOOLS,
+                    "tool_choice": "required",
+                },
+            )
+
+        self.assertIs(result, good_response)
+        self.assertEqual(len(calls), 2)
+        self.assertIn("tool_choice", calls[0])
+        self.assertNotIn("tool_choice", calls[1])
+        self.assertEqual(calls[1]["tools"], _FT_TOOLS)
+
+    async def test_unrelated_400_does_not_retry(self) -> None:
+        """A BadRequestError unrelated to tool_choice is re-raised."""
+        from openai import BadRequestError  # type: ignore[import-not-found]
+
+        async def _fail(**_kwargs: Any) -> Any:
+            raise _bad_request_error(
+                "invalid parameter: temperature must be <=2",
+            )
+
+        self.mock_client.chat.completions.create = AsyncMock(
+            side_effect=_fail,
+        )
+
+        with self.assertRaises(BadRequestError):
+            await self.model._safe_chat_completions_create(
+                {
+                    "model": "gpt-4o",
+                    "messages": [{"role": "user", "content": "Hi"}],
+                    "temperature": 3.5,
+                },
+            )
+
+        # Only one attempt – no retrying unrelated errors
+        self.assertEqual(
+            self.mock_client.chat.completions.create.await_count,
+            1,
+        )
+
+    async def test_second_attempt_failure_raises_first_error(self) -> None:
+        """If the second attempt also fails, re-raise the original
+        BadRequestError so operators see the provider message."""
+        from openai import BadRequestError  # type: ignore[import-not-found]
+
+        captured: list[Exception] = []
+
+        async def _fail_both(**_kwargs: Any) -> Any:
+            err = _bad_request_error(
+                "reasoning models do not accept tool_choice at all",
+            )
+            captured.append(err)
+            raise err
+
+        self.mock_client.chat.completions.create = AsyncMock(
+            side_effect=_fail_both,
+        )
+
+        with self.assertRaises(BadRequestError) as raised, self.assertWarns(
+            UserWarning,
+        ):
+            await self.model._safe_chat_completions_create(
+                {
+                    "model": "deepseek-v4-pro",
+                    "messages": [{"role": "user", "content": "Hi"}],
+                    "tool_choice": "required",
+                },
+            )
+
+        self.assertIs(raised.exception, captured[0])
+        # Exactly two attempts: first with tool_choice, second without
+        self.assertEqual(
+            self.mock_client.chat.completions.create.await_count,
+            2,
+        )
+
+    async def test_agent_invoke_path_observes_fallback(self) -> None:
+        """End-to-end: ``__call__()`` with ``tool_choice`` triggers the
+        fallback flow, drops the bad parameter, and returns a response
+        instead of raising."""
+        import warnings
+
+        calls = []
+
+        async def create_side_effect(**kwargs: Any) -> Any:
+            calls.append({k for k in kwargs if "tool" in k})
+            if "tool_choice" in kwargs:
+                raise _bad_request_error(
+                    "deepseek-reasoner does not support this tool_choice",
+                )
+            return _mock_completion(
+                tool_calls=[
+                    {
+                        "id": "call-x",
+                        "name": "get_weather",
+                        "arguments": '{"city":"Shanghai"}',
+                    },
+                ],
+            )
+
+        self.mock_client.chat.completions.create = AsyncMock(
+            side_effect=create_side_effect,
+        )
+
+        with warnings.catch_warnings(record=True) as captured_warnings:
+            warnings.simplefilter("always")
+            result = await self.model(
+                [UserMsg(name="user", content="Shanghai weather?")],
+                tools=_FT_TOOLS,
+                tool_choice=ToolChoice(mode="required"),
+            )
+
+        self.assertTrue(result.is_last)
+        blocks = [b for b in result.content if isinstance(b, ToolCallBlock)]
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(blocks[0].name, "get_weather")
+
+        self.assertEqual(len(calls), 2)
+        self.assertIn("tool_choice", calls[0])
+        self.assertNotIn("tool_choice", calls[1])
+        self.assertTrue(
+            any(
+                "tool_choice parameter rejected" in str(w.message)
+                for w in captured_warnings
+            ),
+        )


### PR DESCRIPTION
## Summary

- **closes #1608**

## Background

Issue #1608 reports that tool-using agents crash on DeepSeek V4 reasoning
models (and similar reasoning variants served through OpenAI-compatible
endpoints, e.g. certain OpenRouter or Together partitions) because the
client framework unconditionally passes a ``tool_choice`` parameter:

```json
{"error": {"message": "deepseek-reasoner does not support this tool_choice"}}
```

The scenario originally filed uses ReActAgent, which sets
``tool_choice=required`` in its ``reply(msg, structured_model=...)``
path. However the same 400 hits any direct OpenAIChatModel caller that
hands a tool_choice to a reasoning-model provider – it is not specific
to one agent.

A related bug was already fixed for the *structured-output* chat path in
#2137/PR #2189 (``_call_api_with_structured_output``, which is used by
``compress_context`` when it requests a pydantic schema). That fix did
*not* cover the normal chat call (``OpenAIChatModel._call_api`` →
``client.chat.completions.create``), which is precisely the path that
ReActAgent and most ordinary tool-using agents travel. This PR closes
the gap.

## Changes

1. New helper ``OpenAIChatModel._safe_chat_completions_create(kwargs)``:
   - Forwards to ``self.client.chat.completions.create(**kwargs)`` on
     the happy path (zero overhead for non-failing providers).
   - On ``openai.BadRequestError`` whose message mentions
     ``tool_choice``, drops the ``tool_choice`` key and retries
     **exactly once** (``attempt < 2`` guard + ``raise`` on the
     second pass to guarantee a bounded retry loop).
   - Retries keep the ``tools`` list intact so the model remains free
     to call any tool; only the rejected selection hint is removed.
   - On retry a ``UserWarning`` is emitted so operators can see
     exactly which provider silently degraded behaviour.
   - If the retry also raises, the **original** BadRequestError is
     re-raised (with the follow-up error linked via ``__context__``)
     so bug reports preserve the provider's verbatim first message
     rather than an unrelated no-tool_choice error.
   - Any BadRequestError that does not mention ``tool_choice`` is
     re-raised immediately, no retries, so unrelated provider
     regressions remain loud.

2. The single ``client.chat.completions.create`` call site inside
   ``_call_api`` is now routed through the helper. Since the SDK
   itself dispatches on ``kwargs["stream"]`` internally this single
   change automatically covers both non-stream and streaming modes.

3. Four new unit tests appended to ``tests/model_openai_chat_test.py``
   under ``TestToolChoiceRejectionFallback``:
   - ``test_400_tool_choice_rejection_retries_without_param`` – first
     attempt 400s, second succeeds, 2 attempts in total, retry
     kwargs still carry ``tools`` but no longer ``tool_choice``,
     and a UserWarning is recorded.
   - ``test_unrelated_400_does_not_retry`` – a validation 400
     about ``temperature`` is re-raised after only 1 attempt.
   - ``test_second_attempt_failure_raises_first_error`` – if both
     attempts fail, the original DeepSeek-style error is the one
     that surfaces (not the second error).
   - ``test_agent_invoke_path_observes_fallback`` – end-to-end
     ``OpenAIChatModel.__call__(msgs, tools, tool_choice=required)``
     is routed through the helper transparently, producing a
     ToolCallBlock for ``get_weather`` without any exception.

## Verification

- pre-commit hook chain (check-ast → trailing-whitespace → sort-yaml →
  add-trailing-comma → mypy → black → flake8 → pylint 3.0.2 →
  pyroma): **ALL PASS**.
- pytest::

      python3 -m pytest tests/model_openai_chat_test.py -v
      ================================= 24 passed =================================
      24 passed in 2.22s

  Includes: all 4 new fallback tests, 6 existing non-stream tests,
  6 existing stream tests, plus _format_tools/parameters suites. No
  regressions.

## Impact Scope

Files changed:

* ``src/agentscope/model/_openai_chat/_model.py`` – 60 LOC added,
  1 LOC changed (the create call routing). Behaviour for non-failing
  providers is byte-for-byte identical.
* ``tests/model_openai_chat_test.py`` – 4 new tests + small imports +
  shared BadRequestError factory.

## Checklist

- [x] Covers the ReActAgent/_call_api path that issue #1608 actually
      hits (not only the compress_context/structured path fixed in
      PR #2189).
- [x] Bounded retry loop (at most 1 retry) + original error is kept
      if the retry also raises.
- [x] Tool list remains available on the retried request – tool
      behaviour is preserved; only the selection hint is dropped.
- [x] UserWarning is emitted on fallback for operator visibility.
- [x] Commit author: RerankerGuo <121015044+RerankerGuo@users.noreply.github.com>
      (GitHub contribution-statistics compliant).
