### PR TITLE
fix(utils): make DictMixin honor missing-attribute semantics

### DIFF
--- a/src/agentscope/_utils/_mixin.py
+++ b/src/agentscope/_utils/_mixin.py
@@ -6,4 +6,23 @@ class DictMixin(dict):
     """The dictionary mixin that allows attribute-style access."""
 
     __setattr__ = dict.__setitem__
-    __getattr__ = dict.__getitem__
+
+    def __getattr__(self, key: str) -> object:
+        """Get a dictionary item through attribute-style access.
+
+        Args:
+            key (`str`):
+                The requested attribute name.
+
+        Returns:
+            `object`:
+                The value stored under ``key``.
+
+        Raises:
+            `AttributeError`:
+                If the dictionary does not contain ``key``.
+        """
+        try:
+            return dict.__getitem__(self, key)
+        except KeyError as error:
+            raise AttributeError(key) from error

--- a/tests/mixin_test.py
+++ b/tests/mixin_test.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for dictionary-backed response attribute access."""
+from copy import deepcopy
+from unittest import TestCase
+
+from agentscope.message import TextBlock
+from agentscope.model import ChatResponse
+
+
+class DictMixinTest(TestCase):
+    """Test response behavior provided by ``DictMixin``."""
+
+    def test_chat_response_can_be_deep_copied(self) -> None:
+        """A chat response can be copied without sharing mutable fields."""
+        response = ChatResponse(
+            content=[TextBlock(text="hello")],
+            is_last=True,
+        )
+
+        copied = deepcopy(response)
+
+        self.assertEqual(copied, response)
+        self.assertIsNot(copied, response)
+        self.assertIsNot(copied.content, response.content)
+        self.assertIsNot(copied.content[0], response.content[0])
+
+    def test_missing_attributes_follow_attribute_protocol(self) -> None:
+        """Missing attributes use normal Python attribute semantics."""
+        response = ChatResponse(content=[], is_last=True)
+
+        self.assertFalse(hasattr(response, "missing"))
+        self.assertEqual(
+            getattr(response, "missing", "fallback"),
+            "fallback",
+        )
+        with self.assertRaises(AttributeError):
+            getattr(response, "missing")
+
+        with self.assertRaises(KeyError):
+            _ = response["missing"]


### PR DESCRIPTION
## AgentScope Version

2.0.5 (`main`, base commit `2c2f612`)

## Description

Fixes #2239

`DictMixin.__getattr__` delegated directly to `dict.__getitem__`, so a missing attribute raised `KeyError`. This violated Python's attribute protocol and broke consumers that probe optional attributes, including `hasattr()`, `getattr(..., default)`, and `copy.deepcopy()`.

This PR:

- translates a missing mapping key into `AttributeError` for attribute-style access;
- preserves the existing built-in `dict.__getitem__` dispatch for present keys;
- preserves `KeyError` for direct mapping access such as `response["missing"]`;
- adds public `ChatResponse` regression tests for missing attributes and independent nested deep copies.

Behavioral note: missing attribute access now raises the standard `AttributeError` instead of the previous non-standard `KeyError`. Direct mapping access is unchanged.

### Validation

- `python -m pytest tests/mixin_test.py tests/model_response_test.py -q -p no:cacheprovider` — 18 passed
- `pre-commit run --all-files` — all hooks passed
- Full-suite comparison in the same Windows environment:
  - patched branch: 1428 passed, 287 skipped, 92 failed
  - clean base `2c2f612`: 1426 passed, 287 skipped, 92 failed
  - the same 92 environment/optional-dependency failures occur on both revisions; this branch adds two passing regression tests and no new failures

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation has been updated (not applicable: this fixes existing behavior without adding or changing a documented public API)
- [x] Code is ready for review