### PR TITLE
fix(mcp): support mcp 2.x Python SDK, unpin mcp<2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "filetype",
     "json5",
     "json_repair",
-    "mcp<2.0.0",
+    "mcp>=2.0.0",
     "httpx",
     "numpy",
     "openai",

--- a/src/agentscope/tool/_adapters.py
+++ b/src/agentscope/tool/_adapters.py
@@ -4,7 +4,6 @@ import inspect
 import json
 import re
 from contextlib import _AsyncGeneratorContextManager
-from datetime import timedelta
 from typing import Callable, Any, AsyncGenerator, Generator
 
 from mcp import ClientSession
@@ -226,11 +225,11 @@ class MCPTool(ToolBase):
 
         self.description = tool.description or ""
 
-        # Preserve the full inputSchema (including $defs, anyOf, oneOf, etc.)
-        # rather than only copying "properties" and "required", which would
-        # silently drop any nested type definitions that the LLM needs to
-        # resolve $ref pointers.
-        _schema = dict(tool.inputSchema) if tool.inputSchema else {}
+        # Preserve the full input_schema (including $defs, anyOf, oneOf,
+        # etc.) rather than only copying "properties" and "required",
+        # which would silently drop any nested type definitions that the
+        # LLM needs to resolve $ref pointers.
+        _schema = dict(tool.input_schema) if tool.input_schema else {}
         _schema.setdefault("type", "object")
         _schema.setdefault("properties", {})
         _schema.setdefault("required", [])
@@ -251,7 +250,7 @@ class MCPTool(ToolBase):
         self._session = session
 
         if timeout:
-            self._timeout = timedelta(seconds=timeout)
+            self._timeout = float(timeout)
         else:
             self._timeout = None
 
@@ -323,7 +322,7 @@ class MCPTool(ToolBase):
         return ToolChunk(
             content=self._convert_mcp_content_to_blocks(result.content),
             state=ToolResultState.ERROR
-            if result.isError
+            if result.is_error
             else ToolResultState.RUNNING,
         )
 
@@ -353,7 +352,7 @@ class MCPTool(ToolBase):
                     DataBlock(
                         source=Base64Source(
                             type="base64",
-                            media_type=content.mimeType,
+                            media_type=content.mime_type,
                             data=content.data,
                         ),
                     ),
@@ -380,7 +379,7 @@ class MCPTool(ToolBase):
                 as_content.append(
                     DataBlock(
                         source=URLSource(
-                            media_type=content.mimeType,
+                            media_type=content.mime_type,
                             url=content.uri,
                         ),
                     ),

--- a/src/agentscope/tool/_toolkit.py
+++ b/src/agentscope/tool/_toolkit.py
@@ -336,7 +336,7 @@ class Toolkit:
                     f"but got {type(res)}.",
                 )
 
-        except mcp.shared.exceptions.McpError as e:
+        except mcp.shared.exceptions.MCPError as e:
             chunk = ToolChunk(
                 content=[
                     TextBlock(

--- a/src/agentscope/workspace/_gateway_client.py
+++ b/src/agentscope/workspace/_gateway_client.py
@@ -82,7 +82,7 @@ class GatewayMCPTool(ToolBase):
                 ``mcp__{mcp}__{tool}`` name and the URL path.
             tool (`mcp.types.Tool`):
                 Raw upstream tool descriptor as returned by the gateway.
-                ``inputSchema`` is forwarded verbatim;
+                ``input_schema`` is forwarded verbatim;
                 ``annotations.readOnlyHint`` drives the permission
                 policy.
             gateway (`GatewayClient`):
@@ -93,7 +93,7 @@ class GatewayMCPTool(ToolBase):
         self.name = f"mcp__{mcp_name}__{tool.name}"
         self.description = tool.description or ""
 
-        schema = dict(tool.inputSchema) if tool.inputSchema else {}
+        schema = dict(tool.input_schema) if tool.input_schema else {}
         schema.setdefault("type", "object")
         schema.setdefault("properties", {})
         schema.setdefault("required", [])

--- a/src/agentscope/workspace/_utils.py
+++ b/src/agentscope/workspace/_utils.py
@@ -100,11 +100,12 @@ DEFAULT_GLOB_HELPER_SCRIPT = "_glob_helper.py"
 #:
 #: ``agentscope`` goes in with ``--no-deps``, so anything it imports has
 #: to be named here — depending on another package to drag it along is
-#: what broke when ``mcp`` 2.0 swapped ``httpx`` for ``httpx2``. The
-#: bound on ``mcp`` mirrors ``pyproject.toml``, so the gateway speaks
-#: the same protocol version as the process driving it.
+#: what broke when ``mcp`` 2.0 swapped ``httpx`` for ``httpx2`` as its
+#: own transport dependency, hence the explicit ``httpx`` entry below.
+#: The version on ``mcp`` mirrors ``pyproject.toml``, so the gateway
+#: speaks the same protocol version as the process driving it.
 _GATEWAY_BASE_REQUIREMENTS: tuple[str, ...] = (
-    "mcp<2.0.0",
+    "mcp>=2.0.0",
     "uvicorn",
     "fastapi",
     "httpx",

--- a/tests/mcp_sse_client_test.py
+++ b/tests/mcp_sse_client_test.py
@@ -5,7 +5,7 @@ import json
 from multiprocessing import Process
 from unittest.async_case import IsolatedAsyncioTestCase
 
-from mcp.server import FastMCP
+from mcp.server import MCPServer as FastMCP
 from pydantic import BaseModel
 
 from agentscope.mcp import MCPClient, HttpMCPConfig
@@ -28,9 +28,9 @@ async def tool_1(arg1: str, arg2: list[int]) -> str:
 
 def setup_server() -> None:
     """Set up the streamable HTTP MCP server."""
-    sse_server = FastMCP("SSE", port=8003)
+    sse_server = FastMCP("SSE")
     sse_server.tool(description="A test tool function.")(tool_1)
-    sse_server.run(transport="sse")
+    sse_server.run(transport="sse", port=8003)
 
 
 # ---------------------------------------------------------------------------
@@ -58,9 +58,9 @@ async def tool_with_model(name: str, config: _ItemConfig) -> str:
 def setup_defs_server() -> None:
     """Set up an SSE MCP server that exposes a tool with Pydantic
     sub-models."""
-    server = FastMCP("DefsSSE", port=8005)
+    server = FastMCP("DefsSSE")
     server.tool()(tool_with_model)
-    server.run(transport="sse")
+    server.run(transport="sse", port=8005)
 
 
 class SseMCPClientTest(IsolatedAsyncioTestCase):

--- a/tests/mcp_streamable_http_client_test.py
+++ b/tests/mcp_streamable_http_client_test.py
@@ -4,7 +4,7 @@ import asyncio
 from multiprocessing import Process
 from unittest.async_case import IsolatedAsyncioTestCase
 
-from mcp.server import FastMCP
+from mcp.server import MCPServer as FastMCP
 from mcp.types import EmbeddedResource, TextResourceContents
 
 from agentscope.mcp import MCPClient, HttpMCPConfig
@@ -32,7 +32,7 @@ async def tool_2() -> list:
             type="resource",
             resource=TextResourceContents(
                 uri="file://tmp.txt",
-                mimeType="text/plain",
+                mime_type="text/plain",
                 text="test content",
             ),
         ),
@@ -41,12 +41,12 @@ async def tool_2() -> list:
 
 def setup_server() -> None:
     """Set up the streamable HTTP MCP server."""
-    sse_server = FastMCP("StreamableHTTP", port=8002)
+    sse_server = FastMCP("StreamableHTTP")
     sse_server.tool(description="A test tool function.")(tool_1)
     sse_server.tool(
         description="A test tool function with embedded resource.",
     )(tool_2)
-    sse_server.run(transport="streamable-http")
+    sse_server.run(transport="streamable-http", port=8002)
 
 
 class StreamableHttpMCPClientTest(IsolatedAsyncioTestCase):
@@ -139,8 +139,8 @@ class StreamableHttpMCPClientTest(IsolatedAsyncioTestCase):
         self.assertEqual(
             res.content[0].text,
             """{
-  "uri": "file://tmp.txt/",
-  "mimeType": "text/plain",
+  "uri": "file://tmp.txt",
+  "mime_type": "text/plain",
   "meta": null,
   "text": "test content"
 }""",

--- a/tests/workspace_applecontainer_test.py
+++ b/tests/workspace_applecontainer_test.py
@@ -299,7 +299,7 @@ _GATEWAY_PYTHON = f"{GATEWAY_HOME}/{DEFAULT_GATEWAY_VENV}/bin/python"
 _ECHO_MCP_SERVER_SCRIPT = '''\
 # -*- coding: utf-8 -*-
 """Minimal echo MCP server for live-test verification."""
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer as FastMCP
 
 mcp = FastMCP("EchoServer")
 

--- a/tests/workspace_daytona_test.py
+++ b/tests/workspace_daytona_test.py
@@ -1251,7 +1251,7 @@ class TestDaytonaWorkspaceBuiltinToolsMock(IsolatedAsyncioTestCase):
 
 def _mcp_server_script() -> bytes:
     """Minimal FastMCP stdio server used by live reattach tests."""
-    return b"""from mcp.server import FastMCP
+    return b"""from mcp.server import MCPServer as FastMCP
 
 mcp = FastMCP("Persist")
 


### PR DESCRIPTION
## Summary

`mcp` 2.0.0 is out and renames every camelCase field on `mcp.types` to snake_case, renames `McpError`→`MCPError`, changes `ClientSession.call_tool`'s `read_timeout_seconds` from `timedelta` to `float`, and removes `mcp.server.FastMCP` / `mcp.server.fastmcp.FastMCP` in favor of `mcp.server.MCPServer`. None of this has a backward-compatible alias in 2.0, and 1.x has no forward-compatible alias either — this is a hard, non-straddleable cutover, not a version range bump.

This PR:
- Bumps both `mcp<2.0.0` pins (`pyproject.toml` and the in-sandbox/in-container gateway bootstrap requirements in `src/agentscope/workspace/_utils.py`, which mirrors the main pin) to `mcp>=2.0.0`.
- Fixes the 6 renamed-attribute call sites in `src/agentscope/tool/_adapters.py`, `src/agentscope/tool/_toolkit.py`, and `src/agentscope/workspace/_gateway_client.py`.
- Fixes the MCP test-server fixtures in 4 test files that constructed `mcp.server.FastMCP` (now removed with no alias): `tests/mcp_streamable_http_client_test.py`, `tests/mcp_sse_client_test.py`, `tests/workspace_daytona_test.py`, `tests/workspace_applecontainer_test.py`. The replacement `mcp.server.MCPServer` is imported under a local `FastMCP` alias so most call sites are untouched; its constructor no longer accepts `port`/`host`, so those move to the `.run(transport=..., port=...)` call.
- Fixes one test assertion (`mcp_streamable_http_client_test.py::test_embedded_content`) whose expected JSON literal was written against mcp 1.x's `AnyUrl`-typed `uri` field (which canonicalized and added a trailing slash) and the `mimeType` alias — 2.0's `uri` is a plain `str` with no normalization, and the field is `mime_type`.

## Fix

See commit message for the full breakdown of renamed attributes and the two gaps beyond the issue's own analysis (the second `mcp` pin, and the `FastMCP` removal).

Verified live against a scratch `mcp==2.0.0` install that none of the renamed attributes have aliases in either direction, and that mcp 2.0's new dependency floors (`pydantic>=2.12`, `anyio>=4.9`, `typing-extensions>=4.13`, `httpx2>=2.5.0`, `opentelemetry-api>=1.28`) are already satisfied by this project's existing pins — no other `pyproject.toml` changes needed.

## Test plan

- [x] `uv pip install "mcp>=2.0.0"` into the dev venv; `python -c "import agentscope"` succeeds
- [x] `pytest tests/mcp_streamable_http_client_test.py tests/mcp_sse_client_test.py -v` — both real end-to-end MCP client/server test files pass (5/5) against `mcp==2.0.0`
- [x] `pytest tests/ -q` — full suite green: 1628 passed, 138 skipped
- [x] `pre-commit run --files <all touched files>` — mypy/black/flake8/pylint/pyroma all pass
- [x] Final grep sweep for `inputSchema|isError|mimeType|McpError|FastMCP` confirms no remaining 1.x-only usage in `src/`/`tests/`

Fixes #2208