### PR TITLE
fix(workspace): evict and rebuild OpenSandbox workspaces killed by server-side timeout

### DIFF
--- a/src/agentscope/app/workspace_manager/_opensandbox_workspace_manager.py
+++ b/src/agentscope/app/workspace_manager/_opensandbox_workspace_manager.py
@@ -211,6 +211,13 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
         resume it depending on state, or create a fresh sandbox
         otherwise.
 
+        A cache hit is verified against the server before being
+        returned: OpenSandbox sandboxes carry a server-enforced
+        ``timeout_seconds`` lifetime, and the server destroys them
+        silently on expiry. A cached workspace whose sandbox is no
+        longer alive is evicted and rebuilt rather than handed back as
+        a permanently-broken zombie.
+
         Idle eviction is not performed here; the background sweeper
         started by :meth:`__aenter__` handles that.
 
@@ -243,14 +250,12 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
                 session_id="",
             )
 
-        async with self._lock:
-            cached = self._cache.get(workspace_id)
-            if cached is not None:
-                ws, _ = cached
-                self._cache[workspace_id] = (ws, time.monotonic())
-                return ws
+        ws = await self._get_alive_cached(workspace_id)
+        if ws is not None:
+            return ws
 
-        # Cache miss: build under the lock to prevent two concurrent
+        # Cache miss (or a dead sandbox was just evicted above): build
+        # under the lock to prevent two concurrent
         # get_workspace(workspace_id=X) calls from creating two
         # workspaces (and thus two sandboxes) for the same id.
         async with self._lock:
@@ -267,6 +272,50 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
             )
             self._cache[workspace_id] = (ws, time.monotonic())
             return ws
+
+    async def _get_alive_cached(
+        self,
+        workspace_id: str,
+    ) -> OpenSandboxWorkspace | None:
+        """Return the cached workspace for ``workspace_id`` if alive.
+
+        ``is_healthy`` is a remote round-trip, so it runs outside
+        :attr:`_lock` to avoid blocking unrelated ``get_workspace``
+        calls. A dead workspace is evicted under the lock (re-checking
+        identity first, since a concurrent caller may have already
+        evicted and rebuilt it) and its sandbox is paused best-effort
+        via :meth:`_safe_close`.
+
+        Returns:
+            `OpenSandboxWorkspace | None`:
+                The live cached workspace, or ``None`` on a cache miss
+                or a dead sandbox (now evicted).
+        """
+        async with self._lock:
+            cached = self._cache.get(workspace_id)
+        if cached is None:
+            return None
+        ws, _ = cached
+
+        if await ws.is_healthy():
+            async with self._lock:
+                current = self._cache.get(workspace_id)
+                if current is not None and current[0] is ws:
+                    self._cache[workspace_id] = (ws, time.monotonic())
+            return ws
+
+        logger.warning(
+            "OpenSandboxWorkspaceManager: sandbox for workspace_id=%r "
+            "is no longer alive (likely killed by the server-side "
+            "timeout); evicting and rebuilding",
+            workspace_id,
+        )
+        async with self._lock:
+            current = self._cache.get(workspace_id)
+            if current is not None and current[0] is ws:
+                del self._cache[workspace_id]
+        await self._safe_close(ws)
+        return None
 
     async def close(self, workspace_id: str) -> None:
         """Close (= pause the sandbox) and evict a single workspace."""

--- a/src/agentscope/workspace/_opensandbox/_opensandbox_workspace.py
+++ b/src/agentscope/workspace/_opensandbox/_opensandbox_workspace.py
@@ -186,6 +186,29 @@ class OpenSandboxWorkspace(SandboxedWorkspaceBase):
                 )
             self._sandbox = None
 
+    async def is_healthy(self) -> bool:
+        """Report whether the sandbox is still alive on the server.
+
+        OpenSandbox sandboxes carry a server-enforced ``timeout_seconds``
+        lifetime; once it elapses the server destroys the sandbox without
+        notifying this process. :class:`OpenSandboxWorkspaceManager` calls
+        this before returning a cached workspace so a server-killed
+        sandbox is evicted and rebuilt instead of handed back as an
+        unusable zombie.
+
+        Returns:
+            `bool`:
+                ``False`` before :meth:`initialize` (or after
+                :meth:`close`), and whenever the sandbox no longer
+                responds. ``True`` otherwise.
+        """
+        if self._sandbox is None:
+            return False
+        try:
+            return bool(await self._sandbox.is_healthy())
+        except Exception:
+            return False
+
     async def get_instructions(self) -> str:
         """Return the system-prompt fragment for this workspace.
 

--- a/tests/workspace_manager_opensandbox_test.py
+++ b/tests/workspace_manager_opensandbox_test.py
@@ -1,0 +1,283 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Test cases for :class:`OpenSandboxWorkspaceManager`."""
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.async_case import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+from agentscope.app.workspace_manager import (
+    IsolationPolicy,
+    OpenSandboxWorkspaceManager,
+)
+
+
+class _FakeWorkspace:
+    """Workspace double used by manager tests.
+
+    ``healthy`` mimics the server-side sandbox liveness that
+    :meth:`OpenSandboxWorkspace.is_healthy` reports — flip it to
+    ``False`` to simulate a sandbox that the OpenSandbox server killed
+    after its ``timeout_seconds`` lifetime expired.
+    """
+
+    created: list["_FakeWorkspace"] = []
+
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        self.workspace_id = str(kwargs.get("workspace_id") or "new-id")
+        self.initialized = False
+        self.closed = False
+        self.healthy = True
+        _FakeWorkspace.created.append(self)
+
+    async def initialize(self) -> None:
+        """Mark initialized."""
+        await asyncio.sleep(0)
+        self.initialized = True
+
+    async def close(self) -> None:
+        """Mark closed."""
+        self.closed = True
+
+    async def is_healthy(self) -> bool:
+        """Report the sandbox's simulated liveness."""
+        return self.healthy
+
+
+class TestOpenSandboxWorkspaceManager(IsolatedAsyncioTestCase):
+    """Manager cache, liveness-check and TTL behavior."""
+
+    async def asyncSetUp(self) -> None:
+        """Patch the workspace class used by the manager."""
+        _FakeWorkspace.created.clear()
+        self.workspace_patch = patch(
+            "agentscope.app.workspace_manager."
+            "_opensandbox_workspace_manager.OpenSandboxWorkspace",
+            _FakeWorkspace,
+        )
+        self.workspace_patch.start()
+
+    async def asyncTearDown(self) -> None:
+        """Undo patches."""
+        self.workspace_patch.stop()
+
+    async def test_get_workspace_forwards_config_and_metadata(self) -> None:
+        """Manager forwards only the confirmed OpenSandbox config surface."""
+        manager = OpenSandboxWorkspaceManager(
+            image="python:3.11-slim",
+            api_key="key",
+            domain="https://opensandbox.example",
+            env={"A": "B"},
+            sandbox_metadata={"team": "agents"},
+            extra_pip=["x"],
+            ttl=10,
+            sweep_interval=1,
+        )
+
+        workspace = await manager.get_workspace("u1", "a1", "s1", "wid")
+
+        self.assertIs(workspace, _FakeWorkspace.created[0])
+        self.assertTrue(workspace.initialized)
+        self.assertEqual(workspace.kwargs["workspace_id"], "wid")
+        self.assertEqual(workspace.kwargs["image"], "python:3.11-slim")
+        self.assertEqual(workspace.kwargs["api_key"], "key")
+        self.assertEqual(
+            workspace.kwargs["domain"],
+            "https://opensandbox.example",
+        )
+        self.assertEqual(workspace.kwargs["env"], {"A": "B"})
+        self.assertEqual(
+            workspace.kwargs["sandbox_metadata"],
+            {
+                "agentscope.user.id": "u1",
+                "agentscope.agent.id": "a1",
+                "team": "agents",
+            },
+        )
+        self.assertEqual(workspace.kwargs["extra_pip"], ["x"])
+        self.assertIn(workspace.workspace_id, manager._cache)
+
+    async def test_get_workspace_uses_workspace_id_cache_key(self) -> None:
+        """Same workspace id returns cached instance regardless of session."""
+        manager = OpenSandboxWorkspaceManager()
+
+        first = await manager.get_workspace("u", "a", "s1", "wid")
+        second = await manager.get_workspace("u", "a", "s2", "wid")
+
+        self.assertIs(first, second)
+        self.assertEqual(len(_FakeWorkspace.created), 1)
+        self.assertEqual(first.kwargs["workspace_id"], "wid")
+
+    async def test_get_workspace_without_id_uses_isolation_policy(
+        self,
+    ) -> None:
+        """``workspace_id=None`` follows the base manager API contract."""
+        manager = OpenSandboxWorkspaceManager(
+            isolation=IsolationPolicy.PER_USER,
+        )
+
+        first = await manager.get_workspace("u", "a1", "s1")
+        second = await manager.get_workspace("u", "a2", "s2")
+
+        self.assertIs(first, second)
+        self.assertEqual(len(_FakeWorkspace.created), 1)
+        self.assertEqual(
+            first.kwargs["workspace_id"],
+            manager.assign_workspace_id(
+                user_id="u",
+                agent_id="a1",
+                session_id="",
+            ),
+        )
+
+    async def test_concurrent_get_workspace_creates_one_instance(self) -> None:
+        """Concurrent requests for one id share the initialized workspace."""
+        manager = OpenSandboxWorkspaceManager()
+
+        results = await asyncio.gather(
+            *(
+                manager.get_workspace("u", "a", f"s{i}", "wid-concurrent")
+                for i in range(8)
+            ),
+        )
+
+        self.assertEqual(len(_FakeWorkspace.created), 1)
+        self.assertTrue(_FakeWorkspace.created[0].initialized)
+        self.assertTrue(all(result is results[0] for result in results))
+        self.assertIs(manager._cache["wid-concurrent"][0], results[0])
+
+    async def test_close_and_close_all_release_cached_workspaces(self) -> None:
+        """Explicit close operations evict and close workspaces."""
+        manager = OpenSandboxWorkspaceManager()
+        first = await manager.get_workspace("u", "a", "s", "wid-1")
+        second = await manager.get_workspace("u", "a", "s", "wid-2")
+
+        await manager.close("wid-1")
+        self.assertTrue(first.closed)
+        self.assertNotIn("wid-1", manager._cache)
+
+        await manager.close_all()
+        self.assertTrue(second.closed)
+        self.assertEqual(manager._cache, {})
+
+    async def test_sweep_once_evicts_idle_workspaces(self) -> None:
+        """The TTL sweeper closes expired cache entries."""
+        manager = OpenSandboxWorkspaceManager(ttl=10)
+        workspace = await manager.get_workspace("u", "a", "s", "wid")
+        manager._cache["wid"] = (workspace, 0.0)
+        manager._safe_close = AsyncMock(wraps=manager._safe_close)
+
+        await manager._sweep_once()
+
+        self.assertNotIn("wid", manager._cache)
+        self.assertTrue(workspace.closed)
+        manager._safe_close.assert_awaited_once_with(workspace)
+
+    async def test_context_manager_starts_sweeper_and_closes_all(self) -> None:
+        """Async context starts the sweeper and closes cached workspaces."""
+        manager = OpenSandboxWorkspaceManager(sweep_interval=60)
+        manager.close_all = AsyncMock(wraps=manager.close_all)
+
+        async with manager as entered:
+            sweep_task = manager._sweep_task
+
+            self.assertIs(entered, manager)
+            self.assertIsNotNone(sweep_task)
+            self.assertFalse(sweep_task.done())
+
+        self.assertIsNone(manager._sweep_task)
+        self.assertTrue(sweep_task.done())
+        manager.close_all.assert_awaited_once()
+
+    async def test_safe_close_swallows_workspace_close_errors(self) -> None:
+        """``_safe_close`` logs close errors without raising."""
+
+        async def _raise_close() -> None:
+            raise RuntimeError("close failed")
+
+        workspace = SimpleNamespace(
+            workspace_id="wid-error",
+            close=_raise_close,
+        )
+
+        await OpenSandboxWorkspaceManager._safe_close(
+            workspace,  # type: ignore[arg-type]
+        )
+
+    # ── liveness check (regression for #2202) ──────────────────────
+
+    async def test_get_workspace_reuses_cached_healthy_workspace(
+        self,
+    ) -> None:
+        """A cache hit whose sandbox is still alive is returned as-is,
+        without rebuilding."""
+        manager = OpenSandboxWorkspaceManager()
+        first = await manager.get_workspace("u", "a", "s", "wid")
+
+        second = await manager.get_workspace("u", "a", "s", "wid")
+
+        self.assertIs(first, second)
+        self.assertEqual(len(_FakeWorkspace.created), 1)
+        self.assertFalse(first.closed)
+
+    async def test_get_workspace_evicts_and_rebuilds_dead_sandbox(
+        self,
+    ) -> None:
+        """A cache hit whose sandbox was killed server-side (e.g. by the
+        OpenSandbox ``timeout_seconds`` lifetime) is evicted and a fresh
+        workspace is built and cached in its place — reproducing the
+        permanent-404 zombie from #2202."""
+        manager = OpenSandboxWorkspaceManager()
+        first = await manager.get_workspace("u", "a", "s", "wid")
+        first.healthy = False
+
+        second = await manager.get_workspace("u", "a", "s", "wid")
+
+        self.assertIsNot(second, first)
+        self.assertEqual(len(_FakeWorkspace.created), 2)
+        self.assertTrue(first.closed)
+        self.assertFalse(second.closed)
+        self.assertIs(manager._cache["wid"][0], second)
+
+    async def test_get_workspace_liveness_check_runs_outside_lock(
+        self,
+    ) -> None:
+        """The remote ``is_healthy`` round-trip must not hold the
+        manager lock, or one slow/dead sandbox would stall every other
+        ``get_workspace`` call."""
+        manager = OpenSandboxWorkspaceManager()
+        first = await manager.get_workspace("u", "a", "s", "wid-slow")
+
+        probe_started = asyncio.Event()
+        release_probe = asyncio.Event()
+
+        async def _slow_is_healthy() -> bool:
+            probe_started.set()
+            await release_probe.wait()
+            return True
+
+        first.is_healthy = _slow_is_healthy
+
+        task = asyncio.create_task(
+            manager.get_workspace("u", "a", "s", "wid-slow"),
+        )
+        await asyncio.wait_for(probe_started.wait(), timeout=1.0)
+
+        # The lock must be free while the probe is in flight — an
+        # unrelated workspace_id should resolve immediately.
+        other = await asyncio.wait_for(
+            manager.get_workspace("u", "a", "s", "wid-other"),
+            timeout=1.0,
+        )
+        self.assertIsNotNone(other)
+
+        release_probe.set()
+        result = await asyncio.wait_for(task, timeout=1.0)
+        self.assertIs(result, first)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/workspace_opensandbox_test.py
+++ b/tests/workspace_opensandbox_test.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access
 """Test cases for OpenSandboxWorkspace.
 
-The whole module is skipped when the ``OPENSANDBOX_DOMAIN`` environment
-variable is not set, because every test requires a live OpenSandbox
-service.
+Most of this module is skipped when the ``OPENSANDBOX_DOMAIN``
+environment variable is not set, because those tests require a live
+OpenSandbox service. The ``is_healthy`` liveness-probe tests use a
+sandbox double instead, so they always run.
 """
 import os
 import unittest
@@ -18,6 +20,48 @@ from agentscope.workspace import OpenSandboxWorkspace
 _DOMAIN = os.getenv("OPENSANDBOX_DOMAIN", "")
 _API_KEY = os.getenv("OPENSANDBOX_API_KEY", "")
 _SKIP_REASON = "OPENSANDBOX_DOMAIN environment variable is not set"
+
+
+# ── liveness probe tests (regression for #2202) ────────────────────
+
+
+class _FakeSandbox:
+    """Sandbox double exposing only the ``is_healthy`` probe."""
+
+    def __init__(self, healthy: bool = True, raises: bool = False) -> None:
+        self._healthy = healthy
+        self._raises = raises
+
+    async def is_healthy(self) -> bool:
+        """Report the simulated liveness, or raise if configured to."""
+        if self._raises:
+            raise RuntimeError("sandbox not found")
+        return self._healthy
+
+
+class TestOpenSandboxWorkspaceIsHealthy(IsolatedAsyncioTestCase):
+    """``is_healthy`` before/after initialize and on probe failure."""
+
+    async def test_is_healthy_false_before_initialize(self) -> None:
+        """Without a bound sandbox, the workspace reports unhealthy."""
+        workspace = OpenSandboxWorkspace()
+        self.assertFalse(await workspace.is_healthy())
+
+    async def test_is_healthy_reflects_sandbox_probe(self) -> None:
+        """A live sandbox's probe result is forwarded verbatim."""
+        workspace = OpenSandboxWorkspace()
+        workspace._sandbox = _FakeSandbox(healthy=True)
+        self.assertTrue(await workspace.is_healthy())
+
+        workspace._sandbox = _FakeSandbox(healthy=False)
+        self.assertFalse(await workspace.is_healthy())
+
+    async def test_is_healthy_false_on_probe_error(self) -> None:
+        """A probe that raises (e.g. sandbox 404) is treated as dead,
+        not propagated."""
+        workspace = OpenSandboxWorkspace()
+        workspace._sandbox = _FakeSandbox(raises=True)
+        self.assertFalse(await workspace.is_healthy())
 
 
 # ── lifecycle tests ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`OpenSandboxWorkspaceManager` caches workspaces purely in memory, keyed by `workspace_id`, with no check that the underlying sandbox is still alive on the server. OpenSandbox sandboxes carry a server-enforced `timeout_seconds` lifetime; once it elapses, the server destroys the sandbox without notifying this process. The manager keeps returning the same stale cached workspace forever, so every subsequent tool call fails with `HTTP 404 SANDBOX_NOT_FOUND` — with no recovery short of restarting the whole application.

## Fix

- Added `OpenSandboxWorkspace.is_healthy()`, a thin wrapper around the SDK's `Sandbox.is_healthy()` probe (which already swallows exceptions internally and returns `bool`).
- `OpenSandboxWorkspaceManager.get_workspace()` now delegates its cache-hit path to a new `_get_alive_cached()` helper, which checks `is_healthy()` before returning a cached workspace. A dead sandbox is evicted (closed best-effort) and the caller falls through to the existing cache-miss path, which rebuilds and reattaches/creates a fresh sandbox.
- The liveness probe is a remote round-trip, so it deliberately runs **outside** `self._lock` — otherwise a single dead or slow sandbox for one `workspace_id` would block `get_workspace()` calls for every other workspace. Identity re-checks (`current[0] is ws`) guard the two places that touch the cache after the unlocked probe, so a concurrent caller that already evicted/rebuilt the same entry isn't clobbered.

## Test plan

- [x] New regression tests in `tests/workspace_manager_opensandbox_test.py`:
  - `test_get_workspace_reuses_cached_healthy_workspace` — healthy cache hit is returned as-is, no rebuild.
  - `test_get_workspace_evicts_and_rebuilds_dead_sandbox` — a sandbox that goes unhealthy is evicted, closed, and replaced with a fresh instance on the next call.
  - `test_get_workspace_liveness_check_runs_outside_lock` — uses `asyncio.Event` synchronization to prove an unrelated `workspace_id` resolves promptly while another call is blocked inside a slow `is_healthy()` probe.
  - Plus the standard cache/TTL/concurrency/sweeper coverage mirroring `tests/workspace_manager_daytona_test.py`.
- [x] New `TestOpenSandboxWorkspaceIsHealthy` tests in `tests/workspace_opensandbox_test.py` covering `is_healthy()` before initialize, on a live/dead probe, and on probe error.
- [x] `pytest tests/workspace_manager_opensandbox_test.py tests/workspace_opensandbox_test.py -v` → 14 passed, 1 skipped (pre-existing live-domain-gated lifecycle test, correctly skipped without `OPENSANDBOX_DOMAIN`).
- [x] Full suite: `pytest tests/` → 1642 passed, 138 skipped, no failures.
- [x] `pre-commit run` (mypy, black, flake8, pylint, pyroma) passes on all touched files.

Fixes #2202