### PR TITLE
feat(model): refresh model cards across all providers

### DIFF
--- a/src/agentscope/_version.py
+++ b/src/agentscope/_version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """The version of agentscope."""
 
-__version__ = "2.0.5"
+__version__ = "2.0.6dev"

--- a/src/agentscope/model/_anthropic/_model.py
+++ b/src/agentscope/model/_anthropic/_model.py
@@ -80,17 +80,18 @@ class AnthropicChatModel(ChatModelBase):
             ),
         )
 
-        effort: (
+        reasoning_effort: (
             Literal["low", "medium", "high", "xhigh", "max"] | None
         ) = Field(
             default=None,
-            title="Effort",
+            title="Reasoning Effort",
             description=(
-                "How many tokens Claude spends on the whole response, "
-                "thinking included. Sent as ``output_config.effort``. The "
-                "API default is ``high``. Supported levels vary by model "
-                "— see the model card, and note that Claude Sonnet 4.5 "
-                "and Claude Haiku 4.5 do not accept this parameter at all."
+                "How many tokens Claude spends on the whole response — "
+                "not just thinking, but tool calls and explanation too. "
+                "Sent as Anthropic's ``output_config.effort``. The API "
+                "default is ``high``. Supported levels vary by model — see "
+                "the model card, and note that Claude Sonnet 4.5 and "
+                "Claude Haiku 4.5 do not accept this parameter at all."
             ),
         )
 
@@ -234,8 +235,10 @@ class AnthropicChatModel(ChatModelBase):
             kwargs["thinking"] = thinking
 
         # Effort travels inside ``output_config``, not as a top-level field.
-        if self.parameters.effort and "output_config" not in kwargs:
-            kwargs["output_config"] = {"effort": self.parameters.effort}
+        if self.parameters.reasoning_effort and "output_config" not in kwargs:
+            kwargs["output_config"] = {
+                "effort": self.parameters.reasoning_effort,
+            }
 
         fmt_tools, fmt_tool_choice = self._format_tools(tools, tool_choice)
         if fmt_tools:

--- a/src/agentscope/model/_anthropic/_model.py
+++ b/src/agentscope/model/_anthropic/_model.py
@@ -56,6 +56,44 @@ class AnthropicChatModel(ChatModelBase):
             gt=0,
         )
 
+        thinking_mode: (
+            Literal["adaptive", "enabled", "disabled"] | None
+        ) = Field(
+            default=None,
+            title="Thinking Mode",
+            description=(
+                "How Claude thinks. ``adaptive`` lets the model decide when "
+                "and how deeply, and is the only mode Claude Opus 4.7 and "
+                "later accept — those models reject the ``enabled`` "
+                "(budget-based) mode. Takes precedence over "
+                "``thinking_enable``; leave unset to fall back to it."
+            ),
+        )
+
+        thinking_display: Literal["summarized", "omitted"] | None = Field(
+            default=None,
+            title="Thinking Display",
+            description=(
+                "Whether thinking blocks carry readable summaries or come "
+                "back empty. Claude Opus 4.7 and later default to "
+                "``omitted``, so set ``summarized`` to see the reasoning."
+            ),
+        )
+
+        effort: (
+            Literal["low", "medium", "high", "xhigh", "max"] | None
+        ) = Field(
+            default=None,
+            title="Effort",
+            description=(
+                "How many tokens Claude spends on the whole response, "
+                "thinking included. Sent as ``output_config.effort``. The "
+                "API default is ``high``. Supported levels vary by model "
+                "— see the model card, and note that Claude Sonnet 4.5 "
+                "and Claude Haiku 4.5 do not accept this parameter at all."
+            ),
+        )
+
     def __init__(
         self,
         credential: AnthropicCredential,
@@ -127,6 +165,16 @@ class AnthropicChatModel(ChatModelBase):
             anthropic.InternalServerError,
         )
 
+    def _thinking_mode(self) -> str | None:
+        """Resolve the effective thinking mode.
+
+        ``thinking_mode`` is the modern control; ``thinking_enable`` is the
+        legacy toggle that only ever meant the budget-based mode.
+        """
+        if self.parameters.thinking_mode is not None:
+            return self.parameters.thinking_mode
+        return "enabled" if self.parameters.thinking_enable else None
+
     async def _call_api(
         self,
         model_name: str,
@@ -169,18 +217,25 @@ class AnthropicChatModel(ChatModelBase):
             **generate_kwargs,
         }
 
-        # Anthropic extended thinking — only set when explicitly enabled.
-        # Anthropic requires max_tokens > budget_tokens strictly.
-        if self.parameters.thinking_enable and "thinking" not in kwargs:
-            budget = self.parameters.thinking_budget or (max_tokens // 2)
-            if budget >= max_tokens:
-                # Auto-expand max_tokens to satisfy the strict inequality.
-                max_tokens = budget + 1024
-                kwargs["max_tokens"] = max_tokens
-            kwargs["thinking"] = {
-                "type": "enabled",
-                "budget_tokens": budget,
-            }
+        mode = self._thinking_mode()
+        if mode is not None and "thinking" not in kwargs:
+            thinking: dict[str, Any] = {"type": mode}
+            if mode == "enabled":
+                # Anthropic requires max_tokens > budget_tokens strictly.
+                budget = self.parameters.thinking_budget or (max_tokens // 2)
+                if budget >= max_tokens:
+                    # Auto-expand max_tokens to satisfy the inequality.
+                    max_tokens = budget + 1024
+                    kwargs["max_tokens"] = max_tokens
+                thinking["budget_tokens"] = budget
+            # ``display`` is invalid alongside ``type: "disabled"``.
+            if mode != "disabled" and self.parameters.thinking_display:
+                thinking["display"] = self.parameters.thinking_display
+            kwargs["thinking"] = thinking
+
+        # Effort travels inside ``output_config``, not as a top-level field.
+        if self.parameters.effort and "output_config" not in kwargs:
+            kwargs["output_config"] = {"effort": self.parameters.effort}
 
         fmt_tools, fmt_tool_choice = self._format_tools(tools, tool_choice)
         if fmt_tools:
@@ -529,14 +584,14 @@ class AnthropicChatModel(ChatModelBase):
     ) -> StructuredResponse:
         """Anthropic-specific override for structured output.
 
-        Anthropic's extended thinking mode only supports
+        Anthropic's budget-based thinking mode only supports
         ``tool_choice={"type": "auto"}`` or ``{"type": "none"}``; any
         forcing form (``"any"`` or a specific tool) raises an API error.
-        When ``thinking_enable`` is on we default ``tool_choice`` to
-        ``"auto"`` and rely on the base class's injected system-reminder
-        prompt to guide the model. When thinking is disabled, this falls
+        In that mode we default ``tool_choice`` to ``"auto"`` and rely on
+        the base class's injected system-reminder prompt to guide the
+        model. Adaptive thinking accepts forced tool use, so it falls
         through to the base implementation (force the structured-output
-        tool).
+        tool) just like thinking being off entirely.
 
         See:
          https://platform.claude.com/docs/en/build-with-claude/extended-thinking#extended-thinking-with-tool-use
@@ -562,7 +617,7 @@ class AnthropicChatModel(ChatModelBase):
                 The structured response whose ``content`` is the validated
                 output dict matching ``structured_model``.
         """
-        if tool_choice is None and self.parameters.thinking_enable:
+        if tool_choice is None and self._thinking_mode() == "enabled":
             tool_choice = ToolChoice(mode="auto")
         return await super()._call_api_with_structured_output(
             model_name=model_name,

--- a/src/agentscope/model/_anthropic/_models/claude-fable-5.yaml
+++ b/src/agentscope/model/_anthropic/_models/claude-fable-5.yaml
@@ -1,5 +1,5 @@
-name: claude-opus-4-7
-label: Claude Opus 4.7
+name: claude-fable-5
+label: Claude Fable 5
 status: active
 
 input_types:
@@ -19,8 +19,8 @@ output_size: 128000
 
 parameter_overrides:
   max_tokens: {"maximum": 128000}
-  # Budget-based thinking (``thinking.type: "enabled"``) is rejected by
-  # this generation; adaptive is the only mode it accepts.
+  # Thinking is always on here and cannot be disabled or budgeted —
+  # ``effort`` is the only depth control this model accepts.
   thinking_enable:
     hidden: true
   thinking_budget:
@@ -28,7 +28,7 @@ parameter_overrides:
   thinking_mode:
     default: adaptive
     anyOf:
-      - enum: [adaptive, disabled]
+      - enum: [adaptive]
         type: string
       - type: "null"
   # Defaults to "omitted" on these models, which renders as empty thinking

--- a/src/agentscope/model/_anthropic/_models/claude-fable-5.yaml
+++ b/src/agentscope/model/_anthropic/_models/claude-fable-5.yaml
@@ -20,7 +20,7 @@ output_size: 128000
 parameter_overrides:
   max_tokens: {"maximum": 128000}
   # Thinking is always on here and cannot be disabled or budgeted —
-  # ``effort`` is the only depth control this model accepts.
+  # ``reasoning_effort`` is the only depth control it accepts.
   thinking_enable:
     hidden: true
   thinking_budget:

--- a/src/agentscope/model/_anthropic/_models/claude-haiku-4-5.yaml
+++ b/src/agentscope/model/_anthropic/_models/claude-haiku-4-5.yaml
@@ -25,6 +25,6 @@ parameter_overrides:
     hidden: true
   thinking_display:
     hidden: true
-  # Haiku 4.5 does not accept the effort parameter.
-  effort:
+  # Haiku 4.5 does not accept the reasoning_effort parameter.
+  reasoning_effort:
     hidden: true

--- a/src/agentscope/model/_anthropic/_models/claude-haiku-4-5.yaml
+++ b/src/agentscope/model/_anthropic/_models/claude-haiku-4-5.yaml
@@ -19,3 +19,12 @@ output_size: 65536
 
 parameter_overrides:
   max_tokens: {"maximum": 65536}
+  # Extended-thinking-only generation: adaptive mode is not accepted, and
+  # thinking display is already summarized by default here.
+  thinking_mode:
+    hidden: true
+  thinking_display:
+    hidden: true
+  # Haiku 4.5 does not accept the effort parameter.
+  effort:
+    hidden: true

--- a/src/agentscope/model/_anthropic/_models/claude-opus-4-5.yaml
+++ b/src/agentscope/model/_anthropic/_models/claude-opus-4-5.yaml
@@ -25,9 +25,9 @@ parameter_overrides:
     hidden: true
   thinking_display:
     hidden: true
-  # The oldest model accepting effort at all; xhigh and max arrived with
-  # the 4.6 generation.
-  effort:
+  # The oldest model accepting reasoning_effort at all; xhigh and max
+  # arrived with the 4.6 generation.
+  reasoning_effort:
     anyOf:
       - enum: [low, medium, high]
         type: string

--- a/src/agentscope/model/_anthropic/_models/claude-opus-4-5.yaml
+++ b/src/agentscope/model/_anthropic/_models/claude-opus-4-5.yaml
@@ -19,3 +19,16 @@ output_size: 65536
 
 parameter_overrides:
   max_tokens: {"maximum": 65536}
+  # Extended-thinking-only generation: adaptive mode is not accepted, and
+  # thinking display is already summarized by default here.
+  thinking_mode:
+    hidden: true
+  thinking_display:
+    hidden: true
+  # The oldest model accepting effort at all; xhigh and max arrived with
+  # the 4.6 generation.
+  effort:
+    anyOf:
+      - enum: [low, medium, high]
+        type: string
+      - type: "null"

--- a/src/agentscope/model/_anthropic/_models/claude-opus-4-6.yaml
+++ b/src/agentscope/model/_anthropic/_models/claude-opus-4-6.yaml
@@ -15,7 +15,23 @@ output_types:
   - application/x-thinking
 
 context_size: 1000000
-output_size: 131072
+output_size: 128000
 
 parameter_overrides:
-  max_tokens: {"maximum": 131072}
+  max_tokens: {"maximum": 128000}
+  # The last generation to accept both thinking modes; budget-based
+  # thinking still works here but is deprecated in favour of adaptive.
+  thinking_enable:
+    hidden: true
+  thinking_mode:
+    default: adaptive
+    anyOf:
+      - enum: [adaptive, enabled, disabled]
+        type: string
+      - type: "null"
+  # xhigh landed after this generation; max is supported.
+  effort:
+    anyOf:
+      - enum: [low, medium, high, max]
+        type: string
+      - type: "null"

--- a/src/agentscope/model/_anthropic/_models/claude-opus-4-6.yaml
+++ b/src/agentscope/model/_anthropic/_models/claude-opus-4-6.yaml
@@ -30,7 +30,7 @@ parameter_overrides:
         type: string
       - type: "null"
   # xhigh landed after this generation; max is supported.
-  effort:
+  reasoning_effort:
     anyOf:
       - enum: [low, medium, high, max]
         type: string

--- a/src/agentscope/model/_anthropic/_models/claude-opus-4-8.yaml
+++ b/src/agentscope/model/_anthropic/_models/claude-opus-4-8.yaml
@@ -19,3 +19,19 @@ output_size: 128000
 
 parameter_overrides:
   max_tokens: {"maximum": 128000}
+  # Budget-based thinking (``thinking.type: "enabled"``) is rejected by
+  # this generation; adaptive is the only mode it accepts.
+  thinking_enable:
+    hidden: true
+  thinking_budget:
+    hidden: true
+  thinking_mode:
+    default: adaptive
+    anyOf:
+      - enum: [adaptive, disabled]
+        type: string
+      - type: "null"
+  # Defaults to "omitted" on these models, which renders as empty thinking
+  # blocks — ask for summaries explicitly.
+  thinking_display:
+    default: summarized

--- a/src/agentscope/model/_anthropic/_models/claude-opus-5.yaml
+++ b/src/agentscope/model/_anthropic/_models/claude-opus-5.yaml
@@ -1,5 +1,5 @@
-name: claude-opus-4-7
-label: Claude Opus 4.7
+name: claude-opus-5
+label: Claude Opus 5
 status: active
 
 input_types:

--- a/src/agentscope/model/_anthropic/_models/claude-sonnet-4-5.yaml
+++ b/src/agentscope/model/_anthropic/_models/claude-sonnet-4-5.yaml
@@ -25,6 +25,6 @@ parameter_overrides:
     hidden: true
   thinking_display:
     hidden: true
-  # Sonnet 4.5 does not accept the effort parameter.
-  effort:
+  # Sonnet 4.5 does not accept the reasoning_effort parameter.
+  reasoning_effort:
     hidden: true

--- a/src/agentscope/model/_anthropic/_models/claude-sonnet-4-5.yaml
+++ b/src/agentscope/model/_anthropic/_models/claude-sonnet-4-5.yaml
@@ -19,3 +19,12 @@ output_size: 65536
 
 parameter_overrides:
   max_tokens: {"maximum": 65536}
+  # Extended-thinking-only generation: adaptive mode is not accepted, and
+  # thinking display is already summarized by default here.
+  thinking_mode:
+    hidden: true
+  thinking_display:
+    hidden: true
+  # Sonnet 4.5 does not accept the effort parameter.
+  effort:
+    hidden: true

--- a/src/agentscope/model/_anthropic/_models/claude-sonnet-4-6.yaml
+++ b/src/agentscope/model/_anthropic/_models/claude-sonnet-4-6.yaml
@@ -15,7 +15,23 @@ output_types:
   - application/x-thinking
 
 context_size: 1000000
-output_size: 65536
+output_size: 128000
 
 parameter_overrides:
-  max_tokens: {"maximum": 65536}
+  max_tokens: {"maximum": 128000}
+  # The last generation to accept both thinking modes; budget-based
+  # thinking still works here but is deprecated in favour of adaptive.
+  thinking_enable:
+    hidden: true
+  thinking_mode:
+    default: adaptive
+    anyOf:
+      - enum: [adaptive, enabled, disabled]
+        type: string
+      - type: "null"
+  # xhigh landed after this generation; max is supported.
+  effort:
+    anyOf:
+      - enum: [low, medium, high, max]
+        type: string
+      - type: "null"

--- a/src/agentscope/model/_anthropic/_models/claude-sonnet-4-6.yaml
+++ b/src/agentscope/model/_anthropic/_models/claude-sonnet-4-6.yaml
@@ -30,7 +30,7 @@ parameter_overrides:
         type: string
       - type: "null"
   # xhigh landed after this generation; max is supported.
-  effort:
+  reasoning_effort:
     anyOf:
       - enum: [low, medium, high, max]
         type: string

--- a/src/agentscope/model/_anthropic/_models/claude-sonnet-5.yaml
+++ b/src/agentscope/model/_anthropic/_models/claude-sonnet-5.yaml
@@ -1,5 +1,5 @@
-name: claude-opus-4-7
-label: Claude Opus 4.7
+name: claude-sonnet-5
+label: Claude Sonnet 5
 status: active
 
 input_types:

--- a/src/agentscope/model/_dashscope/_models/qwen-flash.yaml
+++ b/src/agentscope/model/_dashscope/_models/qwen-flash.yaml
@@ -1,27 +1,20 @@
-name: gpt-5.5
-label: GPT-5.5
+name: qwen-flash
+label: Qwen-Flash
 status: active
 
 input_types:
   - text/plain
-  - image/jpeg
-  - image/png
-  - image/gif
-  - image/webp
+  - application/x-thinking
 
 output_types:
   - text/plain
+  - application/x-thinking
 
-context_size: 1050000
-output_size: 128000
+context_size: 1000000
+output_size: 32768
 
 parameter_overrides:
-  max_tokens:
-    maximum: 128000
-  thinking_enable:
-    hidden: true
-  reasoning_effort:
-    hidden: true
+  max_tokens: {"maximum": 32768}
   # Voice only applies to omni-style models; hide the field for this
   # non-omni model so the frontend popover doesn't render it.
   voice:

--- a/src/agentscope/model/_dashscope/_models/qwen3.5-flash.yaml
+++ b/src/agentscope/model/_dashscope/_models/qwen3.5-flash.yaml
@@ -1,0 +1,30 @@
+name: qwen3.5-flash
+label: Qwen3.5-Flash
+status: active
+
+input_types:
+  - text/plain
+  - application/x-thinking
+  - image/bmp
+  - image/jpeg
+  - image/png
+  - image/tiff
+  - image/webp
+  - image/heic
+  - video/mp4
+
+output_types:
+  - text/plain
+  - application/x-thinking
+
+context_size: 1000000
+output_size: 65536
+
+parameter_overrides:
+  max_tokens: {"maximum": 65536}
+  # Max chain-of-thought is independent of max_tokens.
+  thinking_budget: {"maximum": 81920}
+  # Voice only applies to omni-style models; hide the field for this
+  # non-omni model so the frontend popover doesn't render it.
+  voice:
+    hidden: true

--- a/src/agentscope/model/_dashscope/_models/qwen3.6-flash.yaml
+++ b/src/agentscope/model/_dashscope/_models/qwen3.6-flash.yaml
@@ -1,0 +1,30 @@
+name: qwen3.6-flash
+label: Qwen3.6-Flash
+status: active
+
+input_types:
+  - text/plain
+  - application/x-thinking
+  - image/bmp
+  - image/jpeg
+  - image/png
+  - image/tiff
+  - image/webp
+  - image/heic
+  - video/mp4
+
+output_types:
+  - text/plain
+  - application/x-thinking
+
+context_size: 1000000
+output_size: 65536
+
+parameter_overrides:
+  max_tokens: {"maximum": 65536}
+  # Max chain-of-thought is independent of max_tokens.
+  thinking_budget: {"maximum": 131072}
+  # Voice only applies to omni-style models; hide the field for this
+  # non-omni model so the frontend popover doesn't render it.
+  voice:
+    hidden: true

--- a/src/agentscope/model/_dashscope/_models/qwen3.7-flash.yaml
+++ b/src/agentscope/model/_dashscope/_models/qwen3.7-flash.yaml
@@ -1,0 +1,30 @@
+name: qwen3.7-flash
+label: Qwen3.7-Flash
+status: active
+
+input_types:
+  - text/plain
+  - application/x-thinking
+  - image/bmp
+  - image/jpeg
+  - image/png
+  - image/tiff
+  - image/webp
+  - image/heic
+  - video/mp4
+
+output_types:
+  - text/plain
+  - application/x-thinking
+
+context_size: 1000000
+output_size: 131072
+
+parameter_overrides:
+  max_tokens: {"maximum": 131072}
+  # Max chain-of-thought is independent of max_tokens.
+  thinking_budget: {"maximum": 262144}
+  # Voice only applies to omni-style models; hide the field for this
+  # non-omni model so the frontend popover doesn't render it.
+  voice:
+    hidden: true

--- a/src/agentscope/model/_dashscope/_models/qwen3.8-max.yaml
+++ b/src/agentscope/model/_dashscope/_models/qwen3.8-max.yaml
@@ -1,0 +1,30 @@
+name: qwen3.8-max
+label: Qwen3.8-Max
+status: active
+
+input_types:
+  - text/plain
+  - application/x-thinking
+  - image/bmp
+  - image/jpeg
+  - image/png
+  - image/tiff
+  - image/webp
+  - image/heic
+  - video/mp4
+
+output_types:
+  - text/plain
+  - application/x-thinking
+
+context_size: 1000000
+output_size: 131072
+
+parameter_overrides:
+  max_tokens: {"maximum": 131072}
+  # Max chain-of-thought is 262144 tokens, independent of max_tokens.
+  thinking_budget: {"maximum": 262144}
+  # Voice only applies to omni-style models; hide the field for this
+  # non-omni model so the frontend popover doesn't render it.
+  voice:
+    hidden: true

--- a/src/agentscope/model/_gemini/_models/gemini-2.5-flash-lite.yaml
+++ b/src/agentscope/model/_gemini/_models/gemini-2.5-flash-lite.yaml
@@ -1,25 +1,25 @@
-name: kimi-k2.5
-label: Kimi K2.5
-status: deprecated
-deprecated_at: "2026-08-31T00:00:00"
+name: gemini-2.5-flash-lite
+label: Gemini 2.5 Flash-Lite
+status: active
 
 input_types:
   - text/plain
-  - application/x-thinking
   - image/jpeg
   - image/png
   - image/gif
   - image/webp
+  - audio/mp3
+  - audio/wav
+  - video/mp4
+  - application/pdf
 
 output_types:
   - text/plain
   - application/x-thinking
 
-context_size: 262144
+context_size: 1048576
 output_size: 65536
 
 parameter_overrides:
   max_tokens:
     maximum: 65536
-  reasoning_effort:
-    hidden: true

--- a/src/agentscope/model/_gemini/_models/gemini-3.1-flash-lite.yaml
+++ b/src/agentscope/model/_gemini/_models/gemini-3.1-flash-lite.yaml
@@ -1,25 +1,25 @@
-name: kimi-k2.5
-label: Kimi K2.5
-status: deprecated
-deprecated_at: "2026-08-31T00:00:00"
+name: gemini-3.1-flash-lite
+label: Gemini 3.1 Flash-Lite
+status: active
 
 input_types:
   - text/plain
-  - application/x-thinking
   - image/jpeg
   - image/png
   - image/gif
   - image/webp
+  - audio/mp3
+  - audio/wav
+  - video/mp4
+  - application/pdf
 
 output_types:
   - text/plain
   - application/x-thinking
 
-context_size: 262144
+context_size: 1048576
 output_size: 65536
 
 parameter_overrides:
   max_tokens:
     maximum: 65536
-  reasoning_effort:
-    hidden: true

--- a/src/agentscope/model/_gemini/_models/gemini-3.5-flash-lite.yaml
+++ b/src/agentscope/model/_gemini/_models/gemini-3.5-flash-lite.yaml
@@ -1,25 +1,25 @@
-name: kimi-k2.5
-label: Kimi K2.5
-status: deprecated
-deprecated_at: "2026-08-31T00:00:00"
+name: gemini-3.5-flash-lite
+label: Gemini 3.5 Flash-Lite
+status: active
 
 input_types:
   - text/plain
-  - application/x-thinking
   - image/jpeg
   - image/png
   - image/gif
   - image/webp
+  - audio/mp3
+  - audio/wav
+  - video/mp4
+  - application/pdf
 
 output_types:
   - text/plain
   - application/x-thinking
 
-context_size: 262144
+context_size: 1048576
 output_size: 65536
 
 parameter_overrides:
   max_tokens:
     maximum: 65536
-  reasoning_effort:
-    hidden: true

--- a/src/agentscope/model/_gemini/_models/gemini-3.5-flash.yaml
+++ b/src/agentscope/model/_gemini/_models/gemini-3.5-flash.yaml
@@ -1,25 +1,25 @@
-name: kimi-k2.5
-label: Kimi K2.5
-status: deprecated
-deprecated_at: "2026-08-31T00:00:00"
+name: gemini-3.5-flash
+label: Gemini 3.5 Flash
+status: active
 
 input_types:
   - text/plain
-  - application/x-thinking
   - image/jpeg
   - image/png
   - image/gif
   - image/webp
+  - audio/mp3
+  - audio/wav
+  - video/mp4
+  - application/pdf
 
 output_types:
   - text/plain
   - application/x-thinking
 
-context_size: 262144
+context_size: 1048576
 output_size: 65536
 
 parameter_overrides:
   max_tokens:
     maximum: 65536
-  reasoning_effort:
-    hidden: true

--- a/src/agentscope/model/_gemini/_models/gemini-3.6-flash.yaml
+++ b/src/agentscope/model/_gemini/_models/gemini-3.6-flash.yaml
@@ -1,25 +1,25 @@
-name: kimi-k2.5
-label: Kimi K2.5
-status: deprecated
-deprecated_at: "2026-08-31T00:00:00"
+name: gemini-3.6-flash
+label: Gemini 3.6 Flash
+status: active
 
 input_types:
   - text/plain
-  - application/x-thinking
   - image/jpeg
   - image/png
   - image/gif
   - image/webp
+  - audio/mp3
+  - audio/wav
+  - video/mp4
+  - application/pdf
 
 output_types:
   - text/plain
   - application/x-thinking
 
-context_size: 262144
+context_size: 1048576
 output_size: 65536
 
 parameter_overrides:
   max_tokens:
     maximum: 65536
-  reasoning_effort:
-    hidden: true

--- a/src/agentscope/model/_model_card.py
+++ b/src/agentscope/model/_model_card.py
@@ -102,6 +102,8 @@ class ModelCard(BaseModel):
         if "application/x-thinking" not in output_types:
             properties.pop("thinking_enable", None)
             properties.pop("thinking_budget", None)
+            properties.pop("thinking_mode", None)
+            properties.pop("thinking_display", None)
 
         # Auto-filter: only omni-style models that declare an ``audio/*``
         # output type expose the ``voice`` parameter to the frontend

--- a/src/agentscope/model/_moonshot/_models/kimi-k2.7-code-highspeed.yaml
+++ b/src/agentscope/model/_moonshot/_models/kimi-k2.7-code-highspeed.yaml
@@ -1,0 +1,23 @@
+name: kimi-k2.7-code-highspeed
+label: Kimi K2.7 Code Highspeed
+status: active
+
+input_types:
+  - text/plain
+  - application/x-thinking
+
+output_types:
+  - text/plain
+  - application/x-thinking
+
+context_size: 262144
+# Moonshot publishes no per-model output ceiling; matched to kimi-k2.6,
+# which shares the same context window.
+output_size: 32768
+
+parameter_overrides:
+  max_tokens:
+    maximum: 32768
+  # Thinking is always on for the Code models and cannot be disabled.
+  thinking_enable:
+    hidden: true

--- a/src/agentscope/model/_moonshot/_models/kimi-k2.7-code.yaml
+++ b/src/agentscope/model/_moonshot/_models/kimi-k2.7-code.yaml
@@ -1,0 +1,23 @@
+name: kimi-k2.7-code
+label: Kimi K2.7 Code
+status: active
+
+input_types:
+  - text/plain
+  - application/x-thinking
+
+output_types:
+  - text/plain
+  - application/x-thinking
+
+context_size: 262144
+# Moonshot publishes no per-model output ceiling; matched to kimi-k2.6,
+# which shares the same context window.
+output_size: 32768
+
+parameter_overrides:
+  max_tokens:
+    maximum: 32768
+  # Thinking is always on for the Code models and cannot be disabled.
+  thinking_enable:
+    hidden: true

--- a/src/agentscope/model/_moonshot/_models/moonshot-v1-128k.yaml
+++ b/src/agentscope/model/_moonshot/_models/moonshot-v1-128k.yaml
@@ -1,6 +1,7 @@
 name: moonshot-v1-128k
 label: Kimi Moonshot v1 128K
-status: active
+status: deprecated
+deprecated_at: "2026-08-31T00:00:00"
 
 input_types:
   - text/plain

--- a/src/agentscope/model/_moonshot/_models/moonshot-v1-32k.yaml
+++ b/src/agentscope/model/_moonshot/_models/moonshot-v1-32k.yaml
@@ -1,6 +1,7 @@
 name: moonshot-v1-32k
 label: Kimi Moonshot v1 32K
-status: active
+status: deprecated
+deprecated_at: "2026-08-31T00:00:00"
 
 input_types:
   - text/plain

--- a/src/agentscope/model/_moonshot/_models/moonshot-v1-8k.yaml
+++ b/src/agentscope/model/_moonshot/_models/moonshot-v1-8k.yaml
@@ -1,6 +1,7 @@
 name: moonshot-v1-8k
 label: Kimi Moonshot v1 8K
-status: active
+status: deprecated
+deprecated_at: "2026-08-31T00:00:00"
 
 input_types:
   - text/plain

--- a/src/agentscope/model/_openai_chat/_models/gpt-4.1-nano.yaml
+++ b/src/agentscope/model/_openai_chat/_models/gpt-4.1-nano.yaml
@@ -1,6 +1,7 @@
 name: gpt-4.1-nano
 label: GPT-4.1 Nano
-status: active
+status: deprecated
+deprecated_at: "2026-10-23T00:00:00"
 
 input_types:
   - text/plain

--- a/src/agentscope/model/_openai_chat/_models/gpt-5.6-luna.yaml
+++ b/src/agentscope/model/_openai_chat/_models/gpt-5.6-luna.yaml
@@ -1,5 +1,5 @@
-name: gpt-5.5
-label: GPT-5.5
+name: gpt-5.6-luna
+label: GPT-5.6 Luna
 status: active
 
 input_types:
@@ -18,9 +18,9 @@ output_size: 128000
 parameter_overrides:
   max_tokens:
     maximum: 128000
+  # Reasoning happens internally and is never returned as content, so the
+  # thinking toggle has nothing to surface — reasoning_effort is the knob.
   thinking_enable:
-    hidden: true
-  reasoning_effort:
     hidden: true
   # Voice only applies to omni-style models; hide the field for this
   # non-omni model so the frontend popover doesn't render it.

--- a/src/agentscope/model/_openai_chat/_models/gpt-5.6-sol.yaml
+++ b/src/agentscope/model/_openai_chat/_models/gpt-5.6-sol.yaml
@@ -1,5 +1,5 @@
-name: gpt-5.5
-label: GPT-5.5
+name: gpt-5.6-sol
+label: GPT-5.6 Sol
 status: active
 
 input_types:
@@ -18,9 +18,9 @@ output_size: 128000
 parameter_overrides:
   max_tokens:
     maximum: 128000
+  # Reasoning happens internally and is never returned as content, so the
+  # thinking toggle has nothing to surface — reasoning_effort is the knob.
   thinking_enable:
-    hidden: true
-  reasoning_effort:
     hidden: true
   # Voice only applies to omni-style models; hide the field for this
   # non-omni model so the frontend popover doesn't render it.

--- a/src/agentscope/model/_openai_chat/_models/gpt-5.6-terra.yaml
+++ b/src/agentscope/model/_openai_chat/_models/gpt-5.6-terra.yaml
@@ -1,5 +1,5 @@
-name: gpt-5.5
-label: GPT-5.5
+name: gpt-5.6-terra
+label: GPT-5.6 Terra
 status: active
 
 input_types:
@@ -18,9 +18,9 @@ output_size: 128000
 parameter_overrides:
   max_tokens:
     maximum: 128000
+  # Reasoning happens internally and is never returned as content, so the
+  # thinking toggle has nothing to surface — reasoning_effort is the knob.
   thinking_enable:
-    hidden: true
-  reasoning_effort:
     hidden: true
   # Voice only applies to omni-style models; hide the field for this
   # non-omni model so the frontend popover doesn't render it.

--- a/src/agentscope/model/_openai_chat/_models/gpt-audio-mini.yaml
+++ b/src/agentscope/model/_openai_chat/_models/gpt-audio-mini.yaml
@@ -1,6 +1,7 @@
 name: gpt-audio-mini
 label: GPT Audio Mini
-status: active
+status: deprecated
+deprecated_at: "2027-01-20T00:00:00"
 
 input_types:
   - text/plain

--- a/src/agentscope/model/_openai_chat/_models/o3.yaml
+++ b/src/agentscope/model/_openai_chat/_models/o3.yaml
@@ -1,6 +1,7 @@
 name: o3
 label: o3
-status: active
+status: deprecated
+deprecated_at: "2026-12-11T00:00:00"
 
 input_types:
   - text/plain

--- a/src/agentscope/model/_openai_chat/_models/o4-mini.yaml
+++ b/src/agentscope/model/_openai_chat/_models/o4-mini.yaml
@@ -1,6 +1,7 @@
 name: o4-mini
 label: o4-mini
-status: active
+status: deprecated
+deprecated_at: "2026-10-23T00:00:00"
 
 input_types:
   - text/plain

--- a/src/agentscope/model/_openai_response/_models/gpt-4.1-nano.yaml
+++ b/src/agentscope/model/_openai_response/_models/gpt-4.1-nano.yaml
@@ -1,6 +1,7 @@
 name: gpt-4.1-nano
 label: GPT-4.1 Nano
-status: active
+status: deprecated
+deprecated_at: "2026-10-23T00:00:00"
 
 input_types:
   - text/plain

--- a/src/agentscope/model/_openai_response/_models/gpt-5.6-luna.yaml
+++ b/src/agentscope/model/_openai_response/_models/gpt-5.6-luna.yaml
@@ -1,5 +1,5 @@
-name: gpt-5.5
-label: GPT-5.5
+name: gpt-5.6-luna
+label: GPT-5.6 Luna
 status: active
 
 input_types:
@@ -18,7 +18,7 @@ output_size: 128000
 parameter_overrides:
   max_tokens:
     maximum: 128000
+  # Reasoning happens internally and is never returned as content, so the
+  # thinking toggle has nothing to surface — reasoning_effort is the knob.
   thinking_enable:
-    hidden: true
-  reasoning_effort:
     hidden: true

--- a/src/agentscope/model/_openai_response/_models/gpt-5.6-sol.yaml
+++ b/src/agentscope/model/_openai_response/_models/gpt-5.6-sol.yaml
@@ -1,5 +1,5 @@
-name: gpt-5.5
-label: GPT-5.5
+name: gpt-5.6-sol
+label: GPT-5.6 Sol
 status: active
 
 input_types:
@@ -18,7 +18,7 @@ output_size: 128000
 parameter_overrides:
   max_tokens:
     maximum: 128000
+  # Reasoning happens internally and is never returned as content, so the
+  # thinking toggle has nothing to surface — reasoning_effort is the knob.
   thinking_enable:
-    hidden: true
-  reasoning_effort:
     hidden: true

--- a/src/agentscope/model/_openai_response/_models/gpt-5.6-terra.yaml
+++ b/src/agentscope/model/_openai_response/_models/gpt-5.6-terra.yaml
@@ -1,5 +1,5 @@
-name: gpt-5.5
-label: GPT-5.5
+name: gpt-5.6-terra
+label: GPT-5.6 Terra
 status: active
 
 input_types:
@@ -18,7 +18,7 @@ output_size: 128000
 parameter_overrides:
   max_tokens:
     maximum: 128000
+  # Reasoning happens internally and is never returned as content, so the
+  # thinking toggle has nothing to surface — reasoning_effort is the knob.
   thinking_enable:
-    hidden: true
-  reasoning_effort:
     hidden: true

--- a/src/agentscope/model/_openai_response/_models/o3.yaml
+++ b/src/agentscope/model/_openai_response/_models/o3.yaml
@@ -1,6 +1,7 @@
 name: o3
 label: o3 (Responses API)
-status: active
+status: deprecated
+deprecated_at: "2026-12-11T00:00:00"
 
 input_types:
   - text/plain

--- a/src/agentscope/model/_openai_response/_models/o4-mini.yaml
+++ b/src/agentscope/model/_openai_response/_models/o4-mini.yaml
@@ -1,6 +1,7 @@
 name: o4-mini
 label: o4-mini (Responses API)
-status: active
+status: deprecated
+deprecated_at: "2026-10-23T00:00:00"
 
 input_types:
   - text/plain

--- a/src/agentscope/model/_xai/_models/grok-3-fast.yaml
+++ b/src/agentscope/model/_xai/_models/grok-3-fast.yaml
@@ -1,6 +1,6 @@
 name: grok-3-fast
 label: Grok 3 Fast
-status: active
+status: deprecated
 
 input_types:
   - text/plain

--- a/src/agentscope/model/_xai/_models/grok-3-mini.yaml
+++ b/src/agentscope/model/_xai/_models/grok-3-mini.yaml
@@ -1,6 +1,6 @@
 name: grok-3-mini
 label: Grok 3 Mini
-status: active
+status: deprecated
 
 input_types:
   - text/plain

--- a/src/agentscope/model/_xai/_models/grok-3.yaml
+++ b/src/agentscope/model/_xai/_models/grok-3.yaml
@@ -1,6 +1,6 @@
 name: grok-3
 label: Grok 3
-status: active
+status: deprecated
 
 input_types:
   - text/plain

--- a/src/agentscope/model/_xai/_models/grok-4.20-0309-non-reasoning.yaml
+++ b/src/agentscope/model/_xai/_models/grok-4.20-0309-non-reasoning.yaml
@@ -1,15 +1,12 @@
-name: grok-4.3
-label: Grok 4.3
+name: grok-4.20-0309-non-reasoning
+label: Grok 4.20 Non-Reasoning
 status: active
 
 input_types:
   - text/plain
-  - image/jpeg
-  - image/png
 
 output_types:
   - text/plain
-  - application/x-thinking
 
 context_size: 1000000
 # xAI publishes no max-output figure for any Grok model. Derived as 1/16 of
@@ -19,3 +16,8 @@ output_size: 64000
 parameter_overrides:
   max_tokens:
     maximum: 64000
+  # This variant never reasons; its sibling grok-4.20-0309-reasoning does.
+  thinking_enable:
+    hidden: true
+  reasoning_effort:
+    hidden: true

--- a/src/agentscope/model/_xai/_models/grok-4.20-0309-reasoning.yaml
+++ b/src/agentscope/model/_xai/_models/grok-4.20-0309-reasoning.yaml
@@ -1,11 +1,9 @@
-name: grok-4.3
-label: Grok 4.3
+name: grok-4.20-0309-reasoning
+label: Grok 4.20 Reasoning
 status: active
 
 input_types:
   - text/plain
-  - image/jpeg
-  - image/png
 
 output_types:
   - text/plain

--- a/src/agentscope/model/_xai/_models/grok-4.20-multi-agent-0309.yaml
+++ b/src/agentscope/model/_xai/_models/grok-4.20-multi-agent-0309.yaml
@@ -1,11 +1,9 @@
-name: grok-4.3
-label: Grok 4.3
+name: grok-4.20-multi-agent-0309
+label: Grok 4.20 Multi-Agent
 status: active
 
 input_types:
   - text/plain
-  - image/jpeg
-  - image/png
 
 output_types:
   - text/plain

--- a/src/agentscope/model/_xai/_models/grok-4.5.yaml
+++ b/src/agentscope/model/_xai/_models/grok-4.5.yaml
@@ -1,5 +1,5 @@
-name: grok-4.3
-label: Grok 4.3
+name: grok-4.5
+label: Grok 4.5
 status: active
 
 input_types:
@@ -11,11 +11,11 @@ output_types:
   - text/plain
   - application/x-thinking
 
-context_size: 1000000
+context_size: 500000
 # xAI publishes no max-output figure for any Grok model. Derived as 1/16 of
 # the context window, matching the ratio of providers that do publish one.
-output_size: 64000
+output_size: 32000
 
 parameter_overrides:
   max_tokens:
-    maximum: 64000
+    maximum: 32000

--- a/src/agentscope/model/_xai/_models/grok-build-0.1.yaml
+++ b/src/agentscope/model/_xai/_models/grok-build-0.1.yaml
@@ -1,21 +1,19 @@
-name: grok-4.3
-label: Grok 4.3
+name: grok-build-0.1
+label: Grok Build 0.1
 status: active
 
 input_types:
   - text/plain
-  - image/jpeg
-  - image/png
 
 output_types:
   - text/plain
   - application/x-thinking
 
-context_size: 1000000
+context_size: 256000
 # xAI publishes no max-output figure for any Grok model. Derived as 1/16 of
 # the context window, matching the ratio of providers that do publish one.
-output_size: 64000
+output_size: 16000
 
 parameter_overrides:
   max_tokens:
-    maximum: 64000
+    maximum: 16000

--- a/tests/model_anthropic_test.py
+++ b/tests/model_anthropic_test.py
@@ -255,6 +255,164 @@ class TestAnthropicNonStream(IsolatedAsyncioTestCase):
         )
 
 
+class TestAnthropicEffort(IsolatedAsyncioTestCase):
+    """Tests for the ``effort`` parameter."""
+
+    def setUp(self) -> None:
+        self.model = _make_model(stream=False)
+        self.mock_client = MagicMock()
+        self.model.client = self.mock_client
+        self.mock_create = AsyncMock(return_value=_mock_completion(text="hi"))
+        self.mock_client.messages.create = self.mock_create
+
+    async def test_effort_omitted_by_default(self) -> None:
+        """No output_config is sent when effort is unset."""
+        await self.model([])
+
+        self.assertNotIn("output_config", self.mock_create.call_args.kwargs)
+
+    async def test_effort_nested_in_output_config(self) -> None:
+        """Effort travels inside output_config, not as a top-level field."""
+        self.model.parameters.effort = "medium"
+
+        await self.model([])
+
+        kwargs = self.mock_create.call_args.kwargs
+        self.assertEqual(kwargs["output_config"], {"effort": "medium"})
+        self.assertNotIn("effort", kwargs)
+
+    async def test_effort_coexists_with_thinking(self) -> None:
+        """Effort and extended thinking are independent controls."""
+        self.model.parameters.effort = "max"
+        self.model.parameters.thinking_enable = True
+        self.model.parameters.thinking_budget = 1024
+
+        await self.model([])
+
+        kwargs = self.mock_create.call_args.kwargs
+        self.assertEqual(kwargs["output_config"], {"effort": "max"})
+        self.assertEqual(
+            kwargs["thinking"],
+            {"type": "enabled", "budget_tokens": 1024},
+        )
+
+    async def test_caller_output_config_wins(self) -> None:
+        """An explicit output_config kwarg is not overwritten."""
+        self.model.parameters.effort = "low"
+
+        await self.model([], output_config={"effort": "high"})
+
+        self.assertEqual(
+            self.mock_create.call_args.kwargs["output_config"],
+            {"effort": "high"},
+        )
+
+
+class TestAnthropicThinkingMode(IsolatedAsyncioTestCase):
+    """Tests for adaptive vs budget-based thinking configuration."""
+
+    def setUp(self) -> None:
+        self.model = _make_model(stream=False)
+        self.mock_client = MagicMock()
+        self.model.client = self.mock_client
+        self.mock_create = AsyncMock(return_value=_mock_completion(text="hi"))
+        self.mock_client.messages.create = self.mock_create
+
+    def _thinking(self) -> Any:
+        return self.mock_create.call_args.kwargs.get("thinking")
+
+    async def test_no_thinking_by_default(self) -> None:
+        """Neither control set means no thinking config is sent."""
+        await self.model([])
+
+        self.assertIsNone(self._thinking())
+
+    async def test_adaptive_carries_no_budget(self) -> None:
+        """Adaptive mode must not send budget_tokens, which it rejects."""
+        self.model.parameters.thinking_mode = "adaptive"
+        self.model.parameters.thinking_budget = 4096
+
+        await self.model([])
+
+        self.assertEqual(self._thinking(), {"type": "adaptive"})
+
+    async def test_adaptive_with_display(self) -> None:
+        """Display is what makes thinking text visible on newer models."""
+        self.model.parameters.thinking_mode = "adaptive"
+        self.model.parameters.thinking_display = "summarized"
+
+        await self.model([])
+
+        self.assertEqual(
+            self._thinking(),
+            {"type": "adaptive", "display": "summarized"},
+        )
+
+    async def test_disabled_drops_display(self) -> None:
+        """Display is invalid alongside type: disabled."""
+        self.model.parameters.thinking_mode = "disabled"
+        self.model.parameters.thinking_display = "summarized"
+
+        await self.model([])
+
+        self.assertEqual(self._thinking(), {"type": "disabled"})
+
+    async def test_legacy_toggle_still_means_budget_mode(self) -> None:
+        """thinking_enable keeps its old meaning when mode is unset."""
+        self.model.parameters.thinking_enable = True
+        self.model.parameters.thinking_budget = 2048
+
+        await self.model([])
+
+        self.assertEqual(
+            self._thinking(),
+            {"type": "enabled", "budget_tokens": 2048},
+        )
+
+    async def test_mode_overrides_legacy_toggle(self) -> None:
+        """An explicit mode wins over the legacy boolean."""
+        self.model.parameters.thinking_enable = True
+        self.model.parameters.thinking_mode = "adaptive"
+
+        await self.model([])
+
+        self.assertEqual(self._thinking(), {"type": "adaptive"})
+
+    async def test_budget_mode_expands_max_tokens(self) -> None:
+        """max_tokens must stay strictly above budget_tokens."""
+        self.model.parameters.thinking_mode = "enabled"
+        self.model.parameters.thinking_budget = 8192
+
+        await self.model([])
+
+        kwargs = self.mock_create.call_args.kwargs
+        self.assertEqual(kwargs["thinking"]["budget_tokens"], 8192)
+        self.assertGreater(kwargs["max_tokens"], 8192)
+
+    def test_resolved_mode_drives_tool_choice_downgrade(self) -> None:
+        """Only budget mode forbids forced tool use, so only it downgrades.
+
+        ``_call_api_with_structured_output`` keys the downgrade off this
+        resolution — adaptive must not trip it.
+        """
+        cases = [
+            ({}, None),
+            ({"thinking_enable": True}, "enabled"),
+            ({"thinking_mode": "enabled"}, "enabled"),
+            ({"thinking_mode": "adaptive"}, None),
+            ({"thinking_mode": "disabled"}, None),
+            ({"thinking_enable": True, "thinking_mode": "adaptive"}, None),
+        ]
+        for params, expected in cases:
+            with self.subTest(params=params):
+                model = _make_model()
+                for key, val in params.items():
+                    setattr(model.parameters, key, val)
+                resolved = model._thinking_mode()
+                downgrades = resolved == "enabled"
+                self.assertEqual(downgrades, expected == "enabled")
+
+
 # ---------------------------------------------------------------------------
 # Streaming tests
 # ---------------------------------------------------------------------------

--- a/tests/model_anthropic_test.py
+++ b/tests/model_anthropic_test.py
@@ -256,7 +256,7 @@ class TestAnthropicNonStream(IsolatedAsyncioTestCase):
 
 
 class TestAnthropicEffort(IsolatedAsyncioTestCase):
-    """Tests for the ``effort`` parameter."""
+    """Tests for the ``reasoning_effort`` parameter."""
 
     def setUp(self) -> None:
         self.model = _make_model(stream=False)
@@ -266,14 +266,14 @@ class TestAnthropicEffort(IsolatedAsyncioTestCase):
         self.mock_client.messages.create = self.mock_create
 
     async def test_effort_omitted_by_default(self) -> None:
-        """No output_config is sent when effort is unset."""
+        """No output_config is sent when reasoning_effort is unset."""
         await self.model([])
 
         self.assertNotIn("output_config", self.mock_create.call_args.kwargs)
 
     async def test_effort_nested_in_output_config(self) -> None:
         """Effort travels inside output_config, not as a top-level field."""
-        self.model.parameters.effort = "medium"
+        self.model.parameters.reasoning_effort = "medium"
 
         await self.model([])
 
@@ -283,7 +283,7 @@ class TestAnthropicEffort(IsolatedAsyncioTestCase):
 
     async def test_effort_coexists_with_thinking(self) -> None:
         """Effort and extended thinking are independent controls."""
-        self.model.parameters.effort = "max"
+        self.model.parameters.reasoning_effort = "max"
         self.model.parameters.thinking_enable = True
         self.model.parameters.thinking_budget = 1024
 
@@ -298,7 +298,7 @@ class TestAnthropicEffort(IsolatedAsyncioTestCase):
 
     async def test_caller_output_config_wins(self) -> None:
         """An explicit output_config kwarg is not overwritten."""
-        self.model.parameters.effort = "low"
+        self.model.parameters.reasoning_effort = "low"
 
         await self.model([], output_config={"effort": "high"})
 


### PR DESCRIPTION
## Why

The model cards under `src/agentscope/model/*/_models/` had drifted to roughly an April/May 2026 snapshot. Six of the seven hosted providers had shipped a new flagship since, and none of them were selectable in the web UI. While checking every provider's docs to fill the gaps, a few existing cards turned out to disagree with the vendor documentation as well.

## What's new

| Provider | Models added |
|---|---|
| Anthropic | `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5` |
| OpenAI (both dirs) | `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` |
| DashScope | `qwen3.8-max`, `qwen3.7-flash`, `qwen3.6-flash`, `qwen3.5-flash`, `qwen-flash` |
| Gemini | `gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-flash-lite`, `gemini-2.5-flash-lite` |
| Moonshot | `kimi-k2.7-code`, `kimi-k2.7-code-highspeed` |
| xAI | `grok-4.5`, `grok-4.20-0309-reasoning`, `grok-4.20-0309-non-reasoning`, `grok-4.20-multi-agent-0309`, `grok-build-0.1` |

DeepSeek needed nothing — it was already current.

Every context size, output size, input modality and reasoning capability comes from the vendor's own documentation. The one exception is called out below.

## Corrections to existing cards

- **`claude-opus-4-7` / `claude-opus-4-8`** — these generations reject `thinking.type: "enabled"`. Ticking the thinking toggle on those cards could only ever return a 400.
- **`claude-sonnet-4-6`** — `output_size` was 65536; the documented cap is 128k.
- **`claude-opus-4-6`** — said `131072` where its siblings said `128000` for the same documented "128k". Normalised to `128000`.
- **`gpt-5.5`** (both dirs) — declared `audio/mp3` and `audio/wav` input. OpenAI documents gpt-5.x input as text and image only, and the neighbouring `gpt-5.4` card already agreed.
- **`moonshot-v1-*`, `kimi-k2.5`** — marked deprecated with `deprecated_at: 2026-08-31`, their announced platform-wide retirement date.
- **`grok-3`, `grok-3-fast`, `grok-3-mini`** — marked deprecated; xAI no longer lists them in its model or pricing tables.
- **`gpt-4.1-nano`, `o4-mini`, `o3`, `gpt-audio-mini`** — marked deprecated with the shutdown dates OpenAI publishes (2026-10-23, 2026-10-23, 2026-12-11, 2027-01-20).

Every existing card was audited against each vendor's *deprecation* page, not just its model list — a model can stay documented while already carrying a retirement date. Anthropic, Gemini, DashScope and Ollama came back clean. DashScope retires dated snapshots only (`qwen-plus-0112`, `qwen-long-latest` and similar), so the bare aliases these cards use are unaffected.

## Claude thinking API

Claude's thinking configuration split into two modes: the original budget-based one (`{"type": "enabled", "budget_tokens": N}`) and an adaptive one (`{"type": "adaptive"}`) that Opus 4.7 and later accept **exclusively**. A single `thinking_enable` boolean can no longer express what those models need, so `AnthropicChatModel.Parameters` gains:

- `thinking_mode` — `adaptive` / `enabled` / `disabled`. Takes precedence over `thinking_enable`, which keeps its original meaning when no mode is set, so existing configurations are unaffected.
- `thinking_display` — `summarized` / `omitted`. Opus 4.7 and later default to `omitted`, which surfaces as empty thinking blocks in the UI, so the affected cards request summaries explicitly.
- `reasoning_effort` — `low` / `medium` / `high` / `xhigh` / `max`, sent inside Anthropic's `output_config.effort` rather than as a top-level field. Named to match the equivalent knob on OpenAI, xAI, Moonshot and DeepSeek. Supported levels vary by generation and each card is constrained accordingly; Sonnet 4.5 and Haiku 4.5 don't accept it at all and hide it.

Two API constraints are enforced in the request builder: adaptive mode never sends `budget_tokens`, and `disabled` never sends `display`. Both are rejected by the API.

### Incidental fix

`_call_api_with_structured_output` downgraded `tool_choice` to `"auto"` whenever thinking was enabled. That restriction applies to the budget-based mode only — adaptive thinking accepts forced tool use — so the downgrade now keys off the resolved mode instead of the boolean. This restores forced structured output on the newer models.

## One derived value

xAI publishes no max-output figure for **any** Grok model, including the ones already in the repo. The Grok cards derive `output_size` as 1/16 of the context window — the ratio used by the vendors that do publish one (Gemini 6.25%, Qwen 6.55%) — and say so in an inline comment so it isn't mistaken for an official number. This also replaces the unsourced `30000` that `grok-4.3` carried.

## Testing

- `tests/model_anthropic_test.py` — 12 new tests covering effort placement, adaptive vs budget mode, the two rejected-combination guards, legacy-toggle precedence, and the tool_choice downgrade condition. Verified non-vacuous by mutation: leaking `display` into `disabled` mode, letting the legacy toggle win over an explicit mode, and moving `reasoning_effort` to the top level each fail a corresponding test.
- Every card is loaded and its resolved parameter schema inspected, confirming each model exposes exactly the controls its vendor documents.
- `pytest tests/` — 1679 passed. The two failures in `tests/mcp_streamable_http_client_test.py` are pre-existing and reproduce on a clean tree.
- `pre-commit run --all-files` — all hooks pass, no files rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

