### PR TITLE
fix(app): clean up index tasks on cancellation

### DIFF
--- a/src/agentscope/app/_service/_index_worker.py
+++ b/src/agentscope/app/_service/_index_worker.py
@@ -271,6 +271,15 @@ class IndexWorker:
             with contextlib.suppress(asyncio.CancelledError):
                 await heartbeat_task
             await pipeline_task
+        except asyncio.CancelledError:
+            pipeline_task.cancel()
+            heartbeat_task.cancel()
+            await asyncio.gather(
+                pipeline_task,
+                heartbeat_task,
+                return_exceptions=True,
+            )
+            raise
         except Exception as exc:  # noqa: BLE001 — terminal error sink
             await self._mark_error(
                 user_id,

--- a/tests/index_worker_lease_test.py
+++ b/tests/index_worker_lease_test.py
@@ -97,6 +97,8 @@ class _SlowPipelineWorker(IndexWorker):
         self.pipeline_started = asyncio.Event()
         self.pipeline_cancelled = False
         self.pipeline_completed = False
+        self.heartbeat_started = asyncio.Event()
+        self.heartbeat_stopped = False
 
     async def _run_pipeline(
         self,
@@ -114,9 +116,56 @@ class _SlowPipelineWorker(IndexWorker):
             self.pipeline_cancelled = True
             raise
 
+    async def _heartbeat(
+        self,
+        user_id: str,
+        knowledge_base_id: str,
+        document_id: str,
+    ) -> None:
+        """Record heartbeat cancellation while preserving worker behavior."""
+        self.heartbeat_started.set()
+        try:
+            await super()._heartbeat(
+                user_id,
+                knowledge_base_id,
+                document_id,
+            )
+        finally:
+            self.heartbeat_stopped = True
+
 
 class IndexWorkerLeaseTest(IsolatedAsyncioTestCase):
     """Pipeline-vs-heartbeat race coverage."""
+
+    async def test_external_cancel_stops_child_tasks_and_releases(
+        self,
+    ) -> None:
+        """Cancelling process must not leave pipeline or heartbeat running."""
+        storage = _LeaseStorage()
+        worker = _SlowPipelineWorker(storage, pipeline_seconds=5.0)
+        process_task = asyncio.create_task(
+            worker.process("u", "kb", "doc-cancelled"),
+        )
+
+        await asyncio.wait_for(
+            asyncio.gather(
+                worker.pipeline_started.wait(),
+                worker.heartbeat_started.wait(),
+            ),
+            timeout=1.0,
+        )
+        process_task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await process_task
+
+        self.assertTrue(worker.pipeline_cancelled)
+        self.assertFalse(worker.pipeline_completed)
+        self.assertTrue(worker.heartbeat_stopped)
+        self.assertEqual(
+            [u for u in storage.status_updates if u["status"] == "error"],
+            [],
+        )
+        self.assertEqual(len(storage.released), 1)
 
     async def test_lost_lease_cancels_pipeline_and_marks_error(self) -> None:
         """Renew returning False mid-pipeline must abort the pipeline.


### PR DESCRIPTION
## AgentScope Version

`2.0.5` / current `main` at `9d1026f`

## Description

Fixes #2219.

### Background

`IndexWorker.process()` creates a pipeline task and a lease-heartbeat task, then waits for either one to finish. When the parent coroutine is externally cancelled during worker shutdown, `asyncio.CancelledError` bypasses the existing `except Exception` branch on supported Python versions. The `finally` block releases the lease, but the two child tasks are left running without an owner.

That allows indexing work to continue after shutdown and lets the heartbeat continue renewing a lease that the parent has already released.

### Changes

- Handle external cancellation separately from terminal pipeline errors.
- Cancel both the pipeline and heartbeat tasks.
- Await both tasks with `asyncio.gather(..., return_exceptions=True)` so their cleanup finishes before the lease is released.
- Re-raise `CancelledError` to preserve caller shutdown semantics.
- Add a deterministic regression test that starts both children, cancels the parent, and verifies:
  - the pipeline is cancelled instead of completing;
  - the heartbeat stops;
  - no terminal document error is recorded;
  - the lease is released exactly once.

The normal completion and lost-lease paths are unchanged.

### Validation

```text
python -m pytest tests/index_worker_lease_test.py tests/service_index_task_consumer_test.py -q
10 passed

black --check --line-length 79 src/agentscope/app/_service/_index_worker.py tests/index_worker_lease_test.py
2 files would be left unchanged

flake8 --extend-ignore=E203 src/agentscope/app/_service/_index_worker.py tests/index_worker_lease_test.py
passed

mypy [repository pre-commit arguments] src/agentscope/app/_service/_index_worker.py tests/index_worker_lease_test.py
Success: no issues found in 2 source files
```

### Risk and review notes

The change only affects cancellation of `IndexWorker.process()`. It does not change successful indexing, lost-lease error handling, document status semantics, or public APIs. The main review point is the ordering: both children are awaited before the existing `finally` block releases the lease.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated in the documentation repository (not applicable: no user-facing API or configuration change)
- [x] Code is ready for review
