### PR TITLE
fix(app): reject file URLs in chat input

### DIFF
--- a/src/agentscope/app/_router/_schema/_chat.py
+++ b/src/agentscope/app/_router/_schema/_chat.py
@@ -1,10 +1,40 @@
 # -*- coding: utf-8 -*-
 """The chat endpoint schema."""
 
-from pydantic import BaseModel, Field
+from typing import Self
 
-from ....message import Msg
+from pydantic import BaseModel, Field, model_validator
+
+from ....message import (
+    ContentBlock,
+    DataBlock,
+    HintBlock,
+    Msg,
+    ToolResultBlock,
+    URLSource,
+)
 from ....event import UserConfirmResultEvent, ExternalExecutionResultEvent
+
+
+def _reject_file_url_sources(blocks: list[ContentBlock]) -> None:
+    """Reject local-file data sources supplied through the chat API."""
+    for block in blocks:
+        if isinstance(block, DataBlock):
+            if (
+                isinstance(block.source, URLSource)
+                and block.source.url.scheme == "file"
+            ):
+                raise ValueError(
+                    "file:// URL sources are not accepted by the chat API. "
+                    "Upload content as base64 instead.",
+                )
+        elif isinstance(block, HintBlock) and isinstance(block.hint, list):
+            _reject_file_url_sources(block.hint)
+        elif isinstance(block, ToolResultBlock) and isinstance(
+            block.output,
+            list,
+        ):
+            _reject_file_url_sources(block.output)
 
 
 class ChatRequest(BaseModel):
@@ -27,6 +57,20 @@ class ChatRequest(BaseModel):
     ) = Field(
         description="The input message(s), or agent event, or None.",
     )
+
+    @model_validator(mode="after")
+    def reject_file_url_sources(self) -> Self:
+        """Keep request data sources from reading files on the service host."""
+        if isinstance(self.input, Msg):
+            _reject_file_url_sources(self.input.content)
+        elif isinstance(self.input, list):
+            for msg in self.input:
+                _reject_file_url_sources(msg.content)
+        elif isinstance(self.input, ExternalExecutionResultEvent):
+            for result in self.input.execution_results:
+                if isinstance(result.output, list):
+                    _reject_file_url_sources(result.output)
+        return self
 
 
 class ChatTriggerResponse(BaseModel):

--- a/tests/chat_request_test.py
+++ b/tests/chat_request_test.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""Tests for validation of Chat API request payloads."""
+from unittest import TestCase
+
+from pydantic import ValidationError
+
+from agentscope.app._router._schema._chat import ChatRequest
+from agentscope.event import ExternalExecutionResultEvent
+from agentscope.message import (
+    Base64Source,
+    DataBlock,
+    ToolResultBlock,
+    URLSource,
+    UserMsg,
+)
+
+
+class ChatRequestTest(TestCase):
+    """Validate chat request data-source boundaries."""
+
+    def test_rejects_file_url_source(self) -> None:
+        """A chat request must not cause the service to read a local file."""
+        with self.assertRaisesRegex(ValidationError, "file://"):
+            ChatRequest(
+                agent_id="agent",
+                session_id="session",
+                input=UserMsg(
+                    name="user",
+                    content=[
+                        DataBlock(
+                            source=URLSource(
+                                url="file:///tmp/image.png",
+                                media_type="image/png",
+                            ),
+                        ),
+                    ],
+                ),
+            )
+
+    def test_accepts_remote_and_base64_sources(self) -> None:
+        """Existing remote URLs and uploaded base64 content stay valid."""
+        ChatRequest(
+            agent_id="agent",
+            session_id="session",
+            input=UserMsg(
+                name="user",
+                content=[
+                    DataBlock(
+                        source=URLSource(
+                            url="https://example.com/image.png",
+                            media_type="image/png",
+                        ),
+                    ),
+                    DataBlock(
+                        source=Base64Source(
+                            data="aGVsbG8=",
+                            media_type="image/png",
+                        ),
+                    ),
+                ],
+            ),
+        )
+
+    def test_rejects_file_url_in_external_tool_result(self) -> None:
+        """External tool results cannot introduce a service-local path."""
+        with self.assertRaisesRegex(ValidationError, "file://"):
+            ChatRequest(
+                agent_id="agent",
+                session_id="session",
+                input=ExternalExecutionResultEvent(
+                    reply_id="reply",
+                    execution_results=[
+                        ToolResultBlock(
+                            id="tool-call",
+                            name="external-tool",
+                            output=[
+                                DataBlock(
+                                    source=URLSource(
+                                        url="file:///tmp/image.png",
+                                        media_type="image/png",
+                                    ),
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            )


### PR DESCRIPTION
Fixes #2212

## AgentScope Version

2.0.5

## Description

Chat request payloads could pass a `file://` data source to model formatters, causing the service host to read that path before sending the bytes to a model provider.

This change rejects local-file URL sources while parsing Chat API requests, including nested tool results returned by external executors. Trusted SDK and workspace flows retain their existing local-file support; API clients can continue using HTTPS URLs and base64 uploads.

## Validation

- Focused Chat request validation tests: passed
- Full pre-commit gate on the changed files: passed

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the contributing guide
- [x] Docstrings are in Google style
- [x] Related documentation is not required; this is a request-boundary security fix with no public API addition
- [x] Code is ready for review
