### PR TITLE
fix(agent): count reasoning-acting rounds once

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -914,14 +914,6 @@ class Agent:
                             )
                             return
 
-                        # A reasoning step that produces tool calls is counted
-                        # only after all of those calls finish. A plain final
-                        # response exits without consuming another iteration,
-                        # while intermediate responses (e.g. thinking-only or
-                        # text that does not satisfy a structured-output
-                        # requirement) consume one reasoning iteration.
-                        self._count_iteration_if_complete(final_msg)
-
                     case Acting(tool_calls=tool_calls):
                         for batch in await self._batch_tool_calls(tool_calls):
                             if batch.type == "sequential":
@@ -977,19 +969,12 @@ class Agent:
                             if break_execution_for_hitl:
                                 break
 
-                        if break_execution_for_hitl:
-                            # Stop executing the next batches, and go back to
-                            # ``_next_action``, which parks the reply on the
-                            # awaiting tool calls. The unfinished round isn't
-                            # counted into ``cur_iter``
-                            continue
-
-                        # Existing awaiting calls may remain even when this
-                        # Acting pass emits no new HITL event (for example,
-                        # when only one of two ASKING calls was confirmed).
-                        # Count the round only after every tool call has a
-                        # matching result.
-                        self._count_iteration_if_complete()
+                # One reasoning-acting round is over once every tool call it
+                # produced has a result. Reasoning that generated tool calls,
+                # or Acting that parked some of them on a user confirmation
+                # or an external execution, leaves the round unfinished
+                if not self.state.get_unfinished_tool_calls(self.name):
+                    self.state.cur_iter += 1
 
         except asyncio.CancelledError:
             # Handle the CancelledError within the _reply_impl for the
@@ -3027,43 +3012,6 @@ class Agent:
         if last_msg.role == "assistant" and last_msg.name == self.name:
             return last_msg
         return None
-
-    def _has_unfinished_tool_calls(self) -> bool:
-        """Check for tool calls without results in the current reply."""
-        if len(self.state.context) == 0:
-            return False
-
-        last_msg = self.state.context[-1]
-        if not (
-            last_msg.role == "assistant"
-            and last_msg.name == self.name
-            and last_msg.id == self.state.reply_id
-        ):
-            return False
-
-        finished_ids = {
-            block.id for block in last_msg.get_content_blocks("tool_result")
-        }
-        return any(
-            block.id not in finished_ids
-            for block in last_msg.get_content_blocks("tool_call")
-        )
-
-    def _count_iteration_if_complete(
-        self,
-        final_msg: Msg | None = None,
-    ) -> None:
-        """Count a completed non-terminal reasoning-acting iteration."""
-        if self._has_unfinished_tool_calls():
-            return
-
-        if (
-            final_msg is not None
-            and self.state.reply_context.structured_schema is None
-        ):
-            return
-
-        self.state.cur_iter += 1
 
     def _next_action(
         self,

--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -914,6 +914,14 @@ class Agent:
                             )
                             return
 
+                        # A reasoning step that produces tool calls is counted
+                        # only after all of those calls finish. A plain final
+                        # response exits without consuming another iteration,
+                        # while intermediate responses (e.g. thinking-only or
+                        # text that does not satisfy a structured-output
+                        # requirement) consume one reasoning iteration.
+                        self._count_iteration_if_complete(final_msg)
+
                     case Acting(tool_calls=tool_calls):
                         for batch in await self._batch_tool_calls(tool_calls):
                             if batch.type == "sequential":
@@ -976,8 +984,12 @@ class Agent:
                             # counted into ``cur_iter``
                             continue
 
-                # Update iteration count after each round of reasoning-acting
-                self.state.cur_iter += 1
+                        # Existing awaiting calls may remain even when this
+                        # Acting pass emits no new HITL event (for example,
+                        # when only one of two ASKING calls was confirmed).
+                        # Count the round only after every tool call has a
+                        # matching result.
+                        self._count_iteration_if_complete()
 
         except asyncio.CancelledError:
             # Handle the CancelledError within the _reply_impl for the
@@ -3015,6 +3027,43 @@ class Agent:
         if last_msg.role == "assistant" and last_msg.name == self.name:
             return last_msg
         return None
+
+    def _has_unfinished_tool_calls(self) -> bool:
+        """Check for tool calls without results in the current reply."""
+        if len(self.state.context) == 0:
+            return False
+
+        last_msg = self.state.context[-1]
+        if not (
+            last_msg.role == "assistant"
+            and last_msg.name == self.name
+            and last_msg.id == self.state.reply_id
+        ):
+            return False
+
+        finished_ids = {
+            block.id for block in last_msg.get_content_blocks("tool_result")
+        }
+        return any(
+            block.id not in finished_ids
+            for block in last_msg.get_content_blocks("tool_call")
+        )
+
+    def _count_iteration_if_complete(
+        self,
+        final_msg: Msg | None = None,
+    ) -> None:
+        """Count a completed non-terminal reasoning-acting iteration."""
+        if self._has_unfinished_tool_calls():
+            return
+
+        if (
+            final_msg is not None
+            and self.state.reply_context.structured_schema is None
+        ):
+            return
+
+        self.state.cur_iter += 1
 
     def _next_action(
         self,

--- a/src/agentscope/state/_state.py
+++ b/src/agentscope/state/_state.py
@@ -339,10 +339,10 @@ class AgentState(BaseModel):
         ]
 
     def get_unfinished_tool_calls(self, name: str) -> list[ToolCallBlock]:
-        """Get the tail assistant message's tool calls with no matching tool
-        result yet, whatever their state. A reply accumulates into a single
-        message, so the calls of the finished reasoning-acting rounds are
-        excluded while the ones of the ongoing round are returned.
+        """Get the current reply's tool calls with no matching tool result
+        yet, whatever their state. A reply accumulates into a single message,
+        so the calls of the finished reasoning-acting rounds are excluded
+        while the ones of the ongoing round are returned.
 
         Args:
             name (`str`):
@@ -356,7 +356,11 @@ class AgentState(BaseModel):
         if not self.context:
             return []
         last_msg = self.context[-1]
-        if last_msg.role != "assistant" or last_msg.name != name:
+        if (
+            last_msg.role != "assistant"
+            or last_msg.name != name
+            or last_msg.id != self.reply_id
+        ):
             return []
         result_ids = {b.id for b in last_msg.get_content_blocks("tool_result")}
         return [

--- a/src/agentscope/state/_state.py
+++ b/src/agentscope/state/_state.py
@@ -337,3 +337,30 @@ class AgentState(BaseModel):
                 tc.state == ToolCallState.SUBMITTED and tc.id not in result_ids
             )
         ]
+
+    def get_unfinished_tool_calls(self, name: str) -> list[ToolCallBlock]:
+        """Get the tail assistant message's tool calls with no matching tool
+        result yet, whatever their state. A reply accumulates into a single
+        message, so the calls of the finished reasoning-acting rounds are
+        excluded while the ones of the ongoing round are returned.
+
+        Args:
+            name (`str`):
+                Only messages authored by this agent name are inspected;
+                observed messages from other agents are ignored.
+
+        Returns:
+            `list[ToolCallBlock]`:
+                The unfinished tool call blocks, empty if none.
+        """
+        if not self.context:
+            return []
+        last_msg = self.context[-1]
+        if last_msg.role != "assistant" or last_msg.name != name:
+            return []
+        result_ids = {b.id for b in last_msg.get_content_blocks("tool_result")}
+        return [
+            tc
+            for tc in last_msg.get_content_blocks("tool_call")
+            if tc.id not in result_ids
+        ]

--- a/tests/agent_basic_test.py
+++ b/tests/agent_basic_test.py
@@ -333,7 +333,7 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
         ]
         context_dicts = [msg.model_dump() for msg in self.agent.state.context]
         self.assertListEqual(context_dicts, expected_context)
-        self.assertEqual(self.agent.state.cur_iter, 0)
+        self.assertEqual(self.agent.state.cur_iter, 1)
 
         # Test reply interface
         self.model.cnt = 0  # Reset mock model response index
@@ -690,7 +690,7 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
             ["done"],
         )
         self.assertEqual(self.model.cnt, 2)
-        self.assertEqual(self.agent.state.cur_iter, 1)
+        self.assertEqual(self.agent.state.cur_iter, 2)
 
         tool_results = self.agent.state.context[-1].get_content_blocks(
             "tool_result",
@@ -720,7 +720,7 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
 
         # The thinking-only turn must trigger a second reasoning round
         self.assertEqual(self.model.cnt, 2)
-        self.assertEqual(self.agent.state.cur_iter, 1)
+        self.assertEqual(self.agent.state.cur_iter, 2)
 
         # The final reply message only carries the visible text answer
         self.assertDictEqual(
@@ -1082,7 +1082,7 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
         context_dicts = [msg.model_dump() for msg in self.agent.state.context]
         expected_context = [{**msg_base, **_} for _ in expected_context]
         self.assertListEqual(context_dicts, expected_context)
-        self.assertEqual(self.agent.state.cur_iter, 1)
+        self.assertEqual(self.agent.state.cur_iter, 2)
 
     async def test_streaming_concurrent_tool_calls(self) -> None:
         """Test the streaming model inference with tool calls generated.
@@ -1682,7 +1682,7 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
         context_dicts = [msg.model_dump() for msg in self.agent.state.context]
         expected_context = [{**msg_base, **_} for _ in expected_context]
         self.assertListEqual(context_dicts, expected_context)
-        self.assertEqual(self.agent.state.cur_iter, 1)
+        self.assertEqual(self.agent.state.cur_iter, 2)
 
     async def asyncTearDown(self) -> None:
         """The async teardown method."""

--- a/tests/agent_basic_test.py
+++ b/tests/agent_basic_test.py
@@ -5,7 +5,7 @@ from unittest.async_case import IsolatedAsyncioTestCase
 
 from utils import AnyString, MockModel
 
-from agentscope.agent import Agent, ContextConfig, InjectionConfig
+from agentscope.agent import Agent, ContextConfig, InjectionConfig, ReActConfig
 from agentscope.model import ChatResponse
 from agentscope.tool import (
     ToolBase,
@@ -333,6 +333,7 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
         ]
         context_dicts = [msg.model_dump() for msg in self.agent.state.context]
         self.assertListEqual(context_dicts, expected_context)
+        self.assertEqual(self.agent.state.cur_iter, 0)
 
         # Test reply interface
         self.model.cnt = 0  # Reset mock model response index
@@ -658,6 +659,48 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
         context_dicts = [msg.model_dump() for msg in self.agent.state.context]
         self.assertListEqual(context_dicts, expected_context_after_reply)
 
+    async def test_max_iters_counts_reasoning_acting_round_once(self) -> None:
+        """A tool round consumes one iteration before final reasoning."""
+        self.agent.toolkit = Toolkit(tools=[MockSequentialTool()])
+        self.agent.react_config = ReActConfig(max_iters=2)
+        self.model.set_responses(
+            [
+                ChatResponse(
+                    content=[
+                        ToolCallBlock(
+                            id="tool_call_1",
+                            name="mock_sequential_tool",
+                            input='{"input": "x"}',
+                        ),
+                    ],
+                    is_last=True,
+                ),
+                ChatResponse(
+                    content=[TextBlock(text="done")],
+                    is_last=True,
+                ),
+            ],
+        )
+
+        msg = await self.agent.reply(UserMsg(name="user", content="Go"))
+
+        self.assertEqual(msg.finished_reason, ReplyFinishedReason.COMPLETED)
+        self.assertEqual(
+            [block.text for block in msg.get_content_blocks("text")],
+            ["done"],
+        )
+        self.assertEqual(self.model.cnt, 2)
+        self.assertEqual(self.agent.state.cur_iter, 1)
+
+        tool_results = self.agent.state.context[-1].get_content_blocks(
+            "tool_result",
+        )
+        self.assertEqual(len(tool_results), 1)
+        self.assertEqual(
+            tool_results[0].output[0].text,
+            "Sequential result: x",
+        )
+
     async def test_thinking_only_response_continues_reasoning(self) -> None:
         """A thinking-only response should not end with an empty reply."""
         self.model.set_responses(
@@ -677,6 +720,7 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
 
         # The thinking-only turn must trigger a second reasoning round
         self.assertEqual(self.model.cnt, 2)
+        self.assertEqual(self.agent.state.cur_iter, 1)
 
         # The final reply message only carries the visible text answer
         self.assertDictEqual(
@@ -1038,6 +1082,7 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
         context_dicts = [msg.model_dump() for msg in self.agent.state.context]
         expected_context = [{**msg_base, **_} for _ in expected_context]
         self.assertListEqual(context_dicts, expected_context)
+        self.assertEqual(self.agent.state.cur_iter, 1)
 
     async def test_streaming_concurrent_tool_calls(self) -> None:
         """Test the streaming model inference with tool calls generated.
@@ -1637,6 +1682,7 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
         context_dicts = [msg.model_dump() for msg in self.agent.state.context]
         expected_context = [{**msg_base, **_} for _ in expected_context]
         self.assertListEqual(context_dicts, expected_context)
+        self.assertEqual(self.agent.state.cur_iter, 1)
 
     async def asyncTearDown(self) -> None:
         """The async teardown method."""

--- a/tests/agent_structured_output_test.py
+++ b/tests/agent_structured_output_test.py
@@ -138,7 +138,7 @@ class AgentStructuredOutputTest(IsolatedAsyncioTestCase):
             self.agent.state.reply_context.model_dump(),
             {
                 "reply_id": self.agent.state.reply_id,
-                "cur_iter": 2,
+                "cur_iter": 1,
                 "structured_schema": WeatherReport.model_json_schema(),
                 "structured_output": {"city": "Hangzhou", "temperature": 25.0},
             },

--- a/tests/hitl_user_confirmation_test.py
+++ b/tests/hitl_user_confirmation_test.py
@@ -1803,27 +1803,9 @@ class AgentUserConfirmationTest(IsolatedAsyncioTestCase):
             ),
         )
         self.assertIsNone(partial.finished_reason)
+        # The first call has run, but the round isn't over while the second
+        # one is still awaiting confirmation
         self.assertEqual(self.agent.state.cur_iter, 0)
-
-        assistant_msg = self.agent.state.context[-1]
-        self.assertEqual(
-            [
-                block.state
-                for block in assistant_msg.get_content_blocks(
-                    "tool_call",
-                )
-            ],
-            ["finished", "asking"],
-        )
-        self.assertEqual(
-            [
-                block.id
-                for block in assistant_msg.get_content_blocks(
-                    "tool_result",
-                )
-            ],
-            [self.tool_call_id_1],
-        )
 
         completed = await self.agent.reply(
             UserConfirmResultEvent(
@@ -1842,7 +1824,8 @@ class AgentUserConfirmationTest(IsolatedAsyncioTestCase):
         )
         self.assertEqual(completed.finished_reason, "completed")
         self.assertEqual(self.model.cnt, 2)
-        self.assertEqual(self.agent.state.cur_iter, 1)
+        # One tool round plus the final reasoning
+        self.assertEqual(self.agent.state.cur_iter, 2)
 
     async def asyncTearDown(self) -> None:
         """The async teardown method."""

--- a/tests/hitl_user_confirmation_test.py
+++ b/tests/hitl_user_confirmation_test.py
@@ -1748,5 +1748,101 @@ class AgentUserConfirmationTest(IsolatedAsyncioTestCase):
             [self.final_response_text],
         )
 
+    async def test_partial_concurrent_confirmation_defers_iteration(
+        self,
+    ) -> None:
+        """A tool round is not counted while one confirmed call is pending."""
+        name_a = self.concurrent_tool_name
+        name_b = "mock_user_confirm_concurrent_tool_b"
+        self.agent.toolkit = Toolkit(
+            tools=[
+                MockUserConfirmConcurrentTool(),
+                MockUserConfirmConcurrentToolB(),
+            ],
+        )
+        self.model.set_responses(
+            [
+                ChatResponse(
+                    content=[
+                        ToolCallBlock(
+                            id=self.tool_call_id_1,
+                            name=name_a,
+                            input=self.tool_input_1,
+                        ),
+                        ToolCallBlock(
+                            id=self.tool_call_id_2,
+                            name=name_b,
+                            input=self.tool_input_2,
+                        ),
+                    ],
+                    is_last=True,
+                ),
+                self.final_mock_responses,
+            ],
+        )
+
+        parked = await self.agent.reply(
+            UserMsg(name="user", content=self.user_input_text),
+        )
+        self.assertIsNone(parked.finished_reason)
+        self.assertEqual(self.agent.state.cur_iter, 0)
+
+        partial = await self.agent.reply(
+            UserConfirmResultEvent(
+                reply_id=self.agent.state.reply_id,
+                confirm_results=[
+                    ConfirmResult(
+                        confirmed=True,
+                        tool_call=ToolCallBlock(
+                            id=self.tool_call_id_1,
+                            name=name_a,
+                            input=self.tool_input_1,
+                        ),
+                    ),
+                ],
+            ),
+        )
+        self.assertIsNone(partial.finished_reason)
+        self.assertEqual(self.agent.state.cur_iter, 0)
+
+        assistant_msg = self.agent.state.context[-1]
+        self.assertEqual(
+            [
+                block.state
+                for block in assistant_msg.get_content_blocks(
+                    "tool_call",
+                )
+            ],
+            ["finished", "asking"],
+        )
+        self.assertEqual(
+            [
+                block.id
+                for block in assistant_msg.get_content_blocks(
+                    "tool_result",
+                )
+            ],
+            [self.tool_call_id_1],
+        )
+
+        completed = await self.agent.reply(
+            UserConfirmResultEvent(
+                reply_id=self.agent.state.reply_id,
+                confirm_results=[
+                    ConfirmResult(
+                        confirmed=True,
+                        tool_call=ToolCallBlock(
+                            id=self.tool_call_id_2,
+                            name=name_b,
+                            input=self.tool_input_2,
+                        ),
+                    ),
+                ],
+            ),
+        )
+        self.assertEqual(completed.finished_reason, "completed")
+        self.assertEqual(self.model.cnt, 2)
+        self.assertEqual(self.agent.state.cur_iter, 1)
+
     async def asyncTearDown(self) -> None:
         """The async teardown method."""


### PR DESCRIPTION
## PR Title

`fix(agent): count reasoning-acting rounds once`

## AgentScope Version

`2.0.5`

## Description

Fixes #2204

### Background

The ReAct state machine previously incremented `state.cur_iter` after every state-machine action. As a result, `Reasoning` and its subsequent `Acting` step were counted separately.

For example, with `max_iters=2`, the following flow exhausted the iteration budget before the second model call:

```text
Reasoning(tool call) → Acting(tool execution) → Reasoning(final answer)
```

The observed result was:

```text
finished_reason  = exceed_max_iters
model call count = 1
cur_iter         = 2
```

### Purpose

This PR restores single-round iteration accounting:

- A complete `Reasoning → Acting` tool round consumes one iteration.
- A terminal Reasoning response does not consume an additional iteration.
- The existing thinking-only continuation behavior is preserved.
- An ordinary empty response retains its current behavior and exits as a final empty message.

### Changes

- Removed the unconditional `cur_iter` increment after every state-machine action.
- Added a private check for unfinished tool calls in the current reply.
- Matched tool calls and results by their IDs.
- Deferred counting tool-producing Reasoning steps until every tool call has a corresponding result.
- Counted Acting once after all sequential/concurrent batches complete.
- Prevented partial HITL confirmation from counting the round while another tool call is still waiting.
- Updated the structured-output assertion that previously encoded the doubled count.
- Added regression coverage for:
  - `max_iters=2` with a tool call followed by a final answer;
  - direct final responses;
  - thinking-only continuation;
  - structured-output generation;
  - mixed sequential/concurrent tool batches;
  - partial concurrent HITL confirmation.

After the change, the core reproduction produces:

```text
finished_reason  = completed
model call count = 2
cur_iter         = 1
final response   = done
```

### How to test

```bash
pytest -q tests/agent_basic_test.py tests/agent_structured_output_test.py
pytest -q tests/hitl_user_confirmation_test.py tests/hitl_external_execution_test.py
pytest -q tests/agent_interrupt_test.py
pre-commit run --all-files
```

Results:

```text
36 related tests passed
all pre-commit hooks passed
```

The remaining local test suite, excluding a hanging moto S3 test, produced:

```text
1625 passed, 138 skipped, 1 failed
```

The remaining failure is an unrelated MCP schema-description indentation assertion. The moto S3 test blocks while its local server reads an HTTP request body. Neither test exercises the iteration-accounting path changed by this PR.

### Known limitation

This focused change does not settle a pending iteration when an incoming event directly completes a parked tool round without entering Acting again. Examples include an external execution result or rejecting all remaining confirmation requests.

These paths may undercount completed rounds and can weaken `max_iters` across repeated park/resume cycles. Persisting pending iteration state across HITL/external resumption is intentionally left for a follow-up issue.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [[CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation has been updated (not applicable: this change does not affect the public API or user-facing documentation)
- [x] Code is ready for review