### PR TITLE
fix(app): make resume triggers reliable and concurrent across instances

### DIFF
--- a/src/agentscope/app/_bus_ops.py
+++ b/src/agentscope/app/_bus_ops.py
@@ -17,6 +17,7 @@ other's internals.
    * - :func:`enqueue_index_task`
      - Enqueue a knowledge-document indexing task and signal consumers.
 """
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal
@@ -75,10 +76,12 @@ async def enqueue_run_trigger(
     agent_id: str,
     *,
     kind: Literal["wake", "resume"] = MessageBusKeys.WAKEUP_KIND_WAKE,
-    inputs: UserConfirmResultEvent
-    | ExternalExecutionResultEvent
-    | UserInterruptEvent
-    | None = None,
+    inputs: (
+        UserConfirmResultEvent
+        | ExternalExecutionResultEvent
+        | UserInterruptEvent
+        | None
+    ) = None,
 ) -> None:
     """Enqueue a typed run trigger and signal dispatchers.
 
@@ -113,16 +116,21 @@ async def enqueue_run_trigger(
             ``model_dump(mode="json")`` internally — callers pass the
             event object, not a pre-serialised dict.
     """
-    await bus.queue_push(
-        MessageBusKeys.wakeup_queue(),
-        {
-            "user_id": user_id,
-            "session_id": session_id,
-            "agent_id": agent_id,
-            "kind": kind,
-            "input": inputs.model_dump(mode="json") if inputs else None,
-        },
-    )
+    payload = {
+        "user_id": user_id,
+        "session_id": session_id,
+        "agent_id": agent_id,
+        "kind": kind,
+        "input": inputs.model_dump(mode="json") if inputs else None,
+    }
+    if kind == MessageBusKeys.WAKEUP_KIND_RESUME:
+        # Resume commands carry irreplaceable HITL/tool results.  They use a
+        # physically separate explicit-ACK stream so legacy XRANGE/XDEL
+        # consumers can never delete a consumer-group pending entry.
+        await bus.reliable_queue_push(MessageBusKeys.resume_queue(), payload)
+        return
+
+    await bus.queue_push(MessageBusKeys.wakeup_queue(), payload)
     await bus.publish(MessageBusKeys.wakeup_signal(), {})
 
 

--- a/src/agentscope/app/_lifespan.py
+++ b/src/agentscope/app/_lifespan.py
@@ -11,6 +11,7 @@ from ._manager import (
     ChatRunRegistry,
     SchedulerManager,
     WakeupDispatcher,
+    ResumeDispatcher,
 )
 from ._service import (
     ChatService,
@@ -185,6 +186,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         # for us, so we don't need local bindings or app.state slots.
         await stack.enter_async_context(
             WakeupDispatcher(
+                message_bus=message_bus,
+                storage=storage,
+                chat_service=chat_service,
+                chat_run_registry=chat_run_registry,
+            ),
+        )
+        await stack.enter_async_context(
+            ResumeDispatcher(
                 message_bus=message_bus,
                 storage=storage,
                 chat_service=chat_service,

--- a/src/agentscope/app/_manager/__init__.py
+++ b/src/agentscope/app/_manager/__init__.py
@@ -4,6 +4,7 @@ application-wide resources."""
 
 from ._scheduler import SchedulerManager
 from ._wakeup_dispatcher import WakeupDispatcher
+from ._resume_dispatcher import ResumeDispatcher
 from ._cancel_dispatcher import CancelDispatcher
 from ._chat_run_registry import ChatRunRegistry
 from ._background_task_manager import BackgroundTaskManager
@@ -14,4 +15,5 @@ __all__ = [
     "ChatRunRegistry",
     "SchedulerManager",
     "WakeupDispatcher",
+    "ResumeDispatcher",
 ]

--- a/src/agentscope/app/_manager/_resume_dispatcher.py
+++ b/src/agentscope/app/_manager/_resume_dispatcher.py
@@ -1,0 +1,276 @@
+# -*- coding: utf-8 -*-
+"""Reliable cross-process dispatcher for HITL/external resume commands."""
+
+import asyncio
+import os
+import socket
+import uuid
+from typing import TYPE_CHECKING, Self
+
+from pydantic import TypeAdapter
+
+from ..._logging import logger
+from ...event import (
+    ExternalExecutionResultEvent,
+    UserConfirmResultEvent,
+    UserInterruptEvent,
+)
+from ..message_bus import MessageBusKeys
+
+if TYPE_CHECKING:
+    from .._service import ChatService
+    from ..message_bus import MessageBus
+    from ..storage import StorageBase
+    from ._chat_run_registry import ChatRunRegistry
+
+
+_RESUME_INPUT_ADAPTER: TypeAdapter = TypeAdapter(
+    UserConfirmResultEvent | ExternalExecutionResultEvent | UserInterruptEvent,
+)
+
+
+class ResumeDispatcher:
+    """Consume the dedicated resume stream with claim/heartbeat/ACK.
+
+    A stream entry remains in Redis's pending-entry list until the chat
+    service confirms that the updated session state and resume idempotency
+    marker were persisted.  Crashed work is reclaimed by another API process;
+    healthy long-running work refreshes its claim so it is not stolen.
+    """
+
+    def __init__(
+        self,
+        message_bus: "MessageBus",
+        storage: "StorageBase",
+        chat_service: "ChatService",
+        chat_run_registry: "ChatRunRegistry",
+        *,
+        consumer_name: str | None = None,
+        claim_idle_ms: int = MessageBusKeys.RESUME_CLAIM_IDLE_MS,
+        read_block_ms: int = MessageBusKeys.RESUME_READ_BLOCK_MS,
+        reclaim_interval_ms: int = (MessageBusKeys.RESUME_RECLAIM_INTERVAL_MS),
+        max_concurrency: int = MessageBusKeys.RESUME_MAX_CONCURRENCY,
+    ) -> None:
+        self._bus = message_bus
+        self._storage = storage
+        self._chat_service = chat_service
+        self._registry = chat_run_registry
+        self._consumer = consumer_name or (
+            f"{socket.gethostname()}:{os.getpid()}:{uuid.uuid4().hex[:8]}"
+        )
+        self._claim_idle_ms = claim_idle_ms
+        self._read_block_ms = max(1, read_block_ms)
+        self._reclaim_interval_ms = max(1, reclaim_interval_ms)
+        self._max_concurrency = max(1, max_concurrency)
+        self._task: asyncio.Task[None] | None = None
+        self._entry_tasks: set[asyncio.Task[None]] = set()
+
+    async def __aenter__(self) -> Self:
+        await self._bus.reliable_queue_ensure_group(
+            MessageBusKeys.resume_queue(),
+            MessageBusKeys.RESUME_CONSUMER_GROUP,
+        )
+        self._task = asyncio.create_task(
+            self._loop(),
+            name=f"resume-dispatcher:{self._consumer}",
+        )
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        if self._task is None:
+            return
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        self._task = None
+
+        entry_tasks = list(self._entry_tasks)
+        for task in entry_tasks:
+            task.cancel()
+        if entry_tasks:
+            await asyncio.gather(*entry_tasks, return_exceptions=True)
+        self._entry_tasks.clear()
+
+    def _entry_done(self, task: asyncio.Task[None]) -> None:
+        """Remove a completed entry task and retrieve unexpected errors."""
+        self._entry_tasks.discard(task)
+        if task.cancelled():
+            return
+        error = task.exception()
+        if error is not None:
+            logger.error(
+                "ResumeDispatcher entry task failed unexpectedly.",
+                exc_info=(type(error), error, error.__traceback__),
+            )
+
+    async def _wait_for_capacity(self) -> None:
+        """Apply per-process backpressure before claiming more entries."""
+        if len(self._entry_tasks) < self._max_concurrency:
+            return
+        await asyncio.wait(
+            self._entry_tasks,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+    async def _loop(self) -> None:
+        key = MessageBusKeys.resume_queue()
+        group = MessageBusKeys.RESUME_CONSUMER_GROUP
+        event_loop = asyncio.get_running_loop()
+        next_reclaim_at = 0.0
+        while True:
+            try:
+                await self._wait_for_capacity()
+                now = event_loop.time()
+                entries: list[tuple[str, dict]] = []
+                if now >= next_reclaim_at:
+                    entries = await self._bus.reliable_queue_reclaim(
+                        key,
+                        group,
+                        self._consumer,
+                        min_idle_ms=self._claim_idle_ms,
+                        max_count=1,
+                    )
+                    next_reclaim_at = now + self._reclaim_interval_ms / 1000
+                    if entries:
+                        logger.info(
+                            "ResumeDispatcher consumer %s reclaimed %d "
+                            "abandoned entry.",
+                            self._consumer,
+                            len(entries),
+                        )
+                if not entries:
+                    until_reclaim_ms = max(
+                        1,
+                        int((next_reclaim_at - event_loop.time()) * 1000),
+                    )
+                    entries = await self._bus.reliable_queue_read(
+                        key,
+                        group,
+                        self._consumer,
+                        max_count=1,
+                        block_ms=min(
+                            self._read_block_ms,
+                            until_reclaim_ms,
+                        ),
+                    )
+                for entry_id, payload in entries:
+                    task = asyncio.create_task(
+                        self._process_entry(entry_id, payload),
+                        name=f"resume-entry:{entry_id}",
+                    )
+                    self._entry_tasks.add(task)
+                    task.add_done_callback(self._entry_done)
+            except Exception:  # pylint: disable=broad-except
+                logger.exception(
+                    "ResumeDispatcher consumer %s loop failed; retrying.",
+                    self._consumer,
+                )
+                await asyncio.sleep(0.1)
+
+    async def _process_entry(self, entry_id: str, payload: dict) -> None:
+        key = MessageBusKeys.resume_queue()
+        group = MessageBusKeys.RESUME_CONSUMER_GROUP
+
+        try:
+            user_id = payload["user_id"]
+            session_id = payload["session_id"]
+            agent_id = payload["agent_id"]
+            raw_input = payload["input"]
+            input_msg = _RESUME_INPUT_ADAPTER.validate_python(raw_input)
+        except Exception:  # pylint: disable=broad-except
+            logger.exception(
+                "ResumeDispatcher: terminal malformed entry %s: %r",
+                entry_id,
+                payload,
+            )
+            await self._bus.reliable_queue_ack(key, group, [entry_id])
+            return
+
+        heartbeat = asyncio.create_task(
+            self._heartbeat(entry_id),
+            name=f"resume-heartbeat:{entry_id}",
+        )
+        try:
+            if (
+                await self._storage.get_session(
+                    user_id,
+                    agent_id,
+                    session_id,
+                )
+                is None
+            ):
+                logger.warning(
+                    "ResumeDispatcher: ACKing entry %s for deleted session "
+                    "%s.",
+                    entry_id,
+                    session_id,
+                )
+                await self._bus.reliable_queue_ack(key, group, [entry_id])
+                return
+
+            # A local HTTP/wake run can occupy the per-process registry even
+            # before its distributed lock is visible. Keep the same pending
+            # stream entry and wait; never manufacture a retry entry.
+            while True:
+                run_coro = self._chat_service.run_reliable_resume(
+                    user_id=user_id,
+                    session_id=session_id,
+                    agent_id=agent_id,
+                    input_msg=input_msg,
+                )
+                try:
+                    run_task = self._registry.spawn(
+                        run_coro,
+                        session_id=session_id,
+                        name=f"resume-run:{session_id}:{input_msg.id}",
+                    )
+                    break
+                except RuntimeError:
+                    run_coro.close()
+                    await asyncio.sleep(0.1)
+
+            durable = await run_task
+            if durable:
+                await self._bus.reliable_queue_ack(key, group, [entry_id])
+                logger.info(
+                    "ResumeDispatcher: ACKed entry %s event %s session %s.",
+                    entry_id,
+                    input_msg.id,
+                    session_id,
+                )
+            else:
+                logger.warning(
+                    "ResumeDispatcher: leaving entry %s pending after a "
+                    "non-durable setup failure.",
+                    entry_id,
+                )
+        except Exception:  # pylint: disable=broad-except
+            logger.exception(
+                "ResumeDispatcher: entry %s failed and remains pending.",
+                entry_id,
+            )
+        finally:
+            heartbeat.cancel()
+            try:
+                await heartbeat
+            except asyncio.CancelledError:
+                pass
+
+    async def _heartbeat(self, entry_id: str) -> None:
+        interval = max(0.01, self._claim_idle_ms / 3000)
+        while True:
+            await asyncio.sleep(interval)
+            try:
+                await self._bus.reliable_queue_touch(
+                    MessageBusKeys.resume_queue(),
+                    MessageBusKeys.RESUME_CONSUMER_GROUP,
+                    self._consumer,
+                    [entry_id],
+                )
+            except Exception:  # pylint: disable=broad-except
+                logger.exception(
+                    "ResumeDispatcher: failed to heartbeat entry %s.",
+                    entry_id,
+                )

--- a/src/agentscope/app/_manager/_wakeup_dispatcher.py
+++ b/src/agentscope/app/_manager/_wakeup_dispatcher.py
@@ -1,20 +1,18 @@
 # -*- coding: utf-8 -*-
-"""Single per-process dispatcher for all cross-session run triggers.
+"""Per-process dispatcher for rebuildable wake triggers.
 
 One asyncio task per process. Subscribes to the shared trigger signal
-channel and drains the durable trigger queue on each signal. It is the
-**sole** site that spawns :meth:`ChatService.run` into the shared
-:class:`ChatRunRegistry`, which is what makes concurrent-spawn races
-(two writers contending for one session's run slot → a spurious "already
-has an active chat run" 409) structurally impossible: every run trigger
-funnels through this one serial consumer.
+channel and drains the hint-style wake queue on each signal. New HITL and
+external-tool resume commands use the separate consumer-group stream owned
+by :class:`ResumeDispatcher`; this class accepts ``resume`` entries only for
+rolling-upgrade compatibility with the legacy mixed stream.
 
 Each queue entry carries a ``kind`` that selects how a busy session is
 handled:
 
 - ``wake`` (idle-session wake-up, ``input_msg=None``): skipped while the
   session is already running — the live run will drain the inbox.
-- ``resume`` (a parked HITL run being fed its result): must *not* be
+- legacy ``resume`` (a parked HITL run being fed its result): must *not* be
   skipped while running, because the session is typically still running
   the parked tail at trigger time. It is re-queued after a short backoff
   until the parked run releases its session lock, then spawned with the
@@ -25,6 +23,7 @@ All bus keys live on the :class:`MessageBus` base class (see
 ``subscribe_wakeup_signal``, ``session_is_running``), so this file has
 no hard-coded key strings.
 """
+
 import asyncio
 from typing import TYPE_CHECKING, Self
 
@@ -37,7 +36,6 @@ from ...event import (
     UserInterruptEvent,
 )
 from ..message_bus import MessageBusKeys
-from .._bus_ops import enqueue_run_trigger
 
 if TYPE_CHECKING:
     from ..message_bus import MessageBus
@@ -325,9 +323,9 @@ class WakeupDispatcher:
         user_id: str,
         session_id: str,
         agent_id: str,
-        input_msg: UserConfirmResultEvent
-        | ExternalExecutionResultEvent
-        | None,
+        input_msg: (
+            UserConfirmResultEvent | ExternalExecutionResultEvent | None
+        ),
     ) -> None:
         """Re-enqueue a ``resume`` trigger after a short backoff.
 
@@ -350,14 +348,24 @@ class WakeupDispatcher:
         async def _retry() -> None:
             try:
                 await asyncio.sleep(_RESUME_RETRY_BACKOFF_SECS)
-                await enqueue_run_trigger(
-                    self._bus,
-                    user_id=user_id,
-                    session_id=session_id,
-                    agent_id=agent_id,
-                    kind=MessageBusKeys.WAKEUP_KIND_RESUME,
-                    inputs=input_msg,
+                # Compatibility for resume entries written to the legacy
+                # mixed wakeup stream before the v2 producer cut-over. New
+                # resume commands never enter this dispatcher.
+                await self._bus.queue_push(
+                    MessageBusKeys.wakeup_queue(),
+                    {
+                        "user_id": user_id,
+                        "session_id": session_id,
+                        "agent_id": agent_id,
+                        "kind": MessageBusKeys.WAKEUP_KIND_RESUME,
+                        "input": (
+                            input_msg.model_dump(mode="json")
+                            if input_msg
+                            else None
+                        ),
+                    },
                 )
+                await self._bus.publish(MessageBusKeys.wakeup_signal(), {})
             except asyncio.CancelledError:
                 pass
             except Exception:  # pylint: disable=broad-except

--- a/src/agentscope/app/_service/_chat.py
+++ b/src/agentscope/app/_service/_chat.py
@@ -11,7 +11,12 @@ Events produced by the agent are not exposed back through this method
 that wants them subscribes through the
 ``GET /sessions/{sid}/stream`` SSE endpoint.
 """
+
 import asyncio
+import hashlib
+import json
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 
 from fastapi import HTTPException
 
@@ -168,12 +173,14 @@ class ChatService:
         user_id: str,
         session_id: str,
         agent_id: str,
-        input_msg: Msg
-        | list[Msg]
-        | UserConfirmResultEvent
-        | ExternalExecutionResultEvent
-        | UserInterruptEvent
-        | None = None,
+        input_msg: (
+            Msg
+            | list[Msg]
+            | UserConfirmResultEvent
+            | ExternalExecutionResultEvent
+            | UserInterruptEvent
+            | None
+        ) = None,
     ) -> None:
         """Drive a chat run to completion.
 
@@ -225,6 +232,72 @@ class ChatService:
                 agent_id,
                 str(e),
             )
+
+    async def run_reliable_resume(
+        self,
+        user_id: str,
+        session_id: str,
+        agent_id: str,
+        input_msg: (
+            UserConfirmResultEvent
+            | ExternalExecutionResultEvent
+            | UserInterruptEvent
+        ),
+    ) -> bool:
+        """Run one reliable resume while loading state inside its lock.
+
+        Returns ``True`` only when the command reached a durable terminal
+        boundary (applied or rejected as an already-applied duplicate).  A
+        setup failure returns ``False`` so the dispatcher leaves the stream
+        entry pending for recovery instead of acknowledging an in-memory
+        spawn.
+        """
+        async with self._message_bus.acquire_lock(
+            MessageBusKeys.session_lock(session_id),
+            ttl_secs=MessageBusKeys.SESSION_RUN_TTL_SECS,
+        ):
+            return await self._run_impl(
+                user_id,
+                session_id,
+                agent_id,
+                input_msg,
+                session_lock_held=True,
+            )
+
+    @asynccontextmanager
+    async def _session_lock(
+        self,
+        session_id: str,
+        *,
+        already_held: bool,
+    ) -> AsyncGenerator[None, None]:
+        """Acquire the run lock unless the reliable caller already did."""
+        if already_held:
+            yield
+            return
+        async with self._message_bus.acquire_lock(
+            MessageBusKeys.session_lock(session_id),
+            ttl_secs=MessageBusKeys.SESSION_RUN_TTL_SECS,
+        ):
+            yield
+
+    @staticmethod
+    def _resume_identity(
+        input_msg: (
+            UserConfirmResultEvent
+            | ExternalExecutionResultEvent
+            | UserInterruptEvent
+        ),
+    ) -> tuple[str, str]:
+        """Return the durable ledger key and canonical payload hash."""
+        key = f"{input_msg.reply_id}:{input_msg.id}"
+        payload = json.dumps(
+            input_msg.model_dump(mode="json"),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return key, hashlib.sha256(payload).hexdigest()
 
     async def _close_failed_reply(
         self,
@@ -471,13 +544,18 @@ class ChatService:
         user_id: str,
         session_id: str,
         agent_id: str,
-        input_msg: Msg
-        | list[Msg]
-        | UserConfirmResultEvent
-        | ExternalExecutionResultEvent
-        | UserInterruptEvent
-        | None,
-    ) -> None:
+        input_msg: (
+            Msg
+            | list[Msg]
+            | UserConfirmResultEvent
+            | ExternalExecutionResultEvent
+            | UserInterruptEvent
+            | None
+        ),
+        *,
+        session_lock_held: bool = False,
+    ) -> bool:
+        # pylint: disable=too-many-branches,too-many-statements
         """The actual chat-run body; wrapped by :meth:`run` for error
         swallowing. Separated so the try/except doesn't bury the
         per-step logic at one extra indentation level."""
@@ -486,6 +564,7 @@ class ChatService:
         # here has no reply to attach to, so one is synthesized —
         # otherwise the client sees a stream that simply stops and is
         # left saying "unknown error".
+        resume_identity: tuple[str, str] | None = None
         try:
             # -----------------------------------------------------------------
             # 1. Load records + resolve workspace ONCE here, reused below.
@@ -520,6 +599,37 @@ class ChatService:
                         f"agent {agent_id!r}."
                     ),
                 )
+            if isinstance(
+                input_msg,
+                (
+                    UserConfirmResultEvent,
+                    ExternalExecutionResultEvent,
+                    UserInterruptEvent,
+                ),
+            ):
+                resume_identity = self._resume_identity(input_msg)
+                resume_key, payload_hash = resume_identity
+                existing_hash = session_record.state.applied_resume_events.get(
+                    resume_key,
+                )
+                if existing_hash is not None:
+                    if existing_hash == payload_hash:
+                        logger.info(
+                            "Ignoring duplicate resume event %s for session "
+                            "%s reply %s.",
+                            input_msg.id,
+                            session_id,
+                            input_msg.reply_id,
+                        )
+                    else:
+                        logger.error(
+                            "Rejecting resume idempotency conflict for event "
+                            "%s in session %s reply %s.",
+                            input_msg.id,
+                            session_id,
+                            input_msg.reply_id,
+                        )
+                    return True
             workspace = await self._workspace_manager.get_workspace(
                 user_id,
                 agent_id,
@@ -693,27 +803,26 @@ class ChatService:
             )
 
             if self._skip_parked_wakeup(session_id, agent, input_msg):
-                return
+                return True
         except Exception as e:  # pylint: disable=broad-except
             # Under the session lock, like the reply this run never got
             # to make: these events share a channel with a live reply's,
             # so publishing them unserialised would drop a "reply failed"
             # into the middle of an answer another run is streaming.
-            async with self._message_bus.acquire_lock(
-                MessageBusKeys.session_lock(session_id),
-                ttl_secs=MessageBusKeys.SESSION_RUN_TTL_SECS,
+            async with self._session_lock(
+                session_id,
+                already_held=session_lock_held,
             ):
                 await self._report_failure(user_id, session_id, agent_id, e)
-            return
+            return False
 
         # --------------------------------------------------------------------
         # 7. Run the agent inside the distributed session lock
         # ---------------------------------------------------------------------
-        lock_key = MessageBusKeys.session_lock(session_id)
         events_key = MessageBusKeys.session_events(session_id)
-        async with self._message_bus.acquire_lock(
-            lock_key,
-            ttl_secs=MessageBusKeys.SESSION_RUN_TTL_SECS,
+        async with self._session_lock(
+            session_id,
+            already_held=session_lock_held,
         ):
             reply_msg: Msg | None = None
             try:
@@ -834,6 +943,19 @@ class ChatService:
                 # acquire the lock and load a stale state from storage
                 # before this write lands.
                 async def _persist() -> None:
+                    if resume_identity is not None:
+                        resume_key, payload_hash = resume_identity
+                        agent.state.applied_resume_events[
+                            resume_key
+                        ] = payload_hash
+                        # A session only needs a bounded recent ledger: once
+                        # the reply has advanced, old resume events are also
+                        # rejected by the agent's awaiting-tool-call state.
+                        while len(agent.state.applied_resume_events) > 256:
+                            oldest = next(
+                                iter(agent.state.applied_resume_events),
+                            )
+                            agent.state.applied_resume_events.pop(oldest)
                     if reply_msg is not None:
                         await self._storage.upsert_message(
                             user_id,
@@ -857,6 +979,7 @@ class ChatService:
                     # propagate to honour asyncio semantics.
                     await persist_task
                     raise
+        return True
 
     async def _project_event(
         self,

--- a/src/agentscope/app/message_bus/_base.py
+++ b/src/agentscope/app/message_bus/_base.py
@@ -13,7 +13,7 @@ payload's lifetime ends — rather than by business use case. Callers map
 their own concepts (agent inbox, session SSE replay, idle wake-up, …)
 onto the right mode plus a key naming convention they own.
 
-Three orthogonal modes are exposed:
+Four orthogonal modes are exposed:
 
 ============================  ===========================================
 Mode A — drain queue          Mode C — replay log
@@ -32,14 +32,17 @@ Mode D — transient broadcast: ``publish`` / ``subscribe``. Fire-and-forget
 pub/sub; only currently-subscribed listeners receive a payload, no
 history. Use for wake-up signals where missed-while-offline is fine.
 
-Counted broadcast (one entry consumed by N distinct readers) is
-intentionally not exposed as a primitive: in practice it requires
-consumer-group coordination (Redis Streams' XREADGROUP/XACK semantics)
-and adds substantial state. Producers wanting "fan out to N members"
-should fan out at write time — push one entry per recipient inbox using
-Mode A. The bus stays simple; deduplication is the producer's
-responsibility.
+Mode B — reliable work queue: ``reliable_queue_*``. Entries are claimed by
+one member of a consumer group, remain pending while they are processed,
+and disappear only after an explicit acknowledgement. A dead consumer's
+pending entries can be reclaimed by another member after an idle timeout.
+
+Mode B is point-to-point within one consumer group, not counted broadcast.
+Producers wanting "fan out to N members" should fan out at write time —
+push one entry per recipient inbox. Deduplication remains the producer or
+application consumer's responsibility.
 """
+
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -166,6 +169,80 @@ class MessageBus(ABC):  # pylint: disable=too-many-public-methods
             key (`str`):
                 Queue identifier.
         """
+
+    # ------------------------------------------------------------------
+    # Mode B — reliable work queue (consumer group + explicit ACK)
+    # ------------------------------------------------------------------
+
+    async def reliable_queue_push(self, key: str, payload: dict) -> str:
+        """Append a payload to a reliable work queue.
+
+        Backends that support horizontally-scaled application workers must
+        override this mode.  It is deliberately separate from
+        :meth:`queue_push`: mixing an ack-on-read consumer with an
+        explicit-ACK consumer on the same key destroys the latter's pending
+        entries.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support reliable queues.",
+        )
+
+    async def reliable_queue_ensure_group(self, key: str, group: str) -> None:
+        """Create ``group`` for ``key`` if it does not already exist."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support reliable queues.",
+        )
+
+    async def reliable_queue_read(
+        self,
+        key: str,
+        group: str,
+        consumer: str,
+        *,
+        max_count: int = 1,
+        block_ms: int = 1000,
+    ) -> list[tuple[str, dict]]:
+        """Claim new entries for one consumer-group member."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support reliable queues.",
+        )
+
+    async def reliable_queue_reclaim(
+        self,
+        key: str,
+        group: str,
+        consumer: str,
+        *,
+        min_idle_ms: int,
+        max_count: int = 1,
+    ) -> list[tuple[str, dict]]:
+        """Claim entries abandoned by consumers for ``min_idle_ms``."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support reliable queues.",
+        )
+
+    async def reliable_queue_touch(
+        self,
+        key: str,
+        group: str,
+        consumer: str,
+        entry_ids: list[str],
+    ) -> None:
+        """Refresh ownership of entries that are still being processed."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support reliable queues.",
+        )
+
+    async def reliable_queue_ack(
+        self,
+        key: str,
+        group: str,
+        entry_ids: list[str],
+    ) -> int:
+        """Acknowledge durably processed entries and remove their payloads."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support reliable queues.",
+        )
 
     # ------------------------------------------------------------------
     # Mode C — replay log (multi-consumer, externally bounded)
@@ -674,16 +751,20 @@ class MessageBus(ABC):  # pylint: disable=too-many-public-methods
         inputs: dict | None = None,
     ) -> None:
         """Enqueue a typed run trigger."""
-        await self.queue_push(
-            self._WAKEUP_QUEUE_KEY,
-            {
-                "user_id": user_id,
-                "session_id": session_id,
-                "agent_id": agent_id,
-                "kind": kind,
-                "input": inputs,
-            },
-        )
+        payload = {
+            "user_id": user_id,
+            "session_id": session_id,
+            "agent_id": agent_id,
+            "kind": kind,
+            "input": inputs,
+        }
+        if kind == MessageBusKeys.WAKEUP_KIND_RESUME:
+            await self.reliable_queue_push(
+                MessageBusKeys.resume_queue(),
+                payload,
+            )
+            return
+        await self.queue_push(self._WAKEUP_QUEUE_KEY, payload)
         await self.publish(self._WAKEUP_SIGNAL_KEY, {})
 
     @deprecated(

--- a/src/agentscope/app/message_bus/_in_memory_message_bus.py
+++ b/src/agentscope/app/message_bus/_in_memory_message_bus.py
@@ -14,9 +14,11 @@ dependency.
    For real deployments use :class:`RedisMessageBus` (or another
    networked backend).
 """
+
 from __future__ import annotations
 
 import asyncio
+import time
 import uuid
 from collections import defaultdict
 from collections.abc import AsyncGenerator
@@ -26,7 +28,7 @@ from typing import Callable, Self
 from ._base import MessageBus
 
 
-class InMemoryMessageBus(MessageBus):
+class InMemoryMessageBus(MessageBus):  # pylint: disable=R0904
     """In-memory implementation of :class:`MessageBus`.
 
     Mapping of bus modes to in-memory structures:
@@ -59,6 +61,18 @@ class InMemoryMessageBus(MessageBus):
 
         # Mode A — drain queues: key -> [(entry_id, payload), ...]
         self._queues: dict[str, list[tuple[str, dict]]] = defaultdict(list)
+
+        # Mode B — reliable queues. ``delivered`` prevents a new read from
+        # returning an entry already assigned to the group; ``pending`` maps
+        # it to (consumer, last-delivery monotonic timestamp).
+        self._reliable_queues: dict[
+            str,
+            list[tuple[str, dict]],
+        ] = defaultdict(list)
+        self._reliable_groups: dict[
+            tuple[str, str],
+            dict[str, object],
+        ] = {}
 
         # Mode C — replay logs: key -> [(entry_id, payload), ...]
         self._logs: dict[str, list[tuple[str, dict]]] = defaultdict(list)
@@ -180,6 +194,125 @@ class InMemoryMessageBus(MessageBus):
                 Queue identifier.
         """
         self._queues.pop(key, None)
+
+    # ------------------------------------------------------------------
+    # Mode B — reliable work queue
+    # ------------------------------------------------------------------
+
+    async def reliable_queue_push(self, key: str, payload: dict) -> str:
+        """Append an entry without acknowledging it on read."""
+        entry_id = self._next_id()
+        self._reliable_queues[key].append((entry_id, payload))
+        return entry_id
+
+    async def reliable_queue_ensure_group(self, key: str, group: str) -> None:
+        """Create in-memory group bookkeeping when absent."""
+        self._reliable_groups.setdefault(
+            (key, group),
+            {"delivered": set(), "pending": {}},
+        )
+
+    async def reliable_queue_read(
+        self,
+        key: str,
+        group: str,
+        consumer: str,
+        *,
+        max_count: int = 1,
+        block_ms: int = 1000,
+    ) -> list[tuple[str, dict]]:
+        """Assign previously unseen entries to ``consumer``."""
+        await self.reliable_queue_ensure_group(key, group)
+        deadline = time.monotonic() + max(0, block_ms) / 1000
+        while True:
+            state = self._reliable_groups[(key, group)]
+            delivered = state["delivered"]
+            pending = state["pending"]
+            assert isinstance(delivered, set)
+            assert isinstance(pending, dict)
+            result: list[tuple[str, dict]] = []
+            now = time.monotonic()
+            for entry_id, payload in self._reliable_queues.get(key, []):
+                if entry_id in delivered:
+                    continue
+                delivered.add(entry_id)
+                pending[entry_id] = (consumer, now)
+                result.append((entry_id, payload))
+                if len(result) >= max_count:
+                    return result
+            if result or block_ms <= 0 or time.monotonic() >= deadline:
+                return result
+            await asyncio.sleep(min(0.01, max(0, deadline - time.monotonic())))
+
+    async def reliable_queue_reclaim(
+        self,
+        key: str,
+        group: str,
+        consumer: str,
+        *,
+        min_idle_ms: int,
+        max_count: int = 1,
+    ) -> list[tuple[str, dict]]:
+        """Transfer idle pending entries to ``consumer``."""
+        await self.reliable_queue_ensure_group(key, group)
+        state = self._reliable_groups[(key, group)]
+        pending = state["pending"]
+        assert isinstance(pending, dict)
+        payloads = dict(self._reliable_queues.get(key, []))
+        now = time.monotonic()
+        result: list[tuple[str, dict]] = []
+        for entry_id, (_owner, touched_at) in list(pending.items()):
+            if (now - touched_at) * 1000 < min_idle_ms:
+                continue
+            pending[entry_id] = (consumer, now)
+            if entry_id in payloads:
+                result.append((entry_id, payloads[entry_id]))
+            if len(result) >= max_count:
+                break
+        return result
+
+    async def reliable_queue_touch(
+        self,
+        key: str,
+        group: str,
+        consumer: str,
+        entry_ids: list[str],
+    ) -> None:
+        """Refresh entries that are still owned by ``consumer``."""
+        await self.reliable_queue_ensure_group(key, group)
+        pending = self._reliable_groups[(key, group)]["pending"]
+        assert isinstance(pending, dict)
+        now = time.monotonic()
+        for entry_id in entry_ids:
+            current = pending.get(entry_id)
+            if current is not None and current[0] == consumer:
+                pending[entry_id] = (consumer, now)
+
+    async def reliable_queue_ack(
+        self,
+        key: str,
+        group: str,
+        entry_ids: list[str],
+    ) -> int:
+        """Remove acknowledged entries and their pending records."""
+        await self.reliable_queue_ensure_group(key, group)
+        state = self._reliable_groups[(key, group)]
+        pending = state["pending"]
+        delivered = state["delivered"]
+        assert isinstance(pending, dict)
+        assert isinstance(delivered, set)
+        acked = 0
+        for entry_id in entry_ids:
+            if pending.pop(entry_id, None) is not None:
+                acked += 1
+            delivered.discard(entry_id)
+        ids = set(entry_ids)
+        self._reliable_queues[key] = [
+            item
+            for item in self._reliable_queues.get(key, [])
+            if item[0] not in ids
+        ]
+        return acked
 
     # ------------------------------------------------------------------
     # Mode C — replay log

--- a/src/agentscope/app/message_bus/_keys.py
+++ b/src/agentscope/app/message_bus/_keys.py
@@ -150,6 +150,22 @@ class MessageBusKeys:
 
     _WAKEUP_QUEUE = "agentscope:wakeups"
     _WAKEUP_SIGNAL = "agentscope:wakeup_signal"
+    _RESUME_QUEUE = "agentscope:wakeups:resume:v2"
+
+    RESUME_CONSUMER_GROUP: Final = "agentscope-resume-dispatchers-v2"
+    """Shared consumer group for reliable resume commands."""
+
+    RESUME_CLAIM_IDLE_MS: Final = 60_000
+    """Idle time after which an un-heartbeated resume may be reclaimed."""
+
+    RESUME_READ_BLOCK_MS: Final = 1_000
+    """Maximum blocking read duration while waiting for new resume work."""
+
+    RESUME_RECLAIM_INTERVAL_MS: Final = 5_000
+    """Interval between scans for work abandoned by dead consumers."""
+
+    RESUME_MAX_CONCURRENCY: Final = 16
+    """Maximum resume entries processed concurrently by one API process."""
 
     @classmethod
     def wakeup_queue(cls) -> str:
@@ -160,6 +176,11 @@ class MessageBusKeys:
     def wakeup_signal(cls) -> str:
         """Shared signal channel that nudges dispatchers to drain."""
         return cls._WAKEUP_SIGNAL
+
+    @classmethod
+    def resume_queue(cls) -> str:
+        """Reliable v2 stream carrying HITL/external resume commands."""
+        return cls._RESUME_QUEUE
 
     # ------------------------------------------------------------------
     # Cross-process cancel

--- a/src/agentscope/app/message_bus/_redis_message_bus.py
+++ b/src/agentscope/app/message_bus/_redis_message_bus.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """The Redis-backed message bus implementation."""
+
 import asyncio
 import json
 import uuid
@@ -16,7 +17,14 @@ else:
     Redis = Any
 
 
-class RedisMessageBus(MessageBus):
+def _watch_error() -> type[BaseException]:
+    """Lazy-load Redis's optimistic-transaction conflict error."""
+    from redis.exceptions import WatchError
+
+    return WatchError
+
+
+class RedisMessageBus(MessageBus):  # pylint: disable=R0904
     """Redis-backed implementation of :class:`MessageBus`.
 
     Mapping of bus modes to Redis primitives:
@@ -27,6 +35,10 @@ class RedisMessageBus(MessageBus):
       by per-id ``XDEL`` so the read is destructive and idempotent
       under the single-consumer-per-key invariant. ``ttl_secs`` is
       enforced via ``EXPIRE`` after each push (sliding TTL).
+    - **Mode B (reliable work queue)** uses a Redis Stream consumer group.
+      ``XREADGROUP`` assigns new entries, ``XAUTOCLAIM`` recovers abandoned
+      pending entries, and ``XACK`` removes work only after its durable
+      processing boundary.
     - **Mode C (replay log)** also uses a Redis Stream, but never
       ``XDEL``s on read. Trimming happens via ``XADD … MAXLEN ~N``
       (approximate, for performance) on append, via the ``ttl_secs``
@@ -85,6 +97,8 @@ class RedisMessageBus(MessageBus):
         # Populated in __aenter__; None until the context is entered.
         self._client: Redis | None = None
         self._owned_pool: ConnectionPool | None = None
+        self._reliable_reclaim_cursors: dict[tuple[str, str, str], str] = {}
+        self._reliable_groups_ready: set[tuple[str, str]] = set()
 
     async def __aenter__(self) -> Self:
         """Create the connection pool and Redis client.
@@ -275,6 +289,205 @@ class RedisMessageBus(MessageBus):
                 when the key does not exist.
         """
         await self._client.delete(key)
+
+    # ------------------------------------------------------------------
+    # Mode B — reliable work queue
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _decode_stream_entries(entries: list) -> list[tuple[str, dict]]:
+        """Decode Redis Stream fields into the bus payload shape."""
+        results: list[tuple[str, dict]] = []
+        for entry_id, fields in entries:
+            raw = fields.get("payload")
+            if raw is None:
+                # Preserve the id so the consumer can classify and ACK a
+                # malformed entry instead of leaving poison work in the PEL.
+                results.append((entry_id, {}))
+                continue
+            try:
+                results.append((entry_id, json.loads(raw)))
+            except (TypeError, json.JSONDecodeError):
+                results.append((entry_id, {}))
+        return results
+
+    async def reliable_queue_push(self, key: str, payload: dict) -> str:
+        """Append an entry to a consumer-group work stream."""
+        return await self._client.xadd(
+            key,
+            {"payload": json.dumps(payload, ensure_ascii=False)},
+        )
+
+    async def reliable_queue_ensure_group(self, key: str, group: str) -> None:
+        """Create a group at the beginning of the stream, once."""
+        group_key = (key, group)
+        if group_key in self._reliable_groups_ready:
+            return
+        try:
+            await self._client.xgroup_create(
+                name=key,
+                groupname=group,
+                id="0",
+                mkstream=True,
+            )
+        except Exception as exc:  # Redis uses a backend-specific error type.
+            if "BUSYGROUP" not in str(exc):
+                raise
+        self._reliable_groups_ready.add(group_key)
+
+    async def reliable_queue_read(
+        self,
+        key: str,
+        group: str,
+        consumer: str,
+        *,
+        max_count: int = 1,
+        block_ms: int = 1000,
+    ) -> list[tuple[str, dict]]:
+        """Read new work through ``XREADGROUP ... >``."""
+        read_kwargs: dict[str, Any] = {}
+        if block_ms > 0:
+            read_kwargs["block"] = block_ms
+        for attempt in range(2):
+            await self.reliable_queue_ensure_group(key, group)
+            try:
+                streams = await self._client.xreadgroup(
+                    groupname=group,
+                    consumername=consumer,
+                    streams={key: ">"},
+                    count=max_count,
+                    **read_kwargs,
+                )
+                break
+            except Exception as exc:  # Backend-specific response error.
+                if attempt == 0 and "NOGROUP" in str(exc):
+                    self._reliable_groups_ready.discard((key, group))
+                    continue
+                raise
+        if not streams:
+            return []
+        return self._decode_stream_entries(streams[0][1])
+
+    async def reliable_queue_reclaim(
+        self,
+        key: str,
+        group: str,
+        consumer: str,
+        *,
+        min_idle_ms: int,
+        max_count: int = 1,
+    ) -> list[tuple[str, dict]]:
+        """Reclaim abandoned PEL entries with ``XAUTOCLAIM``."""
+        cursor_key = (key, group, consumer)
+        for attempt in range(2):
+            await self.reliable_queue_ensure_group(key, group)
+            try:
+                claimed = await self._client.xautoclaim(
+                    name=key,
+                    groupname=group,
+                    consumername=consumer,
+                    min_idle_time=min_idle_ms,
+                    start_id=self._reliable_reclaim_cursors.get(
+                        cursor_key,
+                        "0-0",
+                    ),
+                    count=max_count,
+                )
+                break
+            except Exception as exc:  # Backend-specific response error.
+                if attempt == 0 and "NOGROUP" in str(exc):
+                    self._reliable_groups_ready.discard((key, group))
+                    self._reliable_reclaim_cursors.pop(cursor_key, None)
+                    continue
+                raise
+        # redis-py returns ``(next_id, entries, deleted_ids)`` on modern
+        # Redis and ``(next_id, entries)`` with older compatible servers.
+        if claimed:
+            self._reliable_reclaim_cursors[cursor_key] = claimed[0]
+        entries = claimed[1] if len(claimed) >= 2 else []
+        return self._decode_stream_entries(entries)
+
+    async def reliable_queue_touch(
+        self,
+        key: str,
+        group: str,
+        consumer: str,
+        entry_ids: list[str],
+    ) -> None:
+        """Reset idle time, but only while ``consumer`` still owns work.
+
+        The ownership check and ``XCLAIM`` must be one Redis operation.  A
+        separate ``XPENDING``/``XCLAIM`` pair would let a stale heartbeat
+        steal an entry back immediately after another process reclaimed it.
+        """
+        if not entry_ids:
+            return
+        for entry_id in entry_ids:
+            async with self._client.pipeline(transaction=True) as pipe:
+                while True:
+                    try:
+                        await pipe.watch(key)
+                        rows = await pipe.xpending_range(
+                            key,
+                            group,
+                            entry_id,
+                            entry_id,
+                            1,
+                        )
+                        if not rows or rows[0]["consumer"] != consumer:
+                            await pipe.unwatch()
+                            break
+                        pipe.multi()
+                        pipe.xclaim(
+                            key,
+                            group,
+                            consumer,
+                            min_idle_time=0,
+                            message_ids=[entry_id],
+                            justid=True,
+                        )
+                        await pipe.execute()
+                        break
+                    except _watch_error():
+                        # Ownership changed between XPENDING and XCLAIM.
+                        # Re-read it rather than letting a stale heartbeat
+                        # steal the entry back from the new consumer.
+                        continue
+
+    async def reliable_queue_ack(
+        self,
+        key: str,
+        group: str,
+        entry_ids: list[str],
+    ) -> int:
+        """Atomically ACK processed work and remove its payload."""
+        if not entry_ids:
+            return 0
+        acked = 0
+        for entry_id in entry_ids:
+            async with self._client.pipeline(transaction=True) as pipe:
+                while True:
+                    try:
+                        await pipe.watch(key)
+                        rows = await pipe.xpending_range(
+                            key,
+                            group,
+                            entry_id,
+                            entry_id,
+                            1,
+                        )
+                        if not rows:
+                            await pipe.unwatch()
+                            break
+                        pipe.multi()
+                        pipe.xack(key, group, entry_id)
+                        pipe.xdel(key, entry_id)
+                        results = await pipe.execute()
+                        acked += int(results[0])
+                        break
+                    except _watch_error():
+                        continue
+        return acked
 
     # ------------------------------------------------------------------
     # Mode C — replay log

--- a/src/agentscope/state/_state.py
+++ b/src/agentscope/state/_state.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """The agent state class."""
+
 from typing import Any, Type
 
 from pydantic import BaseModel, Field, field_serializer, model_validator
@@ -186,6 +187,15 @@ class AgentState(BaseModel):
 
     context: list[Msg] = Field(default_factory=list)
     """The uncompressed conversation context, which will be fed into the LLM"""
+
+    applied_resume_events: dict[str, str] = Field(default_factory=dict)
+    """Durable resume idempotency ledger.
+
+    Keys combine the target reply id and stable resume event id; values are
+    canonical payload hashes.  It is persisted with the rest of the mutable
+    agent state so a consumer-group redelivery after commit can be rejected
+    without a separate cross-backend Redis marker.
+    """
 
     # =================================================================
     # For backword compatibility

--- a/tests/in_memory_message_bus_test.py
+++ b/tests/in_memory_message_bus_test.py
@@ -8,6 +8,7 @@ the base :class:`MessageBus` class.
 
 No external dependencies (no Redis, no fakeredis) — just asyncio.
 """
+
 import asyncio
 from contextlib import AsyncExitStack
 from unittest import IsolatedAsyncioTestCase
@@ -78,6 +79,79 @@ class TestQueuePrimitive(IsolatedAsyncioTestCase):
         b = await self.bus.queue_drain("b", max_count=10)
         self.assertEqual([p for _id, p in a], [{"x": 1}])
         self.assertEqual([p for _id, p in b], [{"x": 2}])
+
+
+class TestReliableQueuePrimitive(IsolatedAsyncioTestCase):
+    """Mode B — consumer assignment, explicit ACK and reclaim."""
+
+    async def asyncSetUp(self) -> None:
+        self._stack = AsyncExitStack()
+        self.bus = await self._stack.enter_async_context(InMemoryMessageBus())
+
+    async def asyncTearDown(self) -> None:
+        await self._stack.aclose()
+
+    async def test_entry_is_pending_until_ack(self) -> None:
+        """A new reader cannot see work pending under another consumer."""
+        entry_id = await self.bus.reliable_queue_push("work", {"i": 1})
+        first = await self.bus.reliable_queue_read(
+            "work",
+            "g",
+            "c1",
+            block_ms=0,
+        )
+        second = await self.bus.reliable_queue_read(
+            "work",
+            "g",
+            "c2",
+            block_ms=0,
+        )
+        self.assertEqual(first, [(entry_id, {"i": 1})])
+        self.assertEqual(second, [])
+
+        self.assertEqual(
+            await self.bus.reliable_queue_ack("work", "g", [entry_id]),
+            1,
+        )
+        self.assertEqual(
+            await self.bus.reliable_queue_reclaim(
+                "work",
+                "g",
+                "c2",
+                min_idle_ms=0,
+            ),
+            [],
+        )
+
+    async def test_idle_entry_can_be_reclaimed_and_touch_defers_it(
+        self,
+    ) -> None:
+        """Heartbeats defer reclaim until the refreshed claim is idle."""
+        entry_id = await self.bus.reliable_queue_push("work", {"i": 1})
+        await self.bus.reliable_queue_read(
+            "work",
+            "g",
+            "dead",
+            block_ms=0,
+        )
+        await self.bus.reliable_queue_touch("work", "g", "dead", [entry_id])
+        self.assertEqual(
+            await self.bus.reliable_queue_reclaim(
+                "work",
+                "g",
+                "healthy",
+                min_idle_ms=100,
+            ),
+            [],
+        )
+        await asyncio.sleep(0.02)
+        reclaimed = await self.bus.reliable_queue_reclaim(
+            "work",
+            "g",
+            "healthy",
+            min_idle_ms=10,
+        )
+        self.assertEqual(reclaimed, [(entry_id, {"i": 1})])
 
 
 class TestLogPrimitive(IsolatedAsyncioTestCase):

--- a/tests/service_message_bus_test.py
+++ b/tests/service_message_bus_test.py
@@ -8,6 +8,7 @@ the abstract surface (queue / log / pubsub / lock) and the domain helpers
 (``session_run`` / ``session_publish_event`` / ``inbox_*`` / ``wakeup_*``)
 that are layered on top.
 """
+
 import asyncio
 from contextlib import AsyncExitStack
 from unittest import IsolatedAsyncioTestCase
@@ -82,6 +83,84 @@ class TestQueuePrimitive(IsolatedAsyncioTestCase):
         rest = await self.bus.queue_drain("k", max_count=10)
         self.assertEqual([p["i"] for _id, p in first], [0, 1, 2])
         self.assertEqual([p["i"] for _id, p in rest], [3, 4])
+
+
+class TestReliableQueuePrimitive(IsolatedAsyncioTestCase):
+    """Redis consumer-group work queue semantics."""
+
+    async def asyncSetUp(self) -> None:
+        self.fr = fakeredis.aioredis.FakeRedis(decode_responses=True)
+        self._stack = AsyncExitStack()
+        self.bus = await self._stack.enter_async_context(_make_bus(self.fr))
+
+    async def asyncTearDown(self) -> None:
+        await self._stack.aclose()
+        await self.fr.aclose()
+
+    async def test_pending_entry_is_not_delivered_as_new_twice(self) -> None:
+        """Pending Redis work is assigned to only one consumer."""
+        entry_id = await self.bus.reliable_queue_push("work", {"i": 1})
+        first = await self.bus.reliable_queue_read(
+            "work",
+            "g",
+            "c1",
+            block_ms=1,
+        )
+        second = await self.bus.reliable_queue_read(
+            "work",
+            "g",
+            "c2",
+            block_ms=1,
+        )
+        self.assertEqual(first, [(entry_id, {"i": 1})])
+        self.assertEqual(second, [])
+        self.assertEqual(
+            await self.bus.reliable_queue_ack("work", "g", [entry_id]),
+            1,
+        )
+
+    async def test_pending_entry_can_be_reclaimed(self) -> None:
+        """A healthy consumer can reclaim abandoned pending work."""
+        entry_id = await self.bus.reliable_queue_push("work", {"i": 1})
+        await self.bus.reliable_queue_read(
+            "work",
+            "g",
+            "dead",
+            block_ms=1,
+        )
+        reclaimed = await self.bus.reliable_queue_reclaim(
+            "work",
+            "g",
+            "healthy",
+            min_idle_ms=0,
+        )
+        self.assertEqual(reclaimed, [(entry_id, {"i": 1})])
+
+    async def test_stale_heartbeat_cannot_steal_reclaimed_entry(self) -> None:
+        """An old owner cannot reclaim work through a late heartbeat."""
+        entry_id = await self.bus.reliable_queue_push("work", {"i": 1})
+        await self.bus.reliable_queue_read(
+            "work",
+            "g",
+            "dead",
+            block_ms=1,
+        )
+        await self.bus.reliable_queue_reclaim(
+            "work",
+            "g",
+            "healthy",
+            min_idle_ms=0,
+        )
+
+        await self.bus.reliable_queue_touch(
+            "work",
+            "g",
+            "dead",
+            [entry_id],
+        )
+
+        pending = await self.fr.xpending_range("work", "g", "-", "+", 1)
+        self.assertEqual(pending[0]["consumer"], "healthy")
 
 
 class TestLogPrimitive(IsolatedAsyncioTestCase):

--- a/tests/service_resume_dispatcher_test.py
+++ b/tests/service_resume_dispatcher_test.py
@@ -1,0 +1,290 @@
+# -*- coding: utf-8 -*-
+"""Tests for reliable resume consumer-group dispatch."""
+
+# The boundary tests intentionally replace and call private service hooks.
+# pylint: disable=protected-access
+
+import asyncio
+from unittest import IsolatedAsyncioTestCase
+
+from agentscope.app._bus_ops import enqueue_run_trigger
+from agentscope.app._manager import ChatRunRegistry, ResumeDispatcher
+from agentscope.app._service import ChatService
+from agentscope.app.message_bus import InMemoryMessageBus, MessageBusKeys
+from agentscope.event import UserInterruptEvent
+
+
+class _Storage:
+    """Minimal session storage stub used by dispatcher tests."""
+
+    async def get_session(
+        self,
+        _user_id: str,
+        _agent_id: str,
+        _session_id: str,
+    ) -> object:
+        """Return a sentinel representing an existing session."""
+        return object()
+
+
+class _ChatService:
+    """Record reliable resume calls without assembling a real agent."""
+
+    def __init__(self, delay: float = 0) -> None:
+        self.delay = delay
+        self.calls: list[str] = []
+        self.called = asyncio.Event()
+
+    async def run_reliable_resume(
+        self,
+        user_id: str,
+        session_id: str,
+        agent_id: str,
+        input_msg: UserInterruptEvent,
+    ) -> bool:
+        """Record one dispatch and optionally emulate a long-running run."""
+        _ = user_id, session_id, agent_id
+        self.calls.append(input_msg.id)
+        self.called.set()
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        return True
+
+
+class _ConcurrentChatService:
+    """Hold resume calls open so dispatcher concurrency is observable."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.active = 0
+        self.max_active = 0
+        self.both_started = asyncio.Event()
+        self.third_started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def run_reliable_resume(
+        self,
+        user_id: str,
+        session_id: str,
+        agent_id: str,
+        input_msg: UserInterruptEvent,
+    ) -> bool:
+        """Wait until the test releases all concurrently started calls."""
+        _ = user_id, agent_id, input_msg
+        self.calls.append(session_id)
+        if len(self.calls) >= 3:
+            self.third_started.set()
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+        if self.active >= 2:
+            self.both_started.set()
+        try:
+            await self.release.wait()
+        finally:
+            self.active -= 1
+        return True
+
+
+class ResumeDispatcherTest(IsolatedAsyncioTestCase):
+    """Exercise dispatcher assignment across competing consumers."""
+
+    async def test_two_consumers_dispatch_one_entry_once(self) -> None:
+        """Two dispatchers apply a single queued resume only once."""
+        bus = InMemoryMessageBus()
+        chat = _ChatService()
+        event = UserInterruptEvent(reply_id="reply-1")
+        async with (
+            ResumeDispatcher(
+                bus,
+                _Storage(),
+                chat,
+                ChatRunRegistry(),
+                consumer_name="c1",
+                claim_idle_ms=100,
+                read_block_ms=10,
+            ),
+            ResumeDispatcher(
+                bus,
+                _Storage(),
+                chat,
+                ChatRunRegistry(),
+                consumer_name="c2",
+                claim_idle_ms=100,
+                read_block_ms=10,
+            ),
+        ):
+            await enqueue_run_trigger(
+                bus,
+                user_id="u",
+                session_id="s",
+                agent_id="a",
+                kind=MessageBusKeys.WAKEUP_KIND_RESUME,
+                inputs=event,
+            )
+            await asyncio.wait_for(chat.called.wait(), timeout=1)
+            await asyncio.sleep(0.05)
+
+        self.assertEqual(chat.calls, [event.id])
+
+    async def test_different_sessions_run_concurrently_within_bound(
+        self,
+    ) -> None:
+        """One slow resume does not block another tenant's session."""
+        bus = InMemoryMessageBus()
+        chat = _ConcurrentChatService()
+        async with ResumeDispatcher(
+            bus,
+            _Storage(),
+            chat,
+            ChatRunRegistry(),
+            consumer_name="concurrent",
+            read_block_ms=10,
+            max_concurrency=2,
+        ):
+            for session_id in ("session-1", "session-2", "session-3"):
+                await enqueue_run_trigger(
+                    bus,
+                    user_id=f"user-{session_id}",
+                    session_id=session_id,
+                    agent_id="agent",
+                    kind=MessageBusKeys.WAKEUP_KIND_RESUME,
+                    inputs=UserInterruptEvent(reply_id="reply"),
+                )
+            await asyncio.wait_for(chat.both_started.wait(), timeout=1)
+            await asyncio.sleep(0.05)
+            self.assertEqual(chat.max_active, 2)
+            self.assertEqual(len(chat.calls), 2)
+            chat.release.set()
+            await asyncio.wait_for(chat.third_started.wait(), timeout=1)
+
+        self.assertCountEqual(
+            chat.calls,
+            ["session-1", "session-2", "session-3"],
+        )
+
+
+class ReliableResumeBoundaryTest(IsolatedAsyncioTestCase):
+    """Exercise locking, identity, reclaim, and heartbeat boundaries."""
+
+    async def test_chat_service_enters_lock_before_loading_resume_state(
+        self,
+    ) -> None:
+        """Reliable resume acquires the session lock before implementation."""
+        bus = InMemoryMessageBus()
+        service = ChatService.__new__(ChatService)
+        service._message_bus = bus
+        observed_locked = False
+
+        async def _run_impl(
+            _user_id: str,
+            session_id: str,
+            _agent_id: str,
+            _input_msg: UserInterruptEvent,
+            *,
+            session_lock_held: bool = False,
+        ) -> bool:
+            nonlocal observed_locked
+            observed_locked = await bus.is_locked(
+                MessageBusKeys.session_lock(session_id),
+            )
+            return session_lock_held
+
+        service._run_impl = _run_impl
+        durable = await service.run_reliable_resume(
+            "u",
+            "s",
+            "a",
+            UserInterruptEvent(reply_id="reply-1"),
+        )
+        self.assertTrue(durable)
+        self.assertTrue(observed_locked)
+
+    def test_resume_identity_uses_event_id_and_payload_hash(self) -> None:
+        """The durable identity distinguishes event target and payload."""
+        event = UserInterruptEvent(id="event-1", reply_id="reply-1")
+        same = event.model_copy(deep=True)
+        different = UserInterruptEvent(id="event-1", reply_id="reply-2")
+
+        key, payload_hash = ChatService._resume_identity(event)
+        self.assertEqual(key, "reply-1:event-1")
+        self.assertEqual(
+            ChatService._resume_identity(same),
+            (key, payload_hash),
+        )
+        self.assertNotEqual(
+            ChatService._resume_identity(different)[1],
+            payload_hash,
+        )
+
+    async def test_abandoned_pending_entry_is_reclaimed(self) -> None:
+        """A dispatcher eventually handles work left by a dead consumer."""
+        bus = InMemoryMessageBus()
+        chat = _ChatService()
+        event = UserInterruptEvent(reply_id="reply-1")
+        await enqueue_run_trigger(
+            bus,
+            user_id="u",
+            session_id="s",
+            agent_id="a",
+            kind=MessageBusKeys.WAKEUP_KIND_RESUME,
+            inputs=event,
+        )
+        await bus.reliable_queue_read(
+            MessageBusKeys.resume_queue(),
+            MessageBusKeys.RESUME_CONSUMER_GROUP,
+            "dead",
+            block_ms=0,
+        )
+        await asyncio.sleep(0.02)
+
+        async with ResumeDispatcher(
+            bus,
+            _Storage(),
+            chat,
+            ChatRunRegistry(),
+            consumer_name="healthy",
+            claim_idle_ms=10,
+            read_block_ms=10,
+        ):
+            await asyncio.wait_for(chat.called.wait(), timeout=1)
+            await asyncio.sleep(0.05)
+
+        self.assertEqual(chat.calls, [event.id])
+
+    async def test_heartbeat_prevents_spurious_reclaim(self) -> None:
+        """Long-running healthy work stays with its original consumer."""
+        bus = InMemoryMessageBus()
+        chat = _ChatService(delay=0.25)
+        event = UserInterruptEvent(reply_id="reply-1")
+        async with (
+            ResumeDispatcher(
+                bus,
+                _Storage(),
+                chat,
+                ChatRunRegistry(),
+                consumer_name="slow",
+                claim_idle_ms=100,
+                read_block_ms=5,
+            ),
+            ResumeDispatcher(
+                bus,
+                _Storage(),
+                chat,
+                ChatRunRegistry(),
+                consumer_name="other",
+                claim_idle_ms=100,
+                read_block_ms=5,
+            ),
+        ):
+            await enqueue_run_trigger(
+                bus,
+                user_id="u",
+                session_id="s",
+                agent_id="a",
+                kind=MessageBusKeys.WAKEUP_KIND_RESUME,
+                inputs=event,
+            )
+            await asyncio.wait_for(chat.called.wait(), timeout=1)
+            await asyncio.sleep(0.35)
+
+        self.assertEqual(chat.calls, [event.id])

--- a/tests/storage_redis_test.py
+++ b/tests/storage_redis_test.py
@@ -249,14 +249,21 @@ class TestSession(IsolatedAsyncioTestCase):
         self.assertIsNotNone(fetched)
         self.assertEqual(fetched.id, session_id)
 
+        state = AgentState(
+            applied_resume_events={"reply:event": "payload-hash"},
+        )
         await self.storage.update_session_state(
             self.user_id,
             self.agent_id,
             session_id,
-            AgentState(),
+            state,
         )
         records = await self.storage.list_sessions(self.user_id, self.agent_id)
         self.assertEqual([record.id for record in records], [session_id])
+        self.assertEqual(
+            records[0].state.applied_resume_events,
+            state.applied_resume_events,
+        )
 
     async def test_delete(self) -> None:
         """Delete a session and verify it is gone from Redis."""

--- a/tests/storage_sql_test.py
+++ b/tests/storage_sql_test.py
@@ -9,6 +9,7 @@ backend implements, mirroring the shape (though not always the
 literal assertions) of the Redis backend's tests so both backends
 stay behavioural equivalents.
 """
+
 from contextlib import AsyncExitStack
 from datetime import datetime, timedelta
 from unittest.async_case import IsolatedAsyncioTestCase
@@ -310,7 +311,9 @@ class AsyncSQLAlchemyStorageTest(IsolatedAsyncioTestCase):
         # State-only update
         from agentscope.state import AgentState
 
-        new_state = AgentState()
+        new_state = AgentState(
+            applied_resume_events={"reply:event": "payload-hash"},
+        )
         await self.storage.update_session_state(
             "user-1",
             agent.id,


### PR DESCRIPTION
## AgentScope Version

2.0.5

## Description

Route HITL and external-tool resume triggers through a dedicated Redis consumer-group stream with explicit ACK, reclaim, heartbeat, and durable idempotency. Add bounded per-node concurrency and blocking reads to prevent lost or duplicate resumes while reducing Redis polling overhead in multi-instance deployments.

Fixes #2227

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review