### PR TITLE
fix(tracing): include input messages in chat spans

### DIFF
--- a/src/agentscope/middleware/_tracing/_extractor.py
+++ b/src/agentscope/middleware/_tracing/_extractor.py
@@ -177,16 +177,18 @@ def _get_llm_request_attributes(
         instance (`ChatModelBase`):
             The chat model instance making the request.
         kwargs (`Dict[str, Any]`):
-            Keyword arguments including generation parameters such as
-            temperature, top_p, top_k, max_tokens, presence_penalty,
-            frequency_penalty, stop_sequences, seed, tools, and tool_choice.
+            Keyword arguments including input messages, tools, tool choice,
+            and generation parameters such as temperature, top_p, top_k,
+            max_tokens, presence_penalty, frequency_penalty, stop sequences,
+            and seed.
 
     Returns:
         `Dict[str, Any]`:
             OpenTelemetry GenAI attributes with mixed-type values (``str``,
             ``int``, ``float``, or ``list``), including operation name,
-            provider name, model name, generation parameters (e.g.
-            temperature, max_tokens, stop_sequences), and tool definitions.
+            provider name, model name, input messages, generation parameters
+            (e.g. temperature, max_tokens, stop sequences), and tool
+            definitions.
     """
 
     attributes = {
@@ -220,6 +222,14 @@ def _get_llm_request_attributes(
     )
     if tool_definitions:
         attributes[SpanAttributes.GEN_AI_TOOL_DEFINITIONS] = tool_definitions
+
+    messages = kwargs.get("messages")
+    if isinstance(messages, (Msg, list)):
+        input_messages = _get_agent_messages(messages)
+        if input_messages:
+            attributes[
+                SpanAttributes.GEN_AI_INPUT_MESSAGES
+            ] = _serialize_to_str(input_messages)
 
     return {k: v for k, v in attributes.items() if v is not None}
 

--- a/tests/tracing_test.py
+++ b/tests/tracing_test.py
@@ -361,6 +361,33 @@ class TracingTest(IsolatedAsyncioTestCase):
             "chat span gen_ai.operation.name should equal chat",
         )
 
+    async def test_chat_span_has_input_messages(self) -> None:
+        """chat span must carry the messages sent to the model."""
+        self.model.set_responses(
+            [_make_text_response("Input captured.")],
+        )
+        user_text = "Which messages reached the model?"
+        await self.agent.reply(UserMsg(name="user", content=user_text))
+
+        chat_spans = self._spans_by_name("chat")
+        self.assertEqual(len(chat_spans), 1, "Expected exactly one chat span")
+        span_attrs = dict(chat_spans[0].attributes or {})
+        input_raw = span_attrs.get("gen_ai.input.messages")
+        assert isinstance(input_raw, str)
+        input_messages = json.loads(input_raw)
+        self.assertTrue(
+            any(
+                message.get("role") == "user"
+                and {
+                    "type": "text",
+                    "content": user_text,
+                }
+                in message.get("parts", [])
+                for message in input_messages
+            ),
+            f"Expected user message in chat span input: {input_messages}",
+        )
+
     async def test_chat_span_has_output_messages(self) -> None:
         """chat span must carry gen_ai.output.messages with response
         content."""


### PR DESCRIPTION
## PR Title Format

`fix(tracing): include input messages in chat spans`

## AgentScope Version

`2.0.5` on current `main`

## Description

Fixes #2224.

OpenTelemetry chat spans currently record model parameters, tool definitions,
output messages, and token usage, but omit the messages sent to the model.
`TracingMiddleware.on_model_call` already passes those messages to
`_get_llm_request_attributes`; the extractor simply did not consume them.

This PR:

- serializes model-call messages with the existing AgentScope-to-GenAI message
  converter;
- stores them in `gen_ai.input.messages`, independently from
  `gen_ai.tool.definitions`;
- adds an integration regression test that verifies the user message is
  present on the emitted chat span.

The change does not alter model requests, tracing-disabled execution, or tool
definition attributes.

### Verification

- Before the fix:
  `pytest -q tests/tracing_test.py::TracingTest::test_chat_span_has_input_messages`
  failed because `gen_ai.input.messages` was `None`.
- After the fix:
  `pytest -q tests/tracing_test.py` -> `16 passed`.
- `pre-commit run --files src/agentscope/middleware/_tracing/_extractor.py tests/tracing_test.py`
  -> all hooks passed.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation does not require an update for this tracing fix
- [x] Code is ready for review
