### PR TITLE
fix(app): clean up index worker tasks on cancellation

### DIFF
--- a/src/agentscope/app/_service/_index_worker.py
+++ b/src/agentscope/app/_service/_index_worker.py
@@ -271,6 +271,15 @@ class IndexWorker:
             with contextlib.suppress(asyncio.CancelledError):
                 await heartbeat_task
             await pipeline_task
+        except asyncio.CancelledError:
+            pipeline_task.cancel()
+            heartbeat_task.cancel()
+            await asyncio.gather(
+                pipeline_task,
+                heartbeat_task,
+                return_exceptions=True,
+            )
+            raise
         except Exception as exc:  # noqa: BLE001 — terminal error sink
             await self._mark_error(
                 user_id,

--- a/tests/index_worker_lease_test.py
+++ b/tests/index_worker_lease_test.py
@@ -97,6 +97,8 @@ class _SlowPipelineWorker(IndexWorker):
         self.pipeline_started = asyncio.Event()
         self.pipeline_cancelled = False
         self.pipeline_completed = False
+        self.heartbeat_started = asyncio.Event()
+        self.heartbeat_stopped = False
 
     async def _run_pipeline(
         self,
@@ -113,6 +115,23 @@ class _SlowPipelineWorker(IndexWorker):
         except asyncio.CancelledError:
             self.pipeline_cancelled = True
             raise
+
+    async def _heartbeat(
+        self,
+        user_id: str,
+        knowledge_base_id: str,
+        document_id: str,
+    ) -> None:
+        """Record heartbeat lifecycle while preserving worker behavior."""
+        self.heartbeat_started.set()
+        try:
+            await super()._heartbeat(
+                user_id,
+                knowledge_base_id,
+                document_id,
+            )
+        finally:
+            self.heartbeat_stopped = True
 
 
 class IndexWorkerLeaseTest(IsolatedAsyncioTestCase):
@@ -180,22 +199,27 @@ class IndexWorkerLeaseTest(IsolatedAsyncioTestCase):
         )
         self.assertEqual(len(storage.released), 1)
 
-    async def test_external_cancellation_stops_child_tasks(self) -> None:
-        """Caller cancellation must tear down pipeline and heartbeat tasks."""
+    async def test_external_cancel_stops_child_tasks_and_releases(
+        self,
+    ) -> None:
+        """Caller cancellation must tear down pipeline and heartbeat."""
         storage = _LeaseStorage()
 
-        worker = _SlowPipelineWorker(storage, pipeline_seconds=0.5)
-        task = asyncio.create_task(
-            worker.process("u", "kb", "doc-cancel"),
+        worker = _SlowPipelineWorker(storage, pipeline_seconds=5.0)
+        process_task = asyncio.create_task(
+            worker.process("u", "kb", "doc-cancelled"),
         )
-        await asyncio.wait_for(worker.pipeline_started.wait(), timeout=1.0)
+        await asyncio.wait_for(
+            asyncio.gather(
+                worker.pipeline_started.wait(),
+                worker.heartbeat_started.wait(),
+            ),
+            timeout=1.0,
+        )
 
-        task.cancel()
+        process_task.cancel()
         with self.assertRaises(asyncio.CancelledError):
-            await asyncio.wait_for(task, timeout=1.0)
-
-        renew_calls_after_cancel = storage.renew_calls
-        await asyncio.sleep(0.15)
+            await asyncio.wait_for(process_task, timeout=1.0)
 
         self.assertTrue(
             worker.pipeline_cancelled,
@@ -205,10 +229,9 @@ class IndexWorkerLeaseTest(IsolatedAsyncioTestCase):
             worker.pipeline_completed,
             "Pipeline completed after worker.process was cancelled.",
         )
-        self.assertEqual(
-            storage.renew_calls,
-            renew_calls_after_cancel,
-            "Heartbeat kept renewing after worker.process was cancelled.",
+        self.assertTrue(
+            worker.heartbeat_stopped,
+            "Heartbeat kept running after worker.process was cancelled.",
         )
         self.assertEqual(
             [u for u in storage.status_updates if u["status"] == "error"],

--- a/tests/index_worker_lease_test.py
+++ b/tests/index_worker_lease_test.py
@@ -180,6 +180,42 @@ class IndexWorkerLeaseTest(IsolatedAsyncioTestCase):
         )
         self.assertEqual(len(storage.released), 1)
 
+    async def test_external_cancellation_stops_child_tasks(self) -> None:
+        """Caller cancellation must tear down pipeline and heartbeat tasks."""
+        storage = _LeaseStorage()
+
+        worker = _SlowPipelineWorker(storage, pipeline_seconds=0.5)
+        task = asyncio.create_task(
+            worker.process("u", "kb", "doc-cancel"),
+        )
+        await asyncio.wait_for(worker.pipeline_started.wait(), timeout=1.0)
+
+        task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=1.0)
+
+        renew_calls_after_cancel = storage.renew_calls
+        await asyncio.sleep(0.15)
+
+        self.assertTrue(
+            worker.pipeline_cancelled,
+            "Pipeline kept running after worker.process was cancelled.",
+        )
+        self.assertFalse(
+            worker.pipeline_completed,
+            "Pipeline completed after worker.process was cancelled.",
+        )
+        self.assertEqual(
+            storage.renew_calls,
+            renew_calls_after_cancel,
+            "Heartbeat kept renewing after worker.process was cancelled.",
+        )
+        self.assertEqual(
+            [u for u in storage.status_updates if u["status"] == "error"],
+            [],
+        )
+        self.assertEqual(len(storage.released), 1)
+
     async def test_not_acquired_short_circuits(self) -> None:
         """When the lease is already held by another worker, do nothing."""
         storage = _LeaseStorage()


### PR DESCRIPTION
﻿## Summary

Fixes #2219.

`IndexWorker.process()` now explicitly handles external `asyncio.CancelledError` by cancelling and awaiting both child tasks it owns: the indexing pipeline task and the lease heartbeat task. It then re-raises cancellation so caller shutdown semantics stay unchanged.

## Root cause

`process()` raced `pipeline_task` and `heartbeat_task`, but only handled the internal outcomes where either child task finished first. When the parent `process()` coroutine itself was cancelled during shutdown, the existing broad `except Exception` did not catch `asyncio.CancelledError` on Python 3.11+, so the method released the document lease while the child tasks could keep running.

## Changes

- Add explicit external cancellation cleanup in `IndexWorker.process()`.
- Add a regression test covering caller cancellation of `worker.process(...)`.
- Assert the pipeline is cancelled, heartbeat renewals stop, no document error status is recorded, and the held lease is still released once.

## Validation

- `PYTHONPATH=C:\Users\79823\Documents\面试\agentscope-latest\src python -m pytest tests/index_worker_lease_test.py tests/service_index_task_consumer_test.py -q`
- `pre-commit run --files src/agentscope/app/_service/_index_worker.py tests/index_worker_lease_test.py`
