### PR TITLE
ci: propagate pre-commit failures

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -26,10 +26,4 @@ jobs:
         pre-commit install
     - name: Pre-commit starts
       run: |
-        pre-commit run --all-files > pre-commit.log 2>&1 || true
-        cat pre-commit.log
-        if grep -q Failed pre-commit.log; then
-          echo -e "\e[41m  [**FAIL**] Please install pre-commit and format your code first. \e[0m"
-          exit 1
-        fi
-        echo -e "\e[46m  ********************************Passed******************************** \e[0m"
+        pre-commit run --all-files


### PR DESCRIPTION
## PR Title Format

`ci: propagate pre-commit failures`

## AgentScope Version

Current `main` at `0cd19d7d`

## Description

Fixes #2231.

The Pre-commit workflow currently discards `pre-commit run --all-files`'s
exit status with `|| true`, then fails only when the captured log contains
the word `Failed`. Configuration and internal errors can return non-zero
without printing that word, so the workflow incorrectly reports Passed.

This PR runs Pre-commit directly. GitHub Actions' shell now propagates every
non-zero status while streaming the normal hook output.

### Reproduction

With an invalid Pre-commit config:

```text
InvalidConfigError:
while parsing a flow sequence
did not find expected ',' or ']'
```

Before:

```text
real_precommit_status=1
current_workflow_status=0
contains_Failed=no
```

After:

```text
fixed_command_status=1
```

## Verification

- Parsed `.github/workflows/pre-commit.yml` successfully with PyYAML.
- `pre-commit run --files .github/workflows/pre-commit.yml` -> all applicable
  hooks passed.
- Re-ran Pre-commit with the same invalid config and confirmed the replacement
  command returns non-zero.
- Confirmed the workflow no longer contains `|| true` or `grep -q Failed`.

## Impact

- Normal hook output remains visible in Actions.
- Hook failures continue to fail the job.
- Configuration, environment, and internal Pre-commit failures now also fail
  the job instead of producing a false success.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read `CONTRIBUTING.md`
- [x] No code or public API changes
- [x] Workflow syntax and repository hooks pass
- [x] Code is ready for review
