### PR TITLE
feat(rag): support Redis vector search as a VDBStore backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ vdb-milvus = [
 ]
 vdb-mongodb = ["pymongo>=4.7"]
 vdb-elasticsearch = ["elasticsearch[async]>=8.12"]
+vdb-redis = ["redis"]
 # ------------ RAG ------------
 # Document parsers; pick a vector store via the vdb-* extras.
 rag = [
@@ -156,6 +157,7 @@ full = [
     "agentscope[vdb-milvus]",
     "agentscope[vdb-mongodb]",
     "agentscope[vdb-elasticsearch]",
+    "agentscope[vdb-redis]",
     "agentscope[memory]",
 ]
 

--- a/src/agentscope/rag/__init__.py
+++ b/src/agentscope/rag/__init__.py
@@ -19,6 +19,7 @@ from ._vdb import (
     DocumentSummary,
     ElasticsearchStore,
     MilvusLiteStore,
+    RedisStore,
     VectorStoreBase,
     VectorRecord,
     VectorSearchResult,
@@ -48,4 +49,5 @@ __all__ = [
     "QdrantStore",
     "KnowledgeBase",
     "MongoDBStore",
+    "RedisStore",
 ]

--- a/src/agentscope/rag/_vdb/__init__.py
+++ b/src/agentscope/rag/_vdb/__init__.py
@@ -11,11 +11,13 @@ from ._qdrant import QdrantStore
 from ._mongodb import MongoDBStore
 from ._milvus_lite import MilvusLiteStore
 from ._elasticsearch import ElasticsearchStore
+from ._redis import RedisStore
 
 __all__ = [
     "DocumentSummary",
     "ElasticsearchStore",
     "MilvusLiteStore",
+    "RedisStore",
     "VectorStoreBase",
     "VectorRecord",
     "VectorSearchResult",

--- a/src/agentscope/rag/_vdb/_redis.py
+++ b/src/agentscope/rag/_vdb/_redis.py
@@ -1,0 +1,675 @@
+# -*- coding: utf-8 -*-
+"""Redis implementation of the vector store backend.
+
+Built on ``redis-py``'s native :mod:`redis.commands.search` module (NOT
+the ``redisvl`` library — redisvl requires ``redis>=5.0,<8.0``, which
+conflicts with the project's pinned redis 8.0.1).  All operations use
+the fully asynchronous client (:class:`redis.asyncio.Redis`) with
+``FT.CREATE`` / ``FT.SEARCH`` / ``FT.AGGREGATE`` / ``FT.DROPINDEX``
+commands.
+
+**Requirements**
+
+- **Redis Stack 7.2** or later, or **Redis 8.0** or later (RediSearch is
+  bundled and loaded automatically).
+- All vector-search queries use **DIALECT 2** (the minimum dialect that
+  supports KNN search and ``PARAMS``).
+- One search index per knowledge base (FT index names are global per
+  Redis server — use unique collection names).
+
+Install with::
+
+    pip install agentscope[vdb-redis]
+"""
+
+import base64
+import hashlib
+import json
+import uuid
+from typing import Any, TYPE_CHECKING
+
+import numpy as np
+
+from ._vector_store import (
+    DocumentSummary,
+    VectorRecord,
+    VectorSearchResult,
+    VectorStoreBase,
+)
+from .._document import Chunk
+
+if TYPE_CHECKING:
+    from redis.asyncio import Redis
+
+
+# ------------------------------------------------------------------
+# Module-level constants
+# ------------------------------------------------------------------
+
+# Default HNSW hyper-parameters.  DISTANCE_METRIC must stay COSINE so
+# the ``1 - vector_distance`` score conversion yields raw cosine
+# similarity (matching the "higher = more similar" contract in
+# :class:`VectorSearchResult`).
+_HNSW_PARAMS: dict[str, object] = {
+    "TYPE": "FLOAT32",
+    "DISTANCE_METRIC": "COSINE",
+    "M": 16,
+    "EF_CONSTRUCTION": 200,
+    "EF_RUNTIME": 10,
+}
+
+# Maximum number of keys deleted in a single FT.SEARCH round-trip during
+# document deletion.
+_PAGE_SIZE = 1000
+
+# Number of document summaries fetched per FT.AGGREGATE cursor read.
+_AGGREGATE_PAGE_SIZE = 1000
+
+# ------------------------------------------------------------------
+# Connection / lifecycle
+# ------------------------------------------------------------------
+
+
+class RedisStore(VectorStoreBase):
+    """Vector store backend backed by `Redis Stack
+    <https://redis.io/docs/latest/develop/get-started/vector-database/>`_.
+
+    Each knowledge base maps to one RediSearch index whose documents are
+    Redis hashes under the ``{collection}:doc:`` key prefix.  Every hash
+    stores the serialised :class:`~agentscope.rag.Chunk` plus the owning
+    ``document_id``, which is used by :meth:`delete` for whole-document
+    removal.
+
+    .. note:: The ``redis`` package is required.  Install it with
+        ``pip install agentscope[vdb-redis]``.
+
+    .. code-block:: python
+
+        store = RedisStore(url="redis://localhost:6379")
+
+        async with store:
+            await store.create_collection("kb-1", dimensions=768)
+
+    """
+
+    def __init__(
+        self,
+        url: str = "redis://localhost:6379",
+        client_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialise the Redis vector store.
+
+        No I/O is performed in the constructor — the connection is
+        established lazily on first use via :meth:`get_client`.
+
+        Args:
+            url (`str`, defaults to ``"redis://localhost:6379"``):
+                The Redis connection URL (``redis://``, ``rediss://``,
+                or ``unix://``).  Passed directly to
+                :func:`redis.asyncio.from_url`.
+            client_kwargs (`dict[str, Any] | None`, optional):
+                Extra keyword arguments forwarded to
+                :func:`redis.asyncio.from_url` (e.g. ``username``,
+                ``password``, ``ssl=True``).
+        """
+        self._url = url
+        self._client_kwargs = client_kwargs or {}
+        self._client: "Redis | None" = None
+        # Per-collection set of metadata keys whose TAG fields have
+        # already been added to the index (lazy FT.ALTER).
+        self._metadata_fields: dict[str, set[str]] = {}
+
+    # ------------------------------------------------------------------
+    # Client lifecycle
+    # ------------------------------------------------------------------
+
+    def get_client(self) -> "Redis":
+        """Lazily create and cache the async Redis client.
+
+        Returns:
+            `redis.asyncio.Redis`:
+                The shared async client instance (``decode_responses=True``).
+        """
+        if self._client is None:
+            from redis.asyncio import from_url
+
+            self._client = from_url(  # type: ignore[no-untyped-call]
+                self._url,
+                decode_responses=True,
+                **self._client_kwargs,
+            )
+        return self._client
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        """Exit the async context — close the underlying client."""
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    # ------------------------------------------------------------------
+    # Collection management
+    # ------------------------------------------------------------------
+
+    async def create_collection(
+        self,
+        name: str,
+        dimensions: int,
+    ) -> None:
+        """Create a new RediSearch index (collection).
+
+        No-op if the index already exists.
+
+        Args:
+            name (`str`):
+                The collection (index) name.  Typically the knowledge
+                base ID.  FT index names are global per server — use
+                unique names.
+            dimensions (`int`):
+                The fixed vector dimensionality for this collection.
+        """
+        from redis.commands.search.field import (
+            TagField,
+            TextField,
+            VectorField,
+        )
+        from redis.commands.search.index_definition import (
+            IndexDefinition,
+            IndexType,
+        )
+
+        client = self.get_client()
+        if await self._has_collection_locked(name):
+            return
+
+        schema = (
+            TextField("content"),
+            TagField(  # type: ignore[no-untyped-call]
+                "document_id",
+                # URL-safe Base64 values cannot contain this separator.
+                separator="\x1f",
+            ),
+            VectorField(  # type: ignore[no-untyped-call]
+                "embedding",
+                "HNSW",
+                {  # type: ignore[arg-type]
+                    "TYPE": "FLOAT32",
+                    "DIM": dimensions,
+                    **_HNSW_PARAMS,
+                },
+            ),
+        )
+
+        await client.ft(name).create_index(  # type: ignore[no-untyped-call]
+            schema,
+            definition=IndexDefinition(  # type: ignore[no-untyped-call]
+                prefix=[f"{name}:doc:"],
+                index_type=IndexType.HASH,
+            ),
+        )
+
+        # Reset the per-collection metadata-field cache so a recreated
+        # index starts with a clean slate.
+        self._metadata_fields[name] = set()
+
+    async def delete_collection(self, name: str) -> None:
+        """Delete a collection (index) and all its data.
+
+        Tolerates a missing index (no-op), matching
+        :class:`MongoDBStore`'s lenient ``drop``.
+
+        Args:
+            name (`str`):
+                The collection (index) name to delete.
+        """
+        try:
+            # delete_documents=True is required — otherwise the hashes
+            # under {name}:doc:* would leak as orphan keys.
+            ft = self.get_client().ft(name)
+            await ft.dropindex(  # type: ignore[no-untyped-call]
+                delete_documents=True,
+            )
+        except self._response_error() as exc:
+            if "unknown index name" not in str(exc).lower():
+                raise
+        self._metadata_fields.pop(name, None)
+
+    async def has_collection(self, name: str) -> bool:
+        """Check whether a collection (index) exists.
+
+        Args:
+            name (`str`):
+                The collection name to check.
+
+        Returns:
+            `bool`: ``True`` if the index exists.
+        """
+        return await self._has_collection_locked(name)
+
+    async def _has_collection_locked(self, name: str) -> bool:
+        """Internal helper — same logic as :meth:`has_collection` but
+        without the extra call layer.
+        """
+        try:
+            ft = self.get_client().ft(name)
+            await ft.info()  # type: ignore[no-untyped-call]
+            return True
+        except self._response_error() as exc:
+            if "unknown index name" in str(exc).lower():
+                return False
+            raise
+
+    # ------------------------------------------------------------------
+    # Data operations
+    # ------------------------------------------------------------------
+
+    async def insert(
+        self,
+        collection: str,
+        records: list[VectorRecord],
+    ) -> None:
+        """Insert records into a collection.
+
+        Each hash stores the serialised :class:`Chunk` (``content``),
+        the owning ``document_id``, the ``embedding`` as float32 bytes,
+        and one ``md_<key>`` TAG field per metadata entry (registered
+        lazily via ``FT.ALTER`` when a new key is encountered).
+
+        Args:
+            collection (`str`):
+                The target collection (index) name.
+            records (`list[VectorRecord]`):
+                The records to insert (each carrying a
+                :class:`Chunk` and its embedding vector).
+        """
+        if not records:
+            return
+
+        # Ensure every metadata key has a corresponding TAG field in
+        # the index schema (lazy FT.ALTER, cached per collection).
+        metadata_keys: set[str] = set()
+        for record in records:
+            metadata_keys.update(record.chunk.metadata.keys())
+        await self._ensure_metadata_fields(collection, metadata_keys)
+
+        client = self.get_client()
+        async with client.pipeline(transaction=False) as pipe:
+            for record in records:
+                mapping: dict[str, Any] = {
+                    "content": json.dumps(
+                        record.chunk.model_dump(mode="json"),
+                        ensure_ascii=False,
+                    ),
+                    "document_id": self._encode_tag_value(
+                        record.document_id,
+                    ),
+                    "embedding": np.asarray(
+                        record.vector,
+                        dtype=np.float32,
+                    ).tobytes(),
+                }
+                for key, value in record.chunk.metadata.items():
+                    mapping[
+                        self._metadata_field_name(key)
+                    ] = self._encode_tag_value(
+                        self._serialize_metadata_value(value),
+                    )
+                pipe.hset(  # type: ignore[no-untyped-call]
+                    f"{collection}:doc:{uuid.uuid4().hex}",
+                    mapping=mapping,
+                )
+            await pipe.execute()  # type: ignore[no-untyped-call]
+
+    async def delete(
+        self,
+        collection: str,
+        document_id: str,
+    ) -> None:
+        """Delete all records belonging to one source document.
+
+        Matches the ``document_id`` hash field written by
+        :meth:`insert`.
+
+        Uses a paginated search-then-unlink loop because RediSearch has
+        no in-query bulk delete.
+
+        Args:
+            collection (`str`):
+                The target collection (index) name.
+            document_id (`str`):
+                The source document ID whose records should be removed.
+        """
+        from redis.commands.search.query import Query
+
+        client = self.get_client()
+        encoded_document_id = self._encode_tag_value(document_id)
+        while True:
+            q = (
+                Query(  # type: ignore[no-untyped-call]
+                    f"@document_id:{{{encoded_document_id}}}",
+                )
+                .no_content()
+                .paging(0, _PAGE_SIZE)
+                .dialect(2)
+            )
+            ft = client.ft(collection)
+            res = await ft.search(q)  # type: ignore[no-untyped-call]
+            keys = [doc.id for doc in res.docs]
+            if keys:
+                await client.unlink(*keys)
+            if len(res.docs) < _PAGE_SIZE:
+                break
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        collection: str,
+        query_vector: list[float],
+        top_k: int = 5,
+        metadata_filter: dict[str, Any] | None = None,
+    ) -> list[VectorSearchResult]:
+        """Find the most similar records to a query vector.
+
+        Args:
+            collection (`str`):
+                The collection (index) to search.
+            query_vector (`list[float]`):
+                The query embedding vector.
+            top_k (`int`, defaults to ``5``):
+                Maximum number of results to return.
+            metadata_filter (`dict[str, Any] | None`, optional):
+                If provided, restrict the search to records whose
+                ``chunk.metadata`` matches every ``key == value`` pair
+                in this dict.  Each key is mapped to a ``md_<key>`` TAG
+                field clause.
+
+        Returns:
+            `list[VectorSearchResult]`:
+                Results ordered by descending similarity score.
+        """
+        if top_k <= 0:
+            return []
+
+        from redis.commands.search.query import Query
+
+        filter_prefix = self._build_metadata_filter(metadata_filter)
+        query_str = (
+            f"{filter_prefix or '*'}=>[KNN {top_k} @embedding $vec AS vd]"
+        )
+        q = (
+            Query(query_str)  # type: ignore[no-untyped-call]
+            .sort_by("vd")
+            .return_fields("content", "document_id", "vd")
+            .paging(0, top_k)
+            .dialect(2)
+        )
+
+        vec_bytes = np.asarray(query_vector, dtype=np.float32).tobytes()
+        res = (
+            await self.get_client()
+            .ft(collection)
+            .search(  # type: ignore[no-untyped-call]
+                q,
+                {"vec": vec_bytes},
+            )
+        )
+
+        results: list[VectorSearchResult] = []
+        for doc in res.docs:
+            raw = doc.content
+            if isinstance(raw, bytes):
+                raw = raw.decode("utf-8")
+            document_id = doc.document_id
+            if isinstance(document_id, bytes):
+                document_id = document_id.decode("utf-8")
+            # COSINE distance in RediSearch is 1 - cos_sim, so
+            # converting back yields the raw cosine similarity
+            # (identical → 1.0, orthogonal → 0.0).
+            score = 1.0 - float(doc.vd)
+            results.append(
+                VectorSearchResult(
+                    score=score,
+                    document_id=self._decode_tag_value(document_id),
+                    chunk=Chunk.model_validate(json.loads(raw)),
+                ),
+            )
+        return results
+
+    # ------------------------------------------------------------------
+    # Document listing
+    # ------------------------------------------------------------------
+
+    async def list_documents(
+        self,
+        collection: str,
+        metadata_filter: dict[str, Any] | None = None,
+    ) -> list[DocumentSummary]:
+        """List all distinct source documents indexed in a collection.
+
+        Uses a cursor-backed ``FT.AGGREGATE`` to group by ``document_id``.
+        The first chunk encountered supplies the ``source`` filename and
+        document-level ``metadata`` (matching the semantics of the other
+        backends).
+
+        Args:
+            collection (`str`):
+                The target collection (index) name.
+            metadata_filter (`dict[str, Any] | None`, optional):
+                If provided, restrict aggregation to records whose
+                ``chunk.metadata`` matches every ``key == value`` pair.
+
+        Returns:
+            `list[DocumentSummary]`:
+                One summary per distinct ``document_id``, in
+                unspecified order.
+        """
+        from redis.commands.search import reducers
+        from redis.commands.search.aggregation import (
+            AggregateRequest,
+            Cursor,
+        )
+
+        agg = (
+            AggregateRequest(  # type: ignore[no-untyped-call]
+                self._build_metadata_filter(metadata_filter) or "*",
+            )
+            .group_by(
+                "@document_id",
+                reducers.count().alias(  # type: ignore[no-untyped-call]
+                    "chunk_count",
+                ),
+                reducers.first_value(  # type: ignore[no-untyped-call]
+                    "@content",
+                ).alias("sample_content"),
+            )
+            .dialect(2)
+            .cursor(count=_AGGREGATE_PAGE_SIZE)
+        )
+
+        ft = self.get_client().ft(collection)
+        res = await ft.aggregate(agg)  # type: ignore[no-untyped-call]
+
+        summaries: list[DocumentSummary] = []
+        while True:
+            for row in res.rows:
+                # Cursor mode returns flat lists of [field, value, ...]
+                # instead of dicts.
+                if isinstance(row, list):
+                    row = dict(zip(row[::2], row[1::2]))
+                document_id = row["document_id"]
+                if isinstance(document_id, bytes):
+                    document_id = document_id.decode("utf-8")
+                chunk_count = int(row["chunk_count"])
+                raw_sample = row.get("sample_content")
+                if isinstance(raw_sample, bytes):
+                    raw_sample = raw_sample.decode("utf-8")
+
+                if raw_sample:
+                    chunk = json.loads(raw_sample)
+                    source = chunk.get("source", "")
+                    metadata = dict(chunk.get("metadata", {}))
+                else:
+                    source = ""
+                    metadata = {}
+
+                summaries.append(
+                    DocumentSummary(
+                        document_id=self._decode_tag_value(document_id),
+                        source=source,
+                        chunk_count=chunk_count,
+                        metadata=metadata,
+                    ),
+                )
+
+            if res.cursor is None or res.cursor.cid == 0:
+                break
+            res = await ft.aggregate(  # type: ignore[no-untyped-call]
+                Cursor(res.cursor.cid),
+            )
+        return summaries
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _response_error() -> type[BaseException]:
+        """Lazy-import ``ResponseError`` so ``redis`` stays optional at
+        module load time."""
+        from redis.exceptions import ResponseError
+
+        return ResponseError
+
+    @staticmethod
+    def _metadata_field_name(key: str) -> str:
+        """Return a collision-resistant RediSearch TAG field name.
+
+        Hashing preserves the distinction between arbitrary metadata
+        dictionary keys while limiting the field name to ASCII characters.
+        """
+        return "md_" + hashlib.sha256(key.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _encode_tag_value(value: str) -> str:
+        """Encode a tag value without separators or query metacharacters."""
+        return (
+            base64.urlsafe_b64encode(value.encode("utf-8"))
+            .decode(
+                "ascii",
+            )
+            .rstrip("=")
+        )
+
+    @staticmethod
+    def _decode_tag_value(value: str) -> str:
+        """Decode a value produced by :meth:`_encode_tag_value`."""
+        padding = "=" * (-len(value) % 4)
+        return base64.urlsafe_b64decode(value + padding).decode("utf-8")
+
+    @staticmethod
+    def _serialize_metadata_value(value: object) -> str:
+        """Serialize a metadata value for storage in a TAG hash field.
+
+        redis-py's encoder raises ``DataError`` on raw ``bool`` values,
+        so booleans are mapped to ``"true"`` / ``"false"`` explicitly.
+        Non-scalar values are JSON-serialised.
+
+        Args:
+            value (`object`):
+                The chunk metadata value to serialize.
+
+        Returns:
+            `str`: The string representation.
+        """
+        if isinstance(value, str):
+            return value
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, int | float):
+            return str(value)
+        return json.dumps(value, ensure_ascii=False)
+
+    @staticmethod
+    def _build_metadata_filter(
+        metadata_filter: dict[str, Any] | None,
+    ) -> str | None:
+        """Translate a flat ``{key: value}`` filter into a RediSearch
+        hybrid-query prefix string.
+
+        Each pair becomes a ``@md_<key>:{<encoded_value>}`` TAG clause.
+        Clauses are joined with spaces (implicit AND).  The result is
+        wrapped in parentheses and trailed by a space so it slots
+        directly before ``=>`` in a KNN query.
+
+        Returns ``None`` when ``metadata_filter`` is empty.
+
+        Args:
+            metadata_filter (`dict[str, Any] | None`):
+                The flat filter, or ``None`` for no filter.
+
+        Returns:
+            `str | None`: The parenthesised filter string, or ``None``.
+        """
+        if not metadata_filter:
+            return None
+        clauses = []
+        for key, value in metadata_filter.items():
+            field = RedisStore._metadata_field_name(key)
+            encoded_value = RedisStore._encode_tag_value(
+                RedisStore._serialize_metadata_value(value),
+            )
+            clauses.append(f"@{field}:{{{encoded_value}}}")
+        return "(" + " ".join(clauses) + ") "
+
+    async def _ensure_metadata_fields(
+        self,
+        collection: str,
+        keys: set[str],
+    ) -> None:
+        """Register metadata keys as TAG fields in the RediSearch index
+        schema (lazy ``FT.ALTER``), if they haven't already been added.
+
+        Uses a per-collection cache so the ALTER is issued at most once
+        per key.  Racing insert calls that try to add the same field
+        concurrently are tolerated by swallowing the "field already
+        exists" error.
+
+        Args:
+            collection (`str`):
+                The target index name.
+            keys (`set[str]`):
+                The metadata keys to ensure in the schema.
+        """
+        known = self._metadata_fields.setdefault(collection, set())
+        new_keys = {k for k in keys if k not in known}
+        if not new_keys:
+            return
+
+        from redis.commands.search.field import TagField
+
+        client = self.get_client()
+        ft = client.ft(collection)
+        # Deterministic order so repeated runs produce the same
+        # ALTER sequence.
+        for key in sorted(new_keys):
+            try:
+                await ft.alter_schema_add(  # type: ignore[no-untyped-call]
+                    TagField(  # type: ignore[no-untyped-call]
+                        RedisStore._metadata_field_name(key),
+                        separator="\x1f",
+                    ),
+                )
+            except self._response_error() as exc:
+                # A concurrent insert may have created this exact field.
+                # Other FT.ALTER failures must remain visible; otherwise we
+                # would write data that cannot be filtered.
+                if "already exists" not in str(exc).lower():
+                    raise
+            known.add(key)

--- a/tests/rag_vdb_redis_integration_test.py
+++ b/tests/rag_vdb_redis_integration_test.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for RedisStore against a real Redis instance.
+
+Skipped by default — set ``REDIS_URL`` to run against a live Redis
+Stack 7.2+ or Redis 8.0+ (requires the RediSearch module).
+
+.. code-block:: bash
+
+    REDIS_URL=redis://localhost:6380 uv run pytest tests/rag_vdb_redis_integration_test.py -v
+"""  # noqa: E501
+
+import os
+import uuid
+from contextlib import AsyncExitStack
+from unittest.async_case import IsolatedAsyncioTestCase
+
+from agentscope.message import TextBlock
+from agentscope.rag import Chunk, RedisStore, VectorRecord
+
+_REDIS_URL = os.environ.get("REDIS_URL")
+
+
+class RedisStoreIntegrationTest(IsolatedAsyncioTestCase):
+    """End-to-end verification against a real Redis with RediSearch."""
+
+    async def asyncSetUp(self) -> None:
+        if not _REDIS_URL:
+            self.skipTest("REDIS_URL not set")
+        self._exit_stack = AsyncExitStack()
+        self.store = await self._exit_stack.enter_async_context(
+            RedisStore(url=_REDIS_URL),
+        )
+        self._collection = f"agentscope_it_{uuid.uuid4().hex}"
+
+    async def asyncTearDown(self) -> None:
+        if not _REDIS_URL:
+            return
+        await self.store.delete_collection(self._collection)
+        await self._exit_stack.aclose()
+
+    async def test_special_chars_document_id(self) -> None:
+        """document_id with special characters round-trips correctly."""
+        await self.store.create_collection(self._collection, dimensions=3)
+        doc_id = r"doc,$|{}\\"
+
+        await self.store.insert(
+            self._collection,
+            [
+                VectorRecord(
+                    vector=[1.0, 0.0, 0.0],
+                    document_id=doc_id,
+                    chunk=Chunk(
+                        content=TextBlock(text="test"),
+                        source="test.txt",
+                        chunk_index=0,
+                        total_chunks=1,
+                    ),
+                ),
+            ],
+        )
+
+        hits = await self.store.search(
+            self._collection,
+            [1.0, 0.0, 0.0],
+        )
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0].document_id, doc_id)
+
+    async def test_metadata_filter_with_special_chars(self) -> None:
+        """metadata_filter works with keys and values containing
+        special characters."""
+        await self.store.create_collection(self._collection, dimensions=3)
+
+        await self.store.insert(
+            self._collection,
+            [
+                VectorRecord(
+                    vector=[1.0, 0.0, 0.0],
+                    document_id="doc-1",
+                    chunk=Chunk(
+                        content=TextBlock(text="a"),
+                        source="a.txt",
+                        chunk_index=0,
+                        total_chunks=1,
+                        metadata={"tenant.id": r"team,$1"},
+                    ),
+                ),
+                VectorRecord(
+                    vector=[0.0, 1.0, 0.0],
+                    document_id="doc-2",
+                    chunk=Chunk(
+                        content=TextBlock(text="b"),
+                        source="b.txt",
+                        chunk_index=0,
+                        total_chunks=1,
+                        metadata={"tenant.id": "team-b"},
+                    ),
+                ),
+            ],
+        )
+
+        # Filter should only match doc-1
+        hits = await self.store.search(
+            self._collection,
+            [1.0, 0.0, 0.0],
+            metadata_filter={"tenant.id": r"team,$1"},
+        )
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0].document_id, "doc-1")
+
+    async def test_list_and_delete(self) -> None:
+        """list_documents + delete + re-list works end-to-end."""
+        await self.store.create_collection(self._collection, dimensions=3)
+        doc_id = "doc-1"
+
+        await self.store.insert(
+            self._collection,
+            [
+                VectorRecord(
+                    vector=[1.0, 0.0, 0.0],
+                    document_id=doc_id,
+                    chunk=Chunk(
+                        content=TextBlock(text="hello"),
+                        source="hello.txt",
+                        chunk_index=0,
+                        total_chunks=1,
+                    ),
+                ),
+            ],
+        )
+
+        documents = await self.store.list_documents(self._collection)
+        self.assertEqual([d.document_id for d in documents], [doc_id])
+
+        await self.store.delete(self._collection, doc_id)
+        self.assertEqual(
+            await self.store.list_documents(self._collection),
+            [],
+        )
+
+    async def test_collection_lifecycle(self) -> None:
+        """create / has / delete collection against real Redis."""
+        await self.store.create_collection(self._collection, dimensions=3)
+        self.assertTrue(await self.store.has_collection(self._collection))
+
+        # Re-creating is a no-op
+        await self.store.create_collection(self._collection, dimensions=3)
+        self.assertTrue(await self.store.has_collection(self._collection))
+
+        await self.store.delete_collection(self._collection)
+        self.assertFalse(await self.store.has_collection(self._collection))

--- a/tests/rag_vdb_redis_test.py
+++ b/tests/rag_vdb_redis_test.py
@@ -1,0 +1,781 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the RedisStore class.
+
+Uses an in-memory fake Redis client (similar to the MongoDBStore test
+pattern) because fakeredis 2.36.2 does not implement RediSearch (FT.*)
+commands.
+"""
+
+import re
+import types
+from contextlib import AsyncExitStack
+from typing import Any
+from unittest.async_case import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+import numpy as np
+
+from utils import AnyString
+
+from agentscope.message import TextBlock
+from agentscope.rag import (
+    Chunk,
+    RedisStore,
+    VectorRecord,
+    VectorSearchResult,
+)
+
+# ------------------------------------------------------------------
+# Module-level helpers (same pattern as rag_vdb_qdrant_test.py)
+# ------------------------------------------------------------------
+
+
+def _dump_results(results: list[VectorSearchResult]) -> list[dict]:
+    """Convert search results into plain dicts for whole-structure
+    comparison.
+
+    Args:
+        results (`list[VectorSearchResult]`):
+            The search results to convert.
+
+    Returns:
+        `list[dict]`: The results as plain dicts.
+    """
+    return [result.model_dump() for result in results]
+
+
+def _make_record(
+    text: str,
+    vector: list[float],
+    document_id: str,
+    chunk_index: int = 0,
+    total_chunks: int = 1,
+) -> VectorRecord:
+    """Build a VectorRecord for testing.
+
+    Args:
+        text (`str`): The chunk text content.
+        vector (`list[float]`): The embedding vector.
+        document_id (`str`): The ID of the source document.
+        chunk_index (`int`, defaults to ``0``): The chunk index.
+        total_chunks (`int`, defaults to ``1``): Total chunks in doc.
+
+    Returns:
+        `VectorRecord`: The constructed record.
+    """
+    return VectorRecord(
+        vector=vector,
+        document_id=document_id,
+        chunk=Chunk(
+            content=TextBlock(text=text),
+            source=f"{document_id}.txt",
+            chunk_index=chunk_index,
+            total_chunks=total_chunks,
+        ),
+    )
+
+
+# ------------------------------------------------------------------
+# Fake Redis client — simulates the async API surface RedisStore uses
+# ------------------------------------------------------------------
+
+_KNN_RE = re.compile(
+    r"^(.*)=>\s*\[KNN\s+(\d+)\s+@embedding\s+\$vec\s+AS\s+(\S+)\]$",
+)
+_TAG_FILTER_RE = re.compile(r"@(\S+):\{([^}]*)\}")
+
+
+# pylint: disable=protected-access,unused-argument
+
+
+class _FakePipeline:
+    """Async context manager that collects HSET calls and flushes them
+    to the parent client on ``execute()``."""
+
+    def __init__(self, client: "_FakeRedisClient") -> None:
+        self._client = client
+        self._commands: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def __aenter__(self) -> "_FakePipeline":
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        pass
+
+    def hset(self, key: str, mapping: dict[str, Any]) -> None:
+        """Queue an HSET."""
+        self._commands.append(("hset", key, mapping))
+
+    async def execute(self) -> None:
+        """Commit all queued commands to the client's data store."""
+        for _, key, mapping in self._commands:
+            self._client._docs[key] = dict(mapping)
+
+
+class _FakeRedisIndex:
+    """Simulates one RediSearch index (created via ``FT.CREATE``)."""
+
+    def __init__(
+        self,
+        client: "_FakeRedisClient",
+        name: str,
+    ) -> None:
+        self._client = client
+        self._name = name
+        self._exists = False
+        self._fields: dict[str, str] = {}  # field_name → field_type
+        self._cursor_rows: dict[int, tuple[list[dict[str, Any]], int]] = {}
+        self._next_cursor_id = 1
+
+    # -- lifecycle -------------------------------------------------------
+
+    async def create_index(
+        self,
+        fields: list[Any],
+        definition: Any | None = None,
+    ) -> None:
+        """Record the schema fields."""
+        for f in fields:
+            if hasattr(f, "name"):
+                self._fields[f.name] = type(f).__name__
+        self._exists = True
+
+    async def alter_schema_add(self, *fields: Any) -> None:
+        """Add TAG fields to the schema (FT.ALTER)."""
+        for f in fields:
+            if hasattr(f, "name"):
+                self._fields[f.name] = type(f).__name__
+
+    async def info(self) -> dict[str, Any]:
+        """Return index info or raise on unknown index."""
+        if not self._exists:
+            import redis.exceptions
+
+            raise redis.exceptions.ResponseError("Unknown Index name")
+        return {
+            "index_name": self._name,
+            "num_docs": len(self._matching_keys()),
+        }
+
+    async def dropindex(self, delete_documents: bool = False) -> None:
+        """Remove the index and optionally its documents."""
+        if delete_documents:
+            prefix = f"{self._name}:doc:"
+            to_delete = [k for k in self._client._docs if k.startswith(prefix)]
+            for k in to_delete:
+                del self._client._docs[k]
+        self._exists = False
+
+    # -- search ---------------------------------------------------------
+
+    async def search(
+        self,
+        query: Any,
+        query_params: dict[str, Any] | None = None,
+    ) -> Any:
+        """Simulate ``FT.SEARCH`` with KNN vector search or pure filter.
+
+        Parses the query string: if it's a hybrid KNN query, computes
+        cosine similarity; otherwise treats it as a pure TAG filter
+        (used by :meth:`RedisStore.delete`).
+        """
+        qs = query.query_string()
+
+        m = _KNN_RE.match(qs)
+        if m:
+            return await self._knn_search(m, query, query_params or {})
+        return self._filter_search(qs, query)
+
+    async def _knn_search(
+        self,
+        m: re.Match,
+        query: Any,
+        query_params: dict[str, Any],
+    ) -> Any:
+        """Hybrid KNN search — parse filter prefix, compute cosine
+        similarity, return top-k sorted by distance ascending."""
+        filter_part = m.group(1).strip()
+        k = int(m.group(2))
+        distance_alias = m.group(3)
+        vec_bytes = list(query_params.values())[0] if query_params else b""
+        paging_offset = query._offset
+        paging_num = query._num
+
+        # Parse metadata filter from the prefix part
+        tag_filters: dict[str, str] = {}
+        if filter_part and filter_part != "*":
+            for tf_m in _TAG_FILTER_RE.finditer(filter_part):
+                tag_filters[tf_m.group(1)] = tf_m.group(2)
+
+        query_vec = np.frombuffer(vec_bytes, dtype=np.float32)
+        scored: list[tuple[float, str]] = []
+
+        for key, doc in self._client._docs.items():
+            if not key.startswith(f"{self._name}:doc:"):
+                continue
+            if not self._matches_filters(doc, tag_filters):
+                continue
+
+            emb_bytes = doc.get("embedding", b"")
+            if isinstance(emb_bytes, str):
+                emb_bytes = emb_bytes.encode("latin-1")
+            emb = np.frombuffer(emb_bytes, dtype=np.float32)
+
+            norm_q = np.linalg.norm(query_vec)
+            norm_d = np.linalg.norm(emb)
+            if norm_q == 0 or norm_d == 0:
+                sim = 0.0
+            else:
+                sim = float(np.dot(query_vec, emb) / (norm_q * norm_d))
+            distance = 1.0 - sim
+            scored.append((distance, key))
+
+        scored.sort(key=lambda x: x[0])
+        page = scored[paging_offset : paging_offset + paging_num]
+        page = page[:k]
+
+        docs = []
+        for dist, key in page:
+            doc = self._client._docs[key]
+            docs.append(
+                types.SimpleNamespace(
+                    id=key,
+                    content=doc.get("content", ""),
+                    document_id=doc.get("document_id", ""),
+                    **{distance_alias: str(dist)},
+                ),
+            )
+
+        return _result(docs, len(scored))
+
+    def _filter_search(
+        self,
+        qs: str,
+        query: Any,
+    ) -> Any:
+        """Pure filter search (no KNN) — used for delete-by-document-id
+        and other metadata lookups."""
+        tag_filters: dict[str, str] = {}
+        for tf_m in _TAG_FILTER_RE.finditer(qs):
+            tag_filters[tf_m.group(1)] = tf_m.group(2)
+
+        paging_offset = query._offset
+        paging_num = query._num
+
+        matching_keys = []
+        for key, doc in self._client._docs.items():
+            if not key.startswith(f"{self._name}:doc:"):
+                continue
+            if self._matches_filters(doc, tag_filters):
+                matching_keys.append(key)
+
+        total = len(matching_keys)
+        page_keys = matching_keys[paging_offset : paging_offset + paging_num]
+        docs = []
+        for key in page_keys:
+            doc = self._client._docs[key]
+            docs.append(
+                types.SimpleNamespace(
+                    id=key,
+                    content=doc.get("content", ""),
+                    document_id=doc.get("document_id", ""),
+                ),
+            )
+
+        return _result(docs, total)
+
+    # -- aggregate ------------------------------------------------------
+
+    async def aggregate(self, request: Any) -> Any:
+        """Simulate ``FT.AGGREGATE`` with GROUPBY on document_id.
+
+        Groups matching documents by ``document_id``, counting chunks
+        and collecting the first chunk's content per group. Supports the
+        cursor reads used by :meth:`RedisStore.list_documents`.
+        """
+        if hasattr(request, "cid"):
+            return self._read_cursor(request.cid)
+
+        args = request.build_args() if hasattr(request, "build_args") else []
+        query_str = args[0] if args else "*"
+
+        # Parse metadata filter
+        tag_filters: dict[str, str] = {}
+        if query_str and query_str != "*":
+            query_str = query_str.strip("() ")
+            for tf_m in _TAG_FILTER_RE.finditer(query_str):
+                tag_filters[tf_m.group(1)] = tf_m.group(2)
+
+        groups: dict[str, dict[str, Any]] = {}
+        prefix = f"{self._name}:doc:"
+
+        for key, doc in self._client._docs.items():
+            if not key.startswith(prefix):
+                continue
+            if not self._matches_filters(doc, tag_filters):
+                continue
+
+            doc_id = doc.get("document_id", "")
+            entry = groups.get(doc_id)
+            if entry is None:
+                groups[doc_id] = {
+                    "document_id": doc_id,
+                    "chunk_count": 1,
+                    "sample_content": doc.get("content", ""),
+                }
+            else:
+                entry["chunk_count"] += 1
+
+        rows = []
+        for entry in groups.values():
+            rows.append(
+                {
+                    "document_id": entry["document_id"],
+                    "chunk_count": str(entry["chunk_count"]),
+                    "sample_content": entry["sample_content"],
+                },
+            )
+
+        cursor_args = getattr(request, "_cursor", None)
+        if not cursor_args:
+            return types.SimpleNamespace(rows=rows, cursor=None)
+
+        page_size = int(cursor_args[cursor_args.index("COUNT") + 1])
+        return self._start_cursor(rows, page_size)
+
+    def _start_cursor(
+        self,
+        rows: list[dict[str, Any]],
+        page_size: int,
+    ) -> Any:
+        """Return the first cursor page and retain remaining rows."""
+        first_page = rows[:page_size]
+        remaining = rows[page_size:]
+        if not remaining:
+            return types.SimpleNamespace(
+                rows=first_page,
+                cursor=types.SimpleNamespace(cid=0),
+            )
+
+        cursor_id = self._next_cursor_id
+        self._next_cursor_id += 1
+        self._cursor_rows[cursor_id] = (remaining, page_size)
+        return types.SimpleNamespace(
+            rows=first_page,
+            cursor=types.SimpleNamespace(cid=cursor_id),
+        )
+
+    def _read_cursor(self, cursor_id: int) -> Any:
+        """Return the next cursor page using the original page size."""
+        rows, page_size = self._cursor_rows.pop(cursor_id)
+        page = rows[:page_size]
+        remaining = rows[page_size:]
+        if remaining:
+            self._cursor_rows[cursor_id] = (remaining, page_size)
+            next_cursor_id = cursor_id
+        else:
+            next_cursor_id = 0
+        return types.SimpleNamespace(
+            rows=page,
+            cursor=types.SimpleNamespace(cid=next_cursor_id),
+        )
+
+    # -- helpers ---------------------------------------------------------
+
+    def _matching_keys(self) -> list[str]:
+        """Return all document keys belonging to this index."""
+        prefix = f"{self._name}:doc:"
+        return [k for k in self._client._docs if k.startswith(prefix)]
+
+    @staticmethod
+    def _matches_filters(
+        doc: dict[str, Any],
+        tag_filters: dict[str, str],
+    ) -> bool:
+        """Check whether a document satisfies all tag filters."""
+        for field, expected in tag_filters.items():
+            actual = doc.get(field)
+            if actual is None:
+                return False
+            if str(actual) != expected:
+                return False
+        return True
+
+
+class _FakeRedisClient:
+    """In-memory fake Redis async client.
+
+    Stores all hash documents in ``self._docs`` and lazily creates
+    ``_FakeRedisIndex`` instances for each FT index name.
+    """
+
+    def __init__(self) -> None:
+        self._docs: dict[str, dict[str, Any]] = {}
+        self._indexes: dict[str, _FakeRedisIndex] = {}
+
+    async def aclose(self) -> None:
+        """No-op close."""
+
+    def ft(self, name: str) -> _FakeRedisIndex:
+        """Return (or lazily create) the search index for *name*."""
+        if name not in self._indexes:
+            self._indexes[name] = _FakeRedisIndex(self, name)
+        return self._indexes[name]
+
+    def pipeline(self, transaction: bool = False) -> _FakePipeline:
+        """Return an async context manager pipeline."""
+        return _FakePipeline(self)
+
+    async def unlink(self, *keys: str) -> None:
+        """Remove one or more keys from the data store."""
+        for key in keys:
+            self._docs.pop(key, None)
+
+
+def _result(
+    docs: list[types.SimpleNamespace],
+    total: int,
+) -> types.SimpleNamespace:
+    """Build a search result namespace matching the real FT.SEARCH
+    return shape."""
+    return types.SimpleNamespace(docs=docs, total=total)
+
+
+# ------------------------------------------------------------------
+# Test cases
+# ------------------------------------------------------------------
+
+
+class RedisStoreTest(IsolatedAsyncioTestCase):
+    """The test cases for the RedisStore class."""
+
+    async def asyncSetUp(self) -> None:
+        """Create a RedisStore wired to an in-memory fake client."""
+        self._fake_client = _FakeRedisClient()
+        self._patcher = patch.object(
+            RedisStore,
+            "get_client",
+            return_value=self._fake_client,
+        )
+        self._patcher.start()
+        self._exit_stack = AsyncExitStack()
+        self.store = await self._exit_stack.enter_async_context(
+            RedisStore(url="redis://fake"),
+        )
+
+    async def asyncTearDown(self) -> None:
+        """Close the store and stop the patch."""
+        await self._exit_stack.aclose()
+        self._patcher.stop()
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    async def test_collection_lifecycle(self) -> None:
+        """Collections can be created, checked, and deleted."""
+        self.assertEqual(await self.store.has_collection("kb-1"), False)
+
+        await self.store.create_collection("kb-1", dimensions=3)
+        self.assertEqual(await self.store.has_collection("kb-1"), True)
+
+        # Creating an existing collection is a no-op
+        await self.store.create_collection("kb-1", dimensions=3)
+        self.assertEqual(await self.store.has_collection("kb-1"), True)
+
+        await self.store.delete_collection("kb-1")
+        self.assertEqual(await self.store.has_collection("kb-1"), False)
+
+    async def test_insert_and_search(self) -> None:
+        """Inserted records are searchable, ordered by similarity."""
+        await self.store.create_collection("kb-1", dimensions=3)
+        await self.store.insert(
+            "kb-1",
+            [
+                _make_record(
+                    "Hello world!",
+                    [1.0, 0.0, 0.0],
+                    document_id="doc-1",
+                    chunk_index=0,
+                    total_chunks=2,
+                ),
+                _make_record(
+                    "Goodbye world!",
+                    [0.0, 1.0, 0.0],
+                    document_id="doc-1",
+                    chunk_index=1,
+                    total_chunks=2,
+                ),
+            ],
+        )
+
+        results = await self.store.search(
+            "kb-1",
+            query_vector=[1.0, 0.0, 0.0],
+            top_k=2,
+        )
+
+        self.assertEqual(
+            _dump_results(results),
+            [
+                {
+                    "score": 1.0,
+                    "document_id": "doc-1",
+                    "chunk": {
+                        "content": {
+                            "type": "text",
+                            "text": "Hello world!",
+                            "id": AnyString(),
+                            "created_at": AnyString(),
+                            "finished_at": None,
+                        },
+                        "source": "doc-1.txt",
+                        "chunk_index": 0,
+                        "total_chunks": 2,
+                        "metadata": {},
+                    },
+                },
+                {
+                    "score": 0.0,
+                    "document_id": "doc-1",
+                    "chunk": {
+                        "content": {
+                            "type": "text",
+                            "text": "Goodbye world!",
+                            "id": AnyString(),
+                            "created_at": AnyString(),
+                            "finished_at": None,
+                        },
+                        "source": "doc-1.txt",
+                        "chunk_index": 1,
+                        "total_chunks": 2,
+                        "metadata": {},
+                    },
+                },
+            ],
+        )
+
+    async def test_search_top_k(self) -> None:
+        """top_k limits the number of returned results."""
+        await self.store.create_collection("kb-1", dimensions=3)
+        await self.store.insert(
+            "kb-1",
+            [
+                _make_record("A", [1.0, 0.0, 0.0], document_id="doc-1"),
+                _make_record("B", [0.9, 0.1, 0.0], document_id="doc-2"),
+                _make_record("C", [0.0, 0.0, 1.0], document_id="doc-3"),
+            ],
+        )
+
+        results = await self.store.search(
+            "kb-1",
+            query_vector=[1.0, 0.0, 0.0],
+            top_k=1,
+        )
+
+        self.assertEqual(
+            _dump_results(results),
+            [
+                {
+                    "score": 1.0,
+                    "document_id": "doc-1",
+                    "chunk": {
+                        "content": {
+                            "type": "text",
+                            "text": "A",
+                            "id": AnyString(),
+                            "created_at": AnyString(),
+                            "finished_at": None,
+                        },
+                        "source": "doc-1.txt",
+                        "chunk_index": 0,
+                        "total_chunks": 1,
+                        "metadata": {},
+                    },
+                },
+            ],
+        )
+
+    async def test_delete_by_document_id(self) -> None:
+        """delete removes all records of one document only."""
+        await self.store.create_collection("kb-1", dimensions=3)
+        await self.store.insert(
+            "kb-1",
+            [
+                _make_record(
+                    "doc1-chunk0",
+                    [1.0, 0.0, 0.0],
+                    document_id="doc-1",
+                    chunk_index=0,
+                    total_chunks=2,
+                ),
+                _make_record(
+                    "doc1-chunk1",
+                    [0.9, 0.1, 0.0],
+                    document_id="doc-1",
+                    chunk_index=1,
+                    total_chunks=2,
+                ),
+                _make_record(
+                    "doc2-chunk0",
+                    [0.0, 1.0, 0.0],
+                    document_id="doc-2",
+                ),
+            ],
+        )
+
+        await self.store.delete("kb-1", document_id="doc-1")
+
+        results = await self.store.search(
+            "kb-1",
+            query_vector=[1.0, 0.0, 0.0],
+            top_k=5,
+        )
+
+        self.assertEqual(
+            _dump_results(results),
+            [
+                {
+                    "score": 0.0,
+                    "document_id": "doc-2",
+                    "chunk": {
+                        "content": {
+                            "type": "text",
+                            "text": "doc2-chunk0",
+                            "id": AnyString(),
+                            "created_at": AnyString(),
+                            "finished_at": None,
+                        },
+                        "source": "doc-2.txt",
+                        "chunk_index": 0,
+                        "total_chunks": 1,
+                        "metadata": {},
+                    },
+                },
+            ],
+        )
+
+    async def test_insert_empty_records(self) -> None:
+        """Inserting an empty record list is a no-op."""
+        await self.store.create_collection("kb-1", dimensions=3)
+        await self.store.insert("kb-1", [])
+
+        results = await self.store.search(
+            "kb-1",
+            query_vector=[1.0, 0.0, 0.0],
+        )
+
+        self.assertEqual(_dump_results(results), [])
+
+    async def test_list_documents_aggregates_by_document_id(self) -> None:
+        """list_documents groups chunks by document_id."""
+        await self.store.create_collection("kb-1", dimensions=3)
+
+        def _record_with_metadata(
+            text: str,
+            document_id: str,
+            metadata: dict[str, Any],
+            chunk_index: int = 0,
+            total_chunks: int = 1,
+        ) -> VectorRecord:
+            return VectorRecord(
+                vector=[1.0, 0.0, 0.0],
+                document_id=document_id,
+                chunk=Chunk(
+                    content=TextBlock(text=text),
+                    source=metadata.get("filename", f"{document_id}.txt"),
+                    chunk_index=chunk_index,
+                    total_chunks=total_chunks,
+                    metadata=metadata,
+                ),
+            )
+
+        await self.store.insert(
+            "kb-1",
+            [
+                _record_with_metadata(
+                    "A",
+                    "doc-1",
+                    {"filename": "alpha.txt", "media_type": "text/plain"},
+                    0,
+                    2,
+                ),
+                _record_with_metadata(
+                    "B",
+                    "doc-1",
+                    {"filename": "alpha.txt", "media_type": "text/plain"},
+                    1,
+                    2,
+                ),
+                _record_with_metadata(
+                    "C",
+                    "doc-2",
+                    {"filename": "beta.md", "media_type": "text/markdown"},
+                    0,
+                    1,
+                ),
+            ],
+        )
+
+        # Force multiple cursor reads without creating a large fixture.
+        with patch(
+            "agentscope.rag._vdb._redis._AGGREGATE_PAGE_SIZE",
+            1,
+        ):
+            summaries = await self.store.list_documents("kb-1")
+        summaries_by_id = {s.document_id: s for s in summaries}
+
+        self.assertEqual(set(summaries_by_id), {"doc-1", "doc-2"})
+        self.assertEqual(summaries_by_id["doc-1"].chunk_count, 2)
+        self.assertEqual(summaries_by_id["doc-1"].source, "alpha.txt")
+        self.assertEqual(
+            summaries_by_id["doc-1"].metadata,
+            {"filename": "alpha.txt", "media_type": "text/plain"},
+        )
+        self.assertEqual(summaries_by_id["doc-2"].chunk_count, 1)
+        self.assertEqual(summaries_by_id["doc-2"].source, "beta.md")
+
+    async def test_search_metadata_filter(self) -> None:
+        """search applies the metadata_filter as a TAG field filter."""
+        await self.store.create_collection("kb-1", dimensions=3)
+
+        def _record(
+            text: str,
+            document_id: str,
+            kb_scope: str,
+        ) -> VectorRecord:
+            return VectorRecord(
+                vector=[1.0, 0.0, 0.0],
+                document_id=document_id,
+                chunk=Chunk(
+                    content=TextBlock(text=text),
+                    source=f"{document_id}.txt",
+                    chunk_index=0,
+                    total_chunks=1,
+                    metadata={"kb_scope": kb_scope},
+                ),
+            )
+
+        await self.store.insert(
+            "kb-1",
+            [
+                _record("A", "doc-1", "kb-a"),
+                _record("B", "doc-2", "kb-b"),
+            ],
+        )
+
+        results = await self.store.search(
+            "kb-1",
+            query_vector=[1.0, 0.0, 0.0],
+            top_k=5,
+            metadata_filter={"kb_scope": "kb-a"},
+        )
+        self.assertEqual([r.document_id for r in results], ["doc-1"])
+
+        results = await self.store.search(
+            "kb-1",
+            query_vector=[1.0, 0.0, 0.0],
+            top_k=5,
+            metadata_filter={"kb_scope": "kb-b"},
+        )
+        self.assertEqual([r.document_id for r in results], ["doc-2"])


### PR DESCRIPTION
## AgentScope Version

2.0.5

## Description

Closes https://github.com/agentscope-ai/agentscope/issues/2170

Adds `RedisStore` as a vector store backend for AgentScope. It uses redis-py's native `redis.commands.search` module, allowing users with an existing Redis deployment to build RAG applications without adding redisvl or another vector database.

### What Changed

**Added `RedisStore` (`src/agentscope/rag/_vdb/_redis.py`):**

Implements all seven abstract methods from `VectorStoreBase`, mapping them to five RediSearch commands:

| Abstract method | RediSearch command | Details |
|-----------------|--------------------|---------|
| `create_collection` | `FT.CREATE ... SCHEMA content TEXT document_id TAG embedding VECTOR HNSW ...` | Creates an HNSW index with cosine distance, limited to the `{name}:doc:` prefix. |
| `has_collection` | `FT.INFO` | Returns `False` for a missing index while propagating other errors. |
| `delete_collection` | `FT.DROPINDEX DD` | Uses `delete_documents` to avoid orphaned hashes. |
| `insert` | Pipelined `HSET` | Stores embeddings as float32 bytes rather than JSON. |
| `delete` | `FT.SEARCH @document_id:{id}` followed by `UNLINK` | Deletes in pages of 1,000 because RediSearch has no query-based bulk delete. |
| `search` | `FT.SEARCH "{filter}=>[KNN k @embedding $vec AS vd]"` | Runs a hybrid query using DIALECT 2 and converts cosine distance to a similarity score. |
| `list_documents` | `FT.AGGREGATE ... GROUPBY @document_id REDUCE COUNT + FIRST_VALUE` | Uses cursor pagination and is O(documents). |

Design notes:

- **No redisvl dependency**: uses redis-py's built-in Search API directly, avoiding an additional redisvl dependency and its version compatibility constraints.
- **TAG encoding strategy**: `document_id` and metadata-filter values use URL-safe Base64 encoding, while metadata keys derive their field names from SHA-256. This prevents Redis TAG special characters, separators, and key-name collisions from affecting filtering or deletion. The public API still returns the original `document_id`.

**Dependency configuration (`pyproject.toml`):**

- `vdb-redis = ["redis"]`, consistent with the existing `storage-redis` dependency declaration.
- Added `"agentscope[vdb-redis]"` to the `full` extra.

**Exports:**

Exports `RedisStore` from both `src/agentscope/rag/_vdb/__init__.py` and `src/agentscope/rag/__init__.py`, consistent with the other VDB backends.

### Environment Notes

- Existing Redis Stack 7.2+ or Redis 8.0+ deployments with the RediSearch module can be used directly; no separate vector database is required.
- Coexists with the Qdrant, MongoDB, Milvus Lite, and Elasticsearch VDB backends; applications can choose the appropriate backend as needed.

### Testing

- **Unit tests**: 7 passed (`tests/rag_vdb_redis_test.py`) using an in-memory `_FakeRedisClient`, with no external Redis dependency. fakeredis 2.36.2 does not support `FT.*` commands, so the tests use the same `patch.object` mock pattern as the MongoDB and Elasticsearch backends.
- **Integration tests**: 4 passed (`tests/rag_vdb_redis_integration_test.py`) against a real Redis Stack instance. Coverage includes special-character document IDs, metadata filtering, the complete list/delete flow, and collection lifecycle operations. These tests run when `REDIS_URL` is set and are skipped by default in CI.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x] Has been tested locally (7 unit tests and 4 integration tests pass)
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in reStructuredText style with full `Args`/`Returns`/`Yields` sections
- [ ] Related documentation has been updated in [documentation repository](https://github.com/agentscope-ai/docs)
- [x] Code is ready for review
