### PR TITLE
feat(agent): let an agent come with its own MCPs and skills

### DIFF
--- a/examples/web_ui/frontend/src/api/hub.ts
+++ b/examples/web_ui/frontend/src/api/hub.ts
@@ -12,8 +12,10 @@ import type {
 } from './types';
 
 /**
- * Card ids are opaque and may contain characters that are not path-safe —
- * ClawHub's search endpoint, for one, returns ids containing `:`.
+ * Hub ids are ours and path-safe, but encode anyway so a future one with
+ * a space or slash cannot break the URL. Card ids never go in the path:
+ * they are opaque strings minted by the hub — ClawHub's search endpoint
+ * returns `owner/slug` — and a `/` cannot survive a path segment.
  */
 const segment = (value: string) => encodeURIComponent(value);
 
@@ -39,7 +41,7 @@ export const hubApi = {
 			client.get<MCPHubPage>(`/hub/mcp/${segment(hubId)}/cards`, browseQuery(params)),
 
 		getCard: (hubId: string, cardId: string) =>
-			client.get<MCPCard>(`/hub/mcp/${segment(hubId)}/cards/${segment(cardId)}`),
+			client.get<MCPCard>(`/hub/mcp/${segment(hubId)}/card`, { card_id: cardId }),
 
 		/**
 		 * Renders the card's template with `body.values` into the user's
@@ -55,9 +57,9 @@ export const hubApi = {
 			options?: { silent?: boolean },
 		) =>
 			client.post<MCPView>(
-				`/hub/mcp/${segment(hubId)}/cards/${segment(cardId)}/install`,
+				`/hub/mcp/${segment(hubId)}/install`,
 				body,
-				undefined,
+				{ card_id: cardId },
 				options,
 			),
 	},
@@ -70,7 +72,7 @@ export const hubApi = {
 
 		/** Unlike the list endpoint, this also fetches the `SKILL.md` body. */
 		getCard: (hubId: string, cardId: string) =>
-			client.get<SkillCard>(`/hub/skill/${segment(hubId)}/cards/${segment(cardId)}`),
+			client.get<SkillCard>(`/hub/skill/${segment(hubId)}/card`, { card_id: cardId }),
 
 		/**
 		 * Records the card in the user's library. Like the MCP install this
@@ -80,9 +82,9 @@ export const hubApi = {
 		 */
 		install: (hubId: string, cardId: string, name?: string, options?: { silent?: boolean }) =>
 			client.post<SkillView>(
-				`/hub/skill/${segment(hubId)}/cards/${segment(cardId)}/install`,
+				`/hub/skill/${segment(hubId)}/install`,
 				undefined,
-				name ? { name } : undefined,
+				name ? { card_id: cardId, name } : { card_id: cardId },
 				options,
 			),
 	},

--- a/examples/web_ui/frontend/src/api/types.ts
+++ b/examples/web_ui/frontend/src/api/types.ts
@@ -47,6 +47,14 @@ export interface AgentData {
 	context_config: ContextConfig;
 	react_config: ReActConfig;
 	invite_config: InviteConfig;
+	/**
+	 * Library ids of the MCPs this agent comes with. Seeded into each of
+	 * its workspaces the first time that workspace boots, and never
+	 * again — editing the list only affects workspaces yet to exist.
+	 */
+	mcp_ids: string[];
+	/** Library ids of the skills it comes with. Same seeding. */
+	skill_ids: string[];
 }
 
 export interface AgentView extends RecordBase {
@@ -65,6 +73,8 @@ export interface CreateAgentRequest {
 	context_config?: ContextConfig;
 	react_config?: ReActConfig;
 	invite_config?: InviteConfig;
+	mcp_ids?: string[];
+	skill_ids?: string[];
 }
 
 export interface CreateAgentResponse {
@@ -77,6 +87,8 @@ export interface UpdateAgentRequest {
 	context_config?: ContextConfig;
 	react_config?: ReActConfig;
 	invite_config?: InviteConfig;
+	mcp_ids?: string[];
+	skill_ids?: string[];
 }
 
 export interface AgentListResponse {
@@ -405,6 +417,24 @@ export interface Skill {
 	dir: string;
 	markdown: string;
 	updated_at: number;
+}
+
+/**
+ * Names of the agent's own MCPs / skills that are not in the workspace,
+ * mapped to why. Populated when the workspace was first created: an MCP
+ * that would not connect, a skill whose hub is gone, a binding pointing
+ * at a deleted library record.
+ */
+export type SeedErrors = Record<string, string>;
+
+export interface ListWorkspaceMCPsResponse {
+	mcps: MCPClientStatus[];
+	seed_errors: SeedErrors;
+}
+
+export interface ListWorkspaceSkillsResponse {
+	skills: Skill[];
+	seed_errors: SeedErrors;
 }
 
 /**

--- a/examples/web_ui/frontend/src/api/workspace.ts
+++ b/examples/web_ui/frontend/src/api/workspace.ts
@@ -3,9 +3,9 @@ import type { UploadProgress } from './knowledgeBase';
 import type {
 	AddFromLibraryResponse,
 	AddSkillRequest,
+	ListWorkspaceMCPsResponse,
+	ListWorkspaceSkillsResponse,
 	MCPClient,
-	MCPClientStatus,
-	Skill,
 } from './types';
 
 export interface UploadOptions {
@@ -100,7 +100,7 @@ function uploadSkillXhr(
 export const workspaceApi = {
 	mcp: {
 		list: (agentId: string, sessionId: string) =>
-			client.get<MCPClientStatus[]>('/workspace/mcp', {
+			client.get<ListWorkspaceMCPsResponse>('/workspace/mcp', {
 				agent_id: agentId,
 				session_id: sessionId,
 			}),
@@ -129,7 +129,10 @@ export const workspaceApi = {
 
 	skill: {
 		list: (agentId: string, sessionId: string) =>
-			client.get<Skill[]>('/workspace/skill', { agent_id: agentId, session_id: sessionId }),
+			client.get<ListWorkspaceSkillsResponse>('/workspace/skill', {
+				agent_id: agentId,
+				session_id: sessionId,
+			}),
 
 		/**
 		 * @deprecated The path is resolved on the server. Use `upload`

--- a/examples/web_ui/frontend/src/components/chat/ASMessageBubble.tsx
+++ b/examples/web_ui/frontend/src/components/chat/ASMessageBubble.tsx
@@ -421,6 +421,8 @@ export function ASMessageBubble({ message }: MessageBubbleProps) {
 	const startMs = new Date(message.created_at).getTime();
 	const endMs = isRunning ? now : new Date(message.finished_at!).getTime();
 	const elapsedSeconds = Math.max(0, (endMs - startMs) / 1000);
+	// Left in the default English units: the badge stands alone with no
+	// surrounding sentence, so a bare "2m30s" reads fine in any locale.
 	const elapsedText = formatTime(elapsedSeconds);
 
 	return (
@@ -511,6 +513,8 @@ function ThinkingBlockView({ block }: { block: ThinkingBlock }) {
 	const startMs = new Date(block.created_at).getTime();
 	const endMs = isRunning ? now : new Date(block.finished_at!).getTime();
 	const elapsedSeconds = Math.max(0, (endMs - startMs) / 1000);
+	// Left in the default English units: the badge stands alone with no
+	// surrounding sentence, so a bare "2m30s" reads fine in any locale.
 	const elapsedText = formatTime(elapsedSeconds);
 	return (
 		<Collapsible>

--- a/examples/web_ui/frontend/src/components/dialog/AddMCPDialog.tsx
+++ b/examples/web_ui/frontend/src/components/dialog/AddMCPDialog.tsx
@@ -119,8 +119,14 @@ export function AddMCPDialog({ children, present, onAdd, onAddFromLibrary }: Pro
 					</TabsList>
 
 					{/* Fixed height on the shared container rather than per
-					    tab, so the dialog does not resize as you switch. */}
-					<div className="mt-4 h-80 overflow-y-auto scroll-fade">
+					    tab, so the dialog does not resize as you switch.
+
+					    ``-mx-4 px-4``: ``overflow-y-auto`` makes the x axis
+					    clip too, which would slice the focus ring off both
+					    sides of a full-width input. The padding gives the
+					    ring room; the negative margin keeps content at the
+					    same x. */}
+					<div className="-mx-4 mt-4 h-80 overflow-y-auto px-4 scroll-fade">
 						<TabsContent value="installed">
 							{loading ? (
 								<div className="flex justify-center py-10">

--- a/examples/web_ui/frontend/src/components/dialog/AgentDialog.tsx
+++ b/examples/web_ui/frontend/src/components/dialog/AgentDialog.tsx
@@ -3,12 +3,13 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { ContextConfig, InviteConfig, ReActConfig } from '@/api';
+import type { AgentBindings } from '@/components/form/AgentBindingFields';
 import {
-	AgentFormFields,
 	defaultAgentFormValues,
 	type AgentFormValues,
 	type AgentSection,
 } from '@/components/form/AgentFormFields';
+import { AgentFormTabs } from '@/components/form/AgentFormTabs';
 import type { SchemaFormValue } from '@/components/form/SchemaForm';
 import { Alert, AlertDescription } from '@/components/ui/alert.tsx';
 import { Button } from '@/components/ui/button';
@@ -37,6 +38,10 @@ export function AgentDialog({ onCreated, triggerId }: Props) {
 	const [open, setOpen] = useState(false);
 	const [submitting, setSubmitting] = useState(false);
 	const [values, setValues] = useState<AgentFormValues | null>(null);
+	const [bindings, setBindings] = useState<AgentBindings>({
+		mcp_ids: [],
+		skill_ids: [],
+	});
 	const [errorMsg, setErrorMsg] = useState('');
 
 	useEffect(() => {
@@ -45,6 +50,7 @@ export function AgentDialog({ onCreated, triggerId }: Props) {
 		}
 		if (!open) {
 			setValues(null);
+			setBindings({ mcp_ids: [], skill_ids: [] });
 			setErrorMsg('');
 		}
 	}, [open, schema, values]);
@@ -70,6 +76,7 @@ export function AgentDialog({ onCreated, triggerId }: Props) {
 					context_config: values.context_config as unknown as ContextConfig,
 					react_config: values.react_config as unknown as ReActConfig,
 					invite_config: values.invite_config as unknown as InviteConfig,
+					...bindings,
 				},
 				{ silent: true },
 			);
@@ -92,20 +99,24 @@ export function AgentDialog({ onCreated, triggerId }: Props) {
 					<span>{t('dialog-agent-create.trigger')}</span>
 				</Button>
 			</DialogTrigger>
-			<DialogContent className="!w-[500px] !max-w-[500px]">
+			<DialogContent className="sm:max-w-2xl">
 				<DialogHeader>
 					<DialogTitle>{t('dialog-agent-create.title')}</DialogTitle>
 					<DialogDescription className="sr-only">
 						{t('dialog-agent-create.description')}
 					</DialogDescription>
 				</DialogHeader>
-				<div className="no-scrollbar -mx-4 max-h-[75vh] overflow-y-auto px-4">
-					{schema && values ? (
-						<AgentFormFields schema={schema} values={values} onChange={handleChange} />
-					) : (
-						<p className="text-muted-foreground text-sm">{t('common.loading')}</p>
-					)}
-				</div>
+				{schema && values ? (
+					<AgentFormTabs
+						schema={schema}
+						values={values}
+						onChange={handleChange}
+						bindings={bindings}
+						onBindingsChange={setBindings}
+					/>
+				) : (
+					<p className="text-muted-foreground text-sm">{t('common.loading')}</p>
+				)}
 				{errorMsg && (
 					<Alert variant="destructive">
 						<CircleAlert />

--- a/examples/web_ui/frontend/src/components/dialog/EditAgentDialog.tsx
+++ b/examples/web_ui/frontend/src/components/dialog/EditAgentDialog.tsx
@@ -3,12 +3,13 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { AgentView, ContextConfig, InviteConfig, ReActConfig } from '@/api';
+import type { AgentBindings } from '@/components/form/AgentBindingFields';
 import {
-	AgentFormFields,
 	defaultAgentFormValues,
 	type AgentFormValues,
 	type AgentSection,
 } from '@/components/form/AgentFormFields';
+import { AgentFormTabs } from '@/components/form/AgentFormTabs';
 import type { SchemaFormValue } from '@/components/form/SchemaForm';
 import { Alert, AlertDescription } from '@/components/ui/alert.tsx';
 import { Button } from '@/components/ui/button';
@@ -37,12 +38,17 @@ export function EditAgentDialog({ open, onOpenChange, agent, onUpdated }: Props)
 	const { schema } = useAgentSchema();
 	const [submitting, setSubmitting] = useState(false);
 	const [values, setValues] = useState<AgentFormValues | null>(null);
+	const [bindings, setBindings] = useState<AgentBindings>({
+		mcp_ids: [],
+		skill_ids: [],
+	});
 	const [errorMsg, setErrorMsg] = useState('');
 
 	useEffect(() => {
 		if (!open || !schema) {
 			if (!open) {
 				setValues(null);
+				setBindings({ mcp_ids: [], skill_ids: [] });
 				setErrorMsg('');
 			}
 			return;
@@ -60,6 +66,10 @@ export function EditAgentDialog({ open, onOpenChange, agent, onUpdated }: Props)
 			context_config: { ...base.context_config, ...(d.context_config ?? {}) },
 			react_config: { ...base.react_config, ...(d.react_config ?? {}) },
 			invite_config: { ...base.invite_config, ...(d.invite_config ?? {}) },
+		});
+		setBindings({
+			mcp_ids: d.mcp_ids ?? [],
+			skill_ids: d.skill_ids ?? [],
 		});
 		setErrorMsg('');
 	}, [open, schema, agent]);
@@ -86,6 +96,7 @@ export function EditAgentDialog({ open, onOpenChange, agent, onUpdated }: Props)
 					context_config: values.context_config as unknown as ContextConfig,
 					react_config: values.react_config as unknown as ReActConfig,
 					invite_config: values.invite_config as unknown as InviteConfig,
+					...bindings,
 				},
 				{ silent: true },
 			);
@@ -102,20 +113,24 @@ export function EditAgentDialog({ open, onOpenChange, agent, onUpdated }: Props)
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="!w-[500px] !max-w-[500px]">
+			<DialogContent className="sm:max-w-2xl">
 				<DialogHeader>
 					<DialogTitle>{t('dialog-agent-edit.title')}</DialogTitle>
 					<DialogDescription className="sr-only">
 						{t('dialog-agent-edit.description')}
 					</DialogDescription>
 				</DialogHeader>
-				<div className="no-scrollbar -mx-4 max-h-[75vh] overflow-y-auto px-4">
-					{schema && values ? (
-						<AgentFormFields schema={schema} values={values} onChange={handleChange} />
-					) : (
-						<p className="text-muted-foreground text-sm">{t('common.loading')}</p>
-					)}
-				</div>
+				{schema && values ? (
+					<AgentFormTabs
+						schema={schema}
+						values={values}
+						onChange={handleChange}
+						bindings={bindings}
+						onBindingsChange={setBindings}
+					/>
+				) : (
+					<p className="text-muted-foreground text-sm">{t('common.loading')}</p>
+				)}
 				{errorMsg && (
 					<Alert variant="destructive">
 						<CircleAlert />

--- a/examples/web_ui/frontend/src/components/dialog/EditAgentDialog.tsx
+++ b/examples/web_ui/frontend/src/components/dialog/EditAgentDialog.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/components/ui/dialog';
 import { useAgents } from '@/hooks/useAgents';
 import { useAgentSchema } from '@/hooks/useAgentSchema';
+import { useSessions } from '@/hooks/useSessions';
 import { formatApiErrorForAlert } from '@/lib/api-error';
 
 interface Props {
@@ -36,6 +37,9 @@ export function EditAgentDialog({ open, onOpenChange, agent, onUpdated }: Props)
 	const { update } = useAgents();
 	const { t } = useTranslation();
 	const { schema } = useAgentSchema();
+	// A session implies the workspace has booted, which is what
+	// freezes the seed list.
+	const { sessions } = useSessions(open ? agent.id : null);
 	const [submitting, setSubmitting] = useState(false);
 	const [values, setValues] = useState<AgentFormValues | null>(null);
 	const [bindings, setBindings] = useState<AgentBindings>({
@@ -127,6 +131,7 @@ export function EditAgentDialog({ open, onOpenChange, agent, onUpdated }: Props)
 						onChange={handleChange}
 						bindings={bindings}
 						onBindingsChange={setBindings}
+						hasWorkspace={sessions.length > 0}
 					/>
 				) : (
 					<p className="text-muted-foreground text-sm">{t('common.loading')}</p>

--- a/examples/web_ui/frontend/src/components/dialog/InstallMCPDialog.tsx
+++ b/examples/web_ui/frontend/src/components/dialog/InstallMCPDialog.tsx
@@ -1,4 +1,4 @@
-import { CircleAlert } from 'lucide-react';
+import { CircleAlert, Download, Save } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import { hubApi, mcpApi } from '@/api';
@@ -135,11 +135,22 @@ export function InstallMCPDialog({ card, editing, onOpenChange, onInstalled }: P
 				)}
 
 				<DialogFooter>
-					<Button variant="outline" onClick={() => onOpenChange(false)}>
+					<Button
+						variant="ghost"
+						onClick={() => onOpenChange(false)}
+						disabled={installing}
+					>
+						<CircleAlert className="size-3.5" />
 						{t('common.cancel')}
 					</Button>
 					<Button onClick={handleInstall} disabled={installing || !name}>
-						{installing && <Spinner />}
+						{installing ? (
+							<Spinner className="size-3.5" />
+						) : editing ? (
+							<Save className="size-3.5" />
+						) : (
+							<Download className="size-3.5" />
+						)}
 						{t(editing ? 'common.save' : 'mcp.install')}
 					</Button>
 				</DialogFooter>

--- a/examples/web_ui/frontend/src/components/form/AgentBindingFields.tsx
+++ b/examples/web_ui/frontend/src/components/form/AgentBindingFields.tsx
@@ -1,0 +1,171 @@
+import { PlusCircle, Search, SearchX } from 'lucide-react';
+import { useState } from 'react';
+
+import type { MCPView, SkillView } from '@/api';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar.tsx';
+import { Checkbox } from '@/components/ui/checkbox.tsx';
+import {
+	Empty,
+	EmptyDescription,
+	EmptyHeader,
+	EmptyMedia,
+	EmptyTitle,
+} from '@/components/ui/empty.tsx';
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group';
+import {
+	Item,
+	ItemContent,
+	ItemDescription,
+	ItemGroup,
+	ItemMedia,
+	ItemTitle,
+} from '@/components/ui/item.tsx';
+import { Spinner } from '@/components/ui/spinner.tsx';
+import { useMCPs } from '@/hooks/useMCPs.ts';
+import { useSkills } from '@/hooks/useSkills.ts';
+import { useTranslation } from '@/i18n/useI18n.ts';
+
+export interface AgentBindings {
+	mcp_ids: string[];
+	skill_ids: string[];
+}
+
+/** Which of the two lists to render. Doubles as the key into `values`. */
+export type AgentBindingKind = keyof AgentBindings;
+
+interface Props {
+	kind: AgentBindingKind;
+	values: AgentBindings;
+	onChange: (next: AgentBindings) => void;
+}
+
+/**
+ * One list of what the agent comes with, picked from the user's library.
+ *
+ * Hand-written rather than schema-driven: `mcp_ids` / `skill_ids` are
+ * lists of opaque ids that have to be picked, not typed, so they are
+ * marked `SkipJsonSchema` on the server and never reach `AgentFormFields`.
+ *
+ * Both hooks run whichever kind is shown — they are the user's own
+ * library, cheap, and prefetching the hidden tab means switching to it
+ * does not flash a spinner.
+ */
+export function AgentBindingFields({ kind, values, onChange }: Props) {
+	const { t } = useTranslation();
+	const { mcps, loading: mcpsLoading } = useMCPs();
+	const { skills, loading: skillsLoading } = useSkills();
+
+	const [search, setSearch] = useState('');
+
+	const isMcp = kind === 'mcp_ids';
+	const i18n = isMcp ? 'mcps' : 'skills';
+	const loading = isMcp ? mcpsLoading : skillsLoading;
+	const items: Array<MCPView | SkillView> = isMcp ? mcps : skills;
+	const picked = values[kind];
+
+	const needle = search.trim().toLowerCase();
+	const shown = needle
+		? items.filter((item) =>
+				[item.name, item.display_name ?? '', item.description, ...item.tags].some((field) =>
+					field.toLowerCase().includes(needle),
+				),
+			)
+		: items;
+
+	const toggle = (id: string) => {
+		onChange({
+			...values,
+			[kind]: picked.includes(id) ? picked.filter((i) => i !== id) : [...picked, id],
+		});
+	};
+
+	return (
+		<div className="flex flex-col gap-y-3">
+			<p className="text-muted-foreground text-sm">
+				{t(`agent-form.bindings.${i18n}.description`)}
+			</p>
+			<InputGroup>
+				<InputGroupInput
+					placeholder={t(`agent-form.bindings.${i18n}.searchPlaceholder`)}
+					value={search}
+					onChange={(e) => setSearch(e.target.value)}
+				/>
+				<InputGroupAddon align="inline-end">
+					<Search />
+				</InputGroupAddon>
+			</InputGroup>
+			{loading ? (
+				<div className="flex justify-center py-10">
+					<Spinner />
+				</div>
+			) : shown.length === 0 ? (
+				<Empty className="border-none py-10">
+					<EmptyHeader>
+						<EmptyMedia variant="icon">
+							{needle ? <SearchX /> : <PlusCircle />}
+						</EmptyMedia>
+						<EmptyTitle>
+							{needle
+								? t('panel.search.emptyTitle')
+								: t(`agent-form.bindings.${i18n}.emptyTitle`)}
+						</EmptyTitle>
+						<EmptyDescription>
+							{needle
+								? t('panel.search.emptyDescription', { query: search })
+								: t(`agent-form.bindings.${i18n}.empty`)}
+						</EmptyDescription>
+					</EmptyHeader>
+				</Empty>
+			) : (
+				<ItemGroup className="gap-1">
+					{shown.map((item) => (
+						<Item key={item.id}>
+							<Checkbox
+								checked={picked.includes(item.id)}
+								onCheckedChange={() => toggle(item.id)}
+							/>
+							<ItemMedia>
+								<Avatar className="rounded-md">
+									<AvatarImage
+										src={item.icon_url ?? undefined}
+										alt={item.display_name || item.name}
+										loading="lazy"
+									/>
+									<AvatarFallback className="rounded-md">
+										{(item.display_name || item.name).slice(0, 1).toUpperCase()}
+									</AvatarFallback>
+								</Avatar>
+							</ItemMedia>
+							<ItemContent>
+								{/* Name, author, tags — each step lighter than
+								    the last, so the eye lands on the name
+								    first. */}
+								<ItemTitle>
+									<span className="font-medium">
+										{item.display_name || item.name}
+									</span>
+									{item.author && (
+										<span className="text-xs text-muted-foreground">
+											@{item.author}
+										</span>
+									)}
+									{item.tags.slice(0, 4).map((tag) => (
+										<span
+											key={tag}
+											className="text-xs text-muted-foreground/60"
+										>
+											#{tag}
+										</span>
+									))}
+								</ItemTitle>
+								<ItemDescription className="line-clamp-1">
+									{item.description}
+								</ItemDescription>
+							</ItemContent>
+						</Item>
+					))}
+				</ItemGroup>
+			)}
+		</div>
+	);
+}

--- a/examples/web_ui/frontend/src/components/form/AgentBindingFields.tsx
+++ b/examples/web_ui/frontend/src/components/form/AgentBindingFields.tsx
@@ -1,11 +1,14 @@
-import { PlusCircle, Search, SearchX } from 'lucide-react';
+import { PlusCircle, Search, SearchX, Store } from 'lucide-react';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import type { MCPView, SkillView } from '@/api';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar.tsx';
+import { Button } from '@/components/ui/button.tsx';
 import { Checkbox } from '@/components/ui/checkbox.tsx';
 import {
 	Empty,
+	EmptyContent,
 	EmptyDescription,
 	EmptyHeader,
 	EmptyMedia,
@@ -55,6 +58,7 @@ export function AgentBindingFields({ kind, values, onChange }: Props) {
 	const { mcps, loading: mcpsLoading } = useMCPs();
 	const { skills, loading: skillsLoading } = useSkills();
 
+	const navigate = useNavigate();
 	const [search, setSearch] = useState('');
 
 	const isMcp = kind === 'mcp_ids';
@@ -84,15 +88,17 @@ export function AgentBindingFields({ kind, values, onChange }: Props) {
 			<p className="text-muted-foreground text-sm">
 				{t(`agent-form.bindings.${i18n}.description`)}
 			</p>
+			{/* Leading icon, matching the hub pages these lists are picked
+			    from. */}
 			<InputGroup>
+				<InputGroupAddon align="inline-start">
+					<Search />
+				</InputGroupAddon>
 				<InputGroupInput
 					placeholder={t(`agent-form.bindings.${i18n}.searchPlaceholder`)}
 					value={search}
 					onChange={(e) => setSearch(e.target.value)}
 				/>
-				<InputGroupAddon align="inline-end">
-					<Search />
-				</InputGroupAddon>
 			</InputGroup>
 			{loading ? (
 				<div className="flex justify-center py-10">
@@ -115,6 +121,20 @@ export function AgentBindingFields({ kind, values, onChange }: Props) {
 								: t(`agent-form.bindings.${i18n}.empty`)}
 						</EmptyDescription>
 					</EmptyHeader>
+					{/* Only offered when the library is genuinely empty — a
+					    search that found nothing is no reason to leave. */}
+					{!needle && (
+						<EmptyContent>
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={() => navigate(isMcp ? '/mcp' : '/skill')}
+							>
+								<Store />
+								{t(`agent-form.bindings.${i18n}.browseHub`)}
+							</Button>
+						</EmptyContent>
+					)}
 				</Empty>
 			) : (
 				<ItemGroup className="gap-1">

--- a/examples/web_ui/frontend/src/components/form/AgentBindingFields.tsx
+++ b/examples/web_ui/frontend/src/components/form/AgentBindingFields.tsx
@@ -1,8 +1,9 @@
-import { PlusCircle, Search, SearchX, Store } from 'lucide-react';
+import { CircleAlert, PlusCircle, Search, SearchX, Store } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import type { MCPView, SkillView } from '@/api';
+import { Alert, AlertDescription } from '@/components/ui/alert.tsx';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar.tsx';
 import { Button } from '@/components/ui/button.tsx';
 import { Checkbox } from '@/components/ui/checkbox.tsx';
@@ -40,6 +41,12 @@ interface Props {
 	kind: AgentBindingKind;
 	values: AgentBindings;
 	onChange: (next: AgentBindings) => void;
+	/**
+	 * Whether this agent already has a workspace, in which case editing
+	 * the list changes nothing about it — seeding happens once, at
+	 * creation. Left `false` on the create form, where it cannot apply.
+	 */
+	hasWorkspace?: boolean;
 }
 
 /**
@@ -53,7 +60,7 @@ interface Props {
  * library, cheap, and prefetching the hidden tab means switching to it
  * does not flash a spinner.
  */
-export function AgentBindingFields({ kind, values, onChange }: Props) {
+export function AgentBindingFields({ kind, values, onChange, hasWorkspace = false }: Props) {
 	const { t } = useTranslation();
 	const { mcps, loading: mcpsLoading } = useMCPs();
 	const { skills, loading: skillsLoading } = useSkills();
@@ -88,6 +95,12 @@ export function AgentBindingFields({ kind, values, onChange }: Props) {
 			<p className="text-muted-foreground text-sm">
 				{t(`agent-form.bindings.${i18n}.description`)}
 			</p>
+			{hasWorkspace && (
+				<Alert>
+					<CircleAlert />
+					<AlertDescription>{t('agent-form.bindings.alreadySeeded')}</AlertDescription>
+				</Alert>
+			)}
 			{/* Leading icon, matching the hub pages these lists are picked
 			    from. */}
 			<InputGroup>

--- a/examples/web_ui/frontend/src/components/form/AgentFormTabs.tsx
+++ b/examples/web_ui/frontend/src/components/form/AgentFormTabs.tsx
@@ -1,0 +1,73 @@
+import type { AgentSchemaV2Response } from '@/api';
+import { AgentBindingFields, type AgentBindings } from '@/components/form/AgentBindingFields';
+import {
+	AgentFormFields,
+	type AgentFormValues,
+	type AgentSection,
+} from '@/components/form/AgentFormFields';
+import type { SchemaFormValue } from '@/components/form/SchemaForm';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs.tsx';
+import { useTranslation } from '@/i18n/useI18n.ts';
+
+interface Props {
+	schema: AgentSchemaV2Response;
+	values: AgentFormValues;
+	onChange: (section: AgentSection, key: string, value: SchemaFormValue) => void;
+	bindings: AgentBindings;
+	onBindingsChange: (next: AgentBindings) => void;
+}
+
+/**
+ * The agent create / edit form, split across tabs.
+ *
+ * The schema-driven fields alone already overflow the dialog, and what
+ * the agent comes with is a separate decision from how it thinks — so
+ * the two picker lists get their own tabs rather than being appended to
+ * an even longer scroll.
+ */
+export function AgentFormTabs({ schema, values, onChange, bindings, onBindingsChange }: Props) {
+	const { t } = useTranslation();
+
+	return (
+		<Tabs defaultValue="general">
+			<TabsList className="w-full">
+				<TabsTrigger value="general" className="flex-1">
+					{t('agent-form.tabs.general')}
+				</TabsTrigger>
+				<TabsTrigger value="mcps" className="flex-1">
+					{t('agent-form.tabs.mcps')}
+				</TabsTrigger>
+				<TabsTrigger value="skills" className="flex-1">
+					{t('agent-form.tabs.skills')}
+				</TabsTrigger>
+			</TabsList>
+
+			{/* Fixed height on the shared container rather than per tab, so
+			    the dialog does not resize as you switch.
+
+			    ``-mx-4 px-4``: ``overflow-y-auto`` makes the x axis clip
+			    too, which would slice the focus ring off both sides of a
+			    full-width input. The padding gives the ring room; the
+			    negative margin keeps content at the same x. */}
+			<div className="-mx-4 mt-4 h-[60vh] overflow-y-auto px-4 scroll-fade">
+				<TabsContent value="general">
+					<AgentFormFields schema={schema} values={values} onChange={onChange} />
+				</TabsContent>
+				<TabsContent value="mcps">
+					<AgentBindingFields
+						kind="mcp_ids"
+						values={bindings}
+						onChange={onBindingsChange}
+					/>
+				</TabsContent>
+				<TabsContent value="skills">
+					<AgentBindingFields
+						kind="skill_ids"
+						values={bindings}
+						onChange={onBindingsChange}
+					/>
+				</TabsContent>
+			</div>
+		</Tabs>
+	);
+}

--- a/examples/web_ui/frontend/src/components/form/AgentFormTabs.tsx
+++ b/examples/web_ui/frontend/src/components/form/AgentFormTabs.tsx
@@ -15,6 +15,8 @@ interface Props {
 	onChange: (section: AgentSection, key: string, value: SchemaFormValue) => void;
 	bindings: AgentBindings;
 	onBindingsChange: (next: AgentBindings) => void;
+	/** Passed through — see {@link AgentBindingFields}. */
+	hasWorkspace?: boolean;
 }
 
 /**
@@ -25,7 +27,14 @@ interface Props {
  * the two picker lists get their own tabs rather than being appended to
  * an even longer scroll.
  */
-export function AgentFormTabs({ schema, values, onChange, bindings, onBindingsChange }: Props) {
+export function AgentFormTabs({
+	schema,
+	values,
+	onChange,
+	bindings,
+	onBindingsChange,
+	hasWorkspace = false,
+}: Props) {
 	const { t } = useTranslation();
 
 	return (
@@ -58,6 +67,7 @@ export function AgentFormTabs({ schema, values, onChange, bindings, onBindingsCh
 						kind="mcp_ids"
 						values={bindings}
 						onChange={onBindingsChange}
+						hasWorkspace={hasWorkspace}
 					/>
 				</TabsContent>
 				<TabsContent value="skills">
@@ -65,6 +75,7 @@ export function AgentFormTabs({ schema, values, onChange, bindings, onBindingsCh
 						kind="skill_ids"
 						values={bindings}
 						onChange={onBindingsChange}
+						hasWorkspace={hasWorkspace}
 					/>
 				</TabsContent>
 			</div>

--- a/examples/web_ui/frontend/src/components/panel/McpPanel.tsx
+++ b/examples/web_ui/frontend/src/components/panel/McpPanel.tsx
@@ -9,10 +9,11 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 
-import type { MCPClient, MCPClientStatus, MCPView } from '@/api';
+import type { MCPClient, MCPClientStatus, MCPView, SeedErrors as SeedErrorMap } from '@/api';
 import { AddMCPDialog } from '@/components/dialog/AddMCPDialog.tsx';
 import { DeleteDialog } from '@/components/dialog/DeleteDialog.tsx';
 import { PanelEmpty } from '@/components/panel/PanelEmpty';
+import { SeedErrors } from '@/components/panel/SeedErrors';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert.tsx';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar.tsx';
 import { Button } from '@/components/ui/button';
@@ -37,6 +38,8 @@ import { useTranslation } from '@/i18n/useI18n.ts';
 interface McpPanelProps {
 	/** The MCP servers equipped in the workspace. */
 	mcps: MCPClientStatus[];
+	/** What the agent came with but could not be given. */
+	seedErrors?: SeedErrorMap;
 	/** Whether the MCP list is still loading. */
 	loading?: boolean;
 	/**
@@ -196,6 +199,7 @@ function McpRow({ mcp, installed, onDelete }: McpRowProps) {
  */
 export function McpPanel({
 	mcps,
+	seedErrors = {},
 	loading = false,
 	onAdd,
 	onAddFromLibrary,
@@ -217,6 +221,7 @@ export function McpPanel({
 	return (
 		<div className="flex flex-col flex-1 min-h-0 gap-y-2">
 			<span className="text-muted-foreground text-sm">{t('panel.mcp.description')}</span>
+			<SeedErrors errors={seedErrors} />
 			<InputGroup>
 				<InputGroupInput
 					placeholder={t('panel.mcp.searchPlaceholder')}

--- a/examples/web_ui/frontend/src/components/panel/SeedErrors.tsx
+++ b/examples/web_ui/frontend/src/components/panel/SeedErrors.tsx
@@ -1,0 +1,40 @@
+import { CircleAlert } from 'lucide-react';
+
+import type { SeedErrors as SeedErrorMap } from '@/api';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert.tsx';
+import { useTranslation } from '@/i18n/useI18n.ts';
+
+interface SeedErrorsProps {
+	/** Names the agent came with that are not here, mapped to why. */
+	errors: SeedErrorMap;
+}
+
+/**
+ * Why something the agent comes with is missing from this workspace.
+ *
+ * The workspace is seeded once, when it is first created, so a failure
+ * there leaves no trace in the list itself — a stateful MCP that would
+ * not connect is simply absent, not red. This is the only place that
+ * reason surfaces.
+ */
+export function SeedErrors({ errors }: SeedErrorsProps) {
+	const { t } = useTranslation();
+	const entries = Object.entries(errors);
+	if (entries.length === 0) return null;
+
+	return (
+		<Alert variant="destructive">
+			<CircleAlert />
+			<AlertTitle>{t('panel.seedErrors.title')}</AlertTitle>
+			<AlertDescription>
+				<ul className="list-disc space-y-1 pl-4">
+					{entries.map(([name, why]) => (
+						<li key={name} className="break-words">
+							<span className="font-medium">{name}</span>: {why}
+						</li>
+					))}
+				</ul>
+			</AlertDescription>
+		</Alert>
+	);
+}

--- a/examples/web_ui/frontend/src/components/panel/SkillPanel.tsx
+++ b/examples/web_ui/frontend/src/components/panel/SkillPanel.tsx
@@ -1,11 +1,12 @@
 import { FileX, PlusCircle, Search, SearchX, Trash } from 'lucide-react';
 import { useState } from 'react';
 
-import type { Skill } from '@/api';
+import type { Skill, SeedErrors as SeedErrorMap } from '@/api';
 import type { UploadOptions } from '@/api/workspace';
 import { AddSkillDialog } from '@/components/dialog/AddSkillDialog.tsx';
 import { DeleteDialog } from '@/components/dialog/DeleteDialog.tsx';
 import { PanelEmpty } from '@/components/panel/PanelEmpty';
+import { SeedErrors } from '@/components/panel/SeedErrors';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar.tsx';
 import { Button } from '@/components/ui/button';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group';
@@ -23,6 +24,8 @@ import { useTranslation } from '@/i18n/useI18n.ts';
 interface SkillPanelProps {
 	/** The skills equipped in the workspace. */
 	skills: Skill[];
+	/** What the agent came with but could not be given. */
+	seedErrors?: SeedErrorMap;
 	/** Whether the skill list is still loading. */
 	loading?: boolean;
 	/**
@@ -64,6 +67,7 @@ interface SkillPanelProps {
  */
 export function SkillPanel({
 	skills,
+	seedErrors = {},
 	loading = false,
 	onUpload,
 	onAddFromLibrary,
@@ -85,6 +89,7 @@ export function SkillPanel({
 	return (
 		<div className="flex flex-col flex-1 min-h-0 gap-y-2">
 			<span className="text-muted-foreground text-sm">{t('panel.skill.description')}</span>
+			<SeedErrors errors={seedErrors} />
 			<InputGroup>
 				<InputGroupInput
 					placeholder={t('panel.skill.searchPlaceholder')}

--- a/examples/web_ui/frontend/src/hooks/useTimeUnits.ts
+++ b/examples/web_ui/frontend/src/hooks/useTimeUnits.ts
@@ -1,0 +1,30 @@
+import { useMemo } from 'react';
+
+import { useTranslation } from '@/i18n/useI18n.ts';
+import type { TimeUnits } from '@/utils/common';
+
+/**
+ * Translated unit suffixes for {@link formatTime}.
+ *
+ * `formatTime` is a pure util and cannot reach i18n itself, so a caller
+ * that renders **into a localised sentence** has to hand it these —
+ * otherwise a Chinese "{{ago}}前更新" comes out as "2mon前更新".
+ *
+ * A duration badge that stands on its own is the opposite case and
+ * should keep the default English units: it reads as a compact figure
+ * rather than as prose, and translating it only makes it wider.
+ */
+export function useTimeUnits(): TimeUnits {
+	const { t } = useTranslation();
+	return useMemo(
+		() => ({
+			s: t('common.timeUnits.s'),
+			m: t('common.timeUnits.m'),
+			h: t('common.timeUnits.h'),
+			d: t('common.timeUnits.d'),
+			mon: t('common.timeUnits.mon'),
+			y: t('common.timeUnits.y'),
+		}),
+		[t],
+	);
+}

--- a/examples/web_ui/frontend/src/hooks/useWorkspace.ts
+++ b/examples/web_ui/frontend/src/hooks/useWorkspace.ts
@@ -1,12 +1,17 @@
 import { useState, useEffect, useCallback } from 'react';
 
 import { workspaceApi } from '@/api';
-import type { MCPClient, MCPClientStatus, Skill } from '@/api';
+import type { MCPClient, MCPClientStatus, SeedErrors, Skill } from '@/api';
 import type { UploadOptions } from '@/api/workspace';
 
 export function useWorkspace(agentId: string | null, sessionId: string | null) {
 	const [mcps, setMcps] = useState<MCPClientStatus[]>([]);
 	const [skills, setSkills] = useState<Skill[]>([]);
+	// What the agent came with but could not be given. Computed server
+	// side against what is actually in the workspace, so a tool the user
+	// removed on purpose never shows up here.
+	const [mcpSeedErrors, setMcpSeedErrors] = useState<SeedErrors>({});
+	const [skillSeedErrors, setSkillSeedErrors] = useState<SeedErrors>({});
 	const [loading, setLoading] = useState(false);
 	const [skillsLoading, setSkillsLoading] = useState(false);
 	const [error, setError] = useState<Error | null>(null);
@@ -19,7 +24,9 @@ export function useWorkspace(agentId: string | null, sessionId: string | null) {
 		setLoading(true);
 		setError(null);
 		try {
-			setMcps(await workspaceApi.mcp.list(agentId, sessionId));
+			const body = await workspaceApi.mcp.list(agentId, sessionId);
+			setMcps(body.mcps);
+			setMcpSeedErrors(body.seed_errors);
 		} catch (e) {
 			setError(e as Error);
 		} finally {
@@ -34,7 +41,9 @@ export function useWorkspace(agentId: string | null, sessionId: string | null) {
 		}
 		setSkillsLoading(true);
 		try {
-			setSkills(await workspaceApi.skill.list(agentId, sessionId));
+			const body = await workspaceApi.skill.list(agentId, sessionId);
+			setSkills(body.skills);
+			setSkillSeedErrors(body.seed_errors);
 		} catch (e) {
 			setError(e as Error);
 		} finally {
@@ -132,6 +141,8 @@ export function useWorkspace(agentId: string | null, sessionId: string | null) {
 
 	return {
 		mcps,
+		mcpSeedErrors,
+		skillSeedErrors,
 		loading,
 		error,
 		refetch,

--- a/examples/web_ui/frontend/src/i18n/locales/en.json
+++ b/examples/web_ui/frontend/src/i18n/locales/en.json
@@ -221,6 +221,7 @@
 			}
 		},
 		"bindings": {
+			"alreadySeeded": "This agent already has a workspace — changes apply to new ones only.",
 			"mcps": {
 				"browseHub": "Browse MCP hubs",
 				"description": "MCP servers the agent's workspace comes with, injected once when that workspace is created.",

--- a/examples/web_ui/frontend/src/i18n/locales/en.json
+++ b/examples/web_ui/frontend/src/i18n/locales/en.json
@@ -50,7 +50,15 @@
 		"mine": "Mine",
 		"my-mcp": "Installed MCPs",
 		"skill-hub": "Skill Hub",
-		"my-skill": "Installed skills"
+		"my-skill": "Installed skills",
+		"timeUnits": {
+			"s": "s",
+			"m": "m",
+			"h": "h",
+			"d": "d",
+			"mon": "mon",
+			"y": "y"
+		}
 	},
 	"error": {
 		"description": "The page hit an unexpected error. You can retry or go back home.",
@@ -214,13 +222,15 @@
 		},
 		"bindings": {
 			"mcps": {
-				"description": "MCP servers the agent's workspace comes with.",
+				"browseHub": "Browse MCP hubs",
+				"description": "MCP servers the agent's workspace comes with, injected once when that workspace is created.",
 				"empty": "Install one from a hub first, then it can be picked here.",
 				"emptyTitle": "No MCP servers yet",
 				"searchPlaceholder": "Search MCP servers"
 			},
 			"skills": {
-				"description": "Skills the agent's workspace comes with.",
+				"browseHub": "Browse skill hubs",
+				"description": "Skills the agent's workspace comes with, injected once when that workspace is created.",
 				"empty": "Install one from a hub first, then it can be picked here.",
 				"emptyTitle": "No skills yet",
 				"searchPlaceholder": "Search skills"

--- a/examples/web_ui/frontend/src/i18n/locales/en.json
+++ b/examples/web_ui/frontend/src/i18n/locales/en.json
@@ -211,6 +211,25 @@
 				"label": "Invite description",
 				"placeholder": "Briefly describe this agent's expertise; required when invitable is on."
 			}
+		},
+		"bindings": {
+			"mcps": {
+				"description": "MCP servers the agent's workspace comes with.",
+				"empty": "Install one from a hub first, then it can be picked here.",
+				"emptyTitle": "No MCP servers yet",
+				"searchPlaceholder": "Search MCP servers"
+			},
+			"skills": {
+				"description": "Skills the agent's workspace comes with.",
+				"empty": "Install one from a hub first, then it can be picked here.",
+				"emptyTitle": "No skills yet",
+				"searchPlaceholder": "Search skills"
+			}
+		},
+		"tabs": {
+			"general": "General",
+			"mcps": "Seed MCPs",
+			"skills": "Seed Skills"
 		}
 	},
 	"dialog-agent-edit": {
@@ -607,7 +626,10 @@
 			"emptyTitle": "No results",
 			"emptyDescription": "Nothing matches “{{query}}”."
 		},
-		"loading": "Loading…"
+		"loading": "Loading…",
+		"seedErrors": {
+			"title": "Some of this agent's own tools are missing"
+		}
 	},
 	"team-sidebar": {
 		"membersHeading": "Members",

--- a/examples/web_ui/frontend/src/i18n/locales/zh.json
+++ b/examples/web_ui/frontend/src/i18n/locales/zh.json
@@ -50,7 +50,15 @@
 		"mine": "我的",
 		"my-mcp": "已安装的 MCP",
 		"skill-hub": "技能中心",
-		"my-skill": "已安装的技能"
+		"my-skill": "已安装的技能",
+		"timeUnits": {
+			"s": "秒",
+			"m": "分",
+			"h": "小时",
+			"d": "天",
+			"mon": "个月",
+			"y": "年"
+		}
 	},
 	"error": {
 		"description": "页面遇到意外错误。你可以重试或返回首页。",
@@ -214,13 +222,15 @@
 		},
 		"bindings": {
 			"mcps": {
-				"description": "智能体工作区中自带的 MCP 服务。",
+				"browseHub": "去 MCP 中心看看",
+				"description": "智能体工作区自带的 MCP 服务，只在创建工作区时一次性注入。",
 				"empty": "先从中心安装一个，之后就能在这里选。",
 				"emptyTitle": "还没有 MCP 服务",
 				"searchPlaceholder": "搜索 MCP 服务"
 			},
 			"skills": {
-				"description": "智能体工作区中自带的技能。",
+				"browseHub": "去技能中心看看",
+				"description": "智能体工作区自带的技能，只在创建工作区时一次性注入。",
 				"empty": "先从中心安装一个，之后就能在这里选。",
 				"emptyTitle": "还没有技能",
 				"searchPlaceholder": "搜索技能"

--- a/examples/web_ui/frontend/src/i18n/locales/zh.json
+++ b/examples/web_ui/frontend/src/i18n/locales/zh.json
@@ -221,6 +221,7 @@
 			}
 		},
 		"bindings": {
+			"alreadySeeded": "该智能体已有工作区，改动只对新工作区生效。",
 			"mcps": {
 				"browseHub": "去 MCP 中心看看",
 				"description": "智能体工作区自带的 MCP 服务，只在创建工作区时一次性注入。",

--- a/examples/web_ui/frontend/src/i18n/locales/zh.json
+++ b/examples/web_ui/frontend/src/i18n/locales/zh.json
@@ -211,6 +211,25 @@
 				"label": "邀请说明",
 				"placeholder": "简要描述此 Agent 的专长；允许被邀请时必填。"
 			}
+		},
+		"bindings": {
+			"mcps": {
+				"description": "智能体工作区中自带的 MCP 服务。",
+				"empty": "先从中心安装一个，之后就能在这里选。",
+				"emptyTitle": "还没有 MCP 服务",
+				"searchPlaceholder": "搜索 MCP 服务"
+			},
+			"skills": {
+				"description": "智能体工作区中自带的技能。",
+				"empty": "先从中心安装一个，之后就能在这里选。",
+				"emptyTitle": "还没有技能",
+				"searchPlaceholder": "搜索技能"
+			}
+		},
+		"tabs": {
+			"general": "基本配置",
+			"mcps": "自带 MCP",
+			"skills": "自带技能"
 		}
 	},
 	"dialog-agent-edit": {
@@ -607,7 +626,10 @@
 			"emptyTitle": "无结果",
 			"emptyDescription": "没有匹配 “{{query}}” 的结果。"
 		},
-		"loading": "加载中…"
+		"loading": "加载中…",
+		"seedErrors": {
+			"title": "该智能体自带的部分工具没有装上"
+		}
 	},
 	"team-sidebar": {
 		"membersHeading": "成员",

--- a/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
+++ b/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
@@ -163,6 +163,8 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 		});
 	const {
 		mcps,
+		mcpSeedErrors,
+		skillSeedErrors,
 		loading: mcpsLoading,
 		addMcps,
 		addMcpsFromLibrary,
@@ -233,6 +235,7 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 				content: (
 					<McpPanel
 						mcps={mcps}
+						seedErrors={mcpSeedErrors}
 						loading={mcpsLoading}
 						onAdd={addMcps}
 						onAddFromLibrary={addMcpsFromLibrary}
@@ -246,6 +249,7 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 				content: (
 					<SkillPanel
 						skills={skills}
+						seedErrors={skillSeedErrors}
 						loading={skillsLoading}
 						onUpload={uploadSkill}
 						onAddFromLibrary={addSkillsFromLibrary}
@@ -302,6 +306,8 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 			t,
 			tasksContext,
 			mcps,
+			mcpSeedErrors,
+			skillSeedErrors,
 			mcpsLoading,
 			addMcps,
 			addMcpsFromLibrary,

--- a/examples/web_ui/frontend/src/pages/mcp/index.tsx
+++ b/examples/web_ui/frontend/src/pages/mcp/index.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import { hubApi } from '@/api';
 import type { HubInfo, MCPCard, MCPView } from '@/api';
+import { DeleteDialog } from '@/components/dialog/DeleteDialog.tsx';
 import { InstallMCPDialog } from '@/components/dialog/InstallMCPDialog.tsx';
 import { ResourceDetailDrawer } from '@/components/drawer/ResourceDetailDrawer.tsx';
 import { LoadMore } from '@/components/hub/LoadMore.tsx';
@@ -46,6 +47,7 @@ import { useMCPHubCards } from '@/hooks/useMCPHubCards.ts';
 import { useMCPHubs } from '@/hooks/useMCPHubs.ts';
 import { useMCPs } from '@/hooks/useMCPs.ts';
 import { useResourceDrawer } from '@/hooks/useResourceDrawer.ts';
+import { useTimeUnits } from '@/hooks/useTimeUnits.ts';
 import { useTranslation } from '@/i18n/useI18n';
 import { formatTime } from '@/utils/common';
 
@@ -87,6 +89,7 @@ interface CardItemProps {
 
 function CardItem({ card, installed, now, onInstall, onOpen }: CardItemProps) {
 	const { t } = useTranslation();
+	const units = useTimeUnits();
 
 	return (
 		<Item className="cursor-pointer hover:bg-accent/50" onClick={onOpen}>
@@ -136,6 +139,7 @@ function CardItem({ card, installed, now, onInstall, onOpen }: CardItemProps) {
 							: t('skill.updatedAgo', {
 									ago: formatTime(now - card.updated_at, {
 										leadingUnitOnly: true,
+										units,
 									}),
 								})
 						: null}
@@ -320,6 +324,7 @@ interface MinePanelProps {
 }
 
 function MinePanel({ mcps, loading, onEdit, onRemove }: MinePanelProps) {
+	const [deleteTarget, setDeleteTarget] = useState<MCPView | null>(null);
 	const { t } = useTranslation();
 	const [query, setQuery] = useState('');
 
@@ -448,7 +453,7 @@ function MinePanel({ mcps, loading, onEdit, onRemove }: MinePanelProps) {
 										size="icon-sm"
 										variant="ghost"
 										className="text-muted-foreground"
-										onClick={() => onRemove(mcp.id)}
+										onClick={() => setDeleteTarget(mcp)}
 										title={t('common.delete')}
 									>
 										<Trash2 />
@@ -459,6 +464,20 @@ function MinePanel({ mcps, loading, onEdit, onRemove }: MinePanelProps) {
 					))}
 				</ItemGroup>
 			)}
+			<DeleteDialog
+				open={deleteTarget !== null}
+				onOpenChange={(open) => {
+					if (!open) setDeleteTarget(null);
+				}}
+				title={t('common.deleteTitle', {
+					entity: t('dialog-mcp-delete.entity'),
+					name: deleteTarget?.display_name || deleteTarget?.name || '',
+				})}
+				description={t('common.deleteDescription')}
+				onConfirm={async () => {
+					if (deleteTarget) await onRemove(deleteTarget.id);
+				}}
+			/>
 		</ResourcePanel>
 	);
 }

--- a/examples/web_ui/frontend/src/pages/skill/index.tsx
+++ b/examples/web_ui/frontend/src/pages/skill/index.tsx
@@ -5,6 +5,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import type { HubInfo, SkillCard, SkillView } from '@/api';
 import { hubApi, skillApi } from '@/api';
 import { ApiError } from '@/api/client';
+import { DeleteDialog } from '@/components/dialog/DeleteDialog.tsx';
 import { ResourceDetailDrawer } from '@/components/drawer/ResourceDetailDrawer.tsx';
 import { LoadMore } from '@/components/hub/LoadMore.tsx';
 import { ResourcePanel } from '@/components/hub/ResourcePanel.tsx';
@@ -44,6 +45,7 @@ import { useResourceDrawer } from '@/hooks/useResourceDrawer.ts';
 import { useSkillHubCards } from '@/hooks/useSkillHubCards.ts';
 import { useSkillHubs } from '@/hooks/useSkillHubs.ts';
 import { useSkills } from '@/hooks/useSkills.ts';
+import { useTimeUnits } from '@/hooks/useTimeUnits.ts';
 import { useTranslation } from '@/i18n/useI18n';
 import { formatTime } from '@/utils/common';
 
@@ -60,6 +62,7 @@ interface CardItemProps {
 
 function CardItem({ card, installed, installing, now, onInstall, onOpen }: CardItemProps) {
 	const { t } = useTranslation();
+	const units = useTimeUnits();
 
 	return (
 		<Item className="cursor-pointer hover:bg-accent/50" onClick={onOpen}>
@@ -105,6 +108,7 @@ function CardItem({ card, installed, installing, now, onInstall, onOpen }: CardI
 							: t('skill.updatedAgo', {
 									ago: formatTime(now - card.updated_at, {
 										leadingUnitOnly: true,
+										units,
 									}),
 								})
 						: null}
@@ -295,6 +299,7 @@ interface MinePanelProps {
 }
 
 function MinePanel({ skills, loading, onRemove }: MinePanelProps) {
+	const [deleteTarget, setDeleteTarget] = useState<SkillView | null>(null);
 	const { t } = useTranslation();
 	const [query, setQuery] = useState('');
 	// The list view omits SKILL.md; the detail endpoint carries it.
@@ -415,7 +420,7 @@ function MinePanel({ skills, loading, onRemove }: MinePanelProps) {
 										// open the drawer behind it.
 										onClick={(e) => {
 											e.stopPropagation();
-											onRemove(skill.id);
+											setDeleteTarget(skill);
 										}}
 										title={t('common.delete')}
 									>
@@ -438,7 +443,7 @@ function MinePanel({ skills, loading, onRemove }: MinePanelProps) {
 					<Button
 						variant="destructive"
 						onClick={() => {
-							if (drawer.opened) onRemove((drawer.opened as SkillView).id);
+							if (drawer.opened) setDeleteTarget(drawer.opened as SkillView);
 							drawer.close();
 						}}
 					>
@@ -446,6 +451,20 @@ function MinePanel({ skills, loading, onRemove }: MinePanelProps) {
 						{t('common.delete')}
 					</Button>
 				}
+			/>
+			<DeleteDialog
+				open={deleteTarget !== null}
+				onOpenChange={(open) => {
+					if (!open) setDeleteTarget(null);
+				}}
+				title={t('common.deleteTitle', {
+					entity: t('dialog-mcp-delete.skillEntity'),
+					name: deleteTarget?.display_name || deleteTarget?.name || '',
+				})}
+				description={t('common.deleteDescription')}
+				onConfirm={async () => {
+					if (deleteTarget) await onRemove(deleteTarget.id);
+				}}
 			/>
 		</ResourcePanel>
 	);

--- a/examples/web_ui/frontend/src/utils/common.ts
+++ b/examples/web_ui/frontend/src/utils/common.ts
@@ -80,41 +80,63 @@ export const formatDuration = (seconds: number): number => {
  *   badge when, e.g., a tool call sits awaiting user confirmation for hours.
  * - The same reasoning extends past a day: only the leading whole unit is
  *   shown, up to years. Months and years use average lengths, so they are
- *   approximate by construction — fine for "updated 3mo ago", wrong for
+ *   approximate by construction — fine for "updated 3mon ago", wrong for
  *   anything that needs calendar accuracy.
  *
  * @param seconds - The duration in seconds to format
  * @param options.leadingUnitOnly - Drop the trailing seconds from the
  *   minutes case, so `49m33s` reads `49m`. Defaults to `false`, keeping the
  *   two-segment form the elapsed-time badges rely on.
- * @returns Formatted string (e.g., "45s", "2min30s", "3h", "5d", "2y")
+ * @param options.units - Suffix per unit. Defaults to the English compact
+ *   set; pass translated ones so the result is not an English tail glued
+ *   onto a localised sentence.
+ * @returns Formatted string (e.g., "45s", "2m30s", "3h", "5d", "2y")
  */
+export interface TimeUnits {
+	s: string;
+	m: string;
+	h: string;
+	d: string;
+	mon: string;
+	y: string;
+}
+
+const DEFAULT_TIME_UNITS: TimeUnits = {
+	s: 's',
+	m: 'm',
+	h: 'h',
+	d: 'd',
+	mon: 'mon',
+	y: 'y',
+};
+
 export const formatTime = (
 	seconds: number,
-	options: { leadingUnitOnly?: boolean } = {},
+	options: { leadingUnitOnly?: boolean; units?: TimeUnits } = {},
 ): string => {
+	const u = options.units ?? DEFAULT_TIME_UNITS;
 	const total = Math.floor(seconds);
 	if (total < 60) {
-		return `${total}s`;
+		return `${total}${u.s}`;
 	}
 	if (total < 3600) {
 		const minutes = Math.floor(total / 60);
 		const remaining = total % 60;
 		if (options.leadingUnitOnly || remaining === 0) {
-			return `${minutes}m`;
+			return `${minutes}${u.m}`;
 		}
-		return `${minutes}m${remaining}s`;
+		return `${minutes}${u.m}${remaining}${u.s}`;
 	}
 	if (total < 86400) {
-		return `${Math.floor(total / 3600)}h`;
+		return `${Math.floor(total / 3600)}${u.h}`;
 	}
 	// 30.44 and 365.25 days — the average month and year, so a "1y" does
 	// not flip back to "12mo" for the leap-day stragglers.
 	if (total < 2629746) {
-		return `${Math.floor(total / 86400)}d`;
+		return `${Math.floor(total / 86400)}${u.d}`;
 	}
 	if (total < 31556952) {
-		return `${Math.floor(total / 2629746)}mo`;
+		return `${Math.floor(total / 2629746)}${u.mon}`;
 	}
-	return `${Math.floor(total / 31556952)}y`;
+	return `${Math.floor(total / 31556952)}${u.y}`;
 };

--- a/src/agentscope/app/_lifespan.py
+++ b/src/agentscope/app/_lifespan.py
@@ -108,6 +108,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             background_task_manager=bg_manager,
             message_bus=message_bus,
             resource_access_service=resource_access_service,
+            skill_hubs=app.state.skill_hubs,
             knowledge_base_manager=knowledge_base_manager,
             extra_agent_middlewares=app.state.extra_agent_middlewares,
             extra_agent_tools=app.state.extra_agent_tools,

--- a/src/agentscope/app/_router/_agent.py
+++ b/src/agentscope/app/_router/_agent.py
@@ -32,6 +32,44 @@ agent_router = APIRouter(
 )
 
 
+async def _ensure_bindings_exist(
+    storage: StorageBase,
+    user_id: str,
+    mcp_ids: list[str] | None,
+    skill_ids: list[str] | None,
+) -> None:
+    """Reject bound ids that are not in the caller's own library.
+
+    Checked on write rather than on use: a typo would otherwise stay
+    invisible until some workspace boots without the tool.
+
+    Args:
+        storage (`StorageBase`): Injected storage backend.
+        user_id (`str`): The authenticated user ID.
+        mcp_ids (`list[str] | None`): Bound MCP ids, or ``None`` to skip.
+        skill_ids (`list[str] | None`): Bound skill ids, or ``None``.
+
+    Raises:
+        `HTTPException`: 404 naming the first id that does not exist.
+    """
+    for ids, owned, kind in (
+        (mcp_ids, storage.list_mcps, "MCP"),
+        (skill_ids, storage.list_skills, "skill"),
+    ):
+        if not ids:
+            continue
+        known = {record.id for record in await owned(user_id)}
+        missing = [i for i in ids if i not in known]
+        if missing:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=(
+                    f"No installed {kind} with id {missing[0]!r} in your "
+                    f"library."
+                ),
+            )
+
+
 @agent_router.get(
     "/schema",
     response_model=AgentSchemaResponse,
@@ -195,6 +233,12 @@ async def create_agent(
             ``invite_description``). Symmetrical with
             :func:`update_agent`.
     """
+    await _ensure_bindings_exist(
+        storage,
+        user_id,
+        body.mcp_ids,
+        body.skill_ids,
+    )
     try:
         data = AgentData(
             name=body.name,
@@ -202,6 +246,8 @@ async def create_agent(
             context_config=body.context_config,
             react_config=body.react_config,
             invite_config=body.invite_config,
+            mcp_ids=body.mcp_ids,
+            skill_ids=body.skill_ids,
         )
     except ValidationError as exc:
         raise HTTPException(
@@ -248,6 +294,15 @@ async def update_agent(
         user_id,
         ResourceKind.AGENT,
         agent_id,
+    )
+
+    # Checked against the owner's library, not the editor's: that is
+    # the only one the seeding can read.
+    await _ensure_bindings_exist(
+        storage,
+        owner_id,
+        body.mcp_ids,
+        body.skill_ids,
     )
 
     updates = body.model_dump(exclude_none=True)

--- a/src/agentscope/app/_router/_hub.py
+++ b/src/agentscope/app/_router/_hub.py
@@ -112,11 +112,18 @@ async def list_mcp_cards(
     return await hub.list_mcps(user_id, q=q, cursor=cursor, limit=limit)
 
 
-@hub_router.get("/mcp/{hub_id}/cards/{card_id}")
+@hub_router.get("/mcp/{hub_id}/card")
 async def get_mcp_card(
     hub_id: str,
-    card_id: str,
     *,
+    card_id: str = Query(
+        description=(
+            "The card's id on this hub. A query parameter rather than "
+            "a path segment: card ids are opaque strings minted by the "
+            "hub, and one containing ``/`` cannot survive a path "
+            "parameter — the server decodes ``%2F`` before routing."
+        ),
+    ),
     user_id: str = Depends(get_current_user_id),
     hubs: dict[str, MCPHubBase] = Depends(get_mcp_hubs),
 ) -> MCPCard:
@@ -132,14 +139,21 @@ async def get_mcp_card(
 
 
 @hub_router.post(
-    "/mcp/{hub_id}/cards/{card_id}/install",
+    "/mcp/{hub_id}/install",
     status_code=status.HTTP_201_CREATED,
 )
 async def install_mcp(
     hub_id: str,
-    card_id: str,
     body: InstallMCPRequest,
     *,
+    card_id: str = Query(
+        description=(
+            "The card's id on this hub. A query parameter rather than "
+            "a path segment: card ids are opaque strings minted by the "
+            "hub, and one containing ``/`` cannot survive a path "
+            "parameter — the server decodes ``%2F`` before routing."
+        ),
+    ),
     user_id: str = Depends(get_current_user_id),
     hubs: dict[str, MCPHubBase] = Depends(get_mcp_hubs),
     storage: StorageBase = Depends(get_storage),
@@ -231,11 +245,18 @@ async def list_skill_cards(
     return await hub.list_skills(user_id, q=q, cursor=cursor, limit=limit)
 
 
-@hub_router.get("/skill/{hub_id}/cards/{card_id}")
+@hub_router.get("/skill/{hub_id}/card")
 async def get_skill_card(
     hub_id: str,
-    card_id: str,
     *,
+    card_id: str = Query(
+        description=(
+            "The card's id on this hub. A query parameter rather than "
+            "a path segment: card ids are opaque strings minted by the "
+            "hub, and one containing ``/`` cannot survive a path "
+            "parameter — the server decodes ``%2F`` before routing."
+        ),
+    ),
     user_id: str = Depends(get_current_user_id),
     hubs: dict[str, SkillHubBase] = Depends(get_skill_hubs),
 ) -> SkillCard:
@@ -251,13 +272,20 @@ async def get_skill_card(
 
 
 @hub_router.post(
-    "/skill/{hub_id}/cards/{card_id}/install",
+    "/skill/{hub_id}/install",
     status_code=status.HTTP_201_CREATED,
 )
 async def install_skill(
     hub_id: str,
-    card_id: str,
     *,
+    card_id: str = Query(
+        description=(
+            "The card's id on this hub. A query parameter rather than "
+            "a path segment: card ids are opaque strings minted by the "
+            "hub, and one containing ``/`` cannot survive a path "
+            "parameter — the server decodes ``%2F`` before routing."
+        ),
+    ),
     name: str | None = Query(default=None),
     user_id: str = Depends(get_current_user_id),
     hubs: dict[str, SkillHubBase] = Depends(get_skill_hubs),

--- a/src/agentscope/app/_router/_schema/__init__.py
+++ b/src/agentscope/app/_router/_schema/__init__.py
@@ -10,6 +10,8 @@ from ._workspace import (
     AddFromLibraryResponse,
     AddSkillRequest,
     AddSkillsFromLibraryRequest,
+    ListWorkspaceMCPsResponse,
+    ListWorkspaceSkillsResponse,
     MCPClientStatus,
     ToolInfo,
 )
@@ -79,6 +81,8 @@ __all__ = [
     "AddFromLibraryResponse",
     "AddSkillRequest",
     "AddSkillsFromLibraryRequest",
+    "ListWorkspaceMCPsResponse",
+    "ListWorkspaceSkillsResponse",
     "MCPClientStatus",
     "ToolInfo",
     # Agent

--- a/src/agentscope/app/_router/_schema/_agent.py
+++ b/src/agentscope/app/_router/_schema/_agent.py
@@ -33,6 +33,18 @@ class CreateAgentRequest(BaseModel):
             "``invitable ⇒ non-empty description`` invariant."
         ),
     )
+    mcp_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Ids of the caller's installed MCPs this agent comes with. "
+            "Seeded into each of its workspaces the first time that "
+            "workspace boots."
+        ),
+    )
+    skill_ids: list[str] = Field(
+        default_factory=list,
+        description="Ids of the caller's installed skills, same seeding.",
+    )
 
 
 class CreateAgentResponse(BaseModel):
@@ -67,6 +79,18 @@ class UpdateAgentRequest(BaseModel):
             "object to update; omit to leave both invitable-related "
             "fields unchanged."
         ),
+    )
+    mcp_ids: list[str] | None = Field(
+        default=None,
+        description=(
+            "New set of bound MCP ids, replacing the old one. Pass an "
+            "empty list to clear; omit to leave unchanged. Only affects "
+            "workspaces that do not exist yet."
+        ),
+    )
+    skill_ids: list[str] | None = Field(
+        default=None,
+        description="New set of bound skill ids, same semantics.",
     )
 
 

--- a/src/agentscope/app/_router/_schema/_workspace.py
+++ b/src/agentscope/app/_router/_schema/_workspace.py
@@ -3,6 +3,7 @@
 from pydantic import BaseModel, Field
 
 from ....mcp import MCPClient
+from ....skill import Skill
 
 
 class AddSkillRequest(BaseModel):
@@ -48,6 +49,35 @@ class AddFromLibraryResponse(BaseModel):
     )
 
 
+class _SeededResponse(BaseModel):
+    """What the agent came with but could not be given.
+
+    Populated when the workspace is first created — an MCP that would
+    not connect, a skill whose hub is gone, a binding pointing at a
+    library record that was deleted. Reported here rather than as an
+    error status because the workspace itself is fine; it is simply
+    missing something the agent was configured with.
+    """
+
+    seed_errors: dict[str, str] = Field(
+        default_factory=dict,
+        description="Names of the agent's own MCPs / skills that are "
+        "not in this workspace, mapped to why.",
+    )
+
+
+class ListWorkspaceMCPsResponse(_SeededResponse):
+    """The MCPs present in a workspace."""
+
+    mcps: list["MCPClientStatus"] = Field(default_factory=list)
+
+
+class ListWorkspaceSkillsResponse(_SeededResponse):
+    """The skills present in a workspace."""
+
+    skills: list[Skill] = Field(default_factory=list)
+
+
 class ToolInfo(BaseModel):
     """The tool info."""
 
@@ -68,3 +98,6 @@ class MCPClientStatus(MCPClient):
             "unreachable host and a missing command all look the same."
         ),
     )
+
+
+ListWorkspaceMCPsResponse.model_rebuild()

--- a/src/agentscope/app/_router/_workspace.py
+++ b/src/agentscope/app/_router/_workspace.py
@@ -26,16 +26,18 @@ from .._service._skill_upload import (
     _tar_stream,
     _validate_manifest,
 )
+from .._service import resolve_agent_seeds
 from ..workspace_manager import WorkspaceManagerBase
 from ..storage import MCPRecord, StorageBase
 from ...mcp import MCPClient
-from ...skill import Skill
 from ...workspace import WorkspaceBase
 from ._schema import (
     AddFromLibraryRequest,
     AddFromLibraryResponse,
     AddSkillRequest,
     AddSkillsFromLibraryRequest,
+    ListWorkspaceMCPsResponse,
+    ListWorkspaceSkillsResponse,
     MCPClientStatus,
     ToolInfo,
 )
@@ -50,8 +52,13 @@ async def _resolve_workspace(
     session_id: str,
     storage: StorageBase,
     workspace_manager: WorkspaceManagerBase,
-) -> WorkspaceBase:
+    skill_hubs: dict[str, SkillHubBase] | None = None,
+) -> tuple[WorkspaceBase, dict[str, str]]:
     """Return the workspace backing the given session.
+
+    The agent's own MCPs and skills ride along as seeds. They are only
+    consumed if this call is what brings the workspace into existence —
+    see :meth:`WorkspaceManagerBase.get_workspace`.
 
     Args:
         user_id (`str`):
@@ -64,10 +71,14 @@ async def _resolve_workspace(
             The storage used to look the session record up.
         workspace_manager (`WorkspaceManagerBase`):
             The manager that opens or reattaches the workspace.
+        skill_hubs (`dict[str, SkillHubBase] | None`, optional):
+            Registered skill hubs, needed to fetch the agent's skills.
+            Omit on the endpoints that do not report seeding problems.
 
     Returns:
-        `WorkspaceBase`:
-            The session's workspace.
+        `tuple[WorkspaceBase, dict[str, str]]`:
+            The session's workspace, and whatever of the agent's own
+            MCPs and skills could not be put into it, mapped to why.
 
     Raises:
         `HTTPException`:
@@ -79,12 +90,23 @@ async def _resolve_workspace(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Session {session_id!r} not found.",
         )
-    return await workspace_manager.get_workspace(
+    seeds = await resolve_agent_seeds(
+        storage,
+        skill_hubs or {},
+        user_id,
+        agent_id,
+    )
+    workspace = await workspace_manager.get_workspace(
         user_id,
         agent_id,
         session_id,
         session_record.config.workspace_id,
+        seed_mcps=seeds.mcps,
+        seed_skills=seeds.skills,
     )
+    # Unresolvable bindings are recomputed every call; seeding failures
+    # happened once and are remembered by the workspace itself.
+    return workspace, {**workspace.seed_errors, **seeds.errors}
 
 
 # ---------------------------------------------------------------------------
@@ -99,14 +121,16 @@ async def list_mcps(
     user_id: str = Depends(get_current_user_id),
     storage: StorageBase = Depends(get_storage),
     workspace_manager: WorkspaceManagerBase = Depends(get_workspace_manager),
-) -> list[MCPClientStatus]:
+    skill_hubs: dict[str, SkillHubBase] = Depends(get_skill_hubs),
+) -> ListWorkspaceMCPsResponse:
     """Return all MCP clients with live tool list and health status."""
-    workspace = await _resolve_workspace(
+    workspace, seed_errors = await _resolve_workspace(
         user_id,
         agent_id,
         session_id,
         storage,
         workspace_manager,
+        skill_hubs,
     )
     clients = await workspace.list_mcps()
 
@@ -135,7 +159,17 @@ async def list_mcps(
                 ),
             )
 
-    return results
+    # A seeded MCP that never connected is absent rather than red, so
+    # the reason has to travel beside the list.
+    present = {client.name for client in clients}
+    return ListWorkspaceMCPsResponse(
+        mcps=results,
+        seed_errors={
+            name: why
+            for name, why in seed_errors.items()
+            if name not in present
+        },
+    )
 
 
 @workspace_router.post("/mcp", status_code=status.HTTP_201_CREATED)
@@ -155,7 +189,7 @@ async def add_mcp(
     that MCP is defined, and adding it to a second workspace must not
     silently redefine it.
     """
-    workspace = await _resolve_workspace(
+    workspace, _ = await _resolve_workspace(
         user_id,
         agent_id,
         session_id,
@@ -193,7 +227,7 @@ async def add_mcps_from_library(
     Adding is per-MCP: one that fails to connect does not cancel the
     rest, and the response says which ones landed.
     """
-    workspace = await _resolve_workspace(
+    workspace, _ = await _resolve_workspace(
         user_id,
         agent_id,
         session_id,
@@ -235,7 +269,7 @@ async def remove_mcp(
     workspace_manager: WorkspaceManagerBase = Depends(get_workspace_manager),
 ) -> None:
     """Remove an MCP client from the session's workspace by name."""
-    workspace = await _resolve_workspace(
+    workspace, _ = await _resolve_workspace(
         user_id,
         agent_id,
         session_id,
@@ -257,16 +291,27 @@ async def list_skills(
     user_id: str = Depends(get_current_user_id),
     storage: StorageBase = Depends(get_storage),
     workspace_manager: WorkspaceManagerBase = Depends(get_workspace_manager),
-) -> list[Skill]:
+    skill_hubs: dict[str, SkillHubBase] = Depends(get_skill_hubs),
+) -> ListWorkspaceSkillsResponse:
     """Return all skills available in the session's workspace."""
-    workspace = await _resolve_workspace(
+    workspace, seed_errors = await _resolve_workspace(
         user_id,
         agent_id,
         session_id,
         storage,
         workspace_manager,
+        skill_hubs,
     )
-    return await workspace.list_skills()
+    skills = await workspace.list_skills()
+    present = {skill.name for skill in skills}
+    return ListWorkspaceSkillsResponse(
+        skills=skills,
+        seed_errors={
+            name: why
+            for name, why in seed_errors.items()
+            if name not in present
+        },
+    )
 
 
 @workspace_router.post(
@@ -289,7 +334,7 @@ async def add_skill(
     to send a folder, or ``POST /skill/from-library`` to install one
     the user already has.
     """
-    workspace = await _resolve_workspace(
+    workspace, _ = await _resolve_workspace(
         user_id,
         agent_id,
         session_id,
@@ -340,7 +385,7 @@ async def upload_skill(
             f"{len(files)} were sent.",
         )
 
-    workspace = await _resolve_workspace(
+    workspace, _ = await _resolve_workspace(
         user_id,
         agent_id,
         session_id,
@@ -382,7 +427,7 @@ async def add_skills_from_library(
     workspace; the server holds no copy in between. Adding is
     per-skill, and the response says which ones landed.
     """
-    workspace = await _resolve_workspace(
+    workspace, _ = await _resolve_workspace(
         user_id,
         agent_id,
         session_id,
@@ -436,7 +481,7 @@ async def remove_skill(
     workspace_manager: WorkspaceManagerBase = Depends(get_workspace_manager),
 ) -> None:
     """Remove a skill from the session's workspace by name."""
-    workspace = await _resolve_workspace(
+    workspace, _ = await _resolve_workspace(
         user_id,
         agent_id,
         session_id,

--- a/src/agentscope/app/_service/__init__.py
+++ b/src/agentscope/app/_service/__init__.py
@@ -14,6 +14,7 @@ from ._index_worker import IndexWorker
 from ._knowledge_base import KnowledgeBaseService
 from ._mcp_render import MCPRenderError, render_mcp
 from ._model import get_model
+from ._provision import AgentSeeds, resolve_agent_seeds
 from ._tts_model import get_tts_model
 from ._session import SessionService, SessionStatus
 from ._session_projection import SessionProjection
@@ -21,6 +22,7 @@ from ._projectors import SubagentHitlProjector
 from ._toolkit import get_toolkit
 
 __all__ = [
+    "AgentSeeds",
     "AgentView",
     "ChatService",
     "CredentialView",
@@ -40,4 +42,5 @@ __all__ = [
     "get_tts_model",
     "get_toolkit",
     "render_mcp",
+    "resolve_agent_seeds",
 ]

--- a/src/agentscope/app/_service/_chat.py
+++ b/src/agentscope/app/_service/_chat.py
@@ -17,6 +17,7 @@ from fastapi import HTTPException
 
 from .._bus_ops import enqueue_run_trigger, publish_session_event
 from ..message_bus import MessageBus, MessageBusKeys
+from ..hub import SkillHubBase
 from ..rag.knowledge_base_manager import KnowledgeBaseManagerBase
 from ..storage import StorageBase, AgentRecord, SessionRecord
 from .._manager import BackgroundTaskManager, SchedulerManager
@@ -36,6 +37,7 @@ from .._types import (
 )
 from ._access import ResourceAccessService
 from ._model import get_model
+from ._provision import resolve_agent_seeds
 from ._tts_model import get_tts_model
 from ._toolkit import get_toolkit
 from ._session_projection import SessionProjection
@@ -81,6 +83,7 @@ class ChatService:
         background_task_manager: BackgroundTaskManager,
         message_bus: MessageBus,
         resource_access_service: ResourceAccessService,
+        skill_hubs: dict[str, SkillHubBase] | None = None,
         knowledge_base_manager: KnowledgeBaseManagerBase | None = None,
         extra_agent_middlewares: AgentMiddlewareFactory | None = None,
         extra_agent_tools: AgentToolFactory | None = None,
@@ -114,6 +117,10 @@ class ChatService:
                 assembly and model / TTS construction all route
                 through this service so shared credentials, agents,
                 and knowledge bases work uniformly.
+            skill_hubs (`dict[str, SkillHubBase] | None`, optional):
+                Registered skill hubs, keyed by id. Needed to seed a
+                brand-new workspace with the skills its agent comes
+                with, since those are re-downloaded rather than stored.
             knowledge_base_manager (`KnowledgeBaseManagerBase | None`, \
              optional):
                 The application's knowledge base manager.  When
@@ -152,6 +159,7 @@ class ChatService:
         self._background_task_manager = background_task_manager
         self._message_bus = message_bus
         self._access = resource_access_service
+        self._skill_hubs = skill_hubs or {}
         self._knowledge_base_manager = knowledge_base_manager
         self._extra_agent_middlewares = extra_agent_middlewares
         self._extra_agent_tools = extra_agent_tools
@@ -520,11 +528,23 @@ class ChatService:
                         f"agent {agent_id!r}."
                     ),
                 )
+            # The seeds only bite if this call is what constructs the
+            # workspace; a chat that starts before the user ever opens
+            # the panel is otherwise the one path that would leave the
+            # agent without the tools it comes with.
+            seeds = await resolve_agent_seeds(
+                self._storage,
+                self._skill_hubs,
+                user_id,
+                agent_id,
+            )
             workspace = await self._workspace_manager.get_workspace(
                 user_id,
                 agent_id,
                 session_id,
                 session_record.config.workspace_id,
+                seed_mcps=seeds.mcps,
+                seed_skills=seeds.skills,
             )
 
             # Add workspace working directory to the permission context

--- a/src/agentscope/app/_service/_provision.py
+++ b/src/agentscope/app/_service/_provision.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""Turning an agent's bound MCPs and skills into workspace seeds."""
+from typing import NamedTuple
+
+from ..hub import HubSkillSource, SkillHubBase
+from ..storage import StorageBase
+from ...mcp import MCPClient
+from ...skill import SkillSourceBase
+
+
+class AgentSeeds(NamedTuple):
+    """What an agent brings to a workspace that does not exist yet.
+
+    Attributes:
+        mcps: Connectable clients, ready for ``default_mcps``.
+        skills: Deferred downloads, ready for ``default_skills``.
+        errors: Bindings that could not be resolved at all, mapped to
+            why. Distinct from a seed that failed to install: these
+            never became a seed, and re-deriving them costs two reads,
+            so they are reported live rather than remembered.
+    """
+
+    mcps: list[MCPClient]
+    skills: list[SkillSourceBase]
+    errors: dict[str, str]
+
+
+async def resolve_agent_seeds(
+    storage: StorageBase,
+    skill_hubs: dict[str, SkillHubBase],
+    user_id: str,
+    agent_id: str,
+) -> AgentSeeds:
+    """Resolve an agent's bound library ids into workspace seeds.
+
+    Reads the library wholesale rather than per id: the number of
+    bindings varies, the number of round trips should not.
+
+    A binding the caller cannot see — because the record is gone, or
+    because the agent is shared and the ids belong to its owner — is
+    reported rather than raised. The other seeds still go in, and
+    failing to open a workspace over one stale id would be worse than
+    opening it short a tool.
+
+    Args:
+        storage (`StorageBase`):
+            Where the user's library lives.
+        skill_hubs (`dict[str, SkillHubBase]`):
+            Registered skill hubs, keyed by id.
+        user_id (`str`):
+            The user whose library the ids are looked up in.
+        agent_id (`str`):
+            The agent whose bindings to resolve.
+
+    Returns:
+        `AgentSeeds`:
+            The seeds, plus whatever could not be resolved.
+    """
+    agent = await storage.get_agent(user_id, agent_id)
+    if agent is None or not (agent.data.mcp_ids or agent.data.skill_ids):
+        return AgentSeeds([], [], {})
+
+    mcps: list[MCPClient] = []
+    errors: dict[str, str] = {}
+    if agent.data.mcp_ids:
+        by_id = {r.id: r for r in await storage.list_mcps(user_id)}
+        for mcp_id in agent.data.mcp_ids:
+            record = by_id.get(mcp_id)
+            if record is None:
+                errors[mcp_id] = "No longer in your library."
+            elif record.enabled:
+                mcps.append(record.client)
+
+    skills: list[SkillSourceBase] = []
+    if agent.data.skill_ids:
+        by_id = {r.id: r for r in await storage.list_skills(user_id)}
+        for skill_id in agent.data.skill_ids:
+            record = by_id.get(skill_id)
+            if record is None:
+                errors[skill_id] = "No longer in your library."
+                continue
+            if not record.enabled:
+                continue
+            hub = skill_hubs.get(record.hub_id or "")
+            if hub is None:
+                errors[
+                    record.name
+                ] = f"Its hub {record.hub_id!r} is no longer registered."
+                continue
+            skills.append(
+                HubSkillSource(
+                    hub,
+                    user_id,
+                    record.card_id or record.name,
+                    record.name,
+                    record.version,
+                ),
+            )
+
+    return AgentSeeds(mcps, skills, errors)

--- a/src/agentscope/app/hub/__init__.py
+++ b/src/agentscope/app/hub/__init__.py
@@ -11,6 +11,7 @@ from ._mcp import (
     MCPHubPage,
 )
 from ._skill import (
+    HubSkillSource,
     SkillArchive,
     SkillHubBase,
     SkillCard,
@@ -25,6 +26,7 @@ __all__ = [
     "MCPHubBase",
     "MCPCard",
     "MCPHubPage",
+    "HubSkillSource",
     "SkillArchive",
     "SkillHubBase",
     "SkillCard",

--- a/src/agentscope/app/hub/_skill/__init__.py
+++ b/src/agentscope/app/hub/_skill/__init__.py
@@ -3,9 +3,11 @@
 
 from ._base import SkillArchive, SkillHubBase
 from ._card import SkillCard, SkillHubPage
+from ._source import HubSkillSource
 from ._claw_hub import ClawSkillHub
 
 __all__ = [
+    "HubSkillSource",
     "SkillArchive",
     "SkillHubBase",
     "SkillCard",

--- a/src/agentscope/app/hub/_skill/_base.py
+++ b/src/agentscope/app/hub/_skill/_base.py
@@ -1,26 +1,14 @@
 # -*- coding: utf-8 -*-
 """The skill hub base class."""
 from abc import ABC, abstractmethod
-from typing import AsyncIterator, Literal, NamedTuple
 
 from ._card import SkillCard, SkillHubPage
 from .._base import HubBase
+from ....skill import SkillArchive
 
-
-class SkillArchive(NamedTuple):
-    """A skill archive as the hub serves it.
-
-    The format travels with the bytes so a hub can forward its upstream
-    response untouched — repacking to a fixed format would force every
-    hub to buffer the whole archive.
-
-    Attributes:
-        format: The archive format, as the installer must unpack it.
-        stream: The archive bytes, in order.
-    """
-
-    format: Literal["zip", "tar", "tar.gz"]
-    stream: AsyncIterator[bytes]
+# Re-exported: a hub serves the same thing a workspace seeds from, and
+# the workspace layer cannot import the app layer to reach it.
+__all__ = ["SkillArchive", "SkillHubBase"]
 
 
 class SkillHubBase(HubBase, ABC):

--- a/src/agentscope/app/hub/_skill/_source.py
+++ b/src/agentscope/app/hub/_skill/_source.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""A skill hub as a workspace seed source."""
+from ._base import SkillHubBase
+from ....skill import SkillArchive, SkillSourceBase
+
+
+class HubSkillSource(SkillSourceBase):
+    """A skill a workspace can seed itself with, fetched from its hub.
+
+    The library record keeps no copy of the archive, so the only way to
+    put a skill into a new workspace is to download it again. Wrapping
+    that in a source rather than doing it up front matters: a workspace
+    that already has the skill — or that never boots — never pays for
+    the request.
+    """
+
+    def __init__(
+        self,
+        hub: SkillHubBase,
+        user_id: str,
+        card_id: str,
+        name: str,
+        version: str | None = None,
+    ) -> None:
+        """Bind what it takes to fetch one skill.
+
+        Args:
+            hub (`SkillHubBase`):
+                The hub the skill was installed from.
+            user_id (`str`):
+                Whose visibility the download is authorized against.
+            card_id (`str`):
+                The card's id on that hub.
+            name (`str`):
+                Directory name to install as.
+            version (`str | None`, optional):
+                The version recorded at install time. ``None`` takes
+                whatever the hub currently calls latest.
+        """
+        super().__init__(name)
+        self._hub = hub
+        self._user_id = user_id
+        self._card_id = card_id
+        self._version = version
+
+    async def open(self) -> SkillArchive:
+        """Stream the archive from the hub."""
+        return await self._hub.download(
+            self._user_id,
+            self._card_id,
+            self._version,
+        )

--- a/src/agentscope/app/storage/_model/_agent.py
+++ b/src/agentscope/app/storage/_model/_agent.py
@@ -108,6 +108,23 @@ class AgentData(BaseModel):
         title="Invite Config",
     )
 
+    mcp_ids: SkipJsonSchema[list[str]] = Field(default_factory=list)
+    """Ids of the user's installed MCPs this agent comes with.
+
+    Seeded into the agent's workspace the first time that workspace
+    boots, and never again — one the user later removes from the
+    workspace is not reinstated. Editing this list therefore only
+    affects workspaces that do not exist yet.
+
+    :class:`SkipJsonSchema` like :attr:`id`: the frontend renders the
+    create / edit form off ``AgentData``'s schema, and a bare list of
+    opaque ids has to be picked from the library rather than typed.
+    """
+
+    skill_ids: SkipJsonSchema[list[str]] = Field(default_factory=list)
+    """Ids of the user's installed skills this agent comes with. Same
+    seeding and form semantics as :attr:`mcp_ids`."""
+
 
 class AgentRecord(_RecordBase):
     """The agent ORM model."""

--- a/src/agentscope/app/workspace_manager/_applecontainer_workspace_manager.py
+++ b/src/agentscope/app/workspace_manager/_applecontainer_workspace_manager.py
@@ -18,10 +18,11 @@ Differences from the Docker manager:
 
 import asyncio
 import time
-from typing import Self
+from typing import Self, Sequence
 
 from ..._logging import logger
 from ...mcp import MCPClient
+from ...skill import Skill, SkillLoaderBase, SkillSourceBase
 from ...workspace import AppleContainerWorkspace
 from ...workspace._applecontainer._constants import (
     DEFAULT_BASE_IMAGE,
@@ -58,6 +59,10 @@ class AppleContainerWorkspaceManager(WorkspaceManagerBase):
         env: dict[str, str] | None = None,
         extra_pip: list[str] | None = None,
         default_mcps: list[MCPClient] | None = None,
+        default_skills: Sequence[
+            str | Skill | SkillLoaderBase | SkillSourceBase
+        ]
+        | None = None,
         skill_paths: list[str] | None = None,
         ttl: float = 3600.0,
         sweep_interval: float = DEFAULT_SWEEP_INTERVAL,
@@ -83,8 +88,12 @@ class AppleContainerWorkspaceManager(WorkspaceManagerBase):
                 during bootstrap.
             default_mcps (`list[MCPClient] | None`, optional):
                 MCP clients seeded into brand-new workspaces.
+            default_skills (`Sequence[str | Skill | SkillLoaderBase | \
+SkillSourceBase] | None`, optional):
+                Skills seeded into brand-new workspaces.
             skill_paths (`list[str] | None`, optional):
-                Skill directories seeded into brand-new workspaces.
+                **Deprecated.** Pass local directories in
+                ``default_skills`` instead.
             ttl (`float`, defaults to `3600.0`):
                 Seconds before an idle cached workspace is evicted
                 and its container torn down.
@@ -99,7 +108,7 @@ class AppleContainerWorkspaceManager(WorkspaceManagerBase):
         self._env = dict(env or {})
         self._extra_pip = list(extra_pip or [])
         self._default_mcps = list(default_mcps or [])
-        self._skill_paths = list(skill_paths or [])
+        self._default_skills = [*(skill_paths or []), *(default_skills or [])]
         super().__init__(isolation=isolation)
         self._ttl = ttl
         self._sweep_interval = sweep_interval
@@ -118,6 +127,9 @@ class AppleContainerWorkspaceManager(WorkspaceManagerBase):
         self,
         *,
         workspace_id: str,
+        seed_mcps: list[MCPClient] | None = None,
+        seed_skills: Sequence[str | Skill | SkillLoaderBase | SkillSourceBase]
+        | None = None,
     ) -> AppleContainerWorkspace:
         """Create an :class:`AppleContainerWorkspace` and run its full
         ``initialize``.
@@ -138,8 +150,8 @@ class AppleContainerWorkspaceManager(WorkspaceManagerBase):
             memory=self._memory,
             env=self._env,
             extra_pip=self._extra_pip,
-            default_mcps=self._default_mcps,
-            skill_paths=self._skill_paths,
+            default_mcps=[*self._default_mcps, *(seed_mcps or [])],
+            default_skills=[*self._default_skills, *(seed_skills or [])],
         )
         await ws.initialize()
         return ws
@@ -152,6 +164,9 @@ class AppleContainerWorkspaceManager(WorkspaceManagerBase):
         agent_id: str,
         session_id: str,
         workspace_id: str | None = None,
+        seed_mcps: list[MCPClient] | None = None,
+        seed_skills: Sequence[str | Skill | SkillLoaderBase | SkillSourceBase]
+        | None = None,
     ) -> AppleContainerWorkspace:
         """Return an initialised workspace, building one on cache miss.
 
@@ -198,6 +213,8 @@ class AppleContainerWorkspaceManager(WorkspaceManagerBase):
 
             ws = await self._build_and_start(
                 workspace_id=workspace_id,
+                seed_mcps=seed_mcps,
+                seed_skills=seed_skills,
             )
             self._cache[workspace_id] = (ws, time.monotonic())
             return ws

--- a/src/agentscope/app/workspace_manager/_base.py
+++ b/src/agentscope/app/workspace_manager/_base.py
@@ -4,9 +4,11 @@
 import hashlib
 from abc import ABC, abstractmethod
 from enum import StrEnum
-from typing import Self
+from typing import Self, Sequence
 
 from ..._utils._common import _generate_id
+from ...mcp import MCPClient
+from ...skill import Skill, SkillLoaderBase, SkillSourceBase
 from ...workspace import WorkspaceBase
 
 
@@ -100,6 +102,9 @@ class WorkspaceManagerBase(ABC):
         agent_id: str,
         session_id: str,
         workspace_id: str | None = None,
+        seed_mcps: list[MCPClient] | None = None,
+        seed_skills: Sequence[str | Skill | SkillLoaderBase | SkillSourceBase]
+        | None = None,
     ) -> WorkspaceBase:
         """Return an initialized workspace.
 
@@ -114,6 +119,20 @@ class WorkspaceManagerBase(ABC):
                 Explicit workspace binding. ``None`` triggers
                 :meth:`assign_workspace_id` fallback — expected only
                 for callers without a persisted binding.
+            seed_mcps (`list[MCPClient] | None`, optional):
+                Caller-supplied MCPs to seed **this** workspace with,
+                appended to the manager's deployment-wide
+                ``default_mcps``. Used for whatever is specific to the
+                agent being opened.
+            seed_skills (`Sequence[str | Skill | SkillLoaderBase | \
+SkillSourceBase] | None`, optional):
+                The skill counterpart of ``seed_mcps``.
+
+        .. note::
+           Both seed arguments only matter when the workspace is
+           constructed. A cached one is returned as-is, and one whose
+           storage already carries a ``.mcp`` file ignores them — see
+           :meth:`WorkspaceBase.initialize`.
         """
 
     @abstractmethod

--- a/src/agentscope/app/workspace_manager/_bubblewrap_workspace_manager.py
+++ b/src/agentscope/app/workspace_manager/_bubblewrap_workspace_manager.py
@@ -7,13 +7,14 @@ import asyncio
 import hashlib
 import os
 import time
-from typing import Self
+from typing import Self, Sequence
 
 from typing_extensions import deprecated
 
 from ..._logging import logger
 from ..._utils._common import _generate_id
 from ...mcp import MCPClient
+from ...skill import Skill, SkillLoaderBase, SkillSourceBase
 from ...workspace import BubblewrapWorkspace
 from ...workspace._bubblewrap._constants import DEFAULT_GATEWAY_PORT
 from ._base import IsolationPolicy, WorkspaceManagerBase
@@ -47,6 +48,10 @@ class BubblewrapWorkspaceManager(WorkspaceManagerBase):
         env: dict[str, str] | None = None,
         extra_pip: list[str] | None = None,
         default_mcps: list[MCPClient] | None = None,
+        default_skills: Sequence[
+            str | Skill | SkillLoaderBase | SkillSourceBase
+        ]
+        | None = None,
         skill_paths: list[str] | None = None,
         ttl: float = 3600.0,
         sweep_interval: float = DEFAULT_SWEEP_INTERVAL,
@@ -70,8 +75,12 @@ class BubblewrapWorkspaceManager(WorkspaceManagerBase):
                 Extra gateway venv requirements.
             default_mcps (`list[MCPClient] | None`, optional):
                 MCPs seeded into new workspaces.
+            default_skills (`Sequence[str | Skill | SkillLoaderBase | \
+SkillSourceBase] | None`, optional):
+                Skills seeded into brand-new workspaces.
             skill_paths (`list[str] | None`, optional):
-                Skill dirs seeded into new workspaces.
+                **Deprecated.** Pass local directories in
+                ``default_skills`` instead.
             ttl (`float`, defaults to `3600.0`):
                 Seconds before an idle workspace is evicted.
             sweep_interval (`float`, defaults to `300.0`):
@@ -93,7 +102,7 @@ class BubblewrapWorkspaceManager(WorkspaceManagerBase):
         self._env = dict(env or {})
         self._extra_pip = list(extra_pip or [])
         self._default_mcps = list(default_mcps or [])
-        self._skill_paths = list(skill_paths or [])
+        self._default_skills = [*(skill_paths or []), *(default_skills or [])]
         self._ttl = ttl
         self._sweep_interval = sweep_interval
         super().__init__(isolation=isolation)
@@ -121,6 +130,9 @@ class BubblewrapWorkspaceManager(WorkspaceManagerBase):
         workspace_id: str,
         user_id: str,
         agent_id: str,
+        seed_mcps: list[MCPClient] | None = None,
+        seed_skills: Sequence[str | Skill | SkillLoaderBase | SkillSourceBase]
+        | None = None,
     ) -> BubblewrapWorkspace:
         """Construct and initialize a Bubblewrap workspace."""
         del agent_id
@@ -134,8 +146,8 @@ class BubblewrapWorkspaceManager(WorkspaceManagerBase):
             share_net=self._share_net,
             env=self._env,
             extra_pip=self._extra_pip,
-            default_mcps=self._default_mcps,
-            skill_paths=self._skill_paths,
+            default_mcps=[*self._default_mcps, *(seed_mcps or [])],
+            default_skills=[*self._default_skills, *(seed_skills or [])],
         )
         await ws.initialize()
         return ws
@@ -146,6 +158,9 @@ class BubblewrapWorkspaceManager(WorkspaceManagerBase):
         agent_id: str,
         session_id: str,
         workspace_id: str | None = None,
+        seed_mcps: list[MCPClient] | None = None,
+        seed_skills: Sequence[str | Skill | SkillLoaderBase | SkillSourceBase]
+        | None = None,
     ) -> BubblewrapWorkspace:
         """Return an initialized workspace, creating it on cache miss."""
         if workspace_id is None:
@@ -166,6 +181,8 @@ class BubblewrapWorkspaceManager(WorkspaceManagerBase):
                 workspace_id=workspace_id,
                 user_id=user_id,
                 agent_id=agent_id,
+                seed_mcps=seed_mcps,
+                seed_skills=seed_skills,
             )
             self._cache[workspace_id] = (ws, time.monotonic())
             return ws

--- a/src/agentscope/app/workspace_manager/_daytona_workspace_manager.py
+++ b/src/agentscope/app/workspace_manager/_daytona_workspace_manager.py
@@ -24,10 +24,11 @@ Daytona-specific behavior:
 
 import asyncio
 import time
-from typing import Self
+from typing import Self, Sequence
 
 from ..._logging import logger
 from ...mcp import MCPClient
+from ...skill import Skill, SkillLoaderBase, SkillSourceBase
 from ...workspace import DaytonaWorkspace
 from ...workspace._daytona._constants import (
     DEFAULT_GATEWAY_PORT,
@@ -58,6 +59,10 @@ class DaytonaWorkspaceManager(WorkspaceManagerBase):
         sandbox_metadata: dict[str, str] | None = None,
         extra_pip: list[str] | None = None,
         default_mcps: list[MCPClient] | None = None,
+        default_skills: Sequence[
+            str | Skill | SkillLoaderBase | SkillSourceBase
+        ]
+        | None = None,
         skill_paths: list[str] | None = None,
         os_user: str | None = None,
         ttl: float = 3600.0,
@@ -95,8 +100,12 @@ class DaytonaWorkspaceManager(WorkspaceManagerBase):
             default_mcps (`list[MCPClient] | None`, optional):
                 MCP clients seeded into brand-new workspaces. Persisted
                 ``.mcp`` state wins on reattach.
+            default_skills (`Sequence[str | Skill | SkillLoaderBase | \
+SkillSourceBase] | None`, optional):
+                Skills seeded into brand-new workspaces.
             skill_paths (`list[str] | None`, optional):
-                Skill directories seeded into brand-new workspaces.
+                **Deprecated.** Pass local directories in
+                ``default_skills`` instead.
             os_user (`str | None`, optional):
                 Optional Daytona OS user forwarded to workspace create
                 params. ``None`` leaves user selection to Daytona.
@@ -116,7 +125,7 @@ class DaytonaWorkspaceManager(WorkspaceManagerBase):
         self._sandbox_metadata = dict(sandbox_metadata or {})
         self._extra_pip = list(extra_pip or [])
         self._default_mcps = list(default_mcps or [])
-        self._skill_paths = list(skill_paths or [])
+        self._default_skills = [*(skill_paths or []), *(default_skills or [])]
         self._os_user = os_user
         self._ttl = ttl
         self._sweep_interval = sweep_interval
@@ -150,6 +159,9 @@ class DaytonaWorkspaceManager(WorkspaceManagerBase):
         workspace_id: str | None,
         user_id: str,
         agent_id: str,
+        seed_mcps: list[MCPClient] | None = None,
+        seed_skills: Sequence[str | Skill | SkillLoaderBase | SkillSourceBase]
+        | None = None,
     ) -> DaytonaWorkspace:
         """Construct a :class:`DaytonaWorkspace` and initialize it.
 
@@ -167,8 +179,8 @@ class DaytonaWorkspaceManager(WorkspaceManagerBase):
             env=self._env,
             sandbox_metadata=self._metadata_for(user_id, agent_id),
             extra_pip=self._extra_pip,
-            default_mcps=self._default_mcps,
-            skill_paths=self._skill_paths,
+            default_mcps=[*self._default_mcps, *(seed_mcps or [])],
+            default_skills=[*self._default_skills, *(seed_skills or [])],
             os_user=self._os_user,
         )
         await ws.initialize()
@@ -182,6 +194,9 @@ class DaytonaWorkspaceManager(WorkspaceManagerBase):
         agent_id: str,
         session_id: str,
         workspace_id: str | None = None,
+        seed_mcps: list[MCPClient] | None = None,
+        seed_skills: Sequence[str | Skill | SkillLoaderBase | SkillSourceBase]
+        | None = None,
     ) -> DaytonaWorkspace:
         """Return an initialized workspace, reattaching on cache miss.
 
@@ -234,6 +249,8 @@ class DaytonaWorkspaceManager(WorkspaceManagerBase):
                 workspace_id=workspace_id,
                 user_id=user_id,
                 agent_id=agent_id,
+                seed_mcps=seed_mcps,
+                seed_skills=seed_skills,
             )
             self._cache[workspace_id] = (ws, time.monotonic())
             return ws

--- a/src/agentscope/app/workspace_manager/_docker_workspace_manager.py
+++ b/src/agentscope/app/workspace_manager/_docker_workspace_manager.py
@@ -28,18 +28,19 @@ constructor):
 import asyncio
 import os
 import time
-from typing import Self
+from typing import Self, Sequence
 
 from typing_extensions import deprecated
 
 from ..._logging import logger
 from ...mcp import MCPClient
+from ...skill import Skill, SkillLoaderBase, SkillSourceBase
 from ...workspace import DockerWorkspace
 from ...workspace._docker._make_dockerfile import (
     DEFAULT_BASE_IMAGE,
     DEFAULT_GATEWAY_PORT,
 )
-from ._base import WorkspaceManagerBase, IsolationPolicy
+from ._base import IsolationPolicy, WorkspaceManagerBase
 
 DEFAULT_SWEEP_INTERVAL = 300.0
 
@@ -68,6 +69,10 @@ class DockerWorkspaceManager(WorkspaceManagerBase):
         gateway_port: int = DEFAULT_GATEWAY_PORT,
         env: dict[str, str] | None = None,
         default_mcps: list[MCPClient] | None = None,
+        default_skills: Sequence[
+            str | Skill | SkillLoaderBase | SkillSourceBase
+        ]
+        | None = None,
         skill_paths: list[str] | None = None,
         ttl: float = 3600.0,
         sweep_interval: float = DEFAULT_SWEEP_INTERVAL,
@@ -105,8 +110,12 @@ class DockerWorkspaceManager(WorkspaceManagerBase):
                 MCP clients seeded into brand-new workspaces. Ignored
                 on subsequent restarts of a workdir that already
                 persists ``.mcp``.
+            default_skills (`Sequence[str | Skill | SkillLoaderBase | \
+SkillSourceBase] | None`, optional):
+                Skills seeded into brand-new workspaces.
             skill_paths (`list[str] | None`, optional):
-                Skill directories seeded into brand-new workspaces.
+                **Deprecated.** Pass local directories in
+                ``default_skills`` instead.
             ttl (`float`, defaults to `3600.0`):
                 Seconds before an idle cached workspace is evicted
                 and its container torn down.
@@ -121,7 +130,7 @@ class DockerWorkspaceManager(WorkspaceManagerBase):
         self._gateway_port = gateway_port
         self._env = dict(env or {})
         self._default_mcps = list(default_mcps or [])
-        self._skill_paths = list(skill_paths or [])
+        self._default_skills = [*(skill_paths or []), *(default_skills or [])]
         super().__init__(isolation=isolation)
         self._ttl = ttl
         self._sweep_interval = sweep_interval
@@ -150,6 +159,9 @@ class DockerWorkspaceManager(WorkspaceManagerBase):
         workspace_id: str,
         user_id: str,
         agent_id: str,
+        seed_mcps: list[MCPClient] | None = None,
+        seed_skills: Sequence[str | Skill | SkillLoaderBase | SkillSourceBase]
+        | None = None,
     ) -> DockerWorkspace:
         """Create a :class:`DockerWorkspace` for ``(user_id, agent_id)``
         and run its full ``initialize``.
@@ -167,8 +179,8 @@ class DockerWorkspaceManager(WorkspaceManagerBase):
             extra_pip=self._extra_pip,
             gateway_port=self._gateway_port,
             env=self._env,
-            default_mcps=self._default_mcps,
-            skill_paths=self._skill_paths,
+            default_mcps=[*self._default_mcps, *(seed_mcps or [])],
+            default_skills=[*self._default_skills, *(seed_skills or [])],
         )
         await ws.initialize()
         return ws
@@ -181,6 +193,9 @@ class DockerWorkspaceManager(WorkspaceManagerBase):
         agent_id: str,
         session_id: str,
         workspace_id: str | None = None,
+        seed_mcps: list[MCPClient] | None = None,
+        seed_skills: Sequence[str | Skill | SkillLoaderBase | SkillSourceBase]
+        | None = None,
     ) -> DockerWorkspace:
         """Return an initialised workspace, building one on cache miss.
 
@@ -242,6 +257,8 @@ class DockerWorkspaceManager(WorkspaceManagerBase):
                 workspace_id=workspace_id,
                 user_id=user_id,
                 agent_id=agent_id,
+                seed_mcps=seed_mcps,
+                seed_skills=seed_skills,
             )
             self._cache[workspace_id] = (ws, time.monotonic())
             return ws
@@ -289,7 +306,7 @@ class DockerWorkspaceManager(WorkspaceManagerBase):
             gateway_port=self._gateway_port,
             env=self._env,
             default_mcps=self._default_mcps,
-            skill_paths=self._skill_paths,
+            default_skills=self._default_skills,
         )
         await ws.initialize()
         async with self._lock:

--- a/src/agentscope/app/workspace_manager/_e2b_workspace_manager.py
+++ b/src/agentscope/app/workspace_manager/_e2b_workspace_manager.py
@@ -34,19 +34,20 @@ Differences from the Docker manager:
 
 import asyncio
 import time
-from typing import Self
+from typing import Self, Sequence
 
 from typing_extensions import deprecated
 
 from ..._logging import logger
 from ...mcp import MCPClient
+from ...skill import Skill, SkillLoaderBase, SkillSourceBase
 from ...workspace import E2BWorkspace
 from ...workspace._e2b._constants import (
     DEFAULT_GATEWAY_PORT,
     DEFAULT_TEMPLATE,
     DEFAULT_TIMEOUT,
 )
-from ._base import WorkspaceManagerBase, IsolationPolicy
+from ._base import IsolationPolicy, WorkspaceManagerBase
 
 DEFAULT_SWEEP_INTERVAL = 300.0
 
@@ -72,6 +73,10 @@ class E2BWorkspaceManager(WorkspaceManagerBase):
         sandbox_metadata: dict[str, str] | None = None,
         extra_pip: list[str] | None = None,
         default_mcps: list[MCPClient] | None = None,
+        default_skills: Sequence[
+            str | Skill | SkillLoaderBase | SkillSourceBase
+        ]
+        | None = None,
         skill_paths: list[str] | None = None,
         ttl: float = 3600.0,
         sweep_interval: float = DEFAULT_SWEEP_INTERVAL,
@@ -110,8 +115,12 @@ class E2BWorkspaceManager(WorkspaceManagerBase):
                 MCP clients seeded into brand-new workspaces. Ignored
                 on subsequent reattachments — the sandbox's persisted
                 ``.mcp`` file wins.
+            default_skills (`Sequence[str | Skill | SkillLoaderBase | \
+SkillSourceBase] | None`, optional):
+                Skills seeded into brand-new workspaces.
             skill_paths (`list[str] | None`, optional):
-                Skill directories seeded into brand-new workspaces.
+                **Deprecated.** Pass local directories in
+                ``default_skills`` instead.
             ttl (`float`, defaults to `3600.0`):
                 Seconds before an idle cached workspace is evicted
                 and its sandbox paused.
@@ -128,7 +137,7 @@ class E2BWorkspaceManager(WorkspaceManagerBase):
         self._sandbox_metadata = dict(sandbox_metadata or {})
         self._extra_pip = list(extra_pip or [])
         self._default_mcps = list(default_mcps or [])
-        self._skill_paths = list(skill_paths or [])
+        self._default_skills = [*(skill_paths or []), *(default_skills or [])]
         self._ttl = ttl
         self._sweep_interval = sweep_interval
         super().__init__(isolation=isolation)
@@ -165,6 +174,9 @@ class E2BWorkspaceManager(WorkspaceManagerBase):
         workspace_id: str | None,
         user_id: str,
         agent_id: str,
+        seed_mcps: list[MCPClient] | None = None,
+        seed_skills: Sequence[str | Skill | SkillLoaderBase | SkillSourceBase]
+        | None = None,
     ) -> E2BWorkspace:
         """Construct an :class:`E2BWorkspace` and run its full ``initialize``.
 
@@ -183,8 +195,8 @@ class E2BWorkspaceManager(WorkspaceManagerBase):
             env=self._env,
             sandbox_metadata=self._metadata_for(user_id, agent_id),
             extra_pip=self._extra_pip,
-            default_mcps=self._default_mcps,
-            skill_paths=self._skill_paths,
+            default_mcps=[*self._default_mcps, *(seed_mcps or [])],
+            default_skills=[*self._default_skills, *(seed_skills or [])],
         )
         await ws.initialize()
         return ws
@@ -197,6 +209,9 @@ class E2BWorkspaceManager(WorkspaceManagerBase):
         agent_id: str,
         session_id: str,
         workspace_id: str | None = None,
+        seed_mcps: list[MCPClient] | None = None,
+        seed_skills: Sequence[str | Skill | SkillLoaderBase | SkillSourceBase]
+        | None = None,
     ) -> E2BWorkspace:
         """Return an initialised workspace, reattaching on cache miss.
 
@@ -261,6 +276,8 @@ class E2BWorkspaceManager(WorkspaceManagerBase):
                 workspace_id=workspace_id,
                 user_id=user_id,
                 agent_id=agent_id,
+                seed_mcps=seed_mcps,
+                seed_skills=seed_skills,
             )
             self._cache[workspace_id] = (ws, time.monotonic())
             return ws

--- a/src/agentscope/app/workspace_manager/_k8s_workspace_manager.py
+++ b/src/agentscope/app/workspace_manager/_k8s_workspace_manager.py
@@ -17,18 +17,19 @@ Differences from the E2B manager:
 
 import asyncio
 import time
-from typing import Any, Self
+from typing import Any, Self, Sequence
 
 from typing_extensions import deprecated
 
 from ..._logging import logger
 from ...mcp import MCPClient
+from ...skill import Skill, SkillLoaderBase, SkillSourceBase
 from ...workspace import K8sWorkspace
 from ...workspace._k8s._constants import (
     DEFAULT_GATEWAY_PORT,
     DEFAULT_IMAGE,
 )
-from ._base import WorkspaceManagerBase, IsolationPolicy
+from ._base import IsolationPolicy, WorkspaceManagerBase
 
 DEFAULT_SWEEP_INTERVAL = 300.0
 
@@ -59,6 +60,10 @@ class K8sWorkspaceManager(WorkspaceManagerBase):
         storage_size: str = "1Gi",
         env: dict[str, str] | None = None,
         default_mcps: list[MCPClient] | None = None,
+        default_skills: Sequence[
+            str | Skill | SkillLoaderBase | SkillSourceBase
+        ]
+        | None = None,
         skill_paths: list[str] | None = None,
         ttl: float = 3600.0,
         sweep_interval: float = DEFAULT_SWEEP_INTERVAL,
@@ -101,8 +106,12 @@ class K8sWorkspaceManager(WorkspaceManagerBase):
                 Environment variables for workspace containers.
             default_mcps (`list[MCPClient] | None`, optional):
                 MCPs seeded into new workspaces.
+            default_skills (`Sequence[str | Skill | SkillLoaderBase | \
+SkillSourceBase] | None`, optional):
+                Skills seeded into brand-new workspaces.
             skill_paths (`list[str] | None`, optional):
-                Skill directories seeded into new workspaces.
+                **Deprecated.** Pass local directories in
+                ``default_skills`` instead.
             ttl (`float`, defaults to `3600.0`):
                 Seconds before an idle workspace is evicted.
             sweep_interval (`float`, defaults to `300.0`):
@@ -126,7 +135,7 @@ class K8sWorkspaceManager(WorkspaceManagerBase):
         self._storage_size = storage_size
         self._env = dict(env or {})
         self._default_mcps = list(default_mcps or [])
-        self._skill_paths = list(skill_paths or [])
+        self._default_skills = [*(skill_paths or []), *(default_skills or [])]
         self._ttl = ttl
         self._sweep_interval = sweep_interval
         self._delete_pvc_on_close = delete_pvc_on_close
@@ -143,6 +152,9 @@ class K8sWorkspaceManager(WorkspaceManagerBase):
         self,
         *,
         workspace_id: str | None,
+        seed_mcps: list[MCPClient] | None = None,
+        seed_skills: Sequence[str | Skill | SkillLoaderBase | SkillSourceBase]
+        | None = None,
     ) -> K8sWorkspace:
         """Construct a :class:`K8sWorkspace` and run ``initialize``."""
         ws = K8sWorkspace(
@@ -162,8 +174,8 @@ class K8sWorkspaceManager(WorkspaceManagerBase):
             storage_size=self._storage_size,
             delete_pvc_on_close=self._delete_pvc_on_close,
             env=self._env,
-            default_mcps=self._default_mcps,
-            skill_paths=self._skill_paths,
+            default_mcps=[*self._default_mcps, *(seed_mcps or [])],
+            default_skills=[*self._default_skills, *(seed_skills or [])],
         )
         await ws.initialize()
         return ws
@@ -176,6 +188,9 @@ class K8sWorkspaceManager(WorkspaceManagerBase):
         agent_id: str,
         session_id: str,
         workspace_id: str | None = None,
+        seed_mcps: list[MCPClient] | None = None,
+        seed_skills: Sequence[str | Skill | SkillLoaderBase | SkillSourceBase]
+        | None = None,
     ) -> K8sWorkspace:
         """Return an initialised workspace, reattaching on cache miss.
 
@@ -220,6 +235,8 @@ class K8sWorkspaceManager(WorkspaceManagerBase):
 
             ws = await self._build_and_start(
                 workspace_id=workspace_id,
+                seed_mcps=seed_mcps,
+                seed_skills=seed_skills,
             )
             self._cache[workspace_id] = (ws, time.monotonic())
             return ws

--- a/src/agentscope/app/workspace_manager/_local_workspace_manager.py
+++ b/src/agentscope/app/workspace_manager/_local_workspace_manager.py
@@ -4,12 +4,15 @@
 import asyncio
 import os
 import time
+from typing import Sequence
 
 from typing_extensions import deprecated
 
 from ..._logging import logger
+from ...mcp import MCPClient
+from ...skill import Skill, SkillLoaderBase, SkillSourceBase
 from ...workspace import LocalWorkspace
-from ._base import WorkspaceManagerBase, IsolationPolicy
+from ._base import IsolationPolicy, WorkspaceManagerBase
 
 
 class LocalWorkspaceManager(WorkspaceManagerBase):
@@ -26,7 +29,11 @@ class LocalWorkspaceManager(WorkspaceManagerBase):
         basedir: str,
         *,
         isolation: IsolationPolicy = IsolationPolicy.PER_AGENT,
-        default_mcps: list | None = None,
+        default_mcps: list[MCPClient] | None = None,
+        default_skills: Sequence[
+            str | Skill | SkillLoaderBase | SkillSourceBase
+        ]
+        | None = None,
         skill_paths: list[str] | None = None,
         ttl: float = 3600.0,
     ) -> None:
@@ -41,14 +48,18 @@ class LocalWorkspaceManager(WorkspaceManagerBase):
                 :class:`DockerWorkspaceManager` for semantics.
             default_mcps (`list | None`, optional):
                 MCP clients seeded into brand-new workspaces.
+            default_skills (`Sequence[str | Skill | SkillLoaderBase | \
+SkillSourceBase] | None`, optional):
+                Skills seeded into brand-new workspaces.
             skill_paths (`list[str] | None`, optional):
-                Skill directories seeded into brand-new workspaces.
+                **Deprecated.** Pass local directories in
+                ``default_skills`` instead.
             ttl (`float`, defaults to `3600.0`):
                 Seconds before an idle cached workspace is evicted.
         """
         self._basedir = os.path.abspath(basedir)
-        self._default_mcps = default_mcps or []
-        self._skill_paths = skill_paths or []
+        self._default_mcps = list(default_mcps or [])
+        self._default_skills = [*(skill_paths or []), *(default_skills or [])]
         self._ttl = ttl
         # workspace_id → (workspace, last_access_monotonic)
         self._cache: dict[str, tuple[LocalWorkspace, float]] = {}
@@ -73,6 +84,9 @@ class LocalWorkspaceManager(WorkspaceManagerBase):
         agent_id: str,
         session_id: str,
         workspace_id: str | None = None,
+        seed_mcps: list[MCPClient] | None = None,
+        seed_skills: Sequence[str | Skill | SkillLoaderBase | SkillSourceBase]
+        | None = None,
     ) -> LocalWorkspace:
         """Return an initialized workspace, reconstructing from
         disk on cache miss.
@@ -132,8 +146,11 @@ class LocalWorkspaceManager(WorkspaceManagerBase):
             ws = LocalWorkspace(
                 workspace_id=workspace_id,
                 workdir=workdir,
-                default_mcps=self._default_mcps,
-                skill_paths=self._skill_paths,
+                default_mcps=[*self._default_mcps, *(seed_mcps or [])],
+                default_skills=[
+                    *self._default_skills,
+                    *(seed_skills or []),
+                ],
             )
             await ws.initialize()
             self._cache[workspace_id] = (ws, time.monotonic())
@@ -164,7 +181,7 @@ class LocalWorkspaceManager(WorkspaceManagerBase):
         ws = LocalWorkspace(
             workdir=workdir,
             default_mcps=self._default_mcps,
-            skill_paths=self._skill_paths,
+            default_skills=self._default_skills,
         )
         await ws.initialize()
         async with self._lock:

--- a/src/agentscope/app/workspace_manager/_opensandbox_workspace_manager.py
+++ b/src/agentscope/app/workspace_manager/_opensandbox_workspace_manager.py
@@ -29,18 +29,18 @@ Differences from the Docker manager:
 
 import asyncio
 import time
-from typing import Any, Literal, Self
+from typing import Any, Literal, Self, Sequence
 
 from ..._logging import logger
 from ...mcp import MCPClient
+from ...skill import Skill, SkillLoaderBase, SkillSourceBase
+from ...workspace import OpenSandboxWorkspace
 from ...workspace._opensandbox._constants import (
     DEFAULT_GATEWAY_PORT,
     DEFAULT_IMAGE,
     DEFAULT_REQUEST_TIMEOUT,
     DEFAULT_TIMEOUT,
 )
-from ...workspace import OpenSandboxWorkspace
-
 from ._base import IsolationPolicy, WorkspaceManagerBase
 
 DEFAULT_SWEEP_INTERVAL = 300.0
@@ -72,6 +72,10 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
         network_policy: Any | None = None,
         extra_pip: list[str] | None = None,
         default_mcps: list[MCPClient] | None = None,
+        default_skills: Sequence[
+            str | Skill | SkillLoaderBase | SkillSourceBase
+        ]
+        | None = None,
         skill_paths: list[str] | None = None,
         ttl: float = 3600.0,
         sweep_interval: float = DEFAULT_SWEEP_INTERVAL,
@@ -124,8 +128,12 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
             default_mcps (`list[MCPClient] | None`, optional):
                 MCP clients seeded into brand-new workspaces. On
                 reattach, the sandbox's persisted ``.mcp`` file wins.
+            default_skills (`Sequence[str | Skill | SkillLoaderBase | \
+SkillSourceBase] | None`, optional):
+                Skills seeded into brand-new workspaces.
             skill_paths (`list[str] | None`, optional):
-                Skill directories seeded into brand-new workspaces.
+                **Deprecated.** Pass local directories in
+                ``default_skills`` instead.
             ttl (`float`, defaults to `3600.0`):
                 Seconds before an idle cached workspace is evicted and
                 its sandbox paused.
@@ -147,7 +155,7 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
         self._network_policy = network_policy
         self._extra_pip = list(extra_pip or [])
         self._default_mcps = list(default_mcps or [])
-        self._skill_paths = list(skill_paths or [])
+        self._default_skills = [*(skill_paths or []), *(default_skills or [])]
         self._ttl = ttl
         self._sweep_interval = sweep_interval
         super().__init__(isolation=isolation)
@@ -163,6 +171,9 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
         workspace_id: str,
         user_id: str,
         agent_id: str,
+        seed_mcps: list[MCPClient] | None = None,
+        seed_skills: Sequence[str | Skill | SkillLoaderBase | SkillSourceBase]
+        | None = None,
     ) -> OpenSandboxWorkspace:
         """Construct an OpenSandbox workspace and run full initialize.
 
@@ -190,8 +201,8 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
             entrypoint=self._entrypoint,
             network_policy=self._network_policy,
             extra_pip=self._extra_pip,
-            default_mcps=self._default_mcps,
-            skill_paths=self._skill_paths,
+            default_mcps=[*self._default_mcps, *(seed_mcps or [])],
+            default_skills=[*self._default_skills, *(seed_skills or [])],
         )
         await ws.initialize()
         return ws
@@ -202,6 +213,9 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
         agent_id: str,
         session_id: str,
         workspace_id: str | None = None,
+        seed_mcps: list[MCPClient] | None = None,
+        seed_skills: Sequence[str | Skill | SkillLoaderBase | SkillSourceBase]
+        | None = None,
     ) -> OpenSandboxWorkspace:
         """Return an initialized workspace, reattaching on cache miss.
 
@@ -264,6 +278,8 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
                 workspace_id=workspace_id,
                 user_id=user_id,
                 agent_id=agent_id,
+                seed_mcps=seed_mcps,
+                seed_skills=seed_skills,
             )
             self._cache[workspace_id] = (ws, time.monotonic())
             return ws

--- a/src/agentscope/skill/__init__.py
+++ b/src/agentscope/skill/__init__.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
 """The skill related classes and functions."""
 
-from ._base import SkillLoaderBase, Skill
+from ._archive import SkillArchive, SkillSourceBase
+from ._base import Skill, SkillLoaderBase
 from ._local_loader import LocalSkillLoader
 
 __all__ = [
     "Skill",
+    "SkillArchive",
     "SkillLoaderBase",
+    "SkillSourceBase",
     "LocalSkillLoader",
 ]

--- a/src/agentscope/skill/_archive.py
+++ b/src/agentscope/skill/_archive.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""Skill archives and the sources they are fetched from."""
+from abc import ABC, abstractmethod
+from typing import AsyncIterator, Literal, NamedTuple
+
+
+class SkillArchive(NamedTuple):
+    """A skill archive, already opened for reading.
+
+    The format travels with the bytes so a source can forward its
+    upstream response untouched — repacking to a fixed format would
+    force every source to buffer the whole archive.
+
+    Attributes:
+        format: The archive format, as the installer must unpack it.
+        stream: The archive bytes, in order.
+    """
+
+    format: Literal["zip", "tar", "tar.gz"]
+    stream: AsyncIterator[bytes]
+
+
+class SkillSourceBase(ABC):
+    """Where a skill archive comes from, before it is fetched.
+
+    :class:`~agentscope.skill.SkillLoaderBase` enumerates skills that
+    already exist as directories. This one has no directory yet — only
+    a way to get the bytes, which the workspace expands inside its
+    sandbox rather than on the host.
+
+    Constructing one does no I/O: a workspace holds sources it may
+    never open, and only calls :meth:`open` if it decides to seed.
+    """
+
+    def __init__(self, name: str) -> None:
+        """Bind the name the skill installs as.
+
+        Args:
+            name (`str`):
+                Directory name to install as, inside ``skills/``.
+        """
+        self.name = name
+
+    @abstractmethod
+    async def open(self) -> SkillArchive:
+        """Fetch the archive.
+
+        Returns:
+            `SkillArchive`:
+                The format plus the archive bytes.
+        """

--- a/src/agentscope/workspace/_applecontainer/_applecontainer_workspace.py
+++ b/src/agentscope/workspace/_applecontainer/_applecontainer_workspace.py
@@ -39,9 +39,11 @@ SDK for the ``container`` CLI:
 import asyncio
 import json
 import shlex
+from typing import Any, Sequence
 
 from ..._logging import logger
 from ...mcp import MCPClient
+from ...skill import Skill, SkillLoaderBase, SkillSourceBase
 from .._sandboxed_base import SandboxedWorkspaceBase
 from .._utils import _GATEWAY_BASE_REQUIREMENTS
 from ._applecontainer_backend import AppleContainerBackend
@@ -75,7 +77,7 @@ Layout:
 class AppleContainerWorkspace(SandboxedWorkspaceBase):
     """Workspace backed by Apple's ``container`` CLI.
 
-    ``default_mcps`` and ``skill_paths`` are seed-time inputs and are
+    ``default_mcps`` and ``default_skills`` are seed-time inputs and are
     not retained as instance state past :meth:`initialize`.
 
     Requires:
@@ -98,7 +100,11 @@ class AppleContainerWorkspace(SandboxedWorkspaceBase):
         extra_pip: list[str] | None = None,
         instructions: str = _DEFAULT_INSTRUCTIONS,
         default_mcps: list[MCPClient] | None = None,
-        skill_paths: list[str] | None = None,
+        default_skills: Sequence[
+            str | Skill | SkillLoaderBase | SkillSourceBase
+        ]
+        | None = None,
+        **kwargs: Any,
     ) -> None:
         """Construct an :class:`AppleContainerWorkspace`.
 
@@ -129,13 +135,15 @@ class AppleContainerWorkspace(SandboxedWorkspaceBase):
             default_mcps (`list[MCPClient] | None`, optional):
                 MCPs registered on first init when no persisted
                 ``.mcp`` exists.
-            skill_paths (`list[str] | None`, optional):
-                Local skill dirs seeded into ``skills/`` on first init.
+            default_skills (`Sequence[str | Skill | SkillLoaderBase | \
+SkillSourceBase] | None`, optional):
+                Skills seeded into ``skills/`` on first init.
         """
         super().__init__(
             workspace_id=workspace_id,
             default_mcps=default_mcps,
-            skill_paths=skill_paths,
+            default_skills=default_skills,
+            **kwargs,
         )
 
         # ── serializable config ─────────────────────────────────

--- a/src/agentscope/workspace/_base.py
+++ b/src/agentscope/workspace/_base.py
@@ -56,12 +56,16 @@ import tarfile
 from abc import abstractmethod
 from copy import deepcopy
 from pathlib import Path
-from typing import AsyncIterator, Literal, Self
+from typing import Any, AsyncIterator, Literal, Self, Sequence
 
 from pydantic import AnyUrl
 
 from .._logging import logger
-from .._utils._common import _generate_id, _normalize_local_path
+from .._utils._common import (
+    _describe_exception,
+    _generate_id,
+    _normalize_local_path,
+)
 from ..mcp import MCPClient
 from ..message import (
     Base64Source,
@@ -71,7 +75,12 @@ from ..message import (
     ToolResultBlock,
     URLSource,
 )
-from ..skill import Skill
+from ..skill import (
+    LocalSkillLoader,
+    Skill,
+    SkillLoaderBase,
+    SkillSourceBase,
+)
 from ..tool import BackendBase, ToolBase
 from ._utils import (
     DEFAULT_DATA_DIR,
@@ -173,8 +182,10 @@ class WorkspaceBase:
     """MCP clients to seed on first :meth:`initialize` when the
     persisted ``.mcp`` file is absent."""
 
-    skill_paths: list[str]
-    """Local skill directories to seed on first :meth:`initialize`."""
+    default_skills: list[Skill | SkillLoaderBase | SkillSourceBase]
+    """Skills to seed on first :meth:`initialize`, already normalised
+    from the ``str`` and deprecated ``skill_paths`` forms the
+    constructor accepts."""
 
     _mcps: list[MCPClient]
     """Currently registered MCP clients (in-memory authoritative copy).
@@ -207,7 +218,11 @@ class WorkspaceBase:
         *,
         workspace_id: str | None = None,
         default_mcps: list[MCPClient] | None = None,
-        skill_paths: list[str] | None = None,
+        default_skills: Sequence[
+            str | Skill | SkillLoaderBase | SkillSourceBase
+        ]
+        | None = None,
+        **kwargs: Any,
     ) -> None:
         """Initialise the shared workspace state.
 
@@ -224,18 +239,67 @@ class WorkspaceBase:
             default_mcps (`list[MCPClient] | None`, optional):
                 MCP clients to register when the workspace boots
                 without a persisted ``.mcp`` file.
-            skill_paths (`list[str] | None`, optional):
-                Local skill directories to copy into ``skills/`` on
-                first start.
+            default_skills (`Sequence[str | Skill | SkillLoaderBase | \
+SkillSourceBase] | None`, optional):
+                Skills to install on first start. A ``str`` is a local
+                directory; a :class:`SkillSourceBase` is fetched instead
+                of copied, and is opened only if the seeding actually
+                happens.
+            **kwargs (`Any`):
+                Accepts the deprecated ``skill_paths``, folded into
+                ``default_skills``. Anything else is an error.
+
+        Raises:
+            `TypeError`:
+                On an unrecognised keyword argument, or a
+                ``default_skills`` entry that is none of the accepted
+                kinds.
         """
+        skill_paths = kwargs.pop("skill_paths", None)
+        if skill_paths is not None:
+            logger.warning(
+                "%s parameter 'skill_paths' is deprecated, pass local "
+                "skill directories in 'default_skills' instead.",
+                type(self).__name__,
+            )
+        if kwargs:
+            raise TypeError(
+                f"{type(self).__name__} got unexpected keyword "
+                f"argument(s): {', '.join(sorted(kwargs))}.",
+            )
+
         self.workspace_id = workspace_id or _generate_id()
         self.is_alive = False
         self._backend = None
 
         self.default_mcps = list(default_mcps or [])
-        self.skill_paths = [
-            _normalize_local_path(path) for path in skill_paths or []
-        ]
+
+        # ``str`` is normalised to a loader exactly as ``ToolGroup``
+        # does, so the two places that accept "a skill or something
+        # that yields one" stay the same shape.
+        self.default_skills: list[
+            Skill | SkillLoaderBase | SkillSourceBase
+        ] = []
+        for item in [*(skill_paths or []), *(default_skills or [])]:
+            if isinstance(item, str):
+                self.default_skills.append(
+                    LocalSkillLoader(directory=_normalize_local_path(item)),
+                )
+            elif isinstance(item, (Skill, SkillLoaderBase, SkillSourceBase)):
+                self.default_skills.append(item)
+            else:
+                raise TypeError(
+                    f"Invalid default skill: {item!r}. Must be a skill, "
+                    f"skill loader, skill source, or directory path.",
+                )
+
+        self.seed_errors: dict[str, str] = {}
+        """What could not be seeded on first start, mapped to why.
+
+        In memory only: it describes a one-off event, and re-deriving it
+        later from "bound but absent" would be wrong — by then the user
+        may simply have removed the skill on purpose.
+        """
 
         self._mcps = []
         self._mcp_lock = asyncio.Lock()
@@ -310,7 +374,7 @@ class WorkspaceBase:
         Closes and removes all registered MCPs, deletes all skills,
         and wipes per-session state (offloaded context / tool results
         and any data files). Constructor-time ``default_mcps`` and
-        ``skill_paths`` are **not** re-seeded — reset returns the
+        ``default_skills`` are **not** re-seeded — reset returns the
         workspace to an empty state, not its initial state.
 
         The default implementation is a no-op. Subclasses with user
@@ -900,33 +964,34 @@ class WorkspaceBase:
         await backend.delete_path(target_dir)
         logger.info("Removed skill %r at %s", name, target_dir)
 
-    async def _setup_skills(self) -> None:
-        """Copy :attr:`skill_paths` into ``${workdir}/skills`` once.
+    async def _seed_skills(self) -> None:
+        """Install :attr:`default_skills` into ``${workdir}/skills``.
 
-        Skips seeding when:
+        Called by :meth:`initialize` only on a workspace's first boot,
+        so a skill the user later deletes is not reinstated on the next
+        start. Dispatch is by how the skill has to travel, not by what
+        it is: one that already exists as a directory is copied, one
+        that has to be fetched is streamed into the sandbox and expanded
+        there.
 
-        - :attr:`skill_paths` is empty;
-        - the backend is not bound; or
-        - ``skills/`` already contains entries (assume the prior
-          run, or the user, is the source of truth).
-
-        Individual failures are logged and skipped — a single bad
-        skill cannot block startup.
+        Individual failures are recorded in :attr:`seed_errors` and
+        skipped — a single bad skill cannot block startup.
         """
-        if not self.skill_paths:
-            return
-        backend = self._backend
-        if backend is None:
-            return
-        entries = await backend.list_dir(self._skills_dir)
-        if entries:
-            return
-        for path in self.skill_paths:
+        for item in self.default_skills:
+            name = getattr(item, "name", None) or str(item)
             try:
-                await self.add_skill(path)
+                if isinstance(item, SkillSourceBase):
+                    archive = await item.open()
+                    await self.add_skill_archive(
+                        archive.stream,
+                        archive.format,
+                        item.name,
+                    )
+                elif isinstance(item, SkillLoaderBase):
+                    for skill in await item.list_skills():
+                        await self.add_skill(skill.dir)
+                else:
+                    await self.add_skill(item.dir)
             except Exception as e:
-                logger.warning(
-                    "Skip skill %r: %s",
-                    path,
-                    e,
-                )
+                self.seed_errors[name] = _describe_exception(e)
+                logger.warning("Skip skill %r: %s", name, e)

--- a/src/agentscope/workspace/_bubblewrap/_bubblewrap_workspace.py
+++ b/src/agentscope/workspace/_bubblewrap/_bubblewrap_workspace.py
@@ -13,10 +13,11 @@ import shutil
 import socket
 import sys
 import tempfile
-from typing import Any
+from typing import Any, Sequence
 
 from ..._logging import logger
 from ...mcp import MCPClient
+from ...skill import Skill, SkillLoaderBase, SkillSourceBase
 from .._gateway_client import GatewayClient
 from .._sandboxed_base import SandboxedWorkspaceBase
 from .._utils import (
@@ -86,7 +87,11 @@ class BubblewrapWorkspace(SandboxedWorkspaceBase):
         extra_pip: list[str] | None = None,
         instructions: str = _DEFAULT_INSTRUCTIONS,
         default_mcps: list[MCPClient] | None = None,
-        skill_paths: list[str] | None = None,
+        default_skills: Sequence[
+            str | Skill | SkillLoaderBase | SkillSourceBase
+        ]
+        | None = None,
+        **kwargs: Any,
     ) -> None:
         """Construct a :class:`BubblewrapWorkspace`.
 
@@ -120,8 +125,9 @@ class BubblewrapWorkspace(SandboxedWorkspaceBase):
                 System-prompt fragment template.
             default_mcps (`list[MCPClient] | None`, optional):
                 MCPs seeded on first initialization.
-            skill_paths (`list[str] | None`, optional):
-                Local skill directories seeded on first initialization.
+            default_skills (`Sequence[str | Skill | SkillLoaderBase | \
+SkillSourceBase] | None`, optional):
+                Skills seeded into ``skills/`` on first init.
         """
         self._validate_gateway_port(gateway_port)
         if not share_net:
@@ -138,7 +144,8 @@ class BubblewrapWorkspace(SandboxedWorkspaceBase):
         super().__init__(
             workspace_id=workspace_id,
             default_mcps=default_mcps,
-            skill_paths=skill_paths,
+            default_skills=default_skills,
+            **kwargs,
         )
 
         self.workdir = SANDBOX_WORKDIR

--- a/src/agentscope/workspace/_daytona/_daytona_workspace.py
+++ b/src/agentscope/workspace/_daytona/_daytona_workspace.py
@@ -45,10 +45,11 @@ from __future__ import annotations
 
 import posixpath
 import shlex
-from typing import Any
+from typing import Any, Sequence
 
 from ..._logging import logger
 from ...mcp import MCPClient
+from ...skill import Skill, SkillLoaderBase, SkillSourceBase
 from .._sandboxed_base import SandboxedWorkspaceBase
 from .._utils import _GATEWAY_BASE_REQUIREMENTS, DEFAULT_WORKSPACE_INSTRUCTIONS
 from ._constants import (
@@ -65,7 +66,7 @@ from ._daytona_backend import DaytonaBackend
 class DaytonaWorkspace(SandboxedWorkspaceBase):
     """Workspace backed by a Daytona sandbox.
 
-    ``default_mcps`` and ``skill_paths`` are seed-time inputs and are
+    ``default_mcps`` and ``default_skills`` are seed-time inputs and are
     not interpreted until :meth:`initialize`, after the Daytona backend
     has been provisioned and the shared sandbox lifecycle can restore
     persisted state.
@@ -90,8 +91,12 @@ class DaytonaWorkspace(SandboxedWorkspaceBase):
         extra_pip: list[str] | None = None,
         instructions: str = DEFAULT_WORKSPACE_INSTRUCTIONS,
         default_mcps: list[MCPClient] | None = None,
-        skill_paths: list[str] | None = None,
+        default_skills: Sequence[
+            str | Skill | SkillLoaderBase | SkillSourceBase
+        ]
+        | None = None,
         os_user: str | None = None,
+        **kwargs: Any,
     ) -> None:
         """Construct a :class:`DaytonaWorkspace`.
 
@@ -130,8 +135,9 @@ class DaytonaWorkspace(SandboxedWorkspaceBase):
             default_mcps (`list[MCPClient] | None`, optional):
                 MCPs registered on first init when no persisted
                 ``.mcp`` exists.
-            skill_paths (`list[str] | None`, optional):
-                Local skill dirs seeded into ``skills/`` on first init.
+            default_skills (`Sequence[str | Skill | SkillLoaderBase | \
+SkillSourceBase] | None`, optional):
+                Skills seeded into ``skills/`` on first init.
             os_user (`str | None`, optional):
                 Optional Daytona OS user. ``None`` means AgentScope
                 lets Daytona and the selected snapshot decide.
@@ -139,7 +145,8 @@ class DaytonaWorkspace(SandboxedWorkspaceBase):
         super().__init__(
             workspace_id=workspace_id,
             default_mcps=default_mcps,
-            skill_paths=skill_paths,
+            default_skills=default_skills,
+            **kwargs,
         )
 
         # ── serializable config ─────────────────────────────────

--- a/src/agentscope/workspace/_docker/__init__.py
+++ b/src/agentscope/workspace/_docker/__init__.py
@@ -7,7 +7,7 @@ servers run *inside* the container behind a FastAPI gateway and are
 reached over HTTP — see :mod:`agentscope.workspace._gateway_client`.
 """
 
-from ._docker_workspace import DockerWorkspace
 from ._docker_backend import DockerBackend
+from ._docker_workspace import DockerWorkspace
 
 __all__ = ["DockerWorkspace", "DockerBackend"]

--- a/src/agentscope/workspace/_docker/_docker_workspace.py
+++ b/src/agentscope/workspace/_docker/_docker_workspace.py
@@ -21,12 +21,13 @@ import os
 import shutil
 import sys
 import tarfile
-from typing import Any
+from typing import Any, Sequence
 
-from .._utils import DEFAULT_WORKSPACE_INSTRUCTIONS
 from ..._logging import logger
 from ...mcp import MCPClient
+from ...skill import Skill, SkillLoaderBase, SkillSourceBase
 from .._sandboxed_base import SandboxedWorkspaceBase
+from .._utils import DEFAULT_WORKSPACE_INSTRUCTIONS
 from ._docker_backend import DockerBackend
 from ._make_dockerfile import (
     CONTAINER_WORKDIR,
@@ -36,14 +37,13 @@ from ._make_dockerfile import (
     prepare_build_context,
 )
 
-
 # ── the workspace ──────────────────────────────────────────────────
 
 
 class DockerWorkspace(SandboxedWorkspaceBase):
     """Workspace backed by a Docker container.
 
-    ``default_mcps`` and ``skill_paths`` are seed-time inputs and are
+    ``default_mcps`` and ``default_skills`` are seed-time inputs and are
     not retained as instance state past :meth:`initialize`.
     """
 
@@ -61,7 +61,10 @@ class DockerWorkspace(SandboxedWorkspaceBase):
         env: dict[str, str] | None = None,
         instructions: str = DEFAULT_WORKSPACE_INSTRUCTIONS,
         default_mcps: list[MCPClient] | None = None,
-        skill_paths: list[str] | None = None,
+        default_skills: Sequence[
+            str | Skill | SkillLoaderBase | SkillSourceBase
+        ]
+        | None = None,
         **kwargs: Any,
     ) -> None:
         """Construct a :class:`DockerWorkspace`.
@@ -94,8 +97,9 @@ class DockerWorkspace(SandboxedWorkspaceBase):
             default_mcps (`list[MCPClient] | None`, optional):
                 MCPs registered on first init when no persisted
                 ``.mcp`` exists.
-            skill_paths (`list[str] | None`, optional):
-                Local skill dirs seeded into ``skills/`` on first init.
+            default_skills (`Sequence[str | Skill | SkillLoaderBase | \
+SkillSourceBase] | None`, optional):
+                Skills seeded into ``skills/`` on first init.
         """
         # Backwards compatibility: accept legacy ``workdir`` kwarg.
         if "workdir" in kwargs:
@@ -109,7 +113,8 @@ class DockerWorkspace(SandboxedWorkspaceBase):
         super().__init__(
             workspace_id=workspace_id,
             default_mcps=default_mcps,
-            skill_paths=skill_paths,
+            default_skills=default_skills,
+            **kwargs,
         )
 
         # ── serializable config ─────────────────────────────────

--- a/src/agentscope/workspace/_e2b/__init__.py
+++ b/src/agentscope/workspace/_e2b/__init__.py
@@ -6,7 +6,7 @@ Re-exports :class:`E2BWorkspace` so callers can write
 poke at the underlying module layout.
 """
 
-from ._e2b_workspace import E2BWorkspace
 from ._e2b_backend import E2BBackend
+from ._e2b_workspace import E2BWorkspace
 
 __all__ = ["E2BWorkspace", "E2BBackend"]

--- a/src/agentscope/workspace/_e2b/_e2b_workspace.py
+++ b/src/agentscope/workspace/_e2b/_e2b_workspace.py
@@ -39,10 +39,11 @@ manager handles cache, TTL eviction and metadata-based reattachment.
 
 import asyncio
 import shlex
-from typing import Any
+from typing import Any, Sequence
 
 from ..._logging import logger
 from ...mcp import MCPClient
+from ...skill import Skill, SkillLoaderBase, SkillSourceBase
 from .._sandboxed_base import SandboxedWorkspaceBase
 from .._utils import _GATEWAY_BASE_REQUIREMENTS, DEFAULT_WORKSPACE_INSTRUCTIONS
 from ._constants import (
@@ -55,14 +56,13 @@ from ._constants import (
 )
 from ._e2b_backend import E2BBackend
 
-
 # ── the workspace ──────────────────────────────────────────────────
 
 
 class E2BWorkspace(SandboxedWorkspaceBase):
     """Workspace backed by an E2B cloud sandbox.
 
-    ``default_mcps`` and ``skill_paths`` are seed-time inputs and are
+    ``default_mcps`` and ``default_skills`` are seed-time inputs and are
     not retained as instance state past :meth:`initialize`.
     """
 
@@ -86,7 +86,11 @@ class E2BWorkspace(SandboxedWorkspaceBase):
         extra_pip: list[str] | None = None,
         instructions: str = DEFAULT_WORKSPACE_INSTRUCTIONS,
         default_mcps: list[MCPClient] | None = None,
-        skill_paths: list[str] | None = None,
+        default_skills: Sequence[
+            str | Skill | SkillLoaderBase | SkillSourceBase
+        ]
+        | None = None,
+        **kwargs: Any,
     ) -> None:
         """Construct an :class:`E2BWorkspace`.
 
@@ -119,13 +123,15 @@ class E2BWorkspace(SandboxedWorkspaceBase):
             default_mcps (`list[MCPClient] | None`, optional):
                 MCPs registered on first init when no persisted
                 ``.mcp`` exists.
-            skill_paths (`list[str] | None`, optional):
-                Local skill dirs seeded into ``skills/`` on first init.
+            default_skills (`Sequence[str | Skill | SkillLoaderBase | \
+SkillSourceBase] | None`, optional):
+                Skills seeded into ``skills/`` on first init.
         """
         super().__init__(
             workspace_id=workspace_id,
             default_mcps=default_mcps,
-            skill_paths=skill_paths,
+            default_skills=default_skills,
+            **kwargs,
         )
 
         # ── serializable config ─────────────────────────────────

--- a/src/agentscope/workspace/_k8s/__init__.py
+++ b/src/agentscope/workspace/_k8s/__init__.py
@@ -6,7 +6,7 @@ can write ``from agentscope.workspace._k8s import K8sWorkspace``
 without having to poke at the underlying module layout.
 """
 
-from ._k8s_workspace import K8sWorkspace
 from ._k8s_backend import K8sBackend
+from ._k8s_workspace import K8sWorkspace
 
 __all__ = ["K8sWorkspace", "K8sBackend"]

--- a/src/agentscope/workspace/_k8s/_k8s_workspace.py
+++ b/src/agentscope/workspace/_k8s/_k8s_workspace.py
@@ -28,13 +28,13 @@ Docker engine for the Kubernetes API (``kubernetes_asyncio``):
 
 import asyncio
 import shlex
-from typing import Any
+from typing import Any, Sequence
 
 from ..._logging import logger
 from ...mcp import MCPClient
+from ...skill import Skill, SkillLoaderBase, SkillSourceBase
 from .._sandboxed_base import SandboxedWorkspaceBase
 from .._utils import _GATEWAY_BASE_REQUIREMENTS, DEFAULT_WORKSPACE_INSTRUCTIONS
-from ._k8s_backend import K8sBackend
 from ._constants import (
     DEFAULT_GATEWAY_PORT,
     DEFAULT_IMAGE,
@@ -43,7 +43,7 @@ from ._constants import (
     SYSTEM_DEPS,
     _k8s_safe_name,
 )
-
+from ._k8s_backend import K8sBackend
 
 # ── the workspace ──────────────────────────────────────────────────
 
@@ -51,7 +51,7 @@ from ._constants import (
 class K8sWorkspace(SandboxedWorkspaceBase):
     """Workspace backed by a Kubernetes Pod with PVC persistence.
 
-    ``default_mcps`` and ``skill_paths`` are seed-time inputs and are
+    ``default_mcps`` and ``default_skills`` are seed-time inputs and are
     not retained as instance state past :meth:`initialize`.
     """
 
@@ -84,7 +84,11 @@ class K8sWorkspace(SandboxedWorkspaceBase):
         instructions: str = DEFAULT_WORKSPACE_INSTRUCTIONS,
         # ── Seed ──
         default_mcps: list[MCPClient] | None = None,
-        skill_paths: list[str] | None = None,
+        default_skills: Sequence[
+            str | Skill | SkillLoaderBase | SkillSourceBase
+        ]
+        | None = None,
+        **kwargs: Any,
     ) -> None:
         """Construct a :class:`K8sWorkspace`.
 
@@ -129,13 +133,15 @@ class K8sWorkspace(SandboxedWorkspaceBase):
                 System-prompt fragment template.
             default_mcps (`list[MCPClient] | None`, optional):
                 MCPs seeded on first init.
-            skill_paths (`list[str] | None`, optional):
-                Skill directories seeded on first init.
+            default_skills (`Sequence[str | Skill | SkillLoaderBase | \
+SkillSourceBase] | None`, optional):
+                Skills seeded into ``skills/`` on first init.
         """
         super().__init__(
             workspace_id=workspace_id,
             default_mcps=default_mcps,
-            skill_paths=skill_paths,
+            default_skills=default_skills,
+            **kwargs,
         )
 
         # ── serializable config ─────────────────────────────────

--- a/src/agentscope/workspace/_local_workspace.py
+++ b/src/agentscope/workspace/_local_workspace.py
@@ -7,22 +7,26 @@ import json
 import os
 import re
 import shutil
-from typing import AsyncIterator, Literal, TypedDict
+from typing import Any, AsyncIterator, Literal, Sequence, TypedDict
 
 import frontmatter
 
-from ._utils import DEFAULT_WORKSPACE_INSTRUCTIONS
 from .._logging import logger
-from .._utils._common import _generate_id, _normalize_local_path
+from .._utils._common import (
+    _describe_exception,
+    _generate_id,
+    _normalize_local_path,
+)
 from ..mcp import MCPClient
-from ..skill import Skill
+from ..skill import Skill, SkillLoaderBase, SkillSourceBase
 from ..tool import ToolBase
 from ..tool._builtin._backend import LocalBackend
 from ._base import (
-    DEFAULT_MAX_EXTRACTED_BYTES,
     _EXTRACT_ARCHIVE_SHIM,
+    DEFAULT_MAX_EXTRACTED_BYTES,
     WorkspaceBase,
 )
+from ._utils import DEFAULT_WORKSPACE_INSTRUCTIONS
 
 
 class _SkillEntry(TypedDict):
@@ -79,8 +83,12 @@ class LocalWorkspace(WorkspaceBase):
         workdir: str,
         workspace_id: str | None = None,
         default_mcps: list[MCPClient] | None = None,
-        skill_paths: list[str] | None = None,
+        default_skills: Sequence[
+            str | Skill | SkillLoaderBase | SkillSourceBase
+        ]
+        | None = None,
         instructions: str = DEFAULT_WORKSPACE_INSTRUCTIONS,
+        **kwargs: Any,
     ) -> None:
         """Construct a :class:`LocalWorkspace`.
 
@@ -95,16 +103,22 @@ class LocalWorkspace(WorkspaceBase):
                 MCP clients seeded into a brand-new workspace.
                 Ignored on subsequent restarts that already have a
                 persisted ``<workdir>/.mcp`` file.
-            skill_paths (`list[str] | None`, optional):
-                Local skill directories seeded into
-                ``<workdir>/skills`` on first :meth:`initialize`.
+            default_skills (`Sequence[str | Skill | SkillLoaderBase | \
+SkillSourceBase] | None`, optional):
+                Skills seeded into ``<workdir>/skills`` on first
+                :meth:`initialize`. Ignored on subsequent restarts.
             instructions (`str`, defaults to \
             `_DEFAULT_WORKSPACE_INSTRUCTIONS`):
                 System-prompt fragment template returned by
                 :meth:`get_instructions`. Supports the ``{workdir}``
                 placeholder.
         """
-        super().__init__(workspace_id=workspace_id)
+        super().__init__(
+            workspace_id=workspace_id,
+            default_mcps=default_mcps,
+            default_skills=default_skills,
+            **kwargs,
+        )
 
         # ── serializable config ─────────────────────────────────
         self.workdir = os.path.abspath(workdir)
@@ -112,12 +126,6 @@ class LocalWorkspace(WorkspaceBase):
             backend="local",
             workdir=self.workdir,
         )
-
-        # ── seed-only ───────────────────────────────────────────
-        self.default_mcps: list[MCPClient] = list(default_mcps or [])
-        self.skill_paths: list[str] = [
-            _normalize_local_path(path) for path in skill_paths or []
-        ]
 
         # ── runtime state ───────────────────────────────────────
         self._backend = LocalBackend()
@@ -154,7 +162,8 @@ class LocalWorkspace(WorkspaceBase):
 
         MCP state is restored from ``.mcp`` if it exists; otherwise
         ``default_mcps`` are used and persisted so the next start picks
-        them up from disk. ``skill_paths`` are seeded on first use.
+        them up from disk. ``default_skills`` are seeded alongside them,
+        under the same first-boot condition.
 
         Idempotent: a no-op when the workspace is already alive.
         """
@@ -163,9 +172,11 @@ class LocalWorkspace(WorkspaceBase):
 
         os.makedirs(self.workdir, exist_ok=True)
 
-        # Restore or seed MCPs
+        # Restore or seed MCPs. The absence of ``.mcp`` is what makes
+        # this the workspace's first boot, and it gates the skills too.
         mcp_file = os.path.join(self.workdir, ".mcp")
-        if await self._backend.file_exists(mcp_file):
+        first_boot = not await self._backend.file_exists(mcp_file)
+        if not first_boot:
             raw = await self._backend.read_file(mcp_file)
             raw_list = json.loads(raw.decode("utf-8"))
             for m in raw_list:
@@ -192,108 +203,23 @@ class LocalWorkspace(WorkspaceBase):
                         mcp.name,
                         e,
                     )
+                    if first_boot:
+                        # Dropped here, so it never reaches ``list_mcps``
+                        # and the caller would otherwise see a seeded MCP
+                        # simply missing, with no reason given.
+                        self.seed_errors[mcp.name] = _describe_exception(e)
                     failed.append(mcp)
         for mcp in failed:
             self._mcps.remove(mcp)
 
-        # Seed skills
-        skills_dir = os.path.join(self.workdir, "skills")
-        os.makedirs(skills_dir, exist_ok=True)
+        os.makedirs(os.path.join(self.workdir, "skills"), exist_ok=True)
 
-        skills_file = await self._load_skills_file(skills_dir)
-        existing: dict[str, _SkillEntry] = skills_file["skills"]
-
-        # Build fast-lookup sets from the current index
-        existing_hashes: set[str] = {e["hash"] for e in existing.values()}
-        existing_agent_names: set[str] = {
-            e["skill_name"] for e in existing.values()
-        }
-        existing_dir_names: set[str] = set(existing.keys())
-
-        updated = False
-        for skill_path in self.skill_paths:
-            result = await self._validate_and_hash_skill(skill_path)
-            if result is None:
-                continue
-
-            _, raw_name, skill_hash = result
-
-            # Skip if already present (by content hash)
-            if skill_hash in existing_hashes:
-                logger.info(
-                    "Skill '%s' (hash: %s...) already exists, skipping",
-                    raw_name,
-                    skill_hash[:8],
-                )
-                continue
-
-            # Resolve agent-facing name conflict
-            agent_name = raw_name
-            counter = 1
-            while agent_name in existing_agent_names:
-                agent_name = f"{raw_name} ({counter})"
-                counter += 1
-
-            # Resolve directory name conflict
-            base_dir = _sanitize_dir_name(raw_name)
-            dir_name = base_dir
-            counter = 1
-            while dir_name in existing_dir_names:
-                dir_name = f"{base_dir}_{counter}"
-                counter += 1
-
-            dest_path = os.path.join(skills_dir, dir_name)
-
-            # Defensive path-traversal check
-            if not os.path.realpath(dest_path).startswith(
-                os.path.realpath(skills_dir) + os.sep,
-            ):
-                logger.warning(
-                    "Skill '%s' resolves outside skills_dir, skipping",
-                    raw_name,
-                )
-                continue
-
-            try:
-                await asyncio.to_thread(
-                    shutil.copytree,
-                    skill_path,
-                    dest_path,
-                    dirs_exist_ok=False,
-                )
-            except Exception as e:
-                logger.warning(
-                    "Failed to copy skill '%s' from %s: %s",
-                    raw_name,
-                    skill_path,
-                    str(e),
-                )
-                continue
-
-            logger.info(
-                "Copied skill '%s' (agent name: '%s') from %s to %s",
-                raw_name,
-                agent_name,
-                skill_path,
-                dest_path,
-            )
-
-            entry: _SkillEntry = {"hash": skill_hash, "skill_name": agent_name}
-            existing[dir_name] = entry
-            existing_hashes.add(skill_hash)
-            existing_agent_names.add(agent_name)
-            existing_dir_names.add(dir_name)
-            updated = True
-
-        if updated:
-            skills_file["skills"] = existing
-            mtime = await self._backend.stat_mtime(skills_dir)
-            skills_file["skills_dir_mtime"] = (
-                mtime if mtime is not None else 0.0
-            )
-            await self._save_skills_file(skills_dir, skills_file)
-
+        # ``is_alive`` has to be set before seeding: ``add_skill`` and
+        # ``add_skill_archive`` operate on a live workspace.
         self.is_alive = True
+
+        if first_boot:
+            await self._seed_skills()
 
     async def get_instructions(self) -> str:
         """Get the workspace instructions."""

--- a/src/agentscope/workspace/_opensandbox/_opensandbox_workspace.py
+++ b/src/agentscope/workspace/_opensandbox/_opensandbox_workspace.py
@@ -4,18 +4,19 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import timedelta
 import shlex
-from typing import TYPE_CHECKING, Literal
+from datetime import timedelta
+from typing import Any, Literal, Sequence, TYPE_CHECKING
 
 from ..._logging import logger
 from ...mcp import MCPClient
+from ...skill import Skill, SkillLoaderBase, SkillSourceBase
 from .._sandboxed_base import SandboxedWorkspaceBase
 from .._utils import _GATEWAY_BASE_REQUIREMENTS, DEFAULT_WORKSPACE_INSTRUCTIONS
 from ._constants import (
+    BOOTSTRAP_COMMAND_TIMEOUT,
     DEFAULT_GATEWAY_PORT,
     DEFAULT_IMAGE,
-    BOOTSTRAP_COMMAND_TIMEOUT,
     DEFAULT_REQUEST_TIMEOUT,
     DEFAULT_TIMEOUT,
     GATEWAY_HOME,
@@ -36,7 +37,7 @@ if TYPE_CHECKING:
 class OpenSandboxWorkspace(SandboxedWorkspaceBase):
     """Workspace backed by an OpenSandbox sandbox.
 
-    ``default_mcps`` and ``skill_paths`` are seed-time inputs and are
+    ``default_mcps`` and ``default_skills`` are seed-time inputs and are
     not retained as instance state past :meth:`initialize`.
     """
 
@@ -65,7 +66,11 @@ class OpenSandboxWorkspace(SandboxedWorkspaceBase):
         extra_pip: list[str] | None = None,
         instructions: str = DEFAULT_WORKSPACE_INSTRUCTIONS,
         default_mcps: list[MCPClient] | None = None,
-        skill_paths: list[str] | None = None,
+        default_skills: Sequence[
+            str | Skill | SkillLoaderBase | SkillSourceBase
+        ]
+        | None = None,
+        **kwargs: Any,
     ) -> None:
         """Construct an :class:`OpenSandboxWorkspace`.
 
@@ -112,13 +117,15 @@ class OpenSandboxWorkspace(SandboxedWorkspaceBase):
             default_mcps (`list[MCPClient] | None`, optional):
                 MCPs registered on first init when no persisted
                 ``.mcp`` exists.
-            skill_paths (`list[str] | None`, optional):
-                Local skill dirs seeded into ``skills/`` on first init.
+            default_skills (`Sequence[str | Skill | SkillLoaderBase | \
+SkillSourceBase] | None`, optional):
+                Skills seeded into ``skills/`` on first init.
         """
         super().__init__(
             workspace_id=workspace_id,
             default_mcps=default_mcps,
-            skill_paths=skill_paths,
+            default_skills=default_skills,
+            **kwargs,
         )
         self.workdir = SANDBOX_WORKDIR
         self.image = image
@@ -215,8 +222,8 @@ class OpenSandboxWorkspace(SandboxedWorkspaceBase):
 
     async def _find_existing_sandbox(self) -> SandboxInfo | None:
         """Return the most recent sandbox matching this workspace id."""
-        from opensandbox.models.sandboxes import SandboxFilter, SandboxState
         from opensandbox import SandboxManager
+        from opensandbox.models.sandboxes import SandboxFilter, SandboxState
 
         manager = await SandboxManager.create(
             connection_config=self._connection_config(),

--- a/src/agentscope/workspace/_sandboxed_base.py
+++ b/src/agentscope/workspace/_sandboxed_base.py
@@ -20,9 +20,11 @@ import asyncio
 import json
 import shlex
 from abc import abstractmethod
+from typing import Any, Sequence
 
 from .._logging import logger
 from ..mcp import MCPClient
+from ..skill import Skill, SkillLoaderBase, SkillSourceBase
 from ._base import WorkspaceBase
 from ._gateway_client import GatewayClient
 from ._utils import (
@@ -119,7 +121,11 @@ class SandboxedWorkspaceBase(WorkspaceBase):
         *,
         workspace_id: str | None = None,
         default_mcps: list[MCPClient] | None = None,
-        skill_paths: list[str] | None = None,
+        default_skills: Sequence[
+            str | Skill | SkillLoaderBase | SkillSourceBase
+        ]
+        | None = None,
+        **kwargs: Any,
     ) -> None:
         """Initialise sandbox-workspace state.
 
@@ -128,13 +134,15 @@ class SandboxedWorkspaceBase(WorkspaceBase):
                 Existing identifier; ``None`` mints a fresh UUID.
             default_mcps (`list[MCPClient] | None`, optional):
                 MCPs registered when no persisted ``.mcp`` exists.
-            skill_paths (`list[str] | None`, optional):
-                Local skill dirs seeded on first start.
+            default_skills (`Sequence[str | Skill | SkillLoaderBase | \
+SkillSourceBase] | None`, optional):
+                Skills seeded into ``skills/`` on first init.
         """
         super().__init__(
             workspace_id=workspace_id,
             default_mcps=default_mcps,
-            skill_paths=skill_paths,
+            default_skills=default_skills,
+            **kwargs,
         )
         self._gateway = None
 
@@ -189,13 +197,16 @@ class SandboxedWorkspaceBase(WorkspaceBase):
         ), "_provision_backend must set self._backend before returning"
 
         # Set up the workspace layout
-        await self._ensure_workspace_layout()
+        first_boot = await self._ensure_workspace_layout()
 
         # Set up the MCP gateway server
         await self._setup_mcp_gateway()
 
-        # Set up the skills if not exists
-        await self._setup_skills()
+        # Seed skills only on the very first boot, for the same reason
+        # ``.mcp`` gates the MCP seeding: one the user later deletes
+        # must not come back on the next start.
+        if first_boot:
+            await self._seed_skills()
 
         self.is_alive = True
 
@@ -315,8 +326,16 @@ class SandboxedWorkspaceBase(WorkspaceBase):
 
     # ── workspace layout helpers ──────────────────────────────────
 
-    async def _ensure_workspace_layout(self) -> None:
-        """Create the standard workspace directories inside the sandbox."""
+    async def _ensure_workspace_layout(self) -> bool:
+        """Create the standard workspace directories inside the sandbox.
+
+        Returns:
+            `bool`:
+                Whether this is the workspace's first boot — i.e. there
+                was no ``.mcp`` file to restore from. A corrupted file
+                is reseeded but does **not** count: the skills beside
+                it are still there.
+        """
         backend = self.get_backend()
         await backend.exec_shell(
             [
@@ -356,7 +375,7 @@ class SandboxedWorkspaceBase(WorkspaceBase):
                 )
             else:
                 if isinstance(parsed, list):
-                    return
+                    return False
                 logger.warning(
                     "%s: %s does not contain a JSON list "
                     "(got %s); reseeding defaults",
@@ -364,7 +383,11 @@ class SandboxedWorkspaceBase(WorkspaceBase):
                     self._mcp_file,
                     type(parsed).__name__,
                 )
+            await backend.write_file(self._mcp_file, payload)
+            return False
+
         await backend.write_file(self._mcp_file, payload)
+        return True
 
     # ── gateway lifecycle helpers ─────────────────────────────────
 

--- a/tests/agent_binding_test.py
+++ b/tests/agent_binding_test.py
@@ -160,12 +160,14 @@ class AgentBindingTest(IsolatedAsyncioTestCase):
         self._client = self.enterContext(TestClient(app))
 
         self._mcp_id = self._client.post(
-            "/hub/mcp/fake/cards/echo/install",
+            "/hub/mcp/fake/install",
+            params={"card_id": "echo"},
             json={},
             headers=HEADERS,
         ).json()["id"]
         self._skill_id = self._client.post(
-            "/hub/skill/fakeskills/cards/gifgrep/install",
+            "/hub/skill/fakeskills/install",
+            params={"card_id": "gifgrep"},
             json={},
             headers=HEADERS,
         ).json()["id"]

--- a/tests/agent_binding_test.py
+++ b/tests/agent_binding_test.py
@@ -1,0 +1,354 @@
+# -*- coding: utf-8 -*-
+"""Agents that come with their own MCPs and skills, without any network."""
+import io
+import tempfile
+import zipfile
+from typing import Any, AsyncIterator
+from unittest import IsolatedAsyncioTestCase
+
+import fakeredis.aioredis
+from fastapi.testclient import TestClient
+
+from agentscope.app import create_app
+from agentscope.app.hub import (
+    MCPCard,
+    MCPHubBase,
+    MCPHubPage,
+    SkillArchive,
+    SkillCard,
+    SkillHubBase,
+    SkillHubPage,
+)
+from agentscope.app.message_bus import RedisMessageBus
+from agentscope.app.storage import RedisStorage
+from agentscope.app.workspace_manager import LocalWorkspaceManager
+
+HEADERS = {"X-User-ID": "alice"}
+
+SKILL_MD = """---
+name: gifgrep
+description: Find GIFs.
+---
+
+# gifgrep
+"""
+
+
+class _MCPHub(MCPHubBase):
+    """One stateless card, so installing needs no connection."""
+
+    def __init__(self) -> None:
+        """Register the fixture card."""
+        super().__init__("fake", "Fake MCP Hub")
+        self.card = MCPCard(
+            hub_id="fake",
+            name="echo",
+            auth="none",
+            is_stateful=False,
+            config_template={
+                "type": "http_mcp",
+                "url": "https://echo.invalid/sse",
+            },
+        )
+
+    async def list_mcps(
+        self,
+        user_id: str,
+        q: str | None = None,
+        cursor: str | None = None,
+        limit: int = 20,
+    ) -> MCPHubPage:
+        """Return the single fixture card."""
+        return MCPHubPage(cards=[self.card])
+
+    async def get_mcp(self, user_id: str, card_id: str) -> MCPCard:
+        """Return the fixture card, or raise for anything else."""
+        if card_id != "echo":
+            raise KeyError(card_id)
+        return self.card
+
+
+class _SkillHub(SkillHubBase):
+    """One card, counting how often its archive is fetched."""
+
+    def __init__(self) -> None:
+        """Register the fixture card."""
+        super().__init__("fakeskills", "Fake Skill Hub")
+        self.card = SkillCard(
+            hub_id="fakeskills",
+            name="gifgrep",
+            description="Find GIFs.",
+            markdown=SKILL_MD,
+        )
+        self.downloads = 0
+
+    async def list_skills(
+        self,
+        user_id: str,
+        q: str | None = None,
+        cursor: str | None = None,
+        limit: int = 20,
+    ) -> SkillHubPage:
+        """Return the single fixture card."""
+        return SkillHubPage(cards=[self.card])
+
+    async def get_skill(self, user_id: str, card_id: str) -> SkillCard:
+        """Return the fixture card, or raise for anything else."""
+        if card_id != "gifgrep":
+            raise KeyError(card_id)
+        return self.card
+
+    async def download(
+        self,
+        user_id: str,
+        card_id: str,
+        version: str | None = None,
+    ) -> SkillArchive:
+        """Open an in-memory ZIP holding one skill."""
+        self.downloads += 1
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w") as archive:
+            archive.writestr("SKILL.md", SKILL_MD)
+        payload = buffer.getvalue()
+
+        async def _stream() -> AsyncIterator[bytes]:
+            yield payload
+
+        return SkillArchive(format="zip", stream=_stream())
+
+
+def _fake_backends() -> tuple:
+    """Build a fakeredis-backed storage and message bus."""
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+
+    class _Storage(RedisStorage):
+        async def __aenter__(self) -> Any:
+            self._client = redis
+            return self
+
+        async def aclose(self) -> None:
+            self._client = None
+
+    class _Bus(RedisMessageBus):
+        async def __aenter__(self) -> Any:
+            self._client = redis
+            return self
+
+        async def aclose(self) -> None:
+            self._client = None
+
+    return _Storage(), _Bus()
+
+
+class AgentBindingTest(IsolatedAsyncioTestCase):
+    """An agent's own MCPs and skills reaching its workspace."""
+
+    def setUp(self) -> None:
+        """Start an app with one MCP and one skill in the library."""
+        # pylint: disable=consider-using-with
+        self._workdir = self.enterContext(tempfile.TemporaryDirectory())
+        storage, bus = _fake_backends()
+        self._skill_hub = _SkillHub()
+        app = create_app(
+            storage=storage,
+            message_bus=bus,
+            workspace_manager=LocalWorkspaceManager(self._workdir),
+            mcp_hubs=[_MCPHub()],
+            skill_hubs=[self._skill_hub],
+            enable_index_worker=False,
+        )
+        self._client = self.enterContext(TestClient(app))
+
+        self._mcp_id = self._client.post(
+            "/hub/mcp/fake/cards/echo/install",
+            json={},
+            headers=HEADERS,
+        ).json()["id"]
+        self._skill_id = self._client.post(
+            "/hub/skill/fakeskills/cards/gifgrep/install",
+            json={},
+            headers=HEADERS,
+        ).json()["id"]
+
+    # ── helpers ───────────────────────────────────────────────────
+
+    def _agent(self, **bindings: list) -> str:
+        """Create an agent, optionally bound to library records."""
+        return self._client.post(
+            "/agent/",
+            json={"name": "tester", **bindings},
+            headers=HEADERS,
+        ).json()["agent_id"]
+
+    def _session(self, agent_id: str) -> dict:
+        """Open a session on an agent and return the workspace scope."""
+        session_id = self._client.post(
+            "/sessions/",
+            json={"agent_id": agent_id},
+            headers=HEADERS,
+        ).json()["session_id"]
+        return {"agent_id": agent_id, "session_id": session_id}
+
+    def _workspace_mcps(self, scope: dict) -> dict:
+        """Read the workspace's MCPs."""
+        return self._client.get(
+            "/workspace/mcp",
+            params=scope,
+            headers=HEADERS,
+        ).json()
+
+    def _workspace_skills(self, scope: dict) -> dict:
+        """Read the workspace's skills."""
+        return self._client.get(
+            "/workspace/skill",
+            params=scope,
+            headers=HEADERS,
+        ).json()
+
+    # ── seeding ───────────────────────────────────────────────────
+
+    def test_bound_mcp_and_skill_reach_a_new_workspace(self) -> None:
+        """What the agent comes with is there the first time it opens."""
+        scope = self._session(
+            self._agent(
+                mcp_ids=[self._mcp_id],
+                skill_ids=[self._skill_id],
+            ),
+        )
+
+        mcps = self._workspace_mcps(scope)
+        skills = self._workspace_skills(scope)
+
+        self.assertEqual([m["name"] for m in mcps["mcps"]], ["echo"])
+        self.assertEqual([s["name"] for s in skills["skills"]], ["gifgrep"])
+        self.assertEqual(mcps["seed_errors"], {})
+
+    def test_no_bindings_leaves_the_workspace_empty(self) -> None:
+        """An agent that comes with nothing seeds nothing."""
+        scope = self._session(self._agent())
+
+        self.assertEqual(self._workspace_mcps(scope)["mcps"], [])
+        self.assertEqual(self._workspace_skills(scope)["skills"], [])
+        self.assertEqual(self._skill_hub.downloads, 0)
+
+    def test_seeding_happens_once_per_workspace(self) -> None:
+        """Reading the workspace again must not re-fetch the archive."""
+        scope = self._session(self._agent(skill_ids=[self._skill_id]))
+
+        self._workspace_skills(scope)
+        self._workspace_skills(scope)
+
+        self.assertEqual(self._skill_hub.downloads, 1)
+
+    def test_a_second_session_does_not_reseed(self) -> None:
+        """Sessions of one agent share a workspace under PER_AGENT."""
+        agent_id = self._agent(skill_ids=[self._skill_id])
+        self._workspace_skills(self._session(agent_id))
+
+        second = self._workspace_skills(self._session(agent_id))
+
+        self.assertEqual([s["name"] for s in second["skills"]], ["gifgrep"])
+        self.assertEqual(self._skill_hub.downloads, 1)
+
+    def test_a_removed_skill_is_not_reinstated(self) -> None:
+        """Deleting one is a decision, not damage to repair."""
+        agent_id = self._agent(skill_ids=[self._skill_id])
+        scope = self._session(agent_id)
+        self._workspace_skills(scope)
+
+        self._client.delete(
+            "/workspace/skill/gifgrep",
+            params=scope,
+            headers=HEADERS,
+        )
+        after = self._workspace_skills(self._session(agent_id))
+
+        self.assertEqual(after["skills"], [])
+        self.assertEqual(self._skill_hub.downloads, 1)
+
+    def test_a_removed_mcp_is_not_reinstated(self) -> None:
+        """The MCP side of the same rule."""
+        agent_id = self._agent(mcp_ids=[self._mcp_id])
+        scope = self._session(agent_id)
+        self._workspace_mcps(scope)
+
+        self._client.delete(
+            "/workspace/mcp/echo",
+            params=scope,
+            headers=HEADERS,
+        )
+        after = self._workspace_mcps(self._session(agent_id))
+
+        self.assertEqual(after["mcps"], [])
+
+    # ── failures ──────────────────────────────────────────────────
+
+    def test_a_deleted_library_record_is_reported(self) -> None:
+        """The binding outlives the record, and says so rather than
+        failing the whole workspace."""
+        agent_id = self._agent(
+            mcp_ids=[self._mcp_id],
+            skill_ids=[self._skill_id],
+        )
+        self._client.delete(f"/skill/{self._skill_id}", headers=HEADERS)
+        scope = self._session(agent_id)
+
+        skills = self._workspace_skills(scope)
+
+        self.assertEqual(skills["skills"], [])
+        self.assertEqual(
+            list(skills["seed_errors"]),
+            [self._skill_id],
+        )
+        # The MCP beside it still landed.
+        self.assertEqual(
+            [m["name"] for m in self._workspace_mcps(scope)["mcps"]],
+            ["echo"],
+        )
+
+    def test_binding_an_unknown_id_is_rejected_on_write(self) -> None:
+        """A typo surfaces at the form, not at some later boot."""
+        created = self._client.post(
+            "/agent/",
+            json={"name": "tester", "mcp_ids": ["no-such-id"]},
+            headers=HEADERS,
+        )
+        patched = self._client.patch(
+            f"/agent/{self._agent()}",
+            json={"skill_ids": ["no-such-id"]},
+            headers=HEADERS,
+        )
+
+        self.assertEqual(created.status_code, 404)
+        self.assertEqual(patched.status_code, 404)
+
+    # ── round trip ────────────────────────────────────────────────
+
+    def test_bindings_round_trip_through_the_record(self) -> None:
+        """Both fields survive create and PATCH."""
+        agent_id = self._agent(mcp_ids=[self._mcp_id])
+
+        patched = self._client.patch(
+            f"/agent/{agent_id}",
+            json={"skill_ids": [self._skill_id]},
+            headers=HEADERS,
+        ).json()
+
+        self.assertEqual(patched["data"]["mcp_ids"], [self._mcp_id])
+        self.assertEqual(patched["data"]["skill_ids"], [self._skill_id])
+
+    def test_an_old_record_reads_as_unbound(self) -> None:
+        """Records written before the fields existed need no migration."""
+        # pylint: disable=import-outside-toplevel
+        from agentscope.app.storage import AgentData
+
+        data = AgentData.model_validate(
+            {
+                "name": "legacy",
+                "context_config": {},
+                "react_config": {},
+            },
+        )
+
+        self.assertEqual(data.mcp_ids, [])
+        self.assertEqual(data.skill_ids, [])

--- a/tests/hub_router_test.py
+++ b/tests/hub_router_test.py
@@ -144,10 +144,16 @@ class FakeSkillHub(SkillHubBase):
         return SkillHubPage(cards=[self.card], next_cursor="page-2")
 
     async def get_skill(self, user_id: str, card_id: str) -> SkillCard:
-        """Return the fixture card, or raise for anything else."""
-        if card_id != "gifgrep":
+        """Return the fixture card, or raise for anything else.
+
+        ``owner/gifgrep`` is the shape a hub whose slugs are not unique
+        mints for a search hit — it has to survive the round trip.
+        """
+        if card_id not in ("gifgrep", "owner/gifgrep"):
             raise KeyError(card_id)
-        return self.card
+        # Echoed the way ClawHub does: the id it mints for a search hit
+        # carries the owner, and that is what an install records.
+        return self.card.model_copy(update={"id": card_id})
 
     async def download(
         self,
@@ -163,7 +169,7 @@ class FakeSkillHub(SkillHubBase):
         if card_id == "nomd":
             yield _zip_bytes({"README.md": "nothing here"})
             return
-        if card_id != "gifgrep":
+        if card_id not in ("gifgrep", "owner/gifgrep"):
             raise KeyError(card_id)
         yield _zip_bytes({"SKILL.md": SKILL_MD, "notes.md": "x"})
 
@@ -272,11 +278,31 @@ class HubRouterTest(IsolatedAsyncioTestCase):
     def test_unknown_card(self) -> None:
         """An unknown card id is a 404."""
         response = self._client.get(
-            "/hub/skill/fakeskills/cards/missing",
+            "/hub/skill/fakeskills/card",
+            params={"card_id": "missing"},
             headers=HEADERS,
         )
 
         self.assertEqual(response.status_code, 404)
+
+    def test_card_id_with_a_slash_round_trips(self) -> None:
+        """A hub whose ids are ``owner/slug`` must still be reachable.
+
+        The id travels as a query parameter for exactly this reason: as
+        a path segment the server decodes ``%2F`` before routing, the
+        route stops matching, and the caller gets a bare 404 from the
+        framework rather than an answer.
+        """
+        fetched = self._client.get(
+            "/hub/skill/fakeskills/card",
+            params={"card_id": "owner/gifgrep"},
+            headers=HEADERS,
+        )
+        installed = self._install_skill("owner/gifgrep")
+
+        self.assertEqual(fetched.status_code, 200)
+        self.assertEqual(installed.status_code, 201)
+        self.assertEqual(installed.json()["card_id"], "owner/gifgrep")
 
     # ── install: MCP ──────────────────────────────────────────────
 
@@ -284,7 +310,8 @@ class HubRouterTest(IsolatedAsyncioTestCase):
         """POST an MCP install. Installing is user-level, so unlike the
         skill endpoint it takes no session scope."""
         return self._client.post(
-            f"/hub/mcp/fake/cards/{card_id}/install",
+            "/hub/mcp/fake/install",
+            params={"card_id": card_id},
             json=body,
             headers=HEADERS,
         )
@@ -619,8 +646,8 @@ class HubRouterTest(IsolatedAsyncioTestCase):
     def _install_skill(self, card_id: str, **params: str) -> Any:
         """POST a skill install. User-level, like the MCP one."""
         return self._client.post(
-            f"/hub/skill/fakeskills/cards/{card_id}/install",
-            params=params,
+            "/hub/skill/fakeskills/install",
+            params={"card_id": card_id, **params},
             headers=HEADERS,
         )
 

--- a/tests/hub_router_test.py
+++ b/tests/hub_router_test.py
@@ -335,7 +335,7 @@ class HubRouterTest(IsolatedAsyncioTestCase):
             params=self._scope,
             headers=HEADERS,
         ).json()
-        self.assertEqual([m["name"] for m in listed], [])
+        self.assertEqual([m["name"] for m in listed["mcps"]], [])
 
     def test_install_never_echoes_the_rendered_config(self) -> None:
         """The response must not hand the submitted secret back."""
@@ -560,7 +560,7 @@ class HubRouterTest(IsolatedAsyncioTestCase):
             params=self._scope,
             headers=HEADERS,
         ).json()
-        self.assertEqual([m["name"] for m in listed], ["echo"])
+        self.assertEqual([m["name"] for m in listed["mcps"]], ["echo"])
 
     def test_add_from_library_skips_what_is_already_there(self) -> None:
         """Adding twice is a no-op, not a duplicate or an error."""
@@ -607,8 +607,8 @@ class HubRouterTest(IsolatedAsyncioTestCase):
             headers=HEADERS,
         ).json()
 
-        self.assertFalse(listed[0]["is_healthy"])
-        detail = listed[0]["error"]
+        self.assertFalse(listed["mcps"][0]["is_healthy"])
+        detail = listed["mcps"][0]["error"]
         self.assertTrue(detail)
         # The bare ExceptionGroup message says nothing useful; the leaf
         # cause is what has to come through.
@@ -655,7 +655,7 @@ class HubRouterTest(IsolatedAsyncioTestCase):
             params=self._scope,
             headers=HEADERS,
         ).json()
-        self.assertEqual([s["name"] for s in listed], [])
+        self.assertEqual([s["name"] for s in listed["skills"]], [])
 
     def test_install_skill_does_not_download(self) -> None:
         """The archive is fetched when the skill reaches a workspace,

--- a/tests/workspace_bubblewrap_test.py
+++ b/tests/workspace_bubblewrap_test.py
@@ -1129,8 +1129,9 @@ class _FakeBubblewrapWorkspaceManager(BubblewrapWorkspaceManager):
         workspace_id: str,
         user_id: str,
         agent_id: str,
+        **seeds: Any,
     ) -> Any:
-        del user_id, agent_id
+        del user_id, agent_id, seeds
         return _FakeWorkspace(workspace_id)
 
 

--- a/tests/workspace_local_test.py
+++ b/tests/workspace_local_test.py
@@ -685,7 +685,7 @@ This skill is seeded through a tilde path.
                     skill_paths=[os.path.join("~", "tilde_skill")],
                 )
                 self.assertEqual(
-                    workspace.skill_paths,
+                    [loader.directory for loader in workspace.default_skills],
                     [os.path.abspath(skill_dir)],
                 )
                 await workspace.initialize()

--- a/tests/workspace_manager_daytona_test.py
+++ b/tests/workspace_manager_daytona_test.py
@@ -88,7 +88,7 @@ class TestDaytonaWorkspaceManager(IsolatedAsyncioTestCase):
                 },
                 "extra_pip": ["x"],
                 "default_mcps": [],
-                "skill_paths": [],
+                "default_skills": [],
                 "os_user": "daytona",
             },
         )


### PR DESCRIPTION
An agent record gains `mcp_ids` / `skill_ids`, pointing at the user's own library. They are seeded into the agent's workspace the first time that workspace boots, and never again.

## Why seed once

A workspace persists. Re-applying the list on every session would reinstate whatever the user had deliberately removed from it.

The signal for "first boot" already existed — the absence of `.mcp` — and gating skills on it too fixes a real divergence that was there before this PR:

| | previous judgement | after the user deletes a seeded skill |
|---|---|---|
| MCP, all backends | `.mcp` absent | stays gone ✅ |
| skill, sandboxed | `skills/` empty | all come back once the last one goes ❌ |
| skill, Local | content hash not in index | comes back every start ❌ |

Both now use the same gate.

## Seeding a skill that has to be fetched

`WorkspaceBase` takes `default_skills`, accepting a directory, a `Skill`, a `SkillLoaderBase`, or the new `SkillSourceBase`. Dispatch is by how the skill has to travel, not by what it is:

| element | how it lands |
|---|---|
| `str` / `Skill` / `SkillLoaderBase` | has a `dir` → `add_skill` |
| `SkillSourceBase` | only a stream → `add_skill_archive`, expanded **inside** the sandbox |

A `SkillRecord` keeps no archive, so putting a skill in a workspace means downloading it again. `SkillSourceBase` exists so that download is deferred: constructing one does no I/O, and `open()` only fires if the workspace decides it actually needs to seed. Seeds are built on every `get_workspace` call and almost always discarded, so an eager `SkillArchive` would re-download on every panel refresh and every chat turn.

`SkillArchive` moves down to `agentscope.skill` so the workspace layer can name it without importing the app; `agentscope.app.hub` re-exports it, so nothing outside changes.

## Seeds travel as an argument, not an attribute

`get_workspace(seed_mcps=, seed_skills=)`, merged with the manager's deployment-wide `default_mcps` at construction.

Not by mutating `self._default_mcps`: that attribute is read under a lock several awaits into the call (including a `gather` that closes expired workspaces), so setting it per request would race one agent's plaintext API keys into another agent's workspace.

## `skill_paths` deprecated

Still accepted, through `**kwargs`, folded into `default_skills`, now with a `logger.warning` naming the concrete subclass — the same shape `DockerWorkspace` already uses for its legacy `workdir`. Anything else left in `kwargs` raises `TypeError`, so a typo does not silently vanish.

## Reporting what did not land

`add_mcp` connects before persisting, so a stateful MCP that fails to connect never reaches `.mcp` — it is simply absent from the panel, with no reason given.

`GET /workspace/mcp` and `GET /workspace/skill` therefore return `{mcps|skills, seed_errors}` instead of a bare array. **This is a breaking response-shape change**; the bundled web UI is updated with it.

Nothing is persisted for this. Failures that happened once live on the workspace object; bindings that cannot be resolved at all (a deleted library record, an unregistered hub) are recomputed per call. Names already present in the workspace are filtered out, so a tool the user removed on purpose never shows up as an error.

## UI

The agent create / edit dialog is split into tabs — General, Seed MCPs, Seed Skills — since the schema-driven fields alone already overflowed it. Both picker lists follow `AddMCPDialog`'s presentation and have their own search.

Also fixes a focus-ring bug in these dialogs and in `AddMCPDialog`: `overflow-y-auto` makes the x axis clip too, slicing the ring off both sides of a full-width input.

## Not in scope

Existing workspaces are not re-synced when the binding list is edited; there is no reverse accounting from workspace back to agent; and under `PER_USER` isolation two agents share a workspace, so whichever opens first seeds it.

## Testing

`tests/agent_binding_test.py` — 10 cases, no network. Two of them are regressions for the table above (a removed skill and a removed MCP must not be reinstated). Full suite: 1582 passed, 133 skipped. `pre-commit run --all-files` clean; frontend builds, `pnpm format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
