### PR TITLE
fix(webui): reset confirmation state between tool calls

### DIFF
--- a/examples/web_ui/frontend/src/components/chat/ChatContent.tsx
+++ b/examples/web_ui/frontend/src/components/chat/ChatContent.tsx
@@ -37,7 +37,7 @@ interface ChatContentProps {
 		confirm: boolean,
 		replyId: string,
 		rules?: ToolCallBlock['suggested_rules'],
-	) => void;
+	) => Promise<void>;
 	autoComplete?: (input: string) => string | null;
 	className?: string;
 	/** Called when the user clicks the stop button. */
@@ -123,15 +123,16 @@ const ChatContentComponent: React.FC<ChatContentProps> = ({
 				>
 					{toConfirmedToolCalls.length > 0 ? (
 						<ConfirmCard
+							key={`${toConfirmedToolCalls[0].replyId}:${toConfirmedToolCalls[0].toolCall.id}`}
 							toolCall={toConfirmedToolCalls[0].toolCall}
-							onUserConfirm={async (confirm, rules) => {
+							onUserConfirm={(confirm, rules) =>
 								onUserConfirm(
 									toConfirmedToolCalls[0].toolCall,
 									confirm,
 									toConfirmedToolCalls[0].replyId,
 									rules,
-								);
-							}}
+								)
+							}
 						/>
 					) : (
 						footerSlot

--- a/examples/web_ui/frontend/src/components/chat/ConfirmCard.tsx
+++ b/examples/web_ui/frontend/src/components/chat/ConfirmCard.tsx
@@ -1,6 +1,6 @@
 import type { ToolCallBlock } from '@agentscope-ai/agentscope/message';
 import { ChevronRight } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { getDisplayName, renderConfirmBody } from './tool-renderers';
 import { Button } from '@/components/ui/button';
@@ -20,19 +20,28 @@ export function ConfirmCard({
 }) {
 	const { t } = useTranslation();
 	const hasSuggestedRules = !!toolCall.suggested_rules?.length;
-	const options: SelectOption[] = hasSuggestedRules
-		? ['yes', 'yes_with_rule', 'no']
-		: ['yes', 'no'];
+	const options = useMemo<SelectOption[]>(
+		() => (hasSuggestedRules ? ['yes', 'yes_with_rule', 'no'] : ['yes', 'no']),
+		[hasSuggestedRules],
+	);
 	const [selected, setSelected] = useState<SelectOption>('yes');
-	const [hasConfirmed, sethasConfirmed] = useState<boolean>(false);
+	const [hasConfirmed, setHasConfirmed] = useState<boolean>(false);
+	const submittingRef = useRef(false);
 
-	const handleConfirm = async (confirm: boolean, rules?: ToolCallBlock['suggested_rules']) => {
-		if (hasConfirmed) return;
-		sethasConfirmed(true);
-		onUserConfirm(confirm, rules).catch(() => {
-			sethasConfirmed(false);
-		});
-	};
+	const handleConfirm = useCallback(
+		async (confirm: boolean, rules?: ToolCallBlock['suggested_rules']) => {
+			if (submittingRef.current) return;
+			submittingRef.current = true;
+			setHasConfirmed(true);
+			try {
+				await onUserConfirm(confirm, rules);
+			} catch {
+				submittingRef.current = false;
+				setHasConfirmed(false);
+			}
+		},
+		[onUserConfirm],
+	);
 
 	useEffect(() => {
 		const handleKeyDown = async (e: KeyboardEvent) => {
@@ -59,7 +68,7 @@ export function ConfirmCard({
 
 		window.addEventListener('keydown', handleKeyDown);
 		return () => window.removeEventListener('keydown', handleKeyDown);
-	}, [onUserConfirm, selected, options]);
+	}, [handleConfirm, selected, options, toolCall.suggested_rules]);
 
 	return (
 		<div className="bg-muted ring ring-border rounded-[28px] w-full px-6 py-5 space-y-4 text-sm overflow-hidden">

--- a/examples/web_ui/frontend/src/hooks/useMessages.ts
+++ b/examples/web_ui/frontend/src/hooks/useMessages.ts
@@ -377,6 +377,7 @@ export function useMessages(
 				});
 			} catch (e) {
 				setError(e as Error);
+				throw e;
 			}
 		},
 		[agentId, sessionId],


### PR DESCRIPTION
## AgentScope Version

`main` at `bf7e8ff75a234a55fbf2b4ae61e4bd43f138e94b`

## Description

Fixes #2242.

When multiple tool calls require confirmation, React reuses the same `ConfirmCard` for the next pending call. The card keeps the previous call's submitted state, so its controls stay disabled and the spinner does not stop.

This change:

- keys the card by reply and tool-call IDs;
- returns the confirmation request promise through `ChatContent`;
- propagates request failures so the card can reset;
- prevents duplicate submissions before React updates state.

No backend protocol changes are included.

Validation:

- `pnpm format:check`
- `pnpm --filter frontend build`
- `pnpm --filter backend build`
- `git diff --check`

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style (not applicable; no Python changes)
- [x] Related documentation has been updated (not applicable; WebUI behavior fix only)
- [x] Code is ready for review
