### PR TITLE
feat(tool): support arguments repairment within the ToolBase class

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """The unified agent class in AgentScope library."""
+
 import asyncio
 import collections
 import inspect
@@ -251,12 +252,14 @@ class Agent:
 
     async def reply_stream(
         self,
-        inputs: Msg
-        | list[Msg]
-        | UserConfirmResultEvent
-        | UserInterruptEvent
-        | ExternalExecutionResultEvent
-        | None = None,
+        inputs: (
+            Msg
+            | list[Msg]
+            | UserConfirmResultEvent
+            | UserInterruptEvent
+            | ExternalExecutionResultEvent
+            | None
+        ) = None,
         structured_schema: Type[BaseModel] | None = None,
         yield_final_msg: bool = False,
     ) -> AsyncGenerator[AgentEvent | Msg, None]:
@@ -295,12 +298,14 @@ class Agent:
 
     async def reply(
         self,
-        inputs: Msg
-        | list[Msg]
-        | UserConfirmResultEvent
-        | UserInterruptEvent
-        | ExternalExecutionResultEvent
-        | None = None,
+        inputs: (
+            Msg
+            | list[Msg]
+            | UserConfirmResultEvent
+            | UserInterruptEvent
+            | ExternalExecutionResultEvent
+            | None
+        ) = None,
         structured_schema: Type[BaseModel] | None = None,
     ) -> Msg:
         """Reply to the given inputs, consuming all streamed events.
@@ -633,12 +638,14 @@ class Agent:
 
     async def _reply(
         self,
-        inputs: Msg
-        | list[Msg]
-        | UserConfirmResultEvent
-        | UserInterruptEvent
-        | ExternalExecutionResultEvent
-        | None = None,
+        inputs: (
+            Msg
+            | list[Msg]
+            | UserConfirmResultEvent
+            | UserInterruptEvent
+            | ExternalExecutionResultEvent
+            | None
+        ) = None,
         structured_schema: Type[BaseModel] | None = None,
     ) -> AsyncGenerator[AgentEvent | Msg, None]:
         """Reply entry point (maybe wrapped by middleware)."""
@@ -652,12 +659,14 @@ class Agent:
 
             async def execute_chain(
                 index: int = 0,
-                inputs: Msg
-                | list[Msg]
-                | UserConfirmResultEvent
-                | UserInterruptEvent
-                | ExternalExecutionResultEvent
-                | None = inputs,
+                inputs: (
+                    Msg
+                    | list[Msg]
+                    | UserConfirmResultEvent
+                    | UserInterruptEvent
+                    | ExternalExecutionResultEvent
+                    | None
+                ) = inputs,
                 structured_schema: Type[BaseModel] | None = structured_schema,
             ) -> AsyncGenerator[AgentEvent | Msg, None]:
                 if index >= len(self._reply_middlewares):
@@ -759,12 +768,14 @@ class Agent:
 
     async def _reply_impl(
         self,
-        inputs: Msg
-        | list[Msg]
-        | UserConfirmResultEvent
-        | UserInterruptEvent
-        | ExternalExecutionResultEvent
-        | None = None,
+        inputs: (
+            Msg
+            | list[Msg]
+            | UserConfirmResultEvent
+            | UserInterruptEvent
+            | ExternalExecutionResultEvent
+            | None
+        ) = None,
         structured_schema: Type[BaseModel] | None = None,
     ) -> AsyncGenerator[AgentEvent | Msg, None]:
         """Core reply logic."""
@@ -1167,9 +1178,11 @@ class Agent:
                     )
                     last_time = last_time.replace(
                         tzinfo=_resolve_timezone(
-                            match_tz.group(1).strip()
-                            if match_tz
-                            else self.injection_config.timezone,
+                            (
+                                match_tz.group(1).strip()
+                                if match_tz
+                                else self.injection_config.timezone
+                            ),
                         ),
                     )
 
@@ -1418,12 +1431,16 @@ class Agent:
         # Send the model call ended event with usage if available
         yield ModelCallEndEvent(
             reply_id=self.state.reply_id,
-            input_tokens=completed_response.usage.input_tokens
-            if completed_response.usage
-            else 0,
-            output_tokens=completed_response.usage.output_tokens
-            if completed_response.usage
-            else 0,
+            input_tokens=(
+                completed_response.usage.input_tokens
+                if completed_response.usage
+                else 0
+            ),
+            output_tokens=(
+                completed_response.usage.output_tokens
+                if completed_response.usage
+                else 0
+            ),
             finished_reason=completed_response.finished_reason,
         )
 
@@ -2082,7 +2099,8 @@ class Agent:
             # Coerce types before validation (e.g. str "42" → int 42).
             if parsed_input and tool.input_schema:
                 parsed_input = _coerce_tool_args(
-                    parsed_input, tool.input_schema
+                    parsed_input,
+                    tool.input_schema,
                 )
                 tool_call.input = json.dumps(parsed_input)
 
@@ -2224,9 +2242,11 @@ class Agent:
                     tool_result_block = ToolResultBlock(
                         id=tool_call.id,
                         name=tool_call.name,
-                        output=[TextBlock(text=chunk.content)]
-                        if isinstance(chunk.content, str)
-                        else chunk.content,
+                        output=(
+                            [TextBlock(text=chunk.content)]
+                            if isinstance(chunk.content, str)
+                            else chunk.content
+                        ),
                         state=chunk.state,
                         metadata=chunk.metadata,
                     )

--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -2109,9 +2109,6 @@ class Agent:
                     "non-finite numbers are not valid JSON values.",
                 )
 
-            if parsed_input and tool.input_schema:
-                tool_call.input = json.dumps(parsed_input)
-
             # Validate the coerced input against the tool schema.
             # TODO: feed validation errors back to the model so it can
             # auto-correct.  Type coercion above already handles common
@@ -2124,6 +2121,9 @@ class Agent:
                     f"Input validation failed for tool '{tool_call.name}': "
                     f"{e.message}",
                 ) from e
+
+            if parsed_input and tool.input_schema:
+                tool_call.input = json.dumps(parsed_input)
 
         # The exceptions that
         #  - cannot found tool

--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -3,6 +3,7 @@
 import asyncio
 import collections
 import inspect
+import json
 import re
 
 from asyncio import Queue
@@ -92,6 +93,7 @@ from ..tool import (
     ToolChoice,
     ToolResponse,
 )
+from ..tool._utils import _coerce_tool_args
 from ..permission import (
     PermissionBehavior,
     PermissionEngine,
@@ -2077,8 +2079,18 @@ class Agent:
                 tool.input_schema,
             )
 
-            # Validate the parsed input with the tool schema
-            # TODO: Maybe some logic to mix the validation error in runtime
+            # Coerce types before validation (e.g. str "42" → int 42).
+            if parsed_input and tool.input_schema:
+                parsed_input = _coerce_tool_args(
+                    parsed_input, tool.input_schema
+                )
+                tool_call.input = json.dumps(parsed_input)
+
+            # Validate the coerced input against the tool schema.
+            # TODO: feed validation errors back to the model so it can
+            # auto-correct.  Type coercion above already handles common
+            # LLM mistakes (e.g. "42" → 42), so this would mainly cover
+            # missing required params or structural mismatches.
             try:
                 jsonschema.validate(parsed_input, tool.input_schema)
             except jsonschema.ValidationError as e:

--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -94,7 +94,7 @@ from ..tool import (
     ToolChoice,
     ToolResponse,
 )
-from ..tool._utils import _coerce_tool_args
+from ..tool._utils import _coerce_tool_args, _contains_non_finite_float
 from ..permission import (
     PermissionBehavior,
     PermissionEngine,
@@ -2102,6 +2102,14 @@ class Agent:
                     parsed_input,
                     tool.input_schema,
                 )
+
+            if _contains_non_finite_float(parsed_input):
+                raise AgentOrientedException(
+                    f"Input validation failed for tool '{tool_call.name}': "
+                    "non-finite numbers are not valid JSON values.",
+                )
+
+            if parsed_input and tool.input_schema:
                 tool_call.input = json.dumps(parsed_input)
 
             # Validate the coerced input against the tool schema.

--- a/src/agentscope/tool/_base.py
+++ b/src/agentscope/tool/_base.py
@@ -17,7 +17,7 @@ from ..permission import (
     PermissionBehavior,
 )
 from ._response import ToolChunk
-from ._utils import _remove_title_field
+from ._utils import _remove_title_field, _coerce_tool_args
 
 
 class ParamsBase(BaseModel):
@@ -197,6 +197,20 @@ class ToolBase(ABC):
                 f"{type(self).__name__} must be called with keyword arguments "
                 f"only, but got {len(args)} positional argument(s).",
             )
+
+        # Best-effort type coercion: LLMs often return arguments with
+        # incorrect types (e.g. str "42" instead of int 42).  Attempt to
+        # repair mismatches based on the tool's input_schema before the
+        # arguments reach the middleware chain or call().
+        #
+        # Note: _toolkit.py also applies _coerce_tool_args before
+        # invoking the tool (to cover subclasses that override __call__
+        # directly).  The function is idempotent — already-correct
+        # values pass through unchanged — so double application is
+        # harmless.
+        if kwargs and hasattr(self, "input_schema"):
+            kwargs = _coerce_tool_args(kwargs, self.input_schema)
+
         # ``getattr`` with a default so the no-middleware path keeps working
         # even if a subclass overrides ``__init__`` without calling
         # ``super().__init__()``.

--- a/src/agentscope/tool/_base.py
+++ b/src/agentscope/tool/_base.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=unused-argument
 """The tool protocol in agentscope."""
+
 import inspect
 import os
 from abc import abstractmethod, ABC

--- a/src/agentscope/tool/_toolkit.py
+++ b/src/agentscope/tool/_toolkit.py
@@ -24,6 +24,7 @@ from ._response import ToolResponse, ToolChunk
 from ..skill import SkillLoaderBase, Skill
 from ._types import RegisteredTool
 from .._utils._common import _describe_exception, _json_loads_with_repair
+from ._utils import _coerce_tool_args
 from ..exception import (
     DeveloperOrientedException,
     ToolNotFoundError,
@@ -297,6 +298,13 @@ class Toolkit:
         try:
             # Prepare keyword arguments
             kwargs = _json_loads_with_repair(tool_call.input)
+
+            # Best-effort type coercion based on the tool's input_schema.
+            # Also covers subclasses that override __call__ directly,
+            # where the base class coercion in ToolBase.__call__ is
+            # bypassed.
+            if kwargs and hasattr(tool_func, "input_schema"):
+                kwargs = _coerce_tool_args(kwargs, tool_func.input_schema)
 
             # State injection
             if (

--- a/src/agentscope/tool/_toolkit.py
+++ b/src/agentscope/tool/_toolkit.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """The toolkit class for tool calls in AgentScope."""
+
 import asyncio
 import inspect
 from collections import OrderedDict
@@ -39,7 +40,6 @@ from ..message import (
 from ._tool_group import ToolGroup
 from .._logging import logger
 from ..state import AgentState
-
 
 # pylint: disable=line-too-long
 DEFAULT_META_TOOL_RESPONSE_TEMPLATE = """{% if groups | length == 0 %}All tool groups are currently deactivated.{% else %}The currently activated tool group(s): {{ groups | map(attribute='name') | join(', ') }}.{% if groups | selectattr('instructions', 'ne', None) | list | length > 0 %}
@@ -89,8 +89,9 @@ class Toolkit:
     def __init__(
         self,
         tools: list[ToolBase] | None = None,
-        skills_or_loaders: Sequence[str | Skill | SkillLoaderBase]
-        | None = None,
+        skills_or_loaders: (
+            Sequence[str | Skill | SkillLoaderBase] | None
+        ) = None,
         mcps: list[MCPClient] | None = None,
         tool_groups: list[ToolGroup] | None = None,
         meta_tool_response_template: str = DEFAULT_META_TOOL_RESPONSE_TEMPLATE,

--- a/src/agentscope/tool/_utils.py
+++ b/src/agentscope/tool/_utils.py
@@ -8,6 +8,7 @@ import sys
 from decimal import Decimal, InvalidOperation
 from typing import Any, Dict, Callable
 
+import jsonschema
 from docstring_parser import parse
 from pydantic import Field, create_model, ConfigDict
 
@@ -278,6 +279,7 @@ def _coerce_value(
         if isinstance(alternatives, list):
             return _coerce_composite(
                 value,
+                prop_schema,
                 alternatives,
                 defs,
                 param,
@@ -303,7 +305,8 @@ def _coerce_value(
 
 def _coerce_composite(
     value: Any,
-    alternatives: list[dict[str, Any]],
+    composite_schema: dict[str, Any],
+    alternatives: list[Any],
     defs: dict[str, Any],
     param: str,
 ) -> Any:
@@ -315,7 +318,9 @@ def _coerce_composite(
     Args:
         value (`Any`):
             The value to coerce.
-        alternatives (`list[dict]`):
+        composite_schema (`dict[str, Any]`):
+            The enclosing schema containing the alternatives.
+        alternatives (`list[Any]`):
             The ``anyOf`` / ``oneOf`` list from the schema.
         defs (`dict[str, Any]`):
             The ``$defs`` block for resolving ``$ref``.
@@ -326,6 +331,9 @@ def _coerce_composite(
         `Any`:
             The coerced value.
     """
+    if _schema_is_valid(value, composite_schema, defs):
+        return value
+
     # Collect all type-matching alternatives (for discriminated unions we
     # need the best match, not just the first).
     type_matches: list[tuple[dict[str, Any], int]] = []
@@ -348,7 +356,15 @@ def _coerce_composite(
         best_alt, best_score = type_matches[0]
         if len(type_matches) > 1 and type_matches[1][1] == best_score:
             return value
-        return _coerce_value(value, best_alt, defs, param)
+        candidate = _coerce_value(value, best_alt, defs, param)
+        if _is_valid_composite_candidate(
+            candidate,
+            best_alt,
+            composite_schema,
+            defs,
+        ):
+            return candidate
+        return value
 
     # If the value matched the type of some alternatives but every one
     # was disqualified by discriminator/required, don't fall through to
@@ -371,9 +387,74 @@ def _coerce_composite(
         if _value_matches_type(coerced, alt_type):
             if coerced is not value:
                 _log_coercion(param, type(value).__name__, alt_type)
-            return _coerce_value(coerced, resolved_alt, defs, param)
+            candidate = _coerce_value(coerced, resolved_alt, defs, param)
+            if _is_valid_composite_candidate(
+                candidate,
+                resolved_alt,
+                composite_schema,
+                defs,
+            ):
+                return candidate
 
     return value
+
+
+def _is_valid_composite_candidate(
+    candidate: Any,
+    alternative: dict[str, Any],
+    composite_schema: dict[str, Any],
+    defs: dict[str, Any],
+) -> bool:
+    """Check that a repaired value satisfies a branch and its composite.
+
+    Args:
+        candidate (`Any`):
+            The repaired value to validate.
+        alternative (`dict[str, Any]`):
+            The selected composite branch.
+        composite_schema (`dict[str, Any]`):
+            The enclosing ``anyOf`` or ``oneOf`` schema.
+        defs (`dict[str, Any]`):
+            Local schema definitions for resolving references.
+
+    Returns:
+        `bool`:
+            Whether the candidate is valid for both schemas.
+    """
+    return _schema_is_valid(candidate, alternative, defs) and _schema_is_valid(
+        candidate,
+        composite_schema,
+        defs,
+    )
+
+
+def _schema_is_valid(
+    value: Any,
+    schema: dict[str, Any],
+    defs: dict[str, Any],
+) -> bool:
+    """Check a value against a schema with locally supplied definitions.
+
+    Args:
+        value (`Any`):
+            The value to validate.
+        schema (`dict[str, Any]`):
+            The schema to validate against.
+        defs (`dict[str, Any]`):
+            Local schema definitions for resolving references.
+
+    Returns:
+        `bool`:
+            Whether the value satisfies the schema.
+    """
+    schema_with_defs = dict(schema)
+    schema_with_defs.setdefault("$defs", defs)
+    schema_with_defs.setdefault("definitions", defs)
+    try:
+        jsonschema.validate(value, schema_with_defs)
+    except jsonschema.ValidationError:
+        return False
+    return True
 
 
 def _discriminator_score(value: Any, schema: dict[str, Any]) -> int:
@@ -401,7 +482,7 @@ def _discriminator_score(value: Any, schema: dict[str, Any]) -> int:
         return 0
     # const contradiction → disqualify
     for key, prop_schema in props.items():
-        if "const" in prop_schema:
+        if isinstance(prop_schema, dict) and "const" in prop_schema:
             if key not in value or value[key] != prop_schema["const"]:
                 return -1
     # missing required field → disqualify
@@ -413,7 +494,7 @@ def _discriminator_score(value: Any, schema: dict[str, Any]) -> int:
     for key in schema.get("required", []):
         score += 1  # each is present (already verified above)
     for key, prop_schema in props.items():
-        if "const" in prop_schema:
+        if isinstance(prop_schema, dict) and "const" in prop_schema:
             score += 10
     return score
 

--- a/src/agentscope/tool/_utils.py
+++ b/src/agentscope/tool/_utils.py
@@ -214,6 +214,27 @@ def _coerce_tool_args(
     return result
 
 
+def _contains_non_finite_float(value: Any) -> bool:
+    """Check whether a JSON-compatible value contains NaN or infinity.
+
+    Args:
+        value (`Any`):
+            The value to inspect.
+
+    Returns:
+        `bool`:
+            Whether the value or one of its nested values is a non-finite
+            float.
+    """
+    if isinstance(value, float):
+        return not math.isfinite(value)
+    if isinstance(value, dict):
+        return any(_contains_non_finite_float(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_non_finite_float(item) for item in value)
+    return False
+
+
 def _coerce_value(
     value: Any,
     prop_schema: dict[str, Any],

--- a/src/agentscope/tool/_utils.py
+++ b/src/agentscope/tool/_utils.py
@@ -663,8 +663,12 @@ def _coerce_to_type(value: Any, expected_type: str) -> Any:
                 return True
             if stripped in ("false", "0", "no"):
                 return False
-        if isinstance(value, (int, float)):
-            return bool(value)
+        if isinstance(value, int):
+            if value in (0, 1):
+                return bool(value)
+        if isinstance(value, float):
+            if value in (0.0, 1.0):
+                return bool(value)
         return value
 
     if expected_type == "array":

--- a/src/agentscope/tool/_utils.py
+++ b/src/agentscope/tool/_utils.py
@@ -4,6 +4,7 @@
 import inspect
 import json
 import math
+import sys
 from decimal import Decimal, InvalidOperation
 from typing import Any, Dict, Callable
 
@@ -11,6 +12,13 @@ from docstring_parser import parse
 from pydantic import Field, create_model, ConfigDict
 
 from .._logging import logger
+
+# Upper bound for integer coercion via Decimal, kept safely below
+# Python's int→str limit (default 4300) so json.dumps won't fail later.
+_int_str_limit = getattr(sys, "get_int_max_str_digits", lambda: 0)()
+_MAX_COERCED_INT_DIGITS: int = (
+    min(4_000, _int_str_limit - 300) if _int_str_limit else 4_000
+)
 
 
 def _remove_title_field(schema: dict) -> dict:
@@ -621,8 +629,11 @@ def _coerce_to_type(value: Any, expected_type: str) -> Any:
             # would silently corrupt.
             try:
                 d = Decimal(stripped)
-                if d == d.to_integral_value():
-                    return int(d)
+                if d.is_finite() and d == d.to_integral_value():
+                    # d.adjusted() estimates digit count; skip huge
+                    # values to avoid OOM (e.g. "1e1000000000").
+                    if d.adjusted() < _MAX_COERCED_INT_DIGITS:
+                        return int(d)
             except (ValueError, TypeError, InvalidOperation, OverflowError):
                 pass
         return value

--- a/src/agentscope/tool/_utils.py
+++ b/src/agentscope/tool/_utils.py
@@ -649,7 +649,9 @@ def _coerce_to_type(value: Any, expected_type: str) -> Any:
         if isinstance(value, str):
             stripped = value.strip()
             try:
-                return float(stripped)
+                parsed = float(stripped)
+                if math.isfinite(parsed):
+                    return parsed
             except (ValueError, TypeError):
                 pass
         return value

--- a/src/agentscope/tool/_utils.py
+++ b/src/agentscope/tool/_utils.py
@@ -179,7 +179,7 @@ def _extract_input_schema(
 
 def _coerce_tool_args(
     kwargs: dict[str, Any],
-    schema: dict[str, Any],
+    schema: dict[str, Any] | bool,
 ) -> dict[str, Any]:
     """Coerce tool arguments to match the expected JSON schema types.
 
@@ -191,7 +191,7 @@ def _coerce_tool_args(
     Args:
         kwargs (`dict[str, Any]`):
             The tool input arguments to coerce.
-        schema (`dict[str, Any]`):
+        schema (`dict[str, Any] | bool`):
             The JSON schema describing the expected parameter types.
 
     Returns:
@@ -199,6 +199,9 @@ def _coerce_tool_args(
             The coerced arguments.  Keys not present in the schema are
             returned unchanged.
     """
+    if not isinstance(schema, dict):
+        return kwargs
+
     properties = schema.get("properties", {})
     if not properties or not kwargs:
         return kwargs

--- a/src/agentscope/tool/_utils.py
+++ b/src/agentscope/tool/_utils.py
@@ -1,10 +1,15 @@
 # -*- coding: utf-8 -*-
 """The tool module utils."""
 import inspect
+import json
+import math
+from decimal import Decimal, InvalidOperation
 from typing import Any, Dict, Callable
 
 from docstring_parser import parse
 from pydantic import Field, create_model, ConfigDict
+
+from .._logging import logger
 
 
 def _remove_title_field(schema: dict) -> dict:
@@ -158,3 +163,513 @@ def _extract_input_schema(
     _remove_title_field(params_json_schema)
 
     return params_json_schema
+
+
+def _coerce_tool_args(
+    kwargs: dict[str, Any],
+    schema: dict[str, Any],
+) -> dict[str, Any]:
+    """Coerce tool arguments to match the expected JSON schema types.
+
+    This is a best-effort function that attempts to repair type mismatches
+    commonly produced by LLMs (e.g. a ``str`` ``"42"`` when an ``int``
+    is expected).  When coercion fails for any reason the original value
+    is kept silently.
+
+    Args:
+        kwargs (`dict[str, Any]`):
+            The tool input arguments to coerce.
+        schema (`dict[str, Any]`):
+            The JSON schema describing the expected parameter types.
+
+    Returns:
+        `dict[str, Any]`:
+            The coerced arguments.  Keys not present in the schema are
+            returned unchanged.
+    """
+    properties = schema.get("properties", {})
+    if not properties or not kwargs:
+        return kwargs
+
+    defs = schema.get("$defs", schema.get("definitions", {}))
+
+    result = dict(kwargs)
+    for key, value in result.items():
+        prop_schema = properties.get(key)
+        if prop_schema is None:
+            continue
+        result[key] = _coerce_value(value, prop_schema, defs, param=key)
+
+    return result
+
+
+def _coerce_value(
+    value: Any,
+    prop_schema: dict[str, Any],
+    defs: dict[str, Any],
+    param: str = "?",
+) -> Any:
+    """Coerce a single value to match a JSON schema property definition.
+
+    Args:
+        value (`Any`):
+            The value to coerce.
+        prop_schema (`dict[str, Any]`):
+            The JSON schema for this property (may contain ``$ref``,
+            ``anyOf``, ``oneOf``).
+        defs (`dict[str, Any]`):
+            The ``$defs`` / ``definitions`` block from the parent schema.
+        param (`str`):
+            The parameter name (for debug logging only).
+
+    Returns:
+        `Any`:
+            The coerced value, or the original value if coercion fails.
+    """
+    # Resolve local references before examining the schema.
+    resolved_schema = _resolve_alt_ref(prop_schema, defs)
+    if resolved_schema is not None:
+        prop_schema = resolved_schema
+
+    # Handle anyOf / oneOf (Pydantic's canonical form for Optional[int],
+    # int | str, etc.)
+    for comb_key in ("anyOf", "oneOf"):
+        alternatives = prop_schema.get(comb_key)
+        if isinstance(alternatives, list):
+            return _coerce_composite(
+                value, alternatives, defs, param,
+            )
+
+    expected_type = prop_schema.get("type")
+
+    # No type constraint — still recurse into nested structures
+    if expected_type is None:
+        return _coerce_nested(value, prop_schema, defs, param)
+
+    # Union types: ["string", "null"], ["integer", "string"], etc.
+    if isinstance(expected_type, list):
+        return _coerce_union(value, expected_type, prop_schema, defs, param)
+
+    # Single type
+    coerced = _coerce_to_type(value, expected_type)
+    if coerced is not value:
+        _log_coercion(param, type(value).__name__, expected_type)
+
+    return _coerce_nested(coerced, prop_schema, defs, param)
+
+
+def _coerce_composite(
+    value: Any,
+    alternatives: list[dict[str, Any]],
+    defs: dict[str, Any],
+    param: str,
+) -> Any:
+    """Coerce against an ``anyOf`` / ``oneOf`` alternative list.
+
+    Selects an unambiguous type-matching alternative first. If the value
+    matches no alternative type, it makes a best-effort coercion attempt.
+
+    Args:
+        value (`Any`):
+            The value to coerce.
+        alternatives (`list[dict]`):
+            The ``anyOf`` / ``oneOf`` list from the schema.
+        defs (`dict[str, Any]`):
+            The ``$defs`` block for resolving ``$ref``.
+        param (`str`):
+            The parameter name for logging.
+
+    Returns:
+        `Any`:
+            The coerced value.
+    """
+    # Collect all type-matching alternatives (for discriminated unions we
+    # need the best match, not just the first).
+    type_matches: list[tuple[dict[str, Any], int]] = []
+    any_type_match = False
+    for alt in alternatives:
+        resolved_alt = _resolve_alt_ref(alt, defs)
+        if resolved_alt is None:
+            continue
+        alt_type = resolved_alt.get("type")
+        if alt_type == "null" and value is None:
+            return _coerce_value(value, resolved_alt, defs, param)
+        if isinstance(alt_type, str) and _value_matches_type(value, alt_type):
+            any_type_match = True
+            score = _discriminator_score(value, resolved_alt)
+            if score >= 0:
+                type_matches.append((resolved_alt, score))
+
+    if type_matches:
+        type_matches.sort(key=lambda x: x[1], reverse=True)
+        best_alt, best_score = type_matches[0]
+        if len(type_matches) > 1 and type_matches[1][1] == best_score:
+            return value
+        return _coerce_value(value, best_alt, defs, param)
+
+    # If the value matched the type of some alternatives but every one
+    # was disqualified by discriminator/required, don't fall through to
+    # the coercion loop — it would blindly use the first alt's schema.
+    if any_type_match and isinstance(value, dict):
+        return value
+
+    # Try coercion against each non-null alternative
+    for alt in alternatives:
+        resolved_alt = _resolve_alt_ref(alt, defs)
+        if resolved_alt is None:
+            continue
+        alt_type = resolved_alt.get("type")
+        if alt_type == "null" or not isinstance(alt_type, str):
+            continue
+        try:
+            coerced = _coerce_to_type(value, alt_type)
+            if coerced is not value:
+                _log_coercion(param, type(value).__name__, alt_type)
+            return _coerce_value(coerced, resolved_alt, defs, param)
+        except (ValueError, TypeError):
+            continue
+
+    return value
+
+
+def _discriminator_score(value: Any, schema: dict[str, Any]) -> int:
+    """Evaluate a discriminated union branch against a value.
+
+    Returns a non-negative score when the branch is a viable match
+    (higher is better).  Returns ``-1`` when the branch is
+    **disqualified** — any ``const`` field contradicts the input, or a
+    ``required`` field is missing.
+
+    Args:
+        value (`Any`):
+            The value to check (typically a ``dict``).
+        schema (`dict[str, Any]`):
+            A resolved alternative schema.
+
+    Returns:
+        `int`:
+            Discrimination score (≥ 0), or ``-1`` if disqualified.
+    """
+    if not isinstance(value, dict):
+        return 0
+    props = schema.get("properties")
+    if not isinstance(props, dict):
+        return 0
+    # const contradiction → disqualify
+    for key, prop_schema in props.items():
+        if "const" in prop_schema:
+            if key not in value or value[key] != prop_schema["const"]:
+                return -1
+    # missing required field → disqualify
+    for key in schema.get("required", []):
+        if key not in value:
+            return -1
+    # Viable: score by how many required fields are present
+    score = 0
+    for key in schema.get("required", []):
+        score += 1  # each is present (already verified above)
+    for key, prop_schema in props.items():
+        if "const" in prop_schema:
+            score += 10
+    return score
+
+
+def _resolve_alt_ref(
+    alt: dict[str, Any],
+    defs: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Resolve a ``$ref`` reference in an anyOf/oneOf alternative.
+
+    Args:
+        alt (`dict`):
+            An alternative schema, possibly containing ``$ref``.
+        defs (`dict`):
+            The ``$defs`` block.
+
+    Returns:
+        `dict | None`:
+            The resolved schema, or ``None`` if unresolvable.
+    """
+    if "$ref" not in alt:
+        return alt
+    ref_name = alt["$ref"].split("/")[-1]
+    return defs.get(ref_name)
+
+
+def _coerce_nested(
+    value: Any,
+    prop_schema: dict[str, Any],
+    defs: dict[str, Any],
+    param: str = "?",
+) -> Any:
+    """Recursively coerce nested structures (array items, object properties).
+
+    Args:
+        value (`Any`):
+            The value whose nested contents to coerce.
+        prop_schema (`dict[str, Any]`):
+            The JSON schema for this value.
+        defs (`dict[str, Any]`):
+            The ``$defs`` block for resolving ``$ref``.
+        param (`str`):
+            The parameter name for logging context.
+
+    Returns:
+        `Any`:
+            The value with nested contents coerced.
+    """
+    # Coerce array items
+    if (
+        isinstance(value, list)
+        and isinstance(prop_schema.get("items"), dict)
+    ):
+        item_schema = prop_schema["items"]
+        return [
+            _coerce_value(
+                item, item_schema, defs,
+                param=f"{param}[{i}]",
+            )
+            for i, item in enumerate(value)
+        ]
+
+    # Coerce object properties recursively
+    if isinstance(value, dict):
+        result = dict(value)
+        # Handle known properties
+        props = prop_schema.get("properties")
+        if isinstance(props, dict):
+            virtual_schema = {"properties": props, "$defs": defs}
+            result = _coerce_tool_args(result, virtual_schema)
+        # Handle additionalProperties (e.g. dict[str, int])
+        addl = prop_schema.get("additionalProperties")
+        if isinstance(addl, dict):
+            known = set(props.keys()) if isinstance(props, dict) else set()
+            for key, val in result.items():
+                if key not in known:
+                    result[key] = _coerce_value(
+                        val, addl, defs, param=f"{param}.{key}",
+                    )
+        return result
+
+    return value
+
+
+def _log_coercion(param: str, from_type: str, to_schema_type: str) -> None:
+    """Log a type coercion event without exposing parameter values.
+
+    Args:
+        param (`str`):
+            The parameter name.
+        from_type (`str`):
+            The original Python type name.
+        to_schema_type (`str`):
+            The target JSON Schema type.
+    """
+    logger.debug(
+        "Coerced tool arg '%s' from %s to match schema type %s",
+        param,
+        from_type,
+        to_schema_type,
+    )
+
+
+def _coerce_union(
+    value: Any,
+    types: list[str],
+    prop_schema: dict[str, Any],
+    defs: dict[str, Any],
+    param: str,
+) -> Any:
+    """Coerce a value against a ``type`` array (e.g. ``["string", "null"]``).
+
+    Tries each type in order; returns the first successful coercion.
+
+    Args:
+        value (`Any`):
+            The value to coerce.
+        types (`list[str]`):
+            The allowed types.
+        prop_schema (`dict[str, Any]`):
+            The JSON schema for this property.
+        defs (`dict[str, Any]`):
+            The ``$defs`` block for resolving ``$ref``.
+        param (`str`):
+            The parameter name for logging.
+
+    Returns:
+        `Any`:
+            The coerced value.
+    """
+    # If the value already matches one of the types, just recurse
+    for t in types:
+        if t == "null" and value is None:
+            return _coerce_nested(value, prop_schema, defs, param)
+        if _value_matches_type(value, t):
+            return _coerce_nested(value, prop_schema, defs, param)
+
+    # Try coercion to each non-null type
+    for t in types:
+        if t == "null":
+            continue
+        try:
+            coerced = _coerce_to_type(value, t)
+            if coerced is not value:
+                _log_coercion(param, type(value).__name__, t)
+            return _coerce_nested(coerced, prop_schema, defs, param)
+        except (ValueError, TypeError):
+            continue
+
+    # Nothing worked — return as-is
+    return value
+
+
+def _value_matches_type(value: Any, expected_type: str) -> bool:
+    """Check whether a value's Python type matches a JSON schema type.
+
+    Args:
+        value (`Any`):
+            The value to check.
+        expected_type (`str`):
+            The JSON schema type name.
+
+    Returns:
+        `bool`:
+            ``True`` if the value matches the expected type.
+    """
+    if expected_type == "string":
+        return isinstance(value, str)
+    if expected_type == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected_type == "number":
+        return isinstance(value, (int, float)) and not isinstance(
+            value, bool,
+        )
+    if expected_type == "boolean":
+        return isinstance(value, bool)
+    if expected_type == "array":
+        return isinstance(value, list)
+    if expected_type == "object":
+        return isinstance(value, dict)
+    if expected_type == "null":
+        return value is None
+    return False
+
+
+# pylint: disable=too-many-return-statements,too-many-branches
+def _coerce_to_type(value: Any, expected_type: str) -> Any:
+    """Best-effort, lossless coercion of a single value to the expected
+    JSON Schema type.
+
+    Only applies when the coercion is unambiguous and preserves the
+    intended value.  Ambiguous or lossy conversions (e.g. ``"42.9"`` →
+    ``int``) are left unchanged so the original validation / tool error
+    surfaces.
+
+    Args:
+        value (`Any`):
+            The value to coerce.
+        expected_type (`str`):
+            The target JSON schema type.
+
+    Returns:
+        `Any`:
+            The coerced value, or the original value if coercion is not
+            applicable or fails.
+    """
+    if expected_type == "string":
+        if not isinstance(value, str):
+            return str(value)
+        return value
+
+    if expected_type == "integer":
+        if isinstance(value, bool):
+            # bool is a subclass of int — keep it as-is
+            return value
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            # inf / nan cannot be coerced to int
+            if not math.isfinite(value):
+                return value
+            # Only coerce if the float represents an exact integer
+            try:
+                as_int = int(value)
+                if value == as_int:
+                    return as_int
+            except (ValueError, OverflowError):
+                pass
+            return value
+        if isinstance(value, str):
+            stripped = value.strip()
+            # Try direct int parsing first — handles plain integer
+            # strings without any precision loss.
+            try:
+                return int(stripped)
+            except (ValueError, TypeError):
+                pass
+            # Fall back via Decimal: preserves precision for strings
+            # like "1e23" or "100000000000000000000000.0" that float()
+            # would silently corrupt.
+            try:
+                d = Decimal(stripped)
+                if d == d.to_integral_value():
+                    return int(d)
+            except (ValueError, TypeError, InvalidOperation, OverflowError):
+                pass
+        return value
+
+    if expected_type == "number":
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            # JSON Schema "number" accepts integers — no coercion needed
+            return value
+        if isinstance(value, str):
+            stripped = value.strip()
+            try:
+                return float(stripped)
+            except (ValueError, TypeError):
+                pass
+        return value
+
+    if expected_type == "boolean":
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            stripped = value.strip().lower()
+            if stripped in ("true", "1", "yes"):
+                return True
+            if stripped in ("false", "0", "no"):
+                return False
+        if isinstance(value, (int, float)):
+            return bool(value)
+        return value
+
+    if expected_type == "array":
+        if isinstance(value, list):
+            return value
+        if isinstance(value, str):
+            stripped = value.strip()
+            try:
+                parsed = json.loads(stripped)
+                if isinstance(parsed, list):
+                    return parsed
+            except (json.JSONDecodeError, TypeError):
+                pass
+        # Wrap single value in a list
+        return [value]
+
+    if expected_type == "object":
+        if isinstance(value, dict):
+            return value
+        if isinstance(value, str):
+            stripped = value.strip()
+            try:
+                parsed = json.loads(stripped)
+                if isinstance(parsed, dict):
+                    return parsed
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return value
+
+    return value

--- a/src/agentscope/tool/_utils.py
+++ b/src/agentscope/tool/_utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """The tool module utils."""
+
 import inspect
 import json
 import math
@@ -70,6 +71,7 @@ def _extract_func_description(docstring: str) -> str:
     return "\n".join(descriptions)
 
 
+# fmt: off
 def _extract_input_schema(
     tool_func: Callable,
     include_var_positional: bool = False,
@@ -151,6 +153,7 @@ def _extract_input_schema(
                     else param.default,
                 ),
             )
+# fmt: on
 
     base_model = create_model(
         "_StructuredOutputDynamicClass",
@@ -237,7 +240,10 @@ def _coerce_value(
         alternatives = prop_schema.get(comb_key)
         if isinstance(alternatives, list):
             return _coerce_composite(
-                value, alternatives, defs, param,
+                value,
+                alternatives,
+                defs,
+                param,
             )
 
     expected_type = prop_schema.get("type")
@@ -419,14 +425,13 @@ def _coerce_nested(
             The value with nested contents coerced.
     """
     # Coerce array items
-    if (
-        isinstance(value, list)
-        and isinstance(prop_schema.get("items"), dict)
-    ):
+    if isinstance(value, list) and isinstance(prop_schema.get("items"), dict):
         item_schema = prop_schema["items"]
         return [
             _coerce_value(
-                item, item_schema, defs,
+                item,
+                item_schema,
+                defs,
                 param=f"{param}[{i}]",
             )
             for i, item in enumerate(value)
@@ -447,7 +452,10 @@ def _coerce_nested(
             for key, val in result.items():
                 if key not in known:
                     result[key] = _coerce_value(
-                        val, addl, defs, param=f"{param}.{key}",
+                        val,
+                        addl,
+                        defs,
+                        param=f"{param}.{key}",
                     )
         return result
 
@@ -542,7 +550,8 @@ def _value_matches_type(value: Any, expected_type: str) -> bool:
         return isinstance(value, int) and not isinstance(value, bool)
     if expected_type == "number":
         return isinstance(value, (int, float)) and not isinstance(
-            value, bool,
+            value,
+            bool,
         )
     if expected_type == "boolean":
         return isinstance(value, bool)

--- a/src/agentscope/tool/_utils.py
+++ b/src/agentscope/tool/_utils.py
@@ -708,7 +708,9 @@ def _coerce_to_type(value: Any, expected_type: str) -> Any:
             applicable or fails.
     """
     if expected_type == "string":
-        if not isinstance(value, str):
+        if isinstance(value, (bool, int)):
+            return str(value)
+        if isinstance(value, float) and math.isfinite(value):
             return str(value)
         return value
 

--- a/src/agentscope/tool/_utils.py
+++ b/src/agentscope/tool/_utils.py
@@ -237,6 +237,11 @@ def _coerce_value(
         `Any`:
             The coerced value, or the original value if coercion fails.
     """
+    # Boolean sub-schemas (true / false) are valid JSON Schema but
+    # carry no type information — let jsonschema handle them.
+    if not isinstance(prop_schema, dict):
+        return value
+
     # Resolve local references before examining the schema.
     resolved_schema = _resolve_alt_ref(prop_schema, defs)
     if resolved_schema is not None:
@@ -303,7 +308,7 @@ def _coerce_composite(
     any_type_match = False
     for alt in alternatives:
         resolved_alt = _resolve_alt_ref(alt, defs)
-        if resolved_alt is None:
+        if resolved_alt is None or not isinstance(resolved_alt, dict):
             continue
         alt_type = resolved_alt.get("type")
         if alt_type == "null" and value is None:
@@ -330,7 +335,7 @@ def _coerce_composite(
     # Try coercion against each non-null alternative
     for alt in alternatives:
         resolved_alt = _resolve_alt_ref(alt, defs)
-        if resolved_alt is None:
+        if resolved_alt is None or not isinstance(resolved_alt, dict):
             continue
         alt_type = resolved_alt.get("type")
         if alt_type == "null" or not isinstance(alt_type, str):
@@ -405,6 +410,8 @@ def _resolve_alt_ref(
         `dict | None`:
             The resolved schema, or ``None`` if unresolvable.
     """
+    if not isinstance(alt, dict):
+        return alt
     if "$ref" not in alt:
         return alt
     ref_name = alt["$ref"].split("/")[-1]

--- a/src/agentscope/tool/_utils.py
+++ b/src/agentscope/tool/_utils.py
@@ -450,9 +450,11 @@ def _schema_is_valid(
         `bool`:
             Whether the value satisfies the schema.
     """
-    schema_with_defs = dict(schema)
-    schema_with_defs.setdefault("$defs", defs)
-    schema_with_defs.setdefault("definitions", defs)
+    schema_with_defs = {
+        "$defs": defs,
+        "definitions": defs,
+        "allOf": [schema],
+    }
     try:
         jsonschema.validate(value, schema_with_defs)
     except jsonschema.ValidationError:

--- a/src/agentscope/tool/_utils.py
+++ b/src/agentscope/tool/_utils.py
@@ -337,11 +337,12 @@ def _coerce_composite(
             continue
         try:
             coerced = _coerce_to_type(value, alt_type)
+        except (ValueError, TypeError):
+            continue
+        if _value_matches_type(coerced, alt_type):
             if coerced is not value:
                 _log_coercion(param, type(value).__name__, alt_type)
             return _coerce_value(coerced, resolved_alt, defs, param)
-        except (ValueError, TypeError):
-            continue
 
     return value
 
@@ -529,11 +530,12 @@ def _coerce_union(
             continue
         try:
             coerced = _coerce_to_type(value, t)
+        except (ValueError, TypeError):
+            continue
+        if _value_matches_type(coerced, t):
             if coerced is not value:
                 _log_coercion(param, type(value).__name__, t)
             return _coerce_nested(coerced, prop_schema, defs, param)
-        except (ValueError, TypeError):
-            continue
 
     # Nothing worked — return as-is
     return value

--- a/src/agentscope/tool/_utils.py
+++ b/src/agentscope/tool/_utils.py
@@ -268,6 +268,9 @@ def _coerce_value(
     if resolved_schema is not None:
         prop_schema = resolved_schema
 
+    if not isinstance(prop_schema, dict):
+        return value
+
     # Handle anyOf / oneOf (Pydantic's canonical form for Optional[int],
     # int | str, etc.)
     for comb_key in ("anyOf", "oneOf"):

--- a/tests/agent_basic_test.py
+++ b/tests/agent_basic_test.py
@@ -1878,5 +1878,65 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
         tool_result_end = [e for e in events if e["type"] == "TOOL_RESULT_END"]
         self.assertTrue(any(e["state"] == "error" for e in tool_result_end))
 
+    async def test_agent_preserves_invalid_original_tool_input(self) -> None:
+        """Failed validation does not overwrite the original tool input."""
+        executed = False
+
+        class MockBoundedIntegerTool(ToolBase):
+            """A test tool with an integer lower bound."""
+
+            name: str = "mock_bounded_integer_tool"
+            description: str = "A tool with a bounded integer parameter"
+            input_schema: dict[str, Any] = {
+                "type": "object",
+                "properties": {"n": {"type": "integer", "minimum": 100}},
+                "required": ["n"],
+            }
+            is_concurrency_safe: bool = True
+            is_read_only: bool = False
+            is_external_tool: bool = False
+            is_mcp: bool = False
+
+            async def check_permissions(
+                self,
+                tool_input: dict[str, Any],
+                context: PermissionContext,
+            ) -> PermissionDecision:
+                return PermissionDecision(
+                    behavior=PermissionBehavior.ALLOW,
+                    message="Always allow",
+                )
+
+            async def __call__(self, n: int, **kwargs: Any) -> ToolChunk:
+                nonlocal executed
+                executed = True
+                return ToolChunk(content=[TextBlock(text="Executed")])
+
+        self.agent.toolkit = Toolkit(tools=[MockBoundedIntegerTool()])
+        tool_call = ToolCallBlock(
+            id="tool_call_invalid_coercion",
+            name="mock_bounded_integer_tool",
+            input='{"n": "42"}',
+        )
+        self.model.set_responses(
+            [
+                [ChatResponse(content=[tool_call], is_last=True)],
+                [
+                    ChatResponse(
+                        content=[TextBlock(text="Done")],
+                        is_last=True,
+                    ),
+                ],
+            ],
+        )
+
+        async for _ in self.agent.reply_stream(
+            UserMsg(name="user", content="Test"),
+        ):
+            pass
+
+        self.assertFalse(executed)
+        self.assertEqual(tool_call.input, '{"n": "42"}')
+
     async def asyncTearDown(self) -> None:
         """The async teardown method."""

--- a/tests/agent_basic_test.py
+++ b/tests/agent_basic_test.py
@@ -1638,5 +1638,104 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
         expected_context = [{**msg_base, **_} for _ in expected_context]
         self.assertListEqual(context_dicts, expected_context)
 
+    async def test_tool_arg_coercion_in_agent(self) -> None:
+        """Agent coerces type-mismatched tool arguments before validation,
+        and both permission checking and execution receive the coerced value.
+        """
+        permission_inputs: list[dict[str, Any]] = []
+        executed_args: list[Any] = []
+
+        class MockIntTool(ToolBase):
+            name: str = "mock_int_tool"
+            description: str = "A tool with an integer parameter"
+            input_schema: dict[str, Any] = {
+                "type": "object",
+                "properties": {
+                    "n": {"type": "integer", "description": "An integer"},
+                },
+                "required": ["n"],
+            }
+            is_concurrency_safe: bool = True
+            is_read_only: bool = False
+            is_external_tool: bool = False
+            is_mcp: bool = False
+
+            async def check_permissions(
+                self,
+                tool_input: dict[str, Any],
+                context: PermissionContext,
+            ) -> PermissionDecision:
+                permission_inputs.append(dict(tool_input))
+                return PermissionDecision(
+                    behavior=PermissionBehavior.ALLOW,
+                    message="Always allow",
+                )
+
+            async def __call__(self, n: int, **kwargs: Any) -> ToolChunk:
+                executed_args.append(n)
+                return ToolChunk(
+                    content=[TextBlock(text=f"Got int: {n}")],
+                )
+
+        self.agent.toolkit = Toolkit(tools=[MockIntTool()])
+        tool_call_id = "tool_call_coerce"
+
+        # Model returns "42" as a string — type mismatch for integer param
+        tool_call = ToolCallBlock(
+            id=tool_call_id,
+            name="mock_int_tool",
+            input='{"n": "42"}',
+        )
+        self.model.set_responses(
+            [
+                [
+                    ChatResponse(
+                        content=[
+                            TextBlock(text="Calling..."),
+                            tool_call,
+                        ],
+                        is_last=True,
+                    ),
+                ],
+                [
+                    ChatResponse(
+                        content=[TextBlock(text="Done")],
+                        is_last=True,
+                    ),
+                ],
+            ],
+        )
+
+        events = []
+        async for event in self.agent.reply_stream(
+            UserMsg(name="user", content="Test"),
+        ):
+            events.append(event.model_dump(mode="json"))
+
+        # Permission and execution must both receive the coerced int value
+        self.assertEqual(
+            permission_inputs,
+            [{"n": 42}],
+            "Permission should receive coerced int, not str",
+        )
+        self.assertEqual(
+            executed_args,
+            [42],
+            "Tool should receive coerced int, not str",
+        )
+        self.assertIsInstance(
+            executed_args[0],
+            int,
+            "Tool argument must be int, not str",
+        )
+
+        # Tool result should be success
+        tool_result_end = [
+            e for e in events if e["type"] == "TOOL_RESULT_END"
+        ]
+        self.assertTrue(
+            any(e["state"] == "success" for e in tool_result_end),
+        )
+
     async def asyncTearDown(self) -> None:
         """The async teardown method."""

--- a/tests/agent_basic_test.py
+++ b/tests/agent_basic_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """The basic test of the agent class."""
+
 from typing import Any
 from unittest.async_case import IsolatedAsyncioTestCase
 
@@ -1646,6 +1647,8 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
         executed_args: list[Any] = []
 
         class MockIntTool(ToolBase):
+            """A test tool that expects an integer parameter."""
+
             name: str = "mock_int_tool"
             description: str = "A tool with an integer parameter"
             input_schema: dict[str, Any] = {
@@ -1730,9 +1733,7 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
         )
 
         # Tool result should be success
-        tool_result_end = [
-            e for e in events if e["type"] == "TOOL_RESULT_END"
-        ]
+        tool_result_end = [e for e in events if e["type"] == "TOOL_RESULT_END"]
         self.assertTrue(
             any(e["state"] == "success" for e in tool_result_end),
         )

--- a/tests/agent_basic_test.py
+++ b/tests/agent_basic_test.py
@@ -1738,5 +1738,78 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
             any(e["state"] == "success" for e in tool_result_end),
         )
 
+    async def test_agent_rejects_unquoted_nan_tool_argument(self) -> None:
+        """Agent rejects non-finite numbers before tool execution."""
+        executed_args: list[float] = []
+
+        class MockBoundedNumberTool(ToolBase):
+            """A test tool that expects a number within a fixed range."""
+
+            name: str = "mock_bounded_number_tool"
+            description: str = "A tool with a bounded number parameter"
+            input_schema: dict[str, Any] = {
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1,
+                    },
+                },
+                "required": ["x"],
+            }
+            is_concurrency_safe: bool = True
+            is_read_only: bool = False
+            is_external_tool: bool = False
+            is_mcp: bool = False
+
+            async def check_permissions(
+                self,
+                tool_input: dict[str, Any],
+                context: PermissionContext,
+            ) -> PermissionDecision:
+                return PermissionDecision(
+                    behavior=PermissionBehavior.ALLOW,
+                    message="Always allow",
+                )
+
+            async def __call__(self, x: float, **kwargs: Any) -> ToolChunk:
+                executed_args.append(x)
+                return ToolChunk(content=[TextBlock(text="Executed")])
+
+        self.agent.toolkit = Toolkit(tools=[MockBoundedNumberTool()])
+        self.model.set_responses(
+            [
+                [
+                    ChatResponse(
+                        content=[
+                            ToolCallBlock(
+                                id="tool_call_nan",
+                                name="mock_bounded_number_tool",
+                                input='{"x": NaN}',
+                            ),
+                        ],
+                        is_last=True,
+                    ),
+                ],
+                [
+                    ChatResponse(
+                        content=[TextBlock(text="Done")],
+                        is_last=True,
+                    ),
+                ],
+            ],
+        )
+
+        events = []
+        async for event in self.agent.reply_stream(
+            UserMsg(name="user", content="Test"),
+        ):
+            events.append(event.model_dump(mode="json"))
+
+        self.assertEqual(executed_args, [])
+        tool_result_end = [e for e in events if e["type"] == "TOOL_RESULT_END"]
+        self.assertTrue(any(e["state"] == "error" for e in tool_result_end))
+
     async def asyncTearDown(self) -> None:
         """The async teardown method."""

--- a/tests/agent_basic_test.py
+++ b/tests/agent_basic_test.py
@@ -1811,5 +1811,72 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
         tool_result_end = [e for e in events if e["type"] == "TOOL_RESULT_END"]
         self.assertTrue(any(e["state"] == "error" for e in tool_result_end))
 
+    async def test_agent_rejects_nan_for_string_tool_argument(self) -> None:
+        """Agent rejects NaN before string coercion can hide it."""
+        executed_args: list[str] = []
+
+        class MockStringTool(ToolBase):
+            """A test tool that expects a string parameter."""
+
+            name: str = "mock_string_tool"
+            description: str = "A tool with a string parameter"
+            input_schema: dict[str, Any] = {
+                "type": "object",
+                "properties": {"x": {"type": "string"}},
+                "required": ["x"],
+            }
+            is_concurrency_safe: bool = True
+            is_read_only: bool = False
+            is_external_tool: bool = False
+            is_mcp: bool = False
+
+            async def check_permissions(
+                self,
+                tool_input: dict[str, Any],
+                context: PermissionContext,
+            ) -> PermissionDecision:
+                return PermissionDecision(
+                    behavior=PermissionBehavior.ALLOW,
+                    message="Always allow",
+                )
+
+            async def __call__(self, x: str, **kwargs: Any) -> ToolChunk:
+                executed_args.append(x)
+                return ToolChunk(content=[TextBlock(text="Executed")])
+
+        self.agent.toolkit = Toolkit(tools=[MockStringTool()])
+        self.model.set_responses(
+            [
+                [
+                    ChatResponse(
+                        content=[
+                            ToolCallBlock(
+                                id="tool_call_nan_string",
+                                name="mock_string_tool",
+                                input='{"x": NaN}',
+                            ),
+                        ],
+                        is_last=True,
+                    ),
+                ],
+                [
+                    ChatResponse(
+                        content=[TextBlock(text="Done")],
+                        is_last=True,
+                    ),
+                ],
+            ],
+        )
+
+        events = []
+        async for event in self.agent.reply_stream(
+            UserMsg(name="user", content="Test"),
+        ):
+            events.append(event.model_dump(mode="json"))
+
+        self.assertEqual(executed_args, [])
+        tool_result_end = [e for e in events if e["type"] == "TOOL_RESULT_END"]
+        self.assertTrue(any(e["state"] == "error" for e in tool_result_end))
+
     async def asyncTearDown(self) -> None:
         """The async teardown method."""

--- a/tests/tool_coercion_test.py
+++ b/tests/tool_coercion_test.py
@@ -185,6 +185,23 @@ class ToolCoercionTest(unittest.TestCase):
             _coerce_tool_args({"optional": None}, schema)["optional"],
         )
 
+    def test_anyof_coercion_continues_on_failure(self) -> None:
+        """When a coercion attempt fails, the loop continues to the next
+        alternative instead of stopping at the first one."""
+        schema = _schema(
+            {
+                "value": {
+                    "anyOf": [{"type": "integer"}, {"type": "number"}],
+                },
+            },
+        )
+        # "3.14" can't be integer, but can be coerced to number (3.14)
+        result = _coerce_tool_args({"value": "3.14"}, schema)
+        self.assertIsInstance(
+            result["value"], float, "Should coerce to float, not keep str",
+        )
+        self.assertEqual(result["value"], 3.14)
+
     def test_discriminated_unions_are_conservative(self) -> None:
         """Select matching branch, leave unknown branches intact."""
         schema = _schema(

--- a/tests/tool_coercion_test.py
+++ b/tests/tool_coercion_test.py
@@ -232,6 +232,31 @@ class ToolCoercionTest(unittest.TestCase):
         self.assertEqual(result, {"value": "42"})
         jsonschema.validate(result, schema)
 
+    def test_composite_coercion_keeps_root_reference_context(self) -> None:
+        """Composite schemas retain access to root definitions."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "$defs": {"LocalType": {"type": "null"}},
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "x": {"$ref": "#/$defs/RootType"},
+                            },
+                        },
+                    ],
+                },
+            },
+            "$defs": {"RootType": {"type": "integer"}},
+        }
+
+        result = _coerce_tool_args({"value": {"x": "42"}}, schema)
+
+        self.assertEqual(result, {"value": {"x": 42}})
+        jsonschema.validate(result, schema)
+
     def test_discriminated_unions_are_conservative(self) -> None:
         """Select matching branch, leave unknown branches intact."""
         schema = _schema(

--- a/tests/tool_coercion_test.py
+++ b/tests/tool_coercion_test.py
@@ -5,6 +5,7 @@ import math
 import unittest
 from typing import Any, Optional
 
+import jsonschema
 from agentscope.message import TextBlock, ToolCallBlock
 from agentscope.tool import (
     FunctionTool,
@@ -204,6 +205,20 @@ class ToolCoercionTest(unittest.TestCase):
         )
         self.assertEqual(result["value"], 3.14)
 
+    def test_composite_coercion_preserves_valid_values(self) -> None:
+        """Coercion does not invalidate an already-valid oneOf value."""
+        schema = _schema(
+            {
+                "value": {
+                    "oneOf": [True, {"type": "integer"}],
+                },
+            },
+        )
+        result = _coerce_tool_args({"value": "42"}, schema)
+
+        self.assertEqual(result, {"value": "42"})
+        jsonschema.validate(result, schema)
+
     def test_discriminated_unions_are_conservative(self) -> None:
         """Select matching branch, leave unknown branches intact."""
         schema = _schema(
@@ -342,6 +357,30 @@ class ToolCoercionTest(unittest.TestCase):
             schema_ref,
         )
         self.assertEqual(result, {"allowed": "42", "denied": 42})
+
+    def test_boolean_property_in_object_union_is_handled_gracefully(
+        self,
+    ) -> None:
+        """Boolean property schemas do not break union discrimination."""
+        schema = _schema(
+            {
+                "item": {
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "properties": {"anything": True},
+                            "required": ["required_key"],
+                        },
+                    ],
+                },
+            },
+        )
+        value = {"anything": "value"}
+
+        self.assertEqual(
+            _coerce_tool_args({"item": value}, schema),
+            {"item": value},
+        )
 
     def test_number_rejects_non_finite_strings(self) -> None:
         """NaN, Infinity, -Infinity stay as strings so schema validation

--- a/tests/tool_coercion_test.py
+++ b/tests/tool_coercion_test.py
@@ -316,6 +316,18 @@ class ToolCoercionTest(unittest.TestCase):
                     v,
                 )
 
+    def test_boolean_subschema_is_handled_gracefully(self) -> None:
+        """Boolean sub-schemas (true/false) don't crash coercion."""
+        # x: true — any value is valid, coercion should pass through
+        schema = {"type": "object", "properties": {"x": True}}
+        result = _coerce_tool_args({"x": "42"}, schema)
+        self.assertEqual(result["x"], "42")
+
+        # x: false — value should be preserved, schema validation rejects
+        schema_false = {"type": "object", "properties": {"x": False}}
+        result = _coerce_tool_args({"x": 42}, schema_false)
+        self.assertEqual(result["x"], 42)
+
     def test_number_rejects_non_finite_strings(self) -> None:
         """NaN, Infinity, -Infinity stay as strings so schema validation
         can reject them with a clear error."""

--- a/tests/tool_coercion_test.py
+++ b/tests/tool_coercion_test.py
@@ -346,6 +346,10 @@ class ToolCoercionTest(unittest.TestCase):
 
     def test_boolean_subschema_is_handled_gracefully(self) -> None:
         """Boolean sub-schemas (true/false) don't crash coercion."""
+        root_value = {"x": "42"}
+        self.assertEqual(_coerce_tool_args(root_value, True), root_value)
+        self.assertEqual(_coerce_tool_args(root_value, False), root_value)
+
         # x: true — any value is valid, coercion should pass through
         schema = {"type": "object", "properties": {"x": True}}
         result = _coerce_tool_args({"x": "42"}, schema)

--- a/tests/tool_coercion_test.py
+++ b/tests/tool_coercion_test.py
@@ -328,6 +328,21 @@ class ToolCoercionTest(unittest.TestCase):
         result = _coerce_tool_args({"x": 42}, schema_false)
         self.assertEqual(result["x"], 42)
 
+        # Boolean schemas resolved through $ref also pass through.
+        schema_ref = {
+            "type": "object",
+            "properties": {
+                "allowed": {"$ref": "#/$defs/allow_any"},
+                "denied": {"$ref": "#/$defs/deny_all"},
+            },
+            "$defs": {"allow_any": True, "deny_all": False},
+        }
+        result = _coerce_tool_args(
+            {"allowed": "42", "denied": 42},
+            schema_ref,
+        )
+        self.assertEqual(result, {"allowed": "42", "denied": 42})
+
     def test_number_rejects_non_finite_strings(self) -> None:
         """NaN, Infinity, -Infinity stay as strings so schema validation
         can reject them with a clear error."""

--- a/tests/tool_coercion_test.py
+++ b/tests/tool_coercion_test.py
@@ -316,6 +316,20 @@ class ToolCoercionTest(unittest.TestCase):
                     v,
                 )
 
+    def test_number_rejects_non_finite_strings(self) -> None:
+        """NaN, Infinity, -Infinity stay as strings so schema validation
+        can reject them with a clear error."""
+        schema = _schema({"value": {"type": "number"}})
+        for v in ("NaN", "Infinity", "-Infinity", "inf", "-inf"):
+            with self.subTest(value=v):
+                result = _coerce_tool_args({"value": v}, schema)
+                self.assertIsInstance(
+                    result["value"],
+                    str,
+                    f"'{v}' should stay str, not become float",
+                )
+                self.assertEqual(result["value"], v)
+
 
 class ToolCoercionIntegrationTest(unittest.IsolatedAsyncioTestCase):
     """Integration tests for the ToolBase and Toolkit invocation paths."""

--- a/tests/tool_coercion_test.py
+++ b/tests/tool_coercion_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Regression tests for schema-driven ToolBase argument coercion."""
+
 import math
 import unittest
 from typing import Any, Optional
@@ -59,7 +60,11 @@ class ToolCoercionTest(unittest.TestCase):
                 )
 
         unchanged = (
-            "42.9", "not_a_number", "Infinity", "-Infinity", 42.9,
+            "42.9",
+            "not_a_number",
+            "Infinity",
+            "-Infinity",
+            42.9,
         )
         for value in unchanged:
             with self.subTest(value=value):
@@ -189,12 +194,14 @@ class ToolCoercionTest(unittest.TestCase):
             },
         )
         matched = _coerce_tool_args(
-            {"item": {"kind": "b", "y": "42"}}, schema,
+            {"item": {"kind": "b", "y": "42"}},
+            schema,
         )
         self.assertEqual(matched["item"], {"kind": "b", "y": 42})
         unknown = {"kind": "c", "x": "1", "extra": "2"}
         self.assertEqual(
-            _coerce_tool_args({"item": unknown}, schema)["item"], unknown,
+            _coerce_tool_args({"item": unknown}, schema)["item"],
+            unknown,
         )
 
     def test_dynamic_maps_and_passthrough_are_preserved(self) -> None:
@@ -239,7 +246,8 @@ class ToolCoercionTest(unittest.TestCase):
         self.assertEqual(_coerce_tool_args(once, schema), once)
         self.assertEqual(_coerce_tool_args({}, schema), {})
         self.assertEqual(
-            _coerce_tool_args({"x": "1"}, {"type": "object"}), {"x": "1"},
+            _coerce_tool_args({"x": "1"}, {"type": "object"}),
+            {"x": "1"},
         )
 
 
@@ -312,7 +320,9 @@ class ToolCoercionIntegrationTest(unittest.IsolatedAsyncioTestCase):
 
         toolkit = Toolkit(tools=[OverrideTool()])
         tool_call = ToolCallBlock(
-            id="call_1", name="override_tool", input='{"count": "42"}',
+            id="call_1",
+            name="override_tool",
+            input='{"count": "42"}',
         )
         state = AgentState(session_id="s1", agent_id="a1")
         async for _ in toolkit.call_tool(tool_call, state):

--- a/tests/tool_coercion_test.py
+++ b/tests/tool_coercion_test.py
@@ -84,6 +84,25 @@ class ToolCoercionTest(unittest.TestCase):
                     ),
                 )
 
+    def test_integer_coercion_guards_against_huge_values(self) -> None:
+        """Huge values via scientific notation are left unchanged."""
+        schema = _schema({"value": {"type": "integer"}})
+        # Should be kept as-is — would produce a billion-digit int
+        self.assertEqual(
+            _coerce_tool_args({"value": "1e1000000000"}, schema)["value"],
+            "1e1000000000",
+        )
+        # Should be kept as-is — exceeds the digit limit
+        self.assertEqual(
+            _coerce_tool_args({"value": "1e10000"}, schema)["value"],
+            "1e10000",
+        )
+        # Within the limit — should be coerced
+        self.assertEqual(
+            _coerce_tool_args({"value": "1e23"}, schema)["value"],
+            100000000000000000000000,
+        )
+
     def test_nested_and_collection_coercion(self) -> None:
         """Recurse through objects, arrays, JSON values, and refs."""
         schema = _schema(

--- a/tests/tool_coercion_test.py
+++ b/tests/tool_coercion_test.py
@@ -286,6 +286,34 @@ class ToolCoercionTest(unittest.TestCase):
             {"x": "1"},
         )
 
+    def test_boolean_only_coerces_zero_and_one(self) -> None:
+        """Only exact 0/1 are coerced to bool; other numbers stay unchanged."""
+        schema = _schema({"flag": {"type": "boolean"}})
+        # Exact 0/1 — coerced
+        self.assertIs(
+            _coerce_tool_args({"flag": 0}, schema)["flag"],
+            False,
+        )
+        self.assertIs(
+            _coerce_tool_args({"flag": 1}, schema)["flag"],
+            True,
+        )
+        self.assertIs(
+            _coerce_tool_args({"flag": 0.0}, schema)["flag"],
+            False,
+        )
+        self.assertIs(
+            _coerce_tool_args({"flag": 1.0}, schema)["flag"],
+            True,
+        )
+        # Other numbers — unchanged
+        for v in (2, -1, 2.0, 3.14):
+            with self.subTest(value=v):
+                self.assertEqual(
+                    _coerce_tool_args({"flag": v}, schema)["flag"],
+                    v,
+                )
+
 
 class ToolCoercionIntegrationTest(unittest.IsolatedAsyncioTestCase):
     """Integration tests for the ToolBase and Toolkit invocation paths."""

--- a/tests/tool_coercion_test.py
+++ b/tests/tool_coercion_test.py
@@ -1,0 +1,333 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for schema-driven ToolBase argument coercion."""
+import math
+import unittest
+from typing import Any, Optional
+
+from agentscope.message import TextBlock, ToolCallBlock
+from agentscope.tool import (
+    FunctionTool,
+    ToolBase,
+    ToolChunk,
+    Toolkit,
+    ToolMiddlewareBase,
+)
+from agentscope.tool._utils import _coerce_tool_args
+
+
+def _schema(properties: dict[str, Any]) -> dict[str, Any]:
+    """Build a minimal object schema for a test case."""
+    return {"type": "object", "properties": properties}
+
+
+class ToolCoercionTest(unittest.TestCase):
+    """Unit tests grouped by coercion behavior."""
+
+    def test_scalar_coercion(self) -> None:
+        """Repair common scalar mismatches without changing valid numbers."""
+        cases = (
+            ("integer", "42", 42, int),
+            ("number", "3.14", 3.14, float),
+            ("number", 42, 42, int),
+            ("boolean", "TRUE", True, bool),
+            ("boolean", "0", False, bool),
+            ("string", 42, "42", str),
+            ("integer", 42.0, 42, int),
+        )
+        for expected_type, value, expected, python_type in cases:
+            with self.subTest(expected_type=expected_type, value=value):
+                result = _coerce_tool_args(
+                    {"value": value},
+                    _schema({"value": {"type": expected_type}}),
+                )
+                self.assertEqual(result["value"], expected)
+                self.assertIsInstance(result["value"], python_type)
+
+    def test_integer_coercion_is_lossless_and_safe(self) -> None:
+        """Avoid truncation, precision loss, and exceptions."""
+        schema = _schema({"value": {"type": "integer"}})
+        exact_cases = {
+            "9007199254740993": 9007199254740993,
+            "1e23": 100000000000000000000000,
+            "100000000000000000000000.0": 100000000000000000000000,
+        }
+        for value, expected in exact_cases.items():
+            with self.subTest(value=value):
+                self.assertEqual(
+                    _coerce_tool_args({"value": value}, schema)["value"],
+                    expected,
+                )
+
+        unchanged = (
+            "42.9", "not_a_number", "Infinity", "-Infinity", 42.9,
+        )
+        for value in unchanged:
+            with self.subTest(value=value):
+                self.assertEqual(
+                    _coerce_tool_args({"value": value}, schema)["value"],
+                    value,
+                )
+
+        for value, check in (
+            (float("inf"), math.isinf),
+            (float("nan"), math.isnan),
+        ):
+            with self.subTest(value=value):
+                self.assertTrue(
+                    check(
+                        _coerce_tool_args({"value": value}, schema)["value"],
+                    ),
+                )
+
+    def test_nested_and_collection_coercion(self) -> None:
+        """Recurse through objects, arrays, JSON values, and refs."""
+        schema = _schema(
+            {
+                "items": {"type": "array", "items": {"type": "integer"}},
+                "config": {
+                    "type": "object",
+                    "properties": {"port": {"type": "integer"}},
+                },
+                "ref": {"$ref": "#/$defs/Config"},
+            },
+        )
+        schema["$defs"] = {
+            "Config": {
+                "type": "object",
+                "properties": {"id": {"type": "integer"}},
+            },
+        }
+        result = _coerce_tool_args(
+            {
+                "items": '["1", "2"]',
+                "config": '{"port": "8080"}',
+                "ref": {"id": "123"},
+            },
+            schema,
+        )
+        self.assertEqual(
+            result,
+            {"items": [1, 2], "config": {"port": 8080}, "ref": {"id": 123}},
+        )
+
+        singleton = _coerce_tool_args(
+            {"items": "1"},
+            _schema(
+                {"items": {"type": "array", "items": {"type": "integer"}}},
+            ),
+        )
+        self.assertEqual(singleton["items"], [1])
+
+    def test_composite_schema_coercion(self) -> None:
+        """Handle Pydantic-style anyOf/oneOf schemas."""
+        schema = _schema(
+            {
+                "optional": {
+                    "anyOf": [{"type": "integer"}, {"type": "null"}],
+                },
+                "union": {
+                    "anyOf": [{"type": "integer"}, {"type": "string"}],
+                },
+                "one_of": {
+                    "oneOf": [{"type": "integer"}, {"type": "string"}],
+                },
+                "numbers": {
+                    "anyOf": [
+                        {"type": "array", "items": {"type": "integer"}},
+                        {"type": "null"},
+                    ],
+                },
+            },
+        )
+        result = _coerce_tool_args(
+            {
+                "optional": "10",
+                "union": "42",
+                "one_of": "100",
+                "numbers": ["1", "2"],
+            },
+            schema,
+        )
+        self.assertEqual(
+            result,
+            {
+                "optional": 10,
+                "union": "42",
+                "one_of": "100",
+                "numbers": [1, 2],
+            },
+        )
+        self.assertIsNone(
+            _coerce_tool_args({"optional": None}, schema)["optional"],
+        )
+
+    def test_discriminated_unions_are_conservative(self) -> None:
+        """Select matching branch, leave unknown branches intact."""
+        schema = _schema(
+            {
+                "item": {
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "kind": {"const": "a"},
+                                "x": {"type": "integer"},
+                                "extra": {"type": "integer"},
+                            },
+                            "required": ["kind", "x", "extra"],
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "kind": {"const": "b"},
+                                "y": {"type": "integer"},
+                            },
+                            "required": ["kind", "y"],
+                        },
+                    ],
+                },
+            },
+        )
+        matched = _coerce_tool_args(
+            {"item": {"kind": "b", "y": "42"}}, schema,
+        )
+        self.assertEqual(matched["item"], {"kind": "b", "y": 42})
+        unknown = {"kind": "c", "x": "1", "extra": "2"}
+        self.assertEqual(
+            _coerce_tool_args({"item": unknown}, schema)["item"], unknown,
+        )
+
+    def test_dynamic_maps_and_passthrough_are_preserved(self) -> None:
+        """Coerce additionalProperties, preserve unknown top-level keys."""
+        schema = _schema(
+            {
+                "counts": {
+                    "type": "object",
+                    "additionalProperties": {"type": "integer"},
+                },
+                "name": {"type": "string"},
+            },
+        )
+        result = _coerce_tool_args(
+            {
+                "counts": {"retries": "3", "timeout": "30"},
+                "name": "ok",
+                "extra": 42,
+            },
+            schema,
+        )
+        self.assertEqual(
+            result,
+            {
+                "counts": {"retries": 3, "timeout": 30},
+                "name": "ok",
+                "extra": 42,
+            },
+        )
+
+    def test_passthrough_and_idempotency(self) -> None:
+        """No-op inputs and repeated coercion should be stable."""
+        schema = _schema(
+            {
+                "count": {"type": "integer"},
+                "name": {"type": "string"},
+                "flag": {"type": "boolean"},
+            },
+        )
+        value = {"count": "42", "name": "hello", "flag": True}
+        once = _coerce_tool_args(value, schema)
+        self.assertEqual(_coerce_tool_args(once, schema), once)
+        self.assertEqual(_coerce_tool_args({}, schema), {})
+        self.assertEqual(
+            _coerce_tool_args({"x": "1"}, {"type": "object"}), {"x": "1"},
+        )
+
+
+class ToolCoercionIntegrationTest(unittest.IsolatedAsyncioTestCase):
+    """Integration tests for the ToolBase and Toolkit invocation paths."""
+
+    async def test_tool_and_middleware_coerced(self) -> None:
+        """Base __call__ repairs before tool and middleware execute."""
+        calls: list[int | None] = []
+        middleware_inputs: list[dict[str, Any]] = []
+
+        class SpyMiddleware(ToolMiddlewareBase):
+            """Middleware that records the inputs it receives."""
+
+            async def on_tool_call(
+                self,
+                tool: Any,
+                input_kwargs: Any,
+                next_handler: Any,
+            ) -> Any:
+                middleware_inputs.append(dict(input_kwargs))
+                async for chunk in next_handler(**input_kwargs):
+                    yield chunk
+
+        async def my_tool(limit: Optional[int] = None) -> str:
+            calls.append(limit)
+            return f"limit={limit}"
+
+        tool = FunctionTool(my_tool, middlewares=[SpyMiddleware()])
+        result = await tool(limit="10")  # type: ignore[arg-type]
+        chunks = [chunk async for chunk in result]
+        self.assertTrue(chunks)
+        self.assertEqual(calls, [10])
+        self.assertEqual(middleware_inputs, [{"limit": 10}])
+
+    async def test_toolkit_legacy_call_override(self) -> None:
+        """Toolkit repairs for subclasses that override __call__."""
+        from agentscope.permission import (  # isort: skip
+            PermissionBehavior,
+            PermissionDecision,
+        )
+        from agentscope.state import AgentState  # isort: skip
+
+        received: dict[str, Any] = {}
+
+        class OverrideTool(ToolBase):
+            """Tool that overrides __call__ directly with typed params."""
+
+            name = "override_tool"
+            description = "Test tool"
+            input_schema = _schema({"count": {"type": "integer"}})
+            is_concurrency_safe = True
+            is_read_only = True
+
+            async def check_permissions(
+                self,
+                tool_input: Any,
+                context: Any,
+            ) -> Any:
+                return PermissionDecision(
+                    behavior=PermissionBehavior.ALLOW,
+                    message="",
+                )
+
+            async def __call__(self, count: int) -> ToolChunk:
+                received["count"] = count
+                return ToolChunk(
+                    content=[TextBlock(text=f"count={count}")],
+                )
+
+        toolkit = Toolkit(tools=[OverrideTool()])
+        tool_call = ToolCallBlock(
+            id="call_1", name="override_tool", input='{"count": "42"}',
+        )
+        state = AgentState(session_id="s1", agent_id="a1")
+        async for _ in toolkit.call_tool(tool_call, state):
+            pass
+        self.assertEqual(received, {"count": 42})
+
+    async def test_function_tool_dynamic_map(self) -> None:
+        """FunctionTool receives repaired values from dict[str, int]."""
+        received: list[dict[str, int]] = []
+
+        async def my_tool(counts: dict[str, int]) -> str:
+            received.append(counts)
+            return "ok"
+
+        await FunctionTool(my_tool)(  # type: ignore[arg-type]
+            counts={"a": "1", "b": "2"},
+        )
+        self.assertEqual(received, [{"a": 1, "b": 2}])

--- a/tests/tool_coercion_test.py
+++ b/tests/tool_coercion_test.py
@@ -198,7 +198,9 @@ class ToolCoercionTest(unittest.TestCase):
         # "3.14" can't be integer, but can be coerced to number (3.14)
         result = _coerce_tool_args({"value": "3.14"}, schema)
         self.assertIsInstance(
-            result["value"], float, "Should coerce to float, not keep str",
+            result["value"],
+            float,
+            "Should coerce to float, not keep str",
         )
         self.assertEqual(result["value"], 3.14)
 

--- a/tests/tool_coercion_test.py
+++ b/tests/tool_coercion_test.py
@@ -45,6 +45,19 @@ class ToolCoercionTest(unittest.TestCase):
                 self.assertEqual(result["value"], expected)
                 self.assertIsInstance(result["value"], python_type)
 
+    def test_string_coercion_preserves_non_scalar_values(self) -> None:
+        """Only scalar values are coerced to strings."""
+        schema = _schema({"value": {"type": "string"}})
+        for value in ({"key": "value"}, ["value"], None, b"value"):
+            with self.subTest(value=value):
+                result = _coerce_tool_args({"value": value}, schema)
+                self.assertEqual(result["value"], value)
+
+        for value in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(value=value):
+                result = _coerce_tool_args({"value": value}, schema)
+                self.assertIs(result["value"], value)
+
     def test_integer_coercion_is_lossless_and_safe(self) -> None:
         """Avoid truncation, precision loss, and exceptions."""
         schema = _schema({"value": {"type": "integer"}})


### PR DESCRIPTION
## AgentScope Version

2.0.5

## Description

Closes https://github.com/agentscope-ai/agentscope/issues/1794

Models occasionally return tool arguments with types that do not match the schema. For example, an `int` parameter may receive `"42"`, or a `bool` parameter may receive `"true"`. Previously, each tool had to handle these cases itself, or fail inside its implementation.

This PR adds a best-effort, JSON Schema-driven coercion step to `ToolBase.__call__` and the `Toolkit` invocation path. Regular tools do not need individual changes. Legacy tools that override `__call__` directly are also covered when invoked through `Toolkit.call_tool`.

## What Changed

`src/agentscope/tool/_utils.py` now provides `_coerce_tool_args` and its supporting helpers.

| Schema pattern | Behavior | Example |
|---|---|---|
| `{"type": "integer"}` | `str` → `int`; exact `float` → `int` | `"42"` → `42`, `42.0` → `42` |
| `{"type": "number"}` | `str` → `float` | `"3.14"` → `3.14` |
| `{"type": "boolean"}` | `str` → `bool` | `"true"` → `True` |
| `{"type": "string"}` | Non-`str` → `str` | `42` → `"42"` |
| `{"type": "array"}` | Wrap a single value; parse JSON arrays | `"a"` → `["a"]` |
| `{"type": "object"}` | Parse JSON objects | `'{"k":"v"}'` → `{"k":"v"}` |
| `additionalProperties` | Recursively coerce dynamic map values | Values in `dict[str, int]` are repaired |
| `anyOf` / `oneOf` | Select an unambiguous branch and recurse | `Optional[int]`, `list[int] \| None`, discriminated unions |
| `$ref` → `$defs` | Resolve references before recursing | Nested Pydantic models |

Principles:

- Only apply conversions that do not lose information; otherwise preserve the original value.
- Support nested objects and arrays, `$ref`, `additionalProperties`, and common Pydantic `anyOf`/`oneOf` schemas.
- Do not coerce a discriminated union when its branch cannot be determined. Debug logs include argument names and type changes, but never argument values.

The coercion runs at two entry points:

| Entry point | Coverage |
|---|---|
| `ToolBase.__call__` (`_base.py`) | Direct calls to tools that do not override `__call__` |
| `Toolkit.call_tool` (`_toolkit.py`) | Tools that override `__call__` directly, such as scheduler and Mem0/ReMe tools |

`_coerce_tool_args` is idempotent: values that already match the schema are not changed, so passing through both entry points is safe.

## Files Changed

| File | Summary |
|---|---|
| `src/agentscope/tool/_utils.py` | Adds schema-driven argument coercion and recursive handling |
| `src/agentscope/tool/_base.py` | Calls `_coerce_tool_args` after positional-argument validation |
| `src/agentscope/tool/_toolkit.py` | Calls `_coerce_tool_args` after `_json_loads_with_repair` |
| `tests/tool_coercion_test.py` | Adds 10 test functions and 17 parameterized subtests |

## Testing

`tests/tool_coercion_test.py` includes 10 test functions and 17 parameterized subtests:

- **Unit tests:** scalar conversions, integer precision, large integers, scientific notation, `inf`/`nan`, nested structures, `$ref`, `additionalProperties`, `anyOf`/`oneOf`, and discriminated unions.
- **Integration tests:** `FunctionTool.__call__`, middleware input, `dict[str, int]` Pydantic schemas, and `Toolkit.call_tool` for tools that override `__call__`.

All 10 test functions and 17 parameterized subtests pass.

## Checklist

- [x] Local tests pass (10 test functions and 17 parameterized subtests)
- [x] Reviewed `CONTRIBUTING.md`
- [x] Added docstrings for new helpers
- [ ] Updated related documentation in the documentation repository
- [x] Ready for review
