### PR TITLE
feat(examples): add ACP Agent (stdio) example (examples/acp/)

### DIFF
--- a/examples/acp/DESIGN.md
+++ b/examples/acp/DESIGN.md
@@ -1,0 +1,1166 @@
+# ACP Agent (stdio) example for AgentScope — design & build plan (examples/acp/)
+
+**Status:** v2 — revised against `main` as of 2026-08-06 and updated to
+match the shipped PR1 implementation in this directory. Original RFC
+discussed in [#1948](https://github.com/agentscope-ai/agentscope/discussions/1948).
+
+**Scope one-liner:** A fully runnable Agent Client Protocol (ACP)
+**Agent role, stdio transport** example under `examples/acp/`, built
+only on AgentScope's existing public API — a desktop shell (ACP Client,
+e.g. Zed) drives an AgentScope kernel (ACP Agent) as a subprocess.
+**No changes to `agentscope/` core.**
+
+> **Changelog v1 → v2 (2026-08-06).** The v1 draft (2026-07-01) was
+> written against a late-June snapshot of `main`; core moved
+> significantly while it sat: **#1995** shipped first-class graceful
+> interruption (the v1 "core gap 1" is closed — §15), **#2001** added
+> the `on_check_permission` middleware hook (weakens v1 gaps 2/6),
+> **#2117** added a DEFAULT-mode read-only fast path plus batch
+> confirmation de-duplication (§12), the workspace grew five new
+> sandbox backends (§13), and **#1997** added an app-layer `channel`
+> subsystem (§2). Two v1 claims were wrong at writing time and are
+> corrected here: Glob never used `find` (§13), and
+> `ReActConfig.stop_on_reject` is declared but consumed nowhere (§18).
+> The op-id binding mechanism (invariant c) was redesigned after
+> implementation showed the v1 ContextVar timing does not survive
+> concurrent tool batches (§14). On the ACP side: the SDK pin moved to
+> 0.12.0, and the v1 claims about SDK/schema versions are corrected
+> (§21 q6, §22).
+
+---
+
+## 0. Header
+
+- **Title:** ACP Agent (stdio) example for AgentScope — design & build plan (examples/acp/)
+- **Status:** v2, implemented (PR1) — see §20 for what shipped vs follow-ons
+- **Deliverable:** `examples/acp/` — a fixed, out-of-the-box general assistant *with coding capabilities*, exposed to any ACP desktop shell over stdio, isolated behind a single `build_agent()` factory so it is trivially forkable into a template.
+- **Non-deliverable (this phase):** any in-tree `agentscope/acp/` module, any core surface-area change, the ACP Client direction, HTTP/WebSocket transport.
+
+---
+
+## 1. Summary & scope
+
+We ship `examples/acp/`: an ACP **Agent** that speaks newline-delimited
+JSON-RPC 2.0 over **stdin/stdout**, wrapping an AgentScope
+`agentscope.agent.Agent`. A desktop code editor (the ACP **Client**)
+spawns the example as a subprocess, calls `initialize` / `session/new` /
+`session/prompt`, and receives streamed `session/update` notifications
+produced by translating AgentScope's `AgentEvent` stream (from
+`Agent.reply_stream`).
+
+**In scope (Phase 1, implemented):**
+- ACP **Agent** role only.
+- **stdio** transport only.
+- The event→protocol mapping built on public API: `Agent`,
+  `reply_stream` → `AgentEvent` union, and the AgentEvent→protocol
+  *conversion pattern* (the same idea the AG-UI middleware uses,
+  re-implemented for stdio).
+- Default **shell delegation** of filesystem *and* terminal (client owns
+  the workspace) via a single client-delegating backend, with an
+  **opt-in** AgentScope Workspace sandbox mode.
+- Receipt-ready event invariants (stable ids, capability snapshot,
+  operation ids, permission binding, terminal taxonomy) as PR1
+  *acceptance criteria*, enforced by the test suite (§19).
+
+**Deferred / out of scope:**
+- The ACP **Client** direction (AgentScope driving Claude Code / Codex
+  as sub-agents).
+- **HTTP / WebSocket** transport. The transport is an in-progress RFD;
+  the Python SDK ships an RFD-based implementation as of 0.12.0, but
+  stdio remains the only stable transport and this example stays
+  stdio-only.
+- Any promotion into an in-tree SDK — reassessed in Phase 2.
+- **No changes to `agentscope/` core.** Everything below is composed
+  from already-public symbols; remaining friction points are flagged as
+  *core gaps to raise separately* (§15), not patched here.
+
+---
+
+## 2. Background & motivation
+
+**The desktop kernel↔shell seam.** ACP factors an agentic coding
+session into two roles: the **Client** (the editor/IDE — owns the UI,
+the open buffers, the local filesystem and terminal) and the **Agent**
+(the model-driven kernel — owns planning, tool intent, and the streamed
+narration of a turn). They talk JSON-RPC over stdio. AgentScope already
+*is* a kernel: `Agent.reply_stream` emits a structured `AgentEvent`
+stream that describes exactly what a turn is doing. ACP is the
+desktop-native presentation of that stream.
+
+**Adapters over one core.** AgentScope now has two in-tree adapter
+families over the AgentEvent core: the **AG-UI** middleware
+(`app/middleware/_protocol/_agui.py`, `AgentEvent` → AG-UI SSE for
+web/HTTP front-ends) and the **channel** subsystem
+(`app/channel/`, #1997 — long-lived IM connectors such as Feishu and
+Discord, built on the service stack's gateway/message-bus). ACP is a
+third presentation of the same stream — the desktop/stdio case:
+
+```
+              AgentScope Agent.reply_stream  ──▶  AgentEvent stream
+                    │                 │                    │
+        (web / HTTP)│    (IM platforms)│     (desktop / stdio)
+                    ▼                 ▼                    ▼
+          AG-UI SSE middleware   app.channel        examples/acp/
+          (service extra)        (service stack)    (this example)
+```
+
+Neither in-tree adapter fits the ACP seam: the AG-UI middleware is
+HTTP-bound (Starlette `BaseHTTPMiddleware`, behind the `service`
+extra), and channels are service-layer constructs (gateway, message
+bus, storage, the `channel` extra) for persistent platform
+connections — not a subprocess speaking JSON-RPC on stdio. The example
+builds its **own** stdio peer (from the ACP SDK) and reuses only the
+*mapping idea* and the discriminated-union deserialization pattern.
+
+**The kernel we ship.** A **general assistant with coding
+capabilities**: an `Agent` with the builtin tools (`Read`, `Write`,
+`Edit`, `Bash`, `Grep`, `Glob`) plus a permission engine, wired so
+file/terminal operations are *mediated by the shell* by default. It
+works against a real ACP client (Zed) out of the box. (Windows-minded
+forkers can swap `Bash` for the builtin `PowerShell` tool through the
+same `backend=` seam.)
+
+**Why example-first.** ACP's v1 schema line is stable but the protocol
+is still moving (v2 exists as a draft); the Python SDK is pre-1.0.
+Committing an in-tree module or a core surface to a still-moving
+protocol is premature. An example on public API proves which
+abstractions matter, ships value now, and is trivially removable if ACP
+churns. *Merging proven functionality later is easier than removing
+unproven functionality.* (See §3, DavdGao Concern 1.)
+
+---
+
+## 3. Maintainer concerns addressed (explicit)
+
+### Concern 1 (DavdGao) — infrastructure duplication vs the multi-tenant core stack
+
+The worry: an ACP integration might duplicate the multi-tenant core
+stack (sessions, storage, service layer) or bake ACP-specific surface
+into `agentscope/` while the protocol is still moving.
+
+**Resolution.** `examples/acp/` uses **only public API** and adds
+**zero** core surface:
+- It does **not** import the service layer (`agentscope.app.*`) or its
+  extras (FastAPI/uvicorn/AG-UI/channel). The stdio peer comes from the
+  ACP SDK (§16).
+- It does **not** reintroduce a multi-tenant session manager. The
+  library's entire public "session" concept is `AgentState.session_id`;
+  the example keeps an in-process `dict[SessionId, Session]` and can
+  persist with `AgentState.model_dump`/`model_validate` if/when
+  `session/load` is added. No Redis, no `agentscope.app.storage`.
+- The new `app.channel` subsystem (#1997) confirms the pattern this
+  example deliberately avoids duplicating: channels live in the service
+  stack precisely because they need its gateway and message bus. The
+  stdio example needs neither.
+- All required behavior is reachable from public symbols (§15). Where
+  friction remains, we **flag it as a gap to raise separately** and
+  work around it in the example — we do **not** patch core here.
+- **Phase 2** reassesses promotion (in-tree `agentscope/acp/`, a
+  separate `agentscope-acp` package, or in-between) *after* the example
+  proves the abstractions and ACP stabilizes; the channel subsystem now
+  provides an in-tree precedent to judge that promotion against.
+
+### Concern 2 (DavdGao) — kernel positioning / configuration
+
+The worry: should the example ship a fixed agent, or a fully
+user-configurable one? A fixed agent risks being a toy; a
+fully-configurable one risks being an empty framework with no runnable
+default.
+
+**Resolution — IN-BETWEEN.** Ship a **fixed, runnable default agent**
+(general assistant with coding capabilities) that works out of the box,
+with all agent construction isolated in a single `build_agent()`
+factory and model/credentials supplied via **environment variables**.
+What the *example author* fixes = the ACP wiring + the default agent.
+What is *exposed to the user* = model/creds via env, plus the
+`build_agent()` seam a forker edits to swap in their own agent. A
+finished demo that is trivially forkable into a template. The explicit
+**fixed-vs-exposed** matrix is in §7.
+
+---
+
+## 4. Goals / Non-goals
+
+**Goals**
+1. A subprocess that any ACP-compliant desktop client can spawn and
+   drive over stdio, demoable against **Zed**.
+2. Faithful mapping of a full AgentScope turn (`reply_stream`) onto ACP
+   `session/prompt` semantics: streamed text/thinking, tool calls,
+   permission prompts, fs/terminal callbacks, stop reason.
+3. **Shell-delegation** as the default fs/terminal authority (client
+   owns the workspace, sees unsaved buffers).
+4. **Receipt-ready invariants** (§14) satisfied so a later, optional
+   receipt emitter needs no log-scraping.
+5. Zero core changes; a single `build_agent()` seam; env-based config.
+
+**Non-goals**
+1. ACP Client role; HTTP/WebSocket transport.
+2. Persistent multi-tenant storage / service layer.
+3. Full ACP optional-method coverage in PR1 (`session/load`,
+   `session/resume`, modes, config options) — *follow-ons within the
+   example* (§20).
+4. Emitting the actual receipt in PR1 — the emitter is an optional,
+   derived, vendor-neutral follow-on. PR1 only *guarantees the
+   invariants that make it possible*.
+
+*(The v1 draft listed "a first-class `Agent.interrupt()`" as a
+non-goal-slash-core-gap; #1995 closed that gap upstream, so
+interruption is now simply part of Goal 2 — see §12, §15, §18.)*
+
+---
+
+## 5. Architecture overview
+
+```
+  ┌────────────────────────────┐     stdio (newline-delimited JSON-RPC 2.0)    ┌──────────────────────────────────────────────┐
+  │      Desktop shell         │ <──────────────────────────────────────────>  │     examples/acp/ kernel (ACP Agent)         │
+  │       (ACP Client)         │  client→agent: initialize, session/new,       │                                              │
+  │   e.g. Zed / any IDE       │    session/prompt, session/cancel             │  ┌────────────────────────────────────────┐  │
+  │                            │  agent→client: session/update (notif),        │  │ stdio JSON-RPC peer (acp.run_agent —   │  │
+  │  owns: UI, open buffers,   │    session/request_permission,                │  │ SDK; task-per-inbound dispatch)        │  │
+  │  local FS + terminal       │    fs/read_text_file, fs/write_text_file,     │  └──────────────────┬─────────────────────┘  │
+  └────────────────────────────┘    terminal/*                                 │                     │ Agent-role handlers    │
+                                                                               │  ┌──────────────────▼─────────────────────┐  │
+                                                                               │  │ session manager (dict[SessionId,       │  │
+                                                                               │  │ Session]; AgentState + turn task/guard │  │
+                                                                               │  │ + per-session OpRegistry)              │  │
+                                                                               │  └──────────────────┬─────────────────────┘  │
+                                                                               │                     │ build_agent()          │
+                                                                               │  ┌──────────────────▼─────────────────────┐  │
+                                                                               │  │ AgentScope Agent (public API)          │  │
+                                                                               │  │ reply_stream(inputs) -> AgentEvent     │  │
+                                                                               │  └──────────────────┬─────────────────────┘  │
+                                                                               │          AgentEvent │ stream                 │
+                                                                               │  ┌──────────────────▼─────────────────────┐  │
+                                                                               │  │ translate.py AgentEvent → SessionUpdate│  │
+                                                                               │  └──────────────────┬─────────────────────┘  │
+                                                                               │  ┌──────────────────▼─────────────────────┐  │
+                                                                               │  │ bridge.py ClientBackend + permission   │  │
+                                                                               │  │ (shell delegation: fs/* + terminal/*;  │  │
+                                                                               │  │  OpBindingMiddleware; Workspace opt-in)│  │
+                                                                               │  └────────────────────────────────────────┘  │
+                                                                               └──────────────────────────────────────────────┘
+```
+
+**Internal layers**
+1. **stdio JSON-RPC peer** — from the official SDK (`acp.run_agent`
+   binds stdin/stdout; §16). The SDK's dispatcher runs one task per
+   inbound request/notification, so `session/cancel` and client
+   callbacks dispatch concurrently with an open `session/prompt` —
+   verified against SDK 0.12.0 source.
+2. **Session manager** — maps `SessionId` → an in-process `Session`
+   holding the AgentScope `Agent`, its `AgentState`, the capability
+   snapshot, the current **turn task + single-active-turn guard**
+   (§16, §18), and the per-session **OpRegistry** (§14).
+3. **AgentScope Agent** — constructed via `build_agent()` (§7, §16).
+   The kernel proper.
+4. **AgentEvent → session/update translator** (`translate.py`) —
+   a stateful per-session `Translator` mapping each `AgentEvent` to
+   zero or more `session/update` variants (§10).
+5. **fs / terminal / permission bridge** (`bridge.py`) — a single
+   `ClientBackend(BackendBase)` implementing **all three** backend
+   primitives (`read_file`/`write_file` → client `fs/*`; `exec_shell`
+   → client `terminal/*`) under shell delegation, or a Workspace
+   backend under the opt-in sandbox mode; the `OpBindingMiddleware`
+   that binds backend calls to their enclosing tool call (§14 c); and
+   the `RequireUserConfirmEvent` ↔ `session/request_permission`
+   conversion (§12).
+
+**Built only on public API.** Nothing here subclasses or imports
+core-internal machinery. The one deliberate reuse from AG-UI is
+*conceptual*: the event→protocol mapping shape. (The v1 draft also
+planned to reuse the `TypeAdapter` discriminated-union deserialization;
+in-process the translator receives typed `AgentEvent` objects directly,
+so no deserialization is needed at all.)
+
+---
+
+## 6. examples/acp/ file layout
+
+The runnable package is named **`acp_example`** — it cannot be named
+`acp` because that is the SDK's import name.
+
+```
+examples/acp/
+├── DESIGN.md            # this document
+├── README.md            # what it is; how to run; Zed setup; fork guide
+├── requirements.txt     # agent-client-protocol==0.12.0 ; agentscope ; pytest
+├── pytest.ini
+├── acp_example/
+│   ├── __init__.py
+│   ├── __main__.py      # `python -m acp_example` — serve over stdio
+│   ├── server.py        # Agent-role handlers (initialize / new_session /
+│   │                    #   prompt / cancel); child turn task + stop reason
+│   ├── agent.py         # build_agent() — the single fixed-vs-exposed seam (§7)
+│   ├── session.py       # Session + SessionManager; capability snapshot;
+│   │                    #   single-active-turn guard
+│   ├── translate.py     # AgentEvent -> SessionUpdate mapping (§10, §11)
+│   ├── bridge.py        # ClientBackend (fs/* + terminal/*), OpRegistry +
+│   │                    #   OpBindingMiddleware (§14c), permission bridge (§12)
+│   └── config.py        # env parsing: provider/creds, authority mode, name
+└── tests/               # §19 — mock-client harness + unit tests
+    ├── conftest.py
+    ├── mock_client.py   # scripted ACP client: fs from a temp dir,
+    │                    #   terminals backed by real subprocesses
+    ├── mock_model.py    # scripted ChatModelBase (mirrors tests/utils.py)
+    ├── test_translate.py
+    ├── test_server.py
+    └── test_stdio_rpc.py  # wire-level smoke test over a socket pair
+```
+
+Optional follow-on files (later PRs within the example, §20):
+`receipt.py` (derived receipt emitter), `persist.py` (`session/load`
+via `AgentState.model_dump`).
+
+---
+
+## 7. Positioning & configuration (Concern 2 resolved)
+
+The example is **IN-BETWEEN**: a fixed runnable default, with agent
+construction isolated in `build_agent()` and model/creds via env.
+
+- **The fixed default agent** — a general assistant with coding
+  capabilities: an `agentscope.agent.Agent` named `"agentscope-acp"`, a
+  coding-oriented `system_prompt`, a `Toolkit` carrying
+  `Read`/`Write`/`Edit`/`Bash`/`Grep`/`Glob`, and a
+  `PermissionMode.DEFAULT` permission posture.
+- **`build_agent()` factory** — the *single* place agent construction
+  lives (`agent.py`). It reads `config.py` (env), picks the model,
+  builds the `Toolkit` (with the client-delegating backend by default,
+  gated on client capabilities; or a Workspace backend when the sandbox
+  env flag is set), and returns a constructed `Agent`. A forker edits
+  this one function.
+- **Env vars** — model provider + credentials + a few knobs; nothing
+  agent-structural is hard-coded to a vendor.
+
+### Fixed-vs-exposed matrix
+
+| Concern | FIXED by the example author | EXPOSED to the user |
+|---|---|---|
+| ACP wiring (peer, routing, lifecycle) | Yes — `server.py`, `session.py` | No |
+| AgentEvent→session/update mapping | Yes — `translate.py` | No |
+| fs/terminal/permission bridge semantics | Yes — `bridge.py` (single `ClientBackend`) | Authority **mode** toggle only (env: `ACP_AUTHORITY=shell` \| `workspace`) |
+| The default agent (name, system prompt, tool set, permission posture) | Yes — default inside `build_agent()` | Overridable by editing `build_agent()` (fork seam) |
+| Model provider & class | Default provided (`dashscope`/`qwen-max`) | `ACP_MODEL_PROVIDER`, `ACP_MODEL_NAME` (env) |
+| Credentials / API base | — | `*_API_KEY`, `*_BASE_URL` (env) — never committed |
+| Permission mode / rules | Default `PermissionMode.DEFAULT` | `ACP_PERMISSION_MODE` (env) → `AgentState.permission_context.mode`; rules editable in `build_agent()` |
+| Workspace sandbox backend | Off by default; `local` wired | Opt-in via `ACP_AUTHORITY=workspace` + `ACP_WORKSPACE_BACKEND`; other backends wired in `build_agent()` |
+| Advertised capabilities | Yes — minimal (§8) | Indirect (follows authority mode) |
+| Tool gating on absent client caps | Yes — `build_agent()` omits tools whose channel is unavailable (§8, §13) | Indirect (follows client `fs`/`terminal` caps) |
+
+**How a forker turns the example into a template.** (1)
+`cp -r examples/acp/ my-acp-agent/`. (2) Edit **only** `build_agent()`
+— swap the model, system prompt, tool set, permission rules, or drop in
+a custom `Agent` subclass. (3) Leave
+`server.py`/`session.py`/`translate.py`/`bridge.py` untouched (the ACP
+plumbing is generic). (4) Set env, point Zed at
+`python -m acp_example`. Because the ACP surface never leaks into
+`build_agent()`, forking is a one-function edit.
+
+---
+
+## 8. Protocol surface
+
+Target **protocol version `1`** (the stable v1 schema line; the pinned
+SDK 0.12.0 bundles schema v1.19.0). `acp.PROTOCOL_VERSION = 1`.
+
+### ACP Agent methods implemented (Client → Agent)
+
+| Method | Kind | PR1? | Notes |
+|---|---|---|---|
+| `initialize` | request | **PR1** | Baseline. Returns `agentCapabilities`, `agentInfo`, `protocolVersion`. |
+| `session/new` | request | **PR1** | Baseline. Requires absolute `cwd`; returns `sessionId`. `mcpServers` accepted but not yet wired (§20). |
+| `session/prompt` | request | **PR1** | Baseline. Drives one `reply_stream` turn; returns `stopReason`. One active turn per session (§16, §18). |
+| `session/cancel` | notification | **PR1** | Baseline. Cancels the in-flight child turn task (§13, §16). |
+| `authenticate` | request | PR1 (no-op) | Local posture: advertise no `authMethods` ⇒ never called; implemented as a defensive no-op. |
+| `session/load` | request | Follow-on | Gated by `agentCapabilities.loadSession`; needs history replay (§9, §20). |
+| `session/set_mode` / `session/set_config_option` | request | Follow-on | Only if we expose `modes`/`configOptions`. |
+| `session/resume` / `session/close` / `session/list` / `session/delete` / `session/fork` | request | Deferred | Gated by respective `sessionCapabilities.*`; not advertised in PR1. |
+
+### ACP Client methods called (Agent → Client)
+
+| Method | Kind | PR1? | Gate we require the client to advertise |
+|---|---|---|---|
+| `session/update` | notification | **PR1** | Baseline (client must accept). |
+| `session/request_permission` | request | **PR1** | Baseline (client must implement). |
+| `fs/read_text_file` | request | **PR1** (shell mode) | `clientCapabilities.fs.readTextFile` |
+| `fs/write_text_file` | request | **PR1** (shell mode) | `clientCapabilities.fs.writeTextFile` |
+| `terminal/create` / `terminal/output` / `terminal/wait_for_exit` / `terminal/kill` / `terminal/release` | request | **PR1** (shell mode) | `clientCapabilities.terminal` — **required in shell mode**: the builtin file tools call `exec_shell` for existence/dir/mkdir/search checks, so fs delegation depends on `terminal/*` too (§13). |
+
+### Capabilities advertised at `initialize`
+
+PR1 advertises a **minimal** `AgentCapabilities` (the SDK defaults):
+- `loadSession: false` (flips to `true` when `session/load` lands).
+- `promptCapabilities`: `{image: false, audio: false, embeddedContext:
+  false}` — we accept baseline `text` and `resource_link` only. (Bump
+  once those are forwarded to the model.)
+- `mcpCapabilities`: `{http: false, sse: false}` (stdio MCP is baseline
+  and needs no capability — but is not wired yet, §20).
+- No `authMethods`; `agentInfo: Implementation(name="agentscope-acp",
+  title="AgentScope ACP Agent", version=...)`.
+
+The example **reads** `clientCapabilities` from the `initialize`
+request and stores the snapshot (§14 invariant b). Shell mode requires
+**both** `fs.readTextFile`/`fs.writeTextFile` **and** `terminal`:
+- If `fs.*` is absent, `Read`/`Write`/`Edit` are **omitted** in shell
+  mode (§13).
+- If `terminal` is absent, no client-delegated tool can run at all —
+  all are omitted until the user opts into Workspace mode (§13). Never
+  call a client method whose capability is false.
+
+---
+
+## 9. Session lifecycle mapping
+
+| ACP step | AgentScope mapping |
+|---|---|
+| `initialize` | Advertise `agentCapabilities` (§8); **snapshot** `clientCapabilities` (invariant b in §14). |
+| `session/new` (`cwd`) | Mint a `Session`: construct a fresh `AgentState()` and call `build_agent(cwd=..., state=..., conn=..., caps=..., ops=..., config=...)`. **The ACP `sessionId` = `AgentState.session_id`** so one stable id is shared end-to-end (invariant a). `cwd` must be absolute (rejected otherwise) and becomes the tools' working directory. |
+| `session/prompt` (`prompt: ContentBlock[]`) | Translate prompt blocks → a `UserMsg` (§11), then run **one turn** = `async for event in agent.reply_stream(inputs=user_msg)` inside a **child `asyncio.Task`** the handler awaits (§16). Each `AgentEvent` → zero or more `session/update`s (§10). A second `session/prompt` for a busy `sessionId` is **rejected** (§18). The request stays open for the whole turn. |
+| `session/cancel` (`{sessionId}`) | Cancel the **child turn task** (`sess.turn_task.cancel()`, never the request handler; §16). Since #1995 the core converts this into a *graceful* ending: unfinished tool calls close with `INTERRUPTED` results and the stream ends with `ReplyEndEvent(finished_reason=INTERRUPTED)` → `stopReason: "cancelled"`. |
+| stop-reason | Derived from **`ReplyEndEvent.finished_reason`** (table below). |
+| multi-session per connection | The single stdio connection holds `dict[SessionId, Session]`; each has its own `Agent`/`AgentState` and its own single-turn guard. The SDK's task-per-inbound receive loop lets sessions, turns and client callbacks interleave. |
+| `authenticate` | **Local no-op posture.** No `authMethods` advertised ⇒ the client creates sessions without auth; the handler is a defensive no-op. |
+
+### Stop-reason mapping
+
+`ReplyEndEvent` is **always** the terminal event of a completed stream
+and carries `finished_reason: ReplyFinishedReason` (plus a structured
+`error: ErrorInfo | None`). `ExceedMaxItersEvent` still exists but is
+an auxiliary signal emitted immediately *before* the terminal
+`ReplyEndEvent` — a consumer that tracks "last terminal event wins"
+would misreport max-iters turns, so the mapping keys on
+`finished_reason` alone:
+
+| `ReplyEndEvent.finished_reason` | `PromptResponse.stopReason` |
+|---|---|
+| `completed` | `end_turn` |
+| `exceed_max_iters` | `max_turn_requests` |
+| `interrupted` (task cancel, `UserInterruptEvent`, model-stream interrupt) | `cancelled` |
+| `error` | surfaced as a JSON-RPC internal error on the open `session/prompt` (with `ErrorInfo` detail) |
+| — (`max_tokens` / `refusal`) | **still unmapped:** AgentScope has no dedicated max-tokens or refusal turn-end signal; PR1 never emits these ACP stop reasons (unchanged gap, §21 q3). |
+
+**Pending-confirmation nuance.** When a turn yields
+`RequireUserConfirmEvent`, `reply_stream` *returns* (the generator
+completes, with **no** `ReplyEndEvent`) — the reply is *parked*. This
+is **not** the end of the ACP turn: the example resolves permission via
+`session/request_permission`, feeds the result back with a resume
+`reply_stream(inputs=UserConfirmResultEvent(...))`, and only reports
+`stopReason` when the *resumed* stream reaches its terminal
+`ReplyEndEvent`. If the client answers `{"outcome": "cancelled"}`, the
+parked reply is aborted with the public
+`reply_stream(inputs=UserInterruptEvent(reply_id=...))` input (#1995),
+which closes the ASKING tool calls with `INTERRUPTED` results. See §12.
+
+---
+
+## 10. Event mapping table
+
+Events arrive in-process as typed `AgentEvent` objects (discriminator
+`type` if serialization is ever needed). `session/update` variants are
+discriminated by `sessionUpdate`; the SDK's model names are
+`AgentMessageChunk`, `AgentThoughtChunk`, `ToolCallStart`
+(`sessionUpdate: "tool_call"`) and `ToolCallProgress`
+(`sessionUpdate: "tool_call_update"`).
+
+| AgentEvent (`type`) | Key fields | ACP mapping | Notes |
+|---|---|---|---|
+| `ReplyStartEvent` | `session_id`, `reply_id`, `name`, `role` | — | Turn boundary; `reply_id` recorded as the turn id (invariant a). |
+| `ReplyEndEvent` | `reply_id`, **`finished_reason`**, **`error`** | — (terminal) | The single terminal signal; drives the stop reason (§9). |
+| `ModelCallStartEvent` / `ModelCallEndEvent` | `model_name`; `input_tokens`, `output_tokens`, `finished_reason` | *(none)* | ACP `usage_update` requires *both* `used` (tokens in context) and `size` (total window); AgentScope reports per-call tokens and no window size, so a schema-valid `usage_update` is impossible — omitted entirely (unchanged gap, §21 q4). |
+| `TextBlockStartEvent` / `EndEvent` | `block_id` | — | Correlation markers only; chunks are additive in ACP, so a new `messageId` implies a new message and no start/end updates are needed. |
+| `TextBlockDeltaEvent` | `block_id`, `delta` | `agent_message_chunk` | One chunk per delta, `messageId = block_id`. |
+| `ThinkingBlock{Start,Delta,End}Event` | `block_id`, `delta` | `agent_thought_chunk` (deltas only) | Reasoning stream; `messageId = block_id`. |
+| `DataBlock{Start,Delta,End}Event` | `block_id`, `data` (b64), `media_type` | `agent_message_chunk` at **End** | Base64 deltas are buffered until `DATA_BLOCK_END` (partial base64 is not renderable), then emitted as one `image`/`audio` ContentBlock. |
+| `HintBlockEvent` | `block_id`, `source`, `hint` | **dropped** | Since #2134 every default-configured agent injects runtime-state hints (time, tasks, context usage) on ordinary turns; rendering them would leak internal system-reminder text into the client UI. *(v1 planned to render hints as agent text — reversed.)* |
+| `ToolCallStartEvent` | `tool_call_id`, `tool_call_name` | `tool_call` | `toolCallId = tool_call_id` (the operation id, invariant c), `title`, `kind` (§12), `status: "pending"`. |
+| `ToolCallDeltaEvent` | `tool_call_id`, `delta` (JSON fragment) | — (buffered) | ACP has no argument-delta update; fragments accumulate. |
+| `ToolCallEndEvent` | `tool_call_id` | `tool_call_update` | Emits the final `rawInput`; registers the pending op for middleware claiming (§14 c). |
+| `ToolResultStartEvent` | `tool_call_id`, `tool_call_name` | `tool_call_update` | `status: "in_progress"` — execution began (permission, if any, resolved). |
+| `ToolResultTextDeltaEvent` | `tool_call_id`, `delta` | `tool_call_update` | `content` *replaces* the collection, so each update carries the accumulated text. |
+| `ToolResultDataDeltaEvent` | `tool_call_id`, `block_id`, `data`, `media_type` | — (buffered) | Flushed into `content` at `TOOL_RESULT_END`. |
+| `ToolResultEndEvent` | `tool_call_id`, `state: ToolResultState`, `metadata` | `tool_call_update` | `SUCCESS→completed`; `ERROR`/`INTERRUPTED`/`DENIED→failed`, with the finer taxonomy label (invariant e) in `_meta.agentscope.result_state`. |
+| `ExceedMaxItersEvent` | `reply_id` | — | Auxiliary; the following `ReplyEndEvent(finished_reason=exceed_max_iters)` drives the stop reason. |
+| `RequireUserConfirmEvent` | `reply_id`, `tool_calls: [ToolCallBlock]` (state `asking`, with `suggested_rules`) | (drives) `session/request_permission` | Not a `session/update`; §12. |
+| `RequireExternalExecutionEvent` | `reply_id`, `tool_calls` | unsupported → abort | The fixed tool set has no external tools; if a forker's does, the example logs and aborts the turn via `UserInterruptEvent` (extend the handler for real external execution). |
+| `UserConfirmResultEvent` / `ExternalExecutionResultEvent` / **`UserInterruptEvent`** | — | — (resume/abort inputs) | Inputs fed back into `reply_stream`, not outputs. `UserInterruptEvent` (new since #1995) aborts a *parked* reply. |
+| `CustomEvent` | `name`, `value` | dropped | No stable ACP mapping; a forker can route these (e.g. onto `plan`). |
+
+**Correlation summary.** Streamed text/thinking/data blocks correlate
+by **`block_id`** → ACP `messageId`. Tool call/result lifecycle
+correlates by **`tool_call_id`** → ACP `toolCallId` (the operation id).
+Turn id = **`reply_id`**; session id = **`session_id`** (= ACP
+`sessionId`). No log-scraping needed (§14).
+
+---
+
+## 11. Content model mapping
+
+AgentScope message blocks → ACP `ContentBlock`. ACP `ContentBlock` is
+MCP-compatible (`type` discriminator), so MCP tool outputs forward with
+minimal transformation.
+
+| AgentScope block | ACP target | Mapping |
+|---|---|---|
+| `TextBlock(text)` | `TextContent` (`type:"text"`) | `acp.text_block`. Baseline; always allowed. |
+| `ThinkingBlock(thinking)` | `TextContent` inside `agent_thought_chunk` | The *update variant* marks it as thinking, not a distinct content type. |
+| `ToolCallBlock(name, input, state)` | `ToolCallStart` / `ToolCallProgress` | Not a ContentBlock — the tool-call channel (§10, §12). `input` (JSON string) → `rawInput`. |
+| `ToolResultBlock(output, state, metadata)` | `ToolCallContent[]` on `tool_call_update` | text → `Content{type:"content"}`; `state` → `status` + taxonomy. |
+| `DataBlock` w/ `Base64Source(data, media_type)` | `ImageContent` / `AudioContent` | By media type; other media degrade to a textual stand-in. Prompt-direction use gated by `promptCapabilities` (PR1: false). |
+| `DataBlock` w/ `URLSource(url, media_type)` | `ResourceLink` | `url` → `uri`. Baseline in prompts. |
+| `HintBlock` | — | Dropped (§10). |
+| Inbound `resource_link` | `TextBlock` | Rendered as a readable link mention for the model. |
+| Inbound embedded `resource` | `TextBlock` | Text resources are inlined defensively even though `embeddedContext` is not advertised. |
+
+**Plan handling.** AgentScope has no first-class "plan" block in the
+public event/message union, so ACP `plan` is **not emitted in PR1**
+(explicitly noted, not fabricated). Todo/plan-like `CustomEvent`s, if a
+forker emits them, can be mapped in a forked translator.
+
+---
+
+## 12. Tool-call & permission model
+
+### ToolCall lifecycle → `tool_call` / `tool_call_update`
+
+```
+ToolCallStartEvent      → tool_call            status=pending      (toolCallId, title, kind)
+ToolCallDelta…End       → tool_call_update     (final rawInput; deltas buffered)
+[permission gate, §below]
+ToolResultStartEvent    → tool_call_update     status=in_progress
+ToolResult*Delta        → tool_call_update     (content replaced with buffered output)
+ToolResultEndEvent      → tool_call_update     status=completed|failed  (content, rawOutput, taxonomy in _meta)
+```
+
+**`kind` mapping** (presentation hint only): `Read` → `read`,
+`Grep`/`Glob` → `search`, `Write`/`Edit` → `edit`,
+`Bash`/`PowerShell` → `execute`, others → `other`.
+
+### RequireUserConfirmEvent ↔ `session/request_permission`
+
+The AgentScope permission flow is a **park/resume** flow:
+
+1. Inside a turn, the agent finds `check_permission` returns
+   `ASK`/`PASSTHROUGH`, sets the `ToolCallBlock.state = ASKING`,
+   attaches `suggested_rules`, **yields
+   `RequireUserConfirmEvent(reply_id, tool_calls=[...])`**, and
+   `reply_stream` returns (the reply parks).
+2. The example sends **`session/request_permission`** to the client for
+   each gated tool call: `toolCall: ToolCallUpdate{toolCallId =
+   tool_call.id, title, rawInput}` (binds the request to the *exact
+   operation id* — invariant d), `options:` the four
+   `PermissionOptionKind`s (`allow_once`, `allow_always`,
+   `reject_once`, `reject_always`).
+3. The client returns `RequestPermissionResponse.outcome`:
+   - `{"outcome":"selected","optionId":...}` → mapped to a
+     `ConfirmResult(confirmed=..., tool_call=..., rules=...)`:
+     `allow_always` carries the core's own `suggested_rules` (they
+     encode the tool-specific `rule_content` — a path glob, a command
+     prefix) or a minted `PermissionRule(tool_name=...,
+     behavior=ALLOW, source="acp-client")`; `reject_always` a DENY
+     rule. Rules ride in `ConfirmResult.rules` and are applied by the
+     agent internally on resume — the example never touches the
+     private `agent._engine` (§15 gap 5).
+   - `{"outcome":"cancelled"}` → the turn is aborted: the parked reply
+     is closed via `reply_stream(inputs=UserInterruptEvent(reply_id))`
+     (closing ASKING calls as `INTERRUPTED`) and the open
+     `session/prompt` resolves with `stopReason:"cancelled"`.
+4. Otherwise the example resumes:
+   `reply_stream(inputs=UserConfirmResultEvent(reply_id,
+   confirm_results=[...]))`. The agent validates against the awaiting
+   tool-call ids, applies each decision (state `ALLOWED`, or a `DENIED`
+   `ToolResultEnd`), installs any `rules`, and continues the react
+   loop. Partial confirmations are allowed.
+
+### PermissionEngine composed with shell-mediated approval — one prompt, with stated exceptions
+
+Two approval authorities exist: AgentScope's `PermissionEngine`
+(kernel) and the client's own permission UI. To avoid double-prompting:
+
+- The kernel's `PermissionEngine` decides **whether a permission is
+  needed at all**. Only `ASK`/`PASSTHROUGH` surface
+  `session/request_permission`; an outright `ALLOW`/`DENY` never
+  prompts.
+- **Read-only fast path (#2117).** Under `PermissionMode.DEFAULT` the
+  engine auto-allows read-only invocations — `Read`, `Grep`, `Glob`
+  and read-only `Bash` commands never prompt. Only side-effecting
+  operations (`Write`/`Edit`/side-effecting `Bash`) reach the client.
+- The client is the **sole interactive prompt surface** for `ASK`
+  cases; the kernel is a subprocess with no UI and always delegates.
+- **Batch de-duplication (#2117).** Within one concurrent tool batch,
+  core suppresses a second ASK whose invocation is already covered by
+  an earlier confirmation's suggested rule — the call stays PENDING and
+  is re-evaluated after resume. So not every gated call yields its own
+  `RequireUserConfirmEvent`; the "exactly one prompt" property is
+  per-*operation*, sometimes resolved by an earlier prompt's rule.
+- **Bypass-immune safety ASKs (#2117).** Safety-critical decisions are
+  marked bypass-immune and are **not** silenced by installed allow
+  rules — a client may legitimately be prompted again for a dangerous
+  operation after `allow_always`. The v1 "no re-prompting after
+  allow_always" promise is therefore scoped to ordinary operations.
+- **No silent shell writes.** `PermissionMode.DEFAULT` gates
+  `Write`/`Edit`/side-effecting `Bash` behind ASK, so a gated operation
+  always surfaces exactly one client prompt *before* any side effect.
+- **Permission is bound to the exact `toolCallId`**, not to prompt text
+  (invariant d).
+- **Single-gate assumption.** The design assumes the client treats
+  `session/request_permission` as the sole interactive gate and does
+  not independently re-prompt on the resulting `fs/write_text_file` /
+  `terminal/*` callbacks; ACP clients are expected not to.
+
+**Alternative considered — `on_check_permission` middleware (#2001).**
+Core now exposes a live per-call interception hook
+(`MiddlewareBase.on_check_permission`): an adapter middleware could
+await the `session/request_permission` round-trip *inside* the reply
+loop and return ALLOW/DENY directly, avoiding the park/resume dance.
+The example deliberately stays on park/resume because it (a) preserves
+core's ASKING-state bookkeeping, `suggested_rules`, and batch
+de-duplication untouched, (b) keeps the turn cancellable at the gate
+through the same task-cancel path as everywhere else, and (c) leaves
+the permission UX identical for `session/load` replay later. Forkers
+wanting an in-turn gate now have a public seam for it. *(This replaces
+v1's "confirm-feedback ergonomics" core gap — the hook exists now.)*
+
+---
+
+## 13. Filesystem & terminal authority
+
+**Default = shell delegation.** The ACP Client owns the local
+filesystem and terminal (it sees unsaved editor buffers). The kernel
+routes file/terminal *operations* to the client through **one**
+backend.
+
+**One `ClientBackend(BackendBase)` implementing all three primitives.**
+`BackendBase` declares **three** `@abstractmethod` primitives —
+`exec_shell(command: list[str], *, cwd=None, timeout=None) ->
+ExecResult`, `read_file(path) -> bytes`, `write_file(path, data:
+bytes)` — and a subclass must implement all three. Moreover, the
+builtin file tools call `exec_shell` at runtime, so a client-delegating
+backend cannot be fs-only:
+
+- `Read` runs `file_exists` + `is_dir` (base helpers that call
+  `exec_shell(["test","-e"/"-d", path])`) *before* `read_file`.
+- `Write` calls `exec_shell(["mkdir","-p", parent])` plus `file_exists`.
+- `Edit` composes `read_file` + `write_file` with `file_exists`.
+- `Grep` shells out to **ripgrep** (`rg`) via `exec_shell`.
+- `Glob` runs `is_dir` plus the bundled **`_glob_helper.py`** script,
+  invoked as `[python3, <helper_path>, --pattern, P, --base-dir, D]`
+  through `exec_shell`. *(v1 wrongly said Glob runs `find`; the helper
+  script was already the implementation then. `find` is used by the
+  base-class `scandir`/`stat` helpers, which the fixed tool set does
+  not exercise.)*
+
+ACP has no `fs/exists`, `fs/is_dir`, `fs/list`, or `fs/search` method,
+so these existence/dir/mkdir/search paths can only route to
+`terminal/*`. The example therefore ships a **single** `ClientBackend`
+that routes:
+
+- `read_file(path)` → `fs/read_text_file` (returns content **including
+  unsaved editor buffers** — the point of delegation); bytes↔text
+  conversion is UTF-8 at the bridge (ACP's fs channel is text-only),
+- `write_file(path, data)` → `fs/write_text_file`,
+- `exec_shell(command, *, cwd, timeout)` → the client `terminal/*`
+  create→wait→output→release pattern, used both directly by `Bash` and
+  internally by `file_exists`/`is_dir`/`mkdir -p`/ripgrep/the Glob
+  helper. The returned `terminalId` is recorded against the op id
+  (§14 c); a timeout kills the terminal and reports the `ExecResult`
+  internal-failure code (−1). The ACP terminal merges stdout/stderr
+  into one stream, surfaced as `stdout`.
+
+**Same-machine reality check.** In practice the client spawns this
+kernel *locally*, so client-executed commands share the kernel's
+filesystem — which is what makes `rg` and the Glob helper (a path
+inside the installed `agentscope` package) resolvable at all. The
+client machine must have `rg` and `python3` on PATH for `Grep`/`Glob`;
+`Glob(glob_helper_path=...)` exists for exotic layouts. The split —
+existence/dir checks reflect *on-disk* state via `terminal/*` while
+content reads reflect *editor buffers* via `fs/*` — is an accepted
+approximation.
+
+**Consequence — terminal is in PR1.** fs-delegated `Read`/`Write`/
+`Edit` and exec-backed `Grep`/`Glob`/`Bash` **all** require the client
+`terminal` capability *in addition to* `fs.*`. The terminal bridge is
+part of PR1, not a follow-on.
+
+- **Absolute-path requirement:** ACP mandates absolute paths. The
+  backend resolves any relative path against the session `cwd` before
+  calling `fs/*`/`terminal/*`, and overrides `getcwd()` to return the
+  session `cwd` without a client round-trip.
+
+**Workspace opt-in sandbox mode.** Set `ACP_AUTHORITY=workspace`. In
+`build_agent()`, instead of the client-delegating backend, the tools
+are constructed with **one** Workspace backend implementing all three
+primitives natively — `LocalBackend` is wired out of the box, and any
+`agentscope.workspace` backend (**Docker, E2B, Daytona, K8s,
+OpenSandbox, Apple container, Bubblewrap** — all `BackendBase`
+subclasses, each behind its `workspace-*` extra) drops into the same
+one-line seam. Same tools, rebound via injection — no core change, and
+no client `fs`/`terminal` capability needed. (Tools are wired directly
+with `backend=...` rather than via `LocalWorkspace.list_tools()`,
+because `LocalWorkspace._backend` is hard-coded and not injectable —
+§15 gap 2.)
+
+**Authority boundary.** Shell owns local file/terminal *mediation* by
+default; kernel owns agent planning, tool intent, and `AgentEvent`
+production. In Workspace mode the kernel owns the sandboxed FS/terminal
+too. The mode is captured in the capability snapshot (invariant b).
+
+**Capability-absent handling (shell mode).**
+- `terminal` absent: nothing client-delegated can run (even
+  `Read`/`Write`/`Edit` need `exec_shell` for their existence checks) —
+  `build_agent()` omits **all** client-delegated tools, logs to stderr,
+  and the user opts into Workspace mode for local tools.
+- `fs.readTextFile` / `fs.writeTextFile` absent: `Read`/`Write`/`Edit`
+  are omitted (no silent fallback to touching local disk in shell
+  mode); `Grep`/`Glob`/`Bash` still run if `terminal` is present.
+
+---
+
+## 14. Receipt-ready event invariants (PR1 acceptance criteria)
+
+The receipt *emitter* is an optional, derived, vendor-neutral follow-on
+(§20). **PR1 nonetheless guarantees** that a receipt can be
+reconstructed *without log-scraping*. The five invariants and where
+each id comes from:
+
+| # | Invariant | Source (reuse core id vs mint+map) |
+|---|---|---|
+| **a** | **One stable turn/session id** shared by `session/new`+`session/prompt`, emitted tool calls, permission requests, and the final stop reason. | **Reuse core.** Session id = `AgentState.session_id` = ACP `sessionId`. Turn id = `reply_id` (on every event). |
+| **b** | **Initialized capability snapshot**, including whether fs/terminal are **shell-delegated** or **Workspace-backed** for that session. | **Mint+map at adapter.** Captured at `initialize` (client caps) + resolved at `session/new` (authority mode from env). Stored on the `Session`. |
+| **c** | **Stable operation id for every `fs/*`, `terminal/*`, and permission-gated tool call.** | **Reuse core id, threaded via middleware + ContextVar.** Tool-call op id = `tool_call_id` (= ACP `toolCallId`). Mechanism below. |
+| **d** | **Permission decision bound to the operation id**, not only to prompt text. | **Reuse core.** `session/request_permission.toolCall.toolCallId` = `tool_call_id`; the returned outcome maps into a `ConfirmResult(tool_call=<same id>)`. |
+| **e** | **Terminal result state taxonomy:** `completed` / `denied` / `cancelled` / `failed` / `interrupted`. | **Mint+map at adapter,** derived from `ToolResultState` (+ turn-level cancel): carried in `_meta.agentscope.result_state` on the final `tool_call_update`; terminal exit codes attach to the op record. |
+
+### The op-id binding mechanism (invariant c) — revised in v2
+
+`BackendBase.{read_file,write_file,exec_shell}` receive **no**
+enclosing `tool_call_id` (still a core gap — §15 gap 4). The v1 draft
+proposed setting a ContextVar when the event consumer observes
+`ToolResultStartEvent`. **Implementation showed that timing cannot
+work for concurrent tools:** AgentScope executes concurrency-safe
+tools (`Read`/`Grep`/`Glob`) in *parallel worker tasks* whose contexts
+are snapshotted when the batch starts — before the consumer sees any
+`TOOL_RESULT_START` — so a consumer-side ContextVar write never
+reaches them.
+
+The shipped mechanism binds from *inside* the tool's own task instead,
+using two public seams:
+
+1. The translator registers every completed tool call (`TOOL_CALL_END`
+   → `tool_call_id`, tool name, raw JSON input) in the session's
+   `OpRegistry` as *pending*.
+2. Every tool carries an `OpBindingMiddleware`
+   (`ToolMiddlewareBase`) that runs in the tool's execution context:
+   at invocation it *claims* the matching pending entry (by tool name,
+   disambiguated by parsed input when one batch calls the same tool
+   twice) and sets the `_CURRENT_TOOL_CALL_ID` ContextVar **inside the
+   worker task**, where every backend call the tool makes can see it.
+3. `ClientBackend` stamps each outbound `fs/*`/`terminal/*` call with
+   the ContextVar value into the `OpRegistry` records (path/command,
+   `terminalId`, exit code).
+
+A backend call outside any tool records `tool_call_id = None`. A
+first-class backend-call context in core would make the claim-matching
+unnecessary — kept as a gap to raise (§15 gap 4, §21 q2).
+
+---
+
+## 15. Public-API-only implementation notes
+
+Exact public symbols the example imports (all from AgentScope
+subpackages; top-level `agentscope` only re-exports `logger`,
+`setup_logger`, `set_id_factory`, `set_timestamp_factory`,
+`__version__`):
+
+- **`agentscope.agent`**: `Agent` (constructor: `name`,
+  `system_prompt`, `model`, `toolkit`, `state`, plus config objects).
+- **`Agent.reply_stream`** — the turn/streaming API. Current
+  signature: `reply_stream(inputs: Msg | list[Msg] |
+  UserConfirmResultEvent | UserInterruptEvent |
+  ExternalExecutionResultEvent | None = None, structured_schema=None,
+  yield_final_msg=False) -> AsyncGenerator[AgentEvent | Msg, None]`
+  (the `Msg` is only yielded when `yield_final_msg=True`, so the
+  event-only consumption here is unaffected; `structured_schema` is
+  #2150's structured-output support, unused by the example).
+- **`agentscope.event`**: the `AgentEvent` union and every subtype in
+  §10 — including the post-v1 additions `UserInterruptEvent` and the
+  `ReplyFinishedReason`-carrying `ReplyEndEvent` — plus
+  `ConfirmResult` (which lives here, not in `agentscope.message`).
+- **`agentscope.types`**: `ReplyFinishedReason`, `ErrorInfo`.
+- **`agentscope.permission`**: `PermissionMode`, `PermissionBehavior`,
+  `PermissionRule` (engine/context/decision types available but not
+  needed directly).
+- **`agentscope.tool`**: `Toolkit`; builtin tools `Read`, `Write`,
+  `Edit`, `Bash`, `Grep`, `Glob`; backend seam `BackendBase`,
+  `LocalBackend`, `ExecResult`; middleware seam `ToolMiddlewareBase`.
+- **`agentscope.workspace`** (opt-in sandbox): any of the
+  Docker/E2B/Daytona/K8s/OpenSandbox/AppleContainer/Bubblewrap
+  backends.
+- **`agentscope.message`**: `Msg`, `UserMsg`, blocks (`TextBlock`,
+  `DataBlock`, `Base64Source`, `ToolCallBlock`), `ToolResultState`.
+- **`agentscope.state`**: `AgentState` (session id +
+  `permission_context`), `model_dump`/`model_validate` for DIY
+  persistence.
+- **`agentscope.model` / `agentscope.credential`**: the provider
+  chat-model + credential pairs used by `_make_model()`.
+
+**None of the above requires a core change.**
+
+### Core gaps — status after the 2026-08 revision
+
+The v1 draft flagged six gaps. Two were closed or superseded upstream;
+four remain (renumbered):
+
+**Closed upstream:**
+- *(v1 gap 1)* **Hard interrupt — CLOSED by #1995.** Cancelling the
+  task consuming `reply_stream` is now a supported, gracefully-handled
+  path: core catches the `CancelledError`, closes unfinished tool
+  calls with `INTERRUPTED` results, emits
+  `ReplyEndEvent(finished_reason=INTERRUPTED)` plus a fallback
+  assistant message, and swallows the exception by default
+  (`ReActConfig.interruption_raise_cancelled_error=False`). A *parked*
+  reply (awaiting confirm/external execution) is aborted with the new
+  public `UserInterruptEvent` input. The only residue is naming — there
+  is no convenience method literally called `Agent.interrupt()` — not
+  worth a core issue.
+- *(v1 gap 2)* **Confirm-feedback ergonomics — SUPERSEDED by #2001.**
+  The `on_check_permission` middleware hook is a live, public
+  interception point (§12). The example stays on park/resume by
+  choice, not necessity.
+
+**Still open (flagged, not patched here):**
+1. **`usage_update` fidelity** *(v1 gap 4)*. AgentScope exposes
+   per-call `input_tokens`/`output_tokens`
+   (`ModelCallEndEvent`), not context-window `used`/`size`; a faithful
+   ACP `usage_update` needs a total-window signal, so it is omitted
+   (§10). Data gap, not a core-change request.
+2. **Backend injection via `LocalWorkspace`** *(v1 gap 3)*.
+   `LocalWorkspace._backend = LocalBackend()` remains hard-coded (not
+   a constructor param) after the workspace refactor (#1971). Avoided
+   by wiring tools directly with `backend=...`; minor.
+3. **No public API to install a `PermissionRule` on a running agent's
+   engine** *(v1 gap 6, softened)*. `Agent._engine` is still private
+   with no accessor, but two public paths exist: rules fed via
+   `ConfirmResult.rules` on resume (what the example uses), and the
+   engine reads `agent.state.permission_context.{allow,deny,ask}_rules`
+   live, so mutating the public state object is effective. An explicit
+   accessor would still be cleaner; low priority.
+4. **No mechanism to thread the enclosing `tool_call_id` into a
+   `BackendBase` call** *(v1 gap 5, sharpened)*. The three primitives
+   carry no call context, and — worse than v1 assumed — a
+   consumer-side ContextVar cannot reach concurrent tool tasks (§14).
+   The example works around it with middleware claim-matching; a
+   first-class backend-call context (a ContextVar set by
+   `toolkit.call_tool`, or a threaded parameter) would make this
+   robust for everyone. **This is the one gap worth raising as a core
+   issue.**
+
+---
+
+## 16. Implementation notes (as built)
+
+The full source lives beside this document; the load-bearing shapes:
+
+**`build_agent()` (`agent.py`)** — the fork seam. Signature grew two
+adapter-side parameters relative to the v1 sketch (`ops` — the
+session's `OpRegistry`; `config` — parsed env), because op binding
+(§14 c) needs the registry at tool-construction time:
+
+```python
+def build_agent(*, cwd, state, conn, caps, ops, config) -> Agent:
+    middleware = OpBindingMiddleware(ops)
+    if config.is_shell_authority:
+        backend = ClientBackend(conn=conn, session_id=state.session_id,
+                                cwd=cwd, ops=ops)
+        tools = _shell_tools(backend, cwd, caps, middleware)  # §13 gating
+    else:
+        backend = _make_workspace_backend(config)
+        tools = [Read(backend=backend, middlewares=[middleware]), ...]
+    state.permission_context.mode = PermissionMode(config.permission_mode)
+    return Agent(name=..., system_prompt=..., model=_make_model(config),
+                 toolkit=Toolkit(tools=tools), state=state)
+```
+
+**The turn (`server.py`)** — one ACP turn = a `reply_stream`, resumed
+across permission gates, in a child task:
+
+```python
+async def _run_turn(self, sess, inputs) -> str:
+    while True:
+        pending_confirm, finished = None, None
+        async for event in sess.agent.reply_stream(inputs):
+            if isinstance(event, RequireUserConfirmEvent):
+                pending_confirm = event; break
+            if isinstance(event, ReplyEndEvent):
+                finished = event.finished_reason        # #1995: the one
+                ...                                     # terminal signal
+            for update in sess.translator.translate(event):
+                await self._conn.session_update(session_id=sess.id,
+                                                update=update)
+        if pending_confirm is None:
+            return _stop_reason(finished)               # §9 table
+        results = await request_permission_for(self._conn, sess,
+                                               pending_confirm)
+        if results is None:                             # client cancelled
+            await self._drain_interrupt(sess, pending_confirm.reply_id)
+            return "cancelled"
+        inputs = UserConfirmResultEvent(reply_id=pending_confirm.reply_id,
+                                        confirm_results=results)
+```
+
+Cancellation notes (differ from the v1 sketch, because of #1995):
+- When `session/cancel` cancels the child task **inside**
+  `reply_stream`, no exception surfaces — the agent swallows the
+  `CancelledError` and the stream ends normally with
+  `finished_reason=interrupted`, which the loop above maps to
+  `"cancelled"`. The `except asyncio.CancelledError` branch exists
+  only for cancellation landing *outside* the generator (mid
+  `session_update` write, mid permission round-trip), where the
+  example closes the generator or aborts the parked reply via
+  `UserInterruptEvent`.
+- `PromptResponse{stopReason}` is **always** returned on cancel —
+  never a JSON-RPC error.
+
+**SDK surface used** (verified against `agent-client-protocol==0.12.0`):
+`acp.run_agent` (binds stdio, 50 MB buffer), `acp.Agent` base class
+(handlers: `initialize`, `new_session`, `prompt`, `cancel`,
+`authenticate`, `on_connect`), the `acp.interfaces.Client` methods
+(`session_update`, `request_permission`, `read_text_file`,
+`write_text_file`, `create_terminal`, `wait_for_terminal_exit`,
+`terminal_output`, `kill_terminal`, `release_terminal`),
+`acp.schema` models, `acp.RequestError`, and the content helpers
+(`text_block`, `image_block`, `audio_block`, `tool_content`). Handler
+and helper names are snake_case in the SDK; wire names remain the
+protocol's (`session/new`, `fs/read_text_file`, …).
+
+**Vendored fallback.** v1 planned a vendored newline-delimited
+JSON-RPC peer in case the SDK was judged immature. The SDK's stdio
+peer, task-per-inbound dispatcher and typed schema proved solid in
+implementation (§19 exercises the real wire), so the fallback is
+dropped; the SDK stays pinned in `requirements.txt`, **not** a core
+dependency.
+
+---
+
+## 17. End-to-end sequence (desktop, Agent role)
+
+```
+Shell (ACP Client, e.g. Zed)                    examples/acp/ kernel (ACP Agent)
+────────────────────────────                    ────────────────────────────────
+1. spawn subprocess: `python -m acp_example`  ─▶ acp.run_agent binds stdin/stdout;
+                                                  on_connect(conn) stores the Client handle
+2. → initialize { protocolVersion:1,
+      clientCapabilities:{fs:{readTextFile,      ◀─ InitializeResponse { protocolVersion:1,
+      writeTextFile}, terminal:true} }                agentCapabilities:{}, agentInfo }
+                                                   (snapshot clientCapabilities — invariant b)
+3. → session/new { cwd:"/abs/proj" }              build_agent(cwd=..., state=..., conn=..., caps=..., ops=...)
+                                                  ◀─ NewSessionResponse { sessionId = state.session_id }
+                                                   (sessionId == AgentState.session_id — invariant a)
+4. → session/prompt { sessionId,
+      prompt:[text_block("fix the bug in x.py")]}  try_begin_turn(); turn runs in a CHILD task
+                                                   (request stays OPEN for the whole turn)
+5.                                             ◀─ session/update agent_thought_chunk (messageId=block_id)
+6.                                             ◀─ session/update agent_message_chunk (streamed text)
+7.                                             ◀─ session/update tool_call
+                                                     { toolCallId, title:"Read", kind:"read",
+                                                       status:"pending" }        (op id — invariant c)
+8.  [DEFAULT read-only fast path: Read is
+     auto-allowed — NO permission prompt]      ◀─ terminal/create { command:"test", args:["-e", ...] } ...
+                                               ◀─ fs/read_text_file { path:"/abs/proj/x.py", sessionId }
+    → { content:"...file (incl. unsaved buffer)..." }
+9.                                             ◀─ session/update tool_call_update {status:"completed", ...}
+10.                                            ◀─ session/update tool_call
+                                                     { toolCallId', title:"Edit", kind:"edit",
+                                                       status:"pending" }
+11.  [permission gate: Edit is side-effecting
+      → engine returns ASK]                    ◀─ session/request_permission
+                                                     { sessionId, toolCall:{toolCallId'}, options:[
+                                                        allow_once, allow_always,
+                                                        reject_once, reject_always] }
+12. → { outcome:"selected", optionId:"allow_once" }
+                                                   map -> ConfirmResult(confirmed=True, tool_call=<id'>)
+                                                   resume: reply_stream(inputs=UserConfirmResultEvent)
+                                                   (decision bound to toolCallId' — invariant d)
+13.  [Edit: read + write via fs/*]             ◀─ fs/read_text_file { path } / fs/write_text_file { path, content }
+    → {}
+14.                                            ◀─ session/update tool_call_update
+                                                     { status:"completed", content:[...], rawOutput }
+                                                   (ToolResultState.SUCCESS -> completed — invariant e)
+15.  [model done -> ReplyEndEvent(completed)]
+                                               ◀─ PromptResponse { stopReason:"end_turn" }  (closes step 4)
+```
+
+*(v1 showed the permission prompt on the `Read` call; under #2117's
+read-only fast path a `Read` never prompts in DEFAULT mode, so the
+gate is illustrated on the `Edit`.)*
+
+If the user cancels mid-turn: `→ session/cancel {sessionId}`
+(notification) arrives concurrently → the kernel cancels the **child
+turn task** → core closes running tools with `INTERRUPTED` results and
+ends the stream with `finished_reason=interrupted` → the still-open
+`session/prompt` resolves with `stopReason:"cancelled"`. For an
+outstanding `session/request_permission`, the client answers
+`{"outcome":"cancelled"}` and the kernel aborts the parked reply via
+`UserInterruptEvent` (§12, §18).
+
+---
+
+## 18. Error handling & edge cases
+
+| Case | Handling |
+|---|---|
+| **JSON-RPC errors** | Handler exceptions map to JSON-RPC `Error{code,message}` (SDK does the encoding; `RequestError.invalid_params` / `.resource_not_found` / `.internal_error` helpers). Unknown sessions → invalid params; relative `cwd` → invalid params; a turn ending `finished_reason=error` → internal error carrying the `ErrorInfo`. Notifications never get responses. |
+| **Cancellation mid-tool** | `session/cancel` → cancel the **child turn task**, never the request-handler task. Core (#1995) converts this into `ToolResultState.INTERRUPTED` chunks + `ReplyEndEvent(finished_reason=interrupted)` and swallows the `CancelledError` (default `ReActConfig.interruption_raise_cancelled_error=False`); the turn loop maps it to `stopReason:"cancelled"`. Never leaks as a JSON-RPC error. Receipt taxonomy: `interrupted`. |
+| **Cancellation mid-permission** | The client answers the outstanding `session/request_permission` with `{"outcome":"cancelled"}` (per spec); the kernel aborts the parked reply via `UserInterruptEvent` — ASKING calls close as `INTERRUPTED` — and resolves `cancelled`. If the task cancel lands first, the `except CancelledError` path does the same close-out. |
+| **Second `session/prompt` while a turn is active** | Rejected with `-32603`. One `Agent`/`AgentState` must not be driven by two concurrent `reply_stream`s (context/state corruption). **Single-active-turn-per-session** invariant; different sessions remain fully independent. |
+| **Permission denial** | `reject_once`/`reject_always` → `ConfirmResult(confirmed=False)` → agent emits a `DENIED` `ToolResultEnd` → `tool_call_update{status:"failed"}` (taxonomy `denied`). The turn always continues — the model sees the denial and answers accordingly. *(v1 said "unless `ReActConfig.stop_on_reject=True`"; that field exists but is consumed nowhere in core — dead config, dropped here.)* |
+| **fs/terminal errors** | Client returns a JSON-RPC error for `fs/*`/`terminal/*`; the backend surfaces it as a raised read/write error or a non-zero `ExecResult`, which the tool converts into `ToolResultState.ERROR` → `tool_call_update{status:"failed"}`. Relative paths are resolved against the session cwd before any call leaves the process. |
+| **Capability absent** | Never call an fs/terminal method whose capability is false (§13). Degrade (omit the affected tool in `build_agent()`, log to stderr) rather than fall back to silently touching local disk in shell mode. |
+| **Large tool outputs / backpressure** | `terminal/create.outputByteLimit` (1 MiB) truncates from the beginning; tool-result text buffering keyed by `tool_call_id` sends accumulated `content` (which *replaces* the collection). The SDK's 50 MB stdio buffer covers large frames; `ContextConfig.tool_result_limit` (default 50000) caps what re-enters model context. |
+| **External tools** | `RequireExternalExecutionEvent` is not supported by the fixed tool set; if a forker's toolkit emits it, the example logs to stderr and aborts the turn via `UserInterruptEvent` (extend `server.py` for real external execution). |
+| **Malformed frames** | One JSON object per line; the SDK handles framing and `-32700` parse errors. The kernel MUST NOT write non-ACP text to stdout — all example logging goes to **stderr**. |
+| **Concurrent client calls during a turn** | The SDK dispatcher is task-per-inbound, so the child turn task can await `fs/*`/`terminal/*`/`session/request_permission` while `session/cancel` dispatches concurrently. Multiple sessions on one connection are independent. |
+
+---
+
+## 19. Testing & demo
+
+Implemented in `tests/` (all §14 invariants asserted):
+
+1. **Mock ACP client harness** (`mock_client.py`): serves `fs/*`
+   against a temp dir, backs `terminal/*` with **real subprocesses**,
+   records every `session/update`, and answers
+   `session/request_permission` from a script — so
+   Read/Write/Edit/Bash execute the full shell-delegation path
+   end-to-end.
+2. **Translator unit tests** (`test_translate.py`): block_id →
+   messageId and tool_call_id → toolCallId correlation; delta
+   buffering; `usage_update` omission; hint-drop; the
+   `ToolResultState` → status + taxonomy table.
+3. **Permission round-trip** (`test_server.py`):
+   `session/request_permission{toolCall.toolCallId == tool_call_id}`
+   (invariant d); allow → the write lands via `fs/write_text_file`;
+   reject → `DENIED` taxonomy and the turn continues;
+   `{"outcome":"cancelled"}` → parked reply aborted, `stopReason:
+   "cancelled"`, ASKING call closed as `interrupted`.
+4. **Read-only fast path**: a `Read` turn produces **no** permission
+   prompt under DEFAULT (#2117) and binds its `fs/read` + `terminal`
+   ops to the tool_call_id (invariant c).
+5. **Cancellation & concurrency**: `session/cancel` during a running
+   `Bash sleep` yields `stopReason:"cancelled"` (not a JSON-RPC
+   error), an `interrupted` tool result, and the session accepts a
+   fresh turn afterwards; a second `session/prompt` on a busy session
+   is rejected while parked at the gate.
+6. **Capability gating**: no `terminal` → no tools; no `fs.*` →
+   exactly `{Grep, Glob, Bash}`.
+7. **Wire-level smoke test** (`test_stdio_rpc.py`): the kernel behind
+   `acp.run_agent` driven by the SDK's own client connection over a
+   socket pair — real framing, routing and serialization.
+8. **e2e against a real shell (Zed)**: manual; setup documented in
+   `README.md`.
+
+---
+
+## 20. Phasing / milestones
+
+**Phase 1 — `examples/acp/`.**
+- **PR1 (this directory, implemented):** stdio peer (SDK) + session
+  manager (single-active-turn guard) + `build_agent()` +
+  `translate.py` + permission bridge + the single `ClientBackend`
+  delivering shell delegation over both `fs/*` and `terminal/*`,
+  gated on client capabilities; cancellable child-task turns; the five
+  §14 invariants enforced by tests.
+- **Follow-ons within the example:**
+  1. **Receipt emitter** — optional, derived, vendor-neutral; consumes
+     the invariant-carrying stream (can replay via `Msg.append_event`).
+  2. **`session/load`** — flip `loadSession=true`; persist/replay via
+     `AgentState.model_dump`/`model_validate`.
+  3. **MCP pass-through** — `session/new.mcpServers` (stdio baseline)
+     into `Toolkit(mcps=...)`.
+  4. **Workspace sandbox breadth** — exercise Docker/E2B/… backends
+     beyond the wired `LocalBackend`.
+  5. **Session modes / config options** — expose `modes` /
+     `configOptions`.
+  6. **Prompt capabilities** — forward `image`/`audio`/embedded
+     context to capable models and advertise accordingly.
+
+**Phase 2 — reassess SDK promotion.** Once ACP stabilizes, decide
+among: an in-tree `agentscope/acp/` module, a separate `agentscope-acp`
+package, or an in-between — now with `app.channel` as the in-tree
+precedent for adapter promotion. Merging proven functionality is easier
+than removing unproven functionality.
+
+---
+
+## 21. Open questions
+
+**Resolved:**
+- **fs/terminal default → shell-delegated** (client owns the workspace
+  and unsaved buffers; Workspace opt-in). Implemented (§13).
+- **Positioning → in-between** (fixed runnable default,
+  `build_agent()` seam, env config). Implemented (§7).
+- **Hard interrupt** *(v1 q1)* → closed upstream by #1995; the example
+  maps `finished_reason=interrupted` → `cancelled` and uses
+  `UserInterruptEvent` for parked replies. No core issue needed.
+- **Confirm-feedback ergonomics** *(v1 q7)* → superseded by #2001's
+  `on_check_permission` hook; the example documents why it stays on
+  park/resume (§12).
+
+**Genuinely open:**
+1. **Threading `tool_call_id` into the backend** *(sharpened)*. The
+   middleware claim-matching (§14 c) works but is heuristic under
+   same-tool-same-input concurrent batches. Worth a core proposal: a
+   ContextVar set by `toolkit.call_tool` around tool execution (or a
+   context parameter on the backend primitives). **Recommended to
+   raise as an issue.**
+2. **`stopReason` fidelity.** `max_tokens` and `refusal` still have no
+   `AgentEvent` source (`ReplyFinishedReason` covers
+   completed/interrupted/exceed_max_iters/error). Raise only if a
+   client is found to depend on them.
+3. **`usage_update` fidelity.** Needs a context-window `used`/`size`
+   signal from core (`ModelCallEndEvent` has per-call tokens only;
+   `ChatModelBase.context_size` exists but not tokens-in-context).
+4. **Plan mapping.** No first-class plan event; `sessionUpdate:"plan"`
+   stays unmapped. A `CustomEvent`-based convention is possible if
+   demand appears.
+5. **Rule installation on a running engine.** Two public paths exist
+   (§15 gap 3); is an explicit accessor worth core surface?
+6. **SDK / protocol churn.** Facts as of 2026-08-06: Python SDK
+   0.12.0 (2026-08-01; pre-1.0; bundles v1 schema 1.19.0; ships
+   RFD-based HTTP/WS transports), protocol v1 schema line at 1.20.0 —
+   with the SessionUpdate variants, StopReason values, usage_update
+   required fields and fs/terminal registry unchanged since 1.17.0 —
+   and **ACP v2 published as a Draft** (schema 2.0.0-alpha.2,
+   2026-07-21) with the known migrations (`authenticate`→`auth/login`,
+   `session/set_mode` removal, fs/terminal restructuring). Strategy
+   unchanged: pin the SDK, target protocol v1, keep the adapter thin
+   so a rename is a one-file change. *(v1 misstated the 0.10.1 pin as
+   bundling schema v0.13.6 — it bundled v0.12.2 — and called the
+   protocol pre-1.0; corrected.)*
+
+---
+
+## 22. References
+
+**ACP specification (target protocol version `1`)** —
+`github.com/agentclientprotocol/agent-client-protocol`:
+- `docs/protocol/v1/*.mdx` — initialization, session setup, prompt
+  turn, tool calls, content, file-system, terminals.
+- `schema/v1/schema.json` — v1 line, currently 1.20.0; the pinned SDK
+  bundles 1.19.0. v2 draft under `schema/v2/` (2.0.0-alpha.x).
+- JSON-RPC 2.0; stdio transport (newline-delimited, UTF-8; logs on
+  stderr).
+
+**ACP Python SDK** — `github.com/agentclientprotocol/python-sdk`;
+PyPI `agent-client-protocol` (import `acp`), **pinned `==0.12.0`**;
+`acp.PROTOCOL_VERSION = 1`; `acp.run_agent`, `acp.Agent`,
+`acp.interfaces.Client`, `acp.schema`, helpers.
+
+**AgentScope public modules** (under `src/agentscope/`, imported via
+subpackages): `agentscope.agent`, `agentscope.event`,
+`agentscope.types`, `agentscope.permission`, `agentscope.tool`,
+`agentscope.workspace`, `agentscope.message`, `agentscope.state`,
+`agentscope.model`, `agentscope.credential`.
+- **Reference only (not imported):** `agentscope.app.middleware
+  ._protocol` (AG-UI mapping idea), `agentscope.app.channel` (the
+  in-tree adapter precedent, #1997).

--- a/examples/acp/DESIGN.md
+++ b/examples/acp/DESIGN.md
@@ -284,6 +284,9 @@ The runnable package is named **`acp_example`** — it cannot be named
 examples/acp/
 ├── DESIGN.md            # this document
 ├── README.md            # what it is; how to run; Zed setup; fork guide
+├── pyproject.toml       # pip install -e . puts acp_example on sys.path
+│                        #   (an editor spawns the agent with the USER's
+│                        #    project as cwd, so -m must resolve anywhere)
 ├── requirements.txt     # agent-client-protocol==0.12.0 ; agentscope ; pytest
 ├── pytest.ini
 ├── acp_example/
@@ -305,6 +308,8 @@ examples/acp/
     ├── mock_model.py    # scripted ChatModelBase (mirrors tests/utils.py)
     ├── test_translate.py
     ├── test_server.py
+    ├── test_regressions.py  # *_always options, Edit e2e, URL data,
+    │                        #   timeout sentinel, cancel races
     └── test_stdio_rpc.py  # wire-level smoke test over a socket pair
 ```
 
@@ -507,7 +512,7 @@ minimal transformation.
 | `ToolCallBlock(name, input, state)` | `ToolCallStart` / `ToolCallProgress` | Not a ContentBlock — the tool-call channel (§10, §12). `input` (JSON string) → `rawInput`. |
 | `ToolResultBlock(output, state, metadata)` | `ToolCallContent[]` on `tool_call_update` | text → `Content{type:"content"}`; `state` → `status` + taxonomy. |
 | `DataBlock` w/ `Base64Source(data, media_type)` | `ImageContent` / `AudioContent` | By media type; other media degrade to a textual stand-in. Prompt-direction use gated by `promptCapabilities` (PR1: false). |
-| `DataBlock` w/ `URLSource(url, media_type)` | `ResourceLink` | `url` → `uri`. Baseline in prompts. |
+| `DataBlock` w/ `URLSource(url, media_type)` | `ResourceLink` | Tool-result direction only: the core emits `ToolResultDataDeltaEvent(url=..., data=None)`, which the translator surfaces as a `resource_link` content block on the final `tool_call_update`. Unreachable in the assistant-message direction (the core streams only `Base64Source` there). |
 | `HintBlock` | — | Dropped (§10). |
 | Inbound `resource_link` | `TextBlock` | Rendered as a readable link mention for the model. |
 | Inbound embedded `resource` | `TextBlock` | Text resources are inlined defensively even though `embeddedContext` is not advertised. |
@@ -554,13 +559,19 @@ The AgentScope permission flow is a **park/resume** flow:
 3. The client returns `RequestPermissionResponse.outcome`:
    - `{"outcome":"selected","optionId":...}` → mapped to a
      `ConfirmResult(confirmed=..., tool_call=..., rules=...)`:
-     `allow_always` carries the core's own `suggested_rules` (they
-     encode the tool-specific `rule_content` — a path glob, a command
-     prefix) or a minted `PermissionRule(tool_name=...,
-     behavior=ALLOW, source="acp-client")`; `reject_always` a DENY
-     rule. Rules ride in `ConfirmResult.rules` and are applied by the
-     agent internally on resume — the example never touches the
-     private `agent._engine` (§15 gap 5).
+     - `allow_always` carries the core's own `suggested_rules` (they
+       encode the tool-specific `rule_content` — a path glob, a
+       command prefix) or a minted, match-everything
+       `PermissionRule(tool_name=..., rule_content=None,
+       behavior=ALLOW, source="acp-client")`, riding in
+       `ConfirmResult.rules` — the core applies them on resume.
+     - `reject_always` **cannot** ride the confirmation: the core
+       applies `ConfirmResult.rules` only when `confirmed=True` (the
+       documented contract). The example instead appends the DENY rule
+       directly to the public
+       `agent.state.permission_context.deny_rules` — which the engine
+       evaluates live — so the rejection persists. Neither path
+       touches the private `agent._engine` (§15 gap 3).
    - `{"outcome":"cancelled"}` → the turn is aborted: the parked reply
      is closed via `reply_stream(inputs=UserInterruptEvent(reply_id))`
      (closing ASKING calls as `INTERRUPTED`) and the open
@@ -882,49 +893,59 @@ def build_agent(*, cwd, state, conn, caps, ops, config) -> Agent:
 ```
 
 **The turn (`server.py`)** — one ACP turn = a `reply_stream`, resumed
-across permission gates, in a child task:
+across permission gates. The generator is consumed by a dedicated
+**driver task** whose only awaits are the generator's `__anext__`
+steps; events are handed to the request handler through a queue and
+forwarded from there:
 
 ```python
 async def _run_turn(self, sess, inputs) -> str:
     while True:
-        pending_confirm, finished = None, None
-        async for event in sess.agent.reply_stream(inputs):
-            if isinstance(event, RequireUserConfirmEvent):
-                pending_confirm = event; break
-            if isinstance(event, ReplyEndEvent):
-                finished = event.finished_reason        # #1995: the one
-                ...                                     # terminal signal
+        queue = asyncio.Queue()
+        stream = sess.agent.reply_stream(inputs)
+        sess.driver_task = asyncio.create_task(
+            self._drive_stream(stream, queue))     # only awaits __anext__
+        while (event := await queue.get()) is not _STREAM_END:
+            ...  # record reply_id / finished_reason; park on confirm
             for update in sess.translator.translate(event):
                 await self._conn.session_update(session_id=sess.id,
                                                 update=update)
-        if pending_confirm is None:
-            return _stop_reason(finished)               # §9 table
-        results = await request_permission_for(self._conn, sess,
-                                               pending_confirm)
-        if results is None:                             # client cancelled
-            await self._drain_interrupt(sess, pending_confirm.reply_id)
-            return "cancelled"
-        inputs = UserConfirmResultEvent(reply_id=pending_confirm.reply_id,
-                                        confirm_results=results)
+        ...  # await driver; derive stop reason; permission round-trip;
+        ...  # resume with UserConfirmResultEvent
 ```
 
-Cancellation notes (differ from the v1 sketch, because of #1995):
-- When `session/cancel` cancels the child task **inside**
-  `reply_stream`, no exception surfaces — the agent swallows the
-  `CancelledError` and the stream ends normally with
-  `finished_reason=interrupted`, which the loop above maps to
-  `"cancelled"`. The `except asyncio.CancelledError` branch exists
-  only for cancellation landing *outside* the generator (mid
-  `session_update` write, mid permission round-trip), where the
-  example closes the generator or aborts the parked reply via
-  `UserInterruptEvent`.
+Cancellation notes (differ from the v1 sketch, because of #1995 and
+review findings):
+- `session/cancel` cancels the **driver task**, which guarantees the
+  `CancelledError` is delivered *inside* `reply_stream` — the core
+  catches it, closes running tools with `INTERRUPTED` results (also
+  cancelling concurrent tool workers and repairing the context), and
+  ends the stream with `finished_reason=interrupted` → `"cancelled"`.
+  Cancelling the forwarding coroutine instead — or closing the
+  generator with `aclose()`, which raises `GeneratorExit` — would
+  bypass that cleanup, orphan concurrent workers, and leave dangling
+  tool calls in the context.
+- Only when no driver is running (the reply is parked at the
+  permission round-trip) is the **turn task** cancelled; the parked
+  ASKING calls are then closed via `UserInterruptEvent` under
+  `asyncio.shield`, and `cancel()` is idempotent per turn, so a
+  repeated `session/cancel` cannot abort the close-out halfway (which
+  would brick the session — every later prompt would fail with "Agent
+  is waiting for N tool calls").
+- Any *other* exception while a reply is parked also triggers the
+  close-out before propagating, for the same reason.
 - `PromptResponse{stopReason}` is **always** returned on cancel —
   never a JSON-RPC error.
 
 **SDK surface used** (verified against `agent-client-protocol==0.12.0`):
-`acp.run_agent` (binds stdio, 50 MB buffer), `acp.Agent` base class
-(handlers: `initialize`, `new_session`, `prompt`, `cancel`,
-`authenticate`, `on_connect`), the `acp.interfaces.Client` methods
+`acp.run_agent` (binds stdio, 50 MB buffer), the Agent-role handlers
+(`initialize`, `new_session`, `prompt`, `cancel`, `authenticate`,
+`on_connect`) — implemented **structurally**, deliberately not
+subclassing `acp.Agent`: the SDK dispatches via `getattr`, and
+inheriting the Protocol's placeholder bodies would turn every
+unimplemented optional method (`session/load`, `session/list`, …) into
+a bogus no-op success instead of the correct `-32601` — plus the
+`acp.interfaces.Client` methods
 (`session_update`, `request_permission`, `read_text_file`,
 `write_text_file`, `create_terminal`, `wait_for_terminal_exit`,
 `terminal_output`, `kill_terminal`, `release_terminal`),
@@ -1010,11 +1031,11 @@ outstanding `session/request_permission`, the client answers
 | Case | Handling |
 |---|---|
 | **JSON-RPC errors** | Handler exceptions map to JSON-RPC `Error{code,message}` (SDK does the encoding; `RequestError.invalid_params` / `.resource_not_found` / `.internal_error` helpers). Unknown sessions → invalid params; relative `cwd` → invalid params; a turn ending `finished_reason=error` → internal error carrying the `ErrorInfo`. Notifications never get responses. |
-| **Cancellation mid-tool** | `session/cancel` → cancel the **child turn task**, never the request-handler task. Core (#1995) converts this into `ToolResultState.INTERRUPTED` chunks + `ReplyEndEvent(finished_reason=interrupted)` and swallows the `CancelledError` (default `ReActConfig.interruption_raise_cancelled_error=False`); the turn loop maps it to `stopReason:"cancelled"`. Never leaks as a JSON-RPC error. Receipt taxonomy: `interrupted`. |
-| **Cancellation mid-permission** | The client answers the outstanding `session/request_permission` with `{"outcome":"cancelled"}` (per spec); the kernel aborts the parked reply via `UserInterruptEvent` — ASKING calls close as `INTERRUPTED` — and resolves `cancelled`. If the task cancel lands first, the `except CancelledError` path does the same close-out. |
+| **Cancellation mid-tool** | `session/cancel` → cancel the **stream driver task** (never the request handler), so the `CancelledError` lands inside `reply_stream`. Core (#1995) converts this into `ToolResultState.INTERRUPTED` chunks + `ReplyEndEvent(finished_reason=interrupted)`; the turn loop maps it to `stopReason:"cancelled"`. This holds even when the cancel arrives while the handler is blocked forwarding a `session/update` (transport backpressure) — the driver owns the generator, so the graceful close-out still runs. Never leaks as a JSON-RPC error. Receipt taxonomy: `interrupted`. |
+| **Cancellation mid-permission** | The client answers the outstanding `session/request_permission` with `{"outcome":"cancelled"}` (per spec); the kernel aborts the parked reply via `UserInterruptEvent` — ASKING calls close as `INTERRUPTED` — and resolves `cancelled`. If the task cancel lands first, the `except CancelledError` path does the same close-out under `asyncio.shield`; repeated cancels are per-turn no-ops so they cannot abort the close-out halfway. |
 | **Second `session/prompt` while a turn is active** | Rejected with `-32603`. One `Agent`/`AgentState` must not be driven by two concurrent `reply_stream`s (context/state corruption). **Single-active-turn-per-session** invariant; different sessions remain fully independent. |
-| **Permission denial** | `reject_once`/`reject_always` → `ConfirmResult(confirmed=False)` → agent emits a `DENIED` `ToolResultEnd` → `tool_call_update{status:"failed"}` (taxonomy `denied`). The turn always continues — the model sees the denial and answers accordingly. *(v1 said "unless `ReActConfig.stop_on_reject=True`"; that field exists but is consumed nowhere in core — dead config, dropped here.)* |
-| **fs/terminal errors** | Client returns a JSON-RPC error for `fs/*`/`terminal/*`; the backend surfaces it as a raised read/write error or a non-zero `ExecResult`, which the tool converts into `ToolResultState.ERROR` → `tool_call_update{status:"failed"}`. Relative paths are resolved against the session cwd before any call leaves the process. |
+| **Permission denial** | `reject_once`/`reject_always` → `ConfirmResult(confirmed=False)` → agent emits a `DENIED` `ToolResultEnd` → `tool_call_update{status:"failed"}` (taxonomy `denied`). `reject_always` additionally installs a persistent DENY rule on the public permission context (§12), so the identical operation auto-denies next time without a prompt. The turn always continues — the model sees the denial and answers accordingly. *(v1 said "unless `ReActConfig.stop_on_reject=True`"; that field exists but is consumed nowhere in core — dead config, dropped here.)* |
+| **fs/terminal errors** | Client returns a JSON-RPC error for `fs/*`/`terminal/*`; the backend surfaces it as a raised read/write error or a non-zero `ExecResult`, which the tool converts into `ToolResultState.ERROR` → `tool_call_update{status:"failed"}`. A `terminal/*` timeout reports the LocalBackend convention (`exit_code=-1`, `stderr=b"timed out"`) so `Bash`/`Grep` report timeouts as timeouts. Relative paths are resolved against the session cwd before any call leaves the process. |
 | **Capability absent** | Never call an fs/terminal method whose capability is false (§13). Degrade (omit the affected tool in `build_agent()`, log to stderr) rather than fall back to silently touching local disk in shell mode. |
 | **Large tool outputs / backpressure** | `terminal/create.outputByteLimit` (1 MiB) truncates from the beginning; tool-result text buffering keyed by `tool_call_id` sends accumulated `content` (which *replaces* the collection). The SDK's 50 MB stdio buffer covers large frames; `ContextConfig.tool_result_limit` (default 50000) caps what re-enters model context. |
 | **External tools** | `RequireExternalExecutionEvent` is not supported by the fixed tool set; if a forker's toolkit emits it, the example logs to stderr and aborts the turn via `UserInterruptEvent` (extend `server.py` for real external execution). |
@@ -1030,19 +1051,24 @@ Implemented in `tests/` (all §14 invariants asserted):
 1. **Mock ACP client harness** (`mock_client.py`): serves `fs/*`
    against a temp dir, backs `terminal/*` with **real subprocesses**,
    records every `session/update`, and answers
-   `session/request_permission` from a script — so
-   Read/Write/Edit/Bash execute the full shell-delegation path
-   end-to-end.
-2. **Translator unit tests** (`test_translate.py`): block_id →
-   messageId and tool_call_id → toolCallId correlation; delta
-   buffering; `usage_update` omission; hint-drop; the
-   `ToolResultState` → status + taxonomy table.
-3. **Permission round-trip** (`test_server.py`):
+   `session/request_permission` from a script — so Read, Write, Edit
+   and Bash all execute the full shell-delegation path end-to-end
+   (Grep/Glob are constructed and capability-gated but not driven).
+2. **Translator unit tests** (`test_translate.py`,
+   `test_regressions.py`): block_id → messageId and tool_call_id →
+   toolCallId correlation; delta buffering; `usage_update` omission;
+   hint-drop; the `ToolResultState` → status + taxonomy table; the
+   URL-sourced data variant (→ `resource_link`, no crash); the
+   exec_shell timeout sentinel.
+3. **Permission round-trip** (`test_server.py`, `test_regressions.py`):
    `session/request_permission{toolCall.toolCallId == tool_call_id}`
    (invariant d); allow → the write lands via `fs/write_text_file`;
    reject → `DENIED` taxonomy and the turn continues;
    `{"outcome":"cancelled"}` → parked reply aborted, `stopReason:
-   "cancelled"`, ASKING call closed as `interrupted`.
+   "cancelled"`, ASKING call closed as `interrupted`; `allow_always` →
+   the installed rule suppresses the prompt for the identical
+   operation next turn; `reject_always` → a DENY rule lands on the
+   public permission context and auto-denies without a prompt.
 4. **Read-only fast path**: a `Read` turn produces **no** permission
    prompt under DEFAULT (#2117) and binds its `fs/read` + `terminal`
    ops to the tool_call_id (invariant c).
@@ -1050,7 +1076,11 @@ Implemented in `tests/` (all §14 invariants asserted):
    `Bash sleep` yields `stopReason:"cancelled"` (not a JSON-RPC
    error), an `interrupted` tool result, and the session accepts a
    fresh turn afterwards; a second `session/prompt` on a busy session
-   is rejected while parked at the gate.
+   is rejected while parked at the gate; a flurry of repeated cancels
+   while parked still closes out cleanly; a cancel landing while the
+   handler is **blocked forwarding a `session/update`** (backpressured
+   transport) still produces the graceful `interrupted` close-out and
+   a repaired context (`test_regressions.py`).
 6. **Capability gating**: no `terminal` → no tools; no `fs.*` →
    exactly `{Grep, Glob, Bash}`.
 7. **Wire-level smoke test** (`test_stdio_rpc.py`): the kernel behind

--- a/examples/acp/README.md
+++ b/examples/acp/README.md
@@ -1,0 +1,132 @@
+# ACP Agent (stdio) example
+
+Expose an AgentScope agent to any [Agent Client Protocol](https://agentclientprotocol.com)
+(ACP) desktop client — e.g. [Zed](https://zed.dev) — as a stdio
+subprocess. The desktop editor is the ACP **Client** (it owns the UI,
+the open buffers, the local filesystem and terminal); the AgentScope
+kernel is the ACP **Agent** (it owns planning, tool intent, and the
+streamed narration of a turn).
+
+Built **only on AgentScope's public API** — no `agentscope/` core
+changes. Design rationale and the full protocol mapping live in
+[DESIGN.md](DESIGN.md) (companion to discussion
+[#1948](https://github.com/agentscope-ai/agentscope/discussions/1948)).
+
+```
+Desktop shell (ACP Client, e.g. Zed)
+        │  stdio, newline-delimited JSON-RPC 2.0
+        ▼
+examples/acp/  (this example, the ACP Agent)
+        │  Agent.reply_stream → AgentEvent stream
+        ▼
+AgentScope Agent  (public API only)
+```
+
+## What you get
+
+- A fixed, runnable **general assistant with coding capabilities**:
+  the builtin `Read` / `Write` / `Edit` / `Grep` / `Glob` / `Bash`
+  tools behind AgentScope's permission engine.
+- **Shell delegation** by default: file contents go through the
+  client's `fs/read_text_file` / `fs/write_text_file` (so the agent
+  sees *unsaved editor buffers*), and every shell command — including
+  the tools' internal existence/dir/mkdir checks, ripgrep, and the
+  Glob helper — runs in a client-owned terminal via `terminal/*`.
+- **Exactly one permission prompt** per gated operation, raised in the
+  editor's native UI (`session/request_permission`), with
+  `allow/reject once/always` mapped back onto AgentScope
+  `PermissionRule`s.
+- **Cancellation** that works mid-tool: `session/cancel` interrupts
+  the turn gracefully (interrupted tool results, `stopReason:
+  "cancelled"`), courtesy of AgentScope's first-class interruption
+  support.
+
+## Quick start
+
+```bash
+cd examples/acp
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt   # or: pip install -e ../..  + the pin
+
+export DASHSCOPE_API_KEY=sk-...   # default provider
+python -m acp_example             # speaks ACP on stdin/stdout
+```
+
+The process is silent until an ACP client drives it (all logs go to
+stderr — stdout carries only protocol frames).
+
+### Using it from Zed
+
+Add an entry to Zed's `settings.json`:
+
+```json
+{
+  "agent_servers": {
+    "AgentScope": {
+      "command": "/abs/path/to/examples/acp/.venv/bin/python",
+      "args": ["-m", "acp_example"],
+      "env": { "DASHSCOPE_API_KEY": "sk-..." }
+    }
+  }
+}
+```
+
+Then open the Agent Panel, pick **AgentScope**, and prompt away. File
+reads/writes and every command execution are mediated — and gated —
+by Zed.
+
+### Configuration (environment)
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `ACP_MODEL_PROVIDER` | `dashscope` | `dashscope` \| `openai` \| `anthropic` \| `deepseek` \| `moonshot` |
+| `ACP_MODEL_NAME` | `qwen-max` (dashscope only) | Model name; required for other providers |
+| `<PROVIDER>_API_KEY` | — | e.g. `DASHSCOPE_API_KEY`, `OPENAI_API_KEY` |
+| `<PROVIDER>_BASE_URL` | — | Optional API base override |
+| `ACP_AUTHORITY` | `shell` | `shell` (client owns fs/terminal) \| `workspace` (kernel-owned sandbox) |
+| `ACP_WORKSPACE_BACKEND` | `local` | Sandbox backend for workspace mode |
+| `ACP_PERMISSION_MODE` | `default` | AgentScope `PermissionMode` |
+| `ACP_AGENT_NAME` | `agentscope-acp` | Display name |
+
+Shell mode requires the client to advertise **both**
+`fs.readTextFile`/`fs.writeTextFile` **and** `terminal` capabilities;
+tools whose channel is missing are omitted rather than silently
+touching the local disk. Shell mode also assumes the client machine
+has `rg` (ripgrep) and `python3` on PATH — the `Grep` and `Glob`
+tools execute them through the client's terminal.
+
+## Forking this into your own agent
+
+All agent construction lives in **one function**:
+[`acp_example/agent.py::build_agent()`](acp_example/agent.py). To turn
+the example into your own ACP agent:
+
+1. `cp -r examples/acp/ my-acp-agent/`
+2. Edit **only** `build_agent()` — swap the model, system prompt, tool
+   set, or permission rules.
+3. Leave `server.py` / `session.py` / `translate.py` / `bridge.py`
+   untouched — the ACP plumbing is generic.
+4. Point your editor at `python -m acp_example` in your copy.
+
+## Tests
+
+```bash
+cd examples/acp
+pip install pytest pytest-asyncio
+pytest
+```
+
+The suite drives the kernel with a mock ACP client (fs served from a
+temp dir, terminals backed by real subprocesses) and covers the turn
+lifecycle, the permission round-trip (allow / reject / cancelled),
+mid-tool cancellation, capability gating, and a wire-level JSON-RPC
+smoke test.
+
+## Scope and follow-ons
+
+This is PR1 of the plan in [DESIGN.md](DESIGN.md) §20: stdio + Agent
+role only, `session/load` not yet advertised, prompt capabilities
+(image/audio/embedded context) not yet advertised, MCP pass-through
+and the receipt emitter as follow-ons. The ACP SDK is pinned
+(`agent-client-protocol==0.12.0`, protocol v1) because the protocol
+is still evolving.

--- a/examples/acp/README.md
+++ b/examples/acp/README.md
@@ -46,11 +46,17 @@ AgentScope Agent  (public API only)
 ```bash
 cd examples/acp
 python -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt   # or: pip install -e ../..  + the pin
+pip install -e .                  # installs acp_example + its deps
+# (to use the repo checkout instead of PyPI agentscope: pip install -e ../..)
 
 export DASHSCOPE_API_KEY=sk-...   # default provider
 python -m acp_example             # speaks ACP on stdin/stdout
 ```
+
+The editable install puts `acp_example` on the venv's `sys.path`, so
+`python -m acp_example` works from **any** working directory — which is
+what an editor needs, since it spawns the agent with your project as
+cwd.
 
 The process is silent until an ACP client drives it (all logs go to
 stderr — stdout carries only protocol frames).
@@ -112,7 +118,7 @@ the example into your own ACP agent:
 
 ```bash
 cd examples/acp
-pip install pytest pytest-asyncio
+pip install -e ".[test]"
 pytest
 ```
 

--- a/examples/acp/acp_example/__init__.py
+++ b/examples/acp/acp_example/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+"""ACP Agent (stdio) example for AgentScope.
+
+Exposes an AgentScope agent to any Agent Client Protocol (ACP) desktop
+client (e.g. Zed) as a stdio subprocess. Built only on AgentScope's
+public API — no ``agentscope/`` core changes.
+
+Run with::
+
+    python -m acp_example
+
+See ``examples/acp/README.md`` and ``examples/acp/DESIGN.md``.
+"""
+
+__version__ = "0.1.0"

--- a/examples/acp/acp_example/__main__.py
+++ b/examples/acp/acp_example/__main__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""``python -m acp_example`` — serve the AgentScope kernel over stdio."""
+import asyncio
+
+from .server import main
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/acp/acp_example/agent.py
+++ b/examples/acp/acp_example/agent.py
@@ -1,0 +1,265 @@
+# -*- coding: utf-8 -*-
+"""``build_agent()`` — the single fixed-vs-exposed seam (DESIGN.md §7).
+
+This is the ONLY place agent construction lives. A forker copies the
+example, edits this one function (model, system prompt, tool set,
+permission rules), and leaves the ACP plumbing (``server.py``,
+``session.py``, ``translate.py``, ``bridge.py``) untouched.
+"""
+import sys
+from typing import TYPE_CHECKING
+
+from agentscope.agent import Agent
+from agentscope.permission import PermissionMode
+from agentscope.tool import (
+    BackendBase,
+    Bash,
+    Edit,
+    Glob,
+    Grep,
+    Read,
+    Toolkit,
+    Write,
+)
+
+from .bridge import OpBindingMiddleware, OpRegistry
+from .config import Config
+
+if TYPE_CHECKING:
+    from acp.interfaces import Client
+    from acp.schema import ClientCapabilities
+
+    from agentscope.model import ChatModelBase
+    from agentscope.state import AgentState
+
+_SYSTEM_PROMPT = """\
+You are {name}, a general assistant with coding capabilities, running \
+inside a desktop editor over the Agent Client Protocol.
+
+The user's workspace directory is: {cwd}
+
+Guidelines:
+- Use the available tools to read, search, edit and run things in the \
+workspace; prefer small, verifiable steps.
+- File contents you read may include unsaved editor changes — treat \
+them as the source of truth.
+- Always use paths inside the workspace unless the user explicitly \
+points elsewhere.
+- Be concise: your replies stream directly into the editor's UI.\
+"""
+
+# Providers wired out of the box. Everything is resolved lazily so the
+# example only needs the SDK of the provider actually selected.
+# provider -> (model module attr, credential module attr, api-key env,
+#              base-url env, default model name or None)
+_PROVIDERS: dict[str, tuple[str, str, str, str, str | None]] = {
+    "dashscope": (
+        "DashScopeChatModel",
+        "DashScopeCredential",
+        "DASHSCOPE_API_KEY",
+        "DASHSCOPE_BASE_URL",
+        "qwen-max",
+    ),
+    "openai": (
+        "OpenAIChatModel",
+        "OpenAICredential",
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+        None,
+    ),
+    "anthropic": (
+        "AnthropicChatModel",
+        "AnthropicCredential",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_BASE_URL",
+        None,
+    ),
+    "deepseek": (
+        "DeepSeekChatModel",
+        "DeepSeekCredential",
+        "DEEPSEEK_API_KEY",
+        "DEEPSEEK_BASE_URL",
+        None,
+    ),
+    "moonshot": (
+        "MoonshotChatModel",
+        "MoonshotCredential",
+        "MOONSHOT_API_KEY",
+        "MOONSHOT_BASE_URL",
+        None,
+    ),
+}
+
+
+def _make_model(config: Config) -> "ChatModelBase":
+    """Build the chat model strictly from environment configuration."""
+    import os
+
+    import agentscope.credential as credential_mod
+    import agentscope.model as model_mod
+
+    if config.model_provider not in _PROVIDERS:
+        raise ValueError(
+            f"Unsupported ACP_MODEL_PROVIDER={config.model_provider!r}; "
+            f"choose one of {sorted(_PROVIDERS)} or edit build_agent().",
+        )
+    model_attr, cred_attr, key_env, url_env, default_name = _PROVIDERS[
+        config.model_provider
+    ]
+    model_name = config.model_name or default_name
+    if not model_name:
+        raise ValueError(
+            f"ACP_MODEL_NAME is required for provider "
+            f"{config.model_provider!r}.",
+        )
+    api_key = os.environ.get(key_env)
+    if not api_key:
+        raise ValueError(
+            f"{key_env} is required for provider {config.model_provider!r}.",
+        )
+    cred_kwargs: dict = {"api_key": api_key}
+    if os.environ.get(url_env):
+        cred_kwargs["base_url"] = os.environ[url_env]
+    credential = getattr(credential_mod, cred_attr)(**cred_kwargs)
+    return getattr(model_mod, model_attr)(
+        credential=credential,
+        model=model_name,
+    )
+
+
+def _make_workspace_backend(config: Config) -> BackendBase:
+    """The opt-in sandbox backend (``ACP_AUTHORITY=workspace``).
+
+    PR1 wires the local backend; Docker/E2B/Daytona/K8s/OpenSandbox/
+    Bubblewrap/Apple-container backends are all ``BackendBase``
+    subclasses with backend-specific connection settings — swap them in
+    here (this is inside the fork seam).
+    """
+    if config.workspace_backend == "local":
+        from agentscope.tool import LocalBackend
+
+        return LocalBackend()
+    raise ValueError(
+        f"ACP_WORKSPACE_BACKEND={config.workspace_backend!r} is not wired "
+        "in the example; edit _make_workspace_backend() in build_agent()'s "
+        "module to construct the sandbox backend you need "
+        "(agentscope.workspace exports Docker/E2B/Daytona/K8s/OpenSandbox/"
+        "Bubblewrap/AppleContainer backends).",
+    )
+
+
+def _shell_tools(
+    backend: BackendBase,
+    cwd: str,
+    caps: "ClientCapabilities | None",
+    middleware: OpBindingMiddleware,
+) -> list:
+    """Gate client-delegated tools on the client's capabilities (§13).
+
+    Every builtin file tool calls ``exec_shell`` (existence/dir/mkdir
+    checks, ripgrep, the Glob helper), so *all* of them need the client
+    ``terminal`` capability; Read/Write/Edit additionally need
+    ``fs.readTextFile``/``fs.writeTextFile``. Never call a client
+    method whose capability was not advertised — degrade by omitting
+    the tool instead of silently touching the local disk.
+    """
+    fs = getattr(caps, "fs", None)
+    fs_ok = bool(
+        fs
+        and getattr(fs, "read_text_file", False)
+        and getattr(fs, "write_text_file", False),
+    )
+    term_ok = bool(getattr(caps, "terminal", False))
+    mw = [middleware]
+    tools: list = []
+    if not term_ok:
+        print(
+            "acp_example: client lacks the 'terminal' capability — all "
+            "client-delegated tools are disabled in shell mode; set "
+            "ACP_AUTHORITY=workspace for kernel-owned tools.",
+            file=sys.stderr,
+        )
+        return tools
+    if fs_ok:
+        tools += [
+            Read(backend=backend, middlewares=mw),
+            Write(backend=backend, middlewares=mw),
+            Edit(backend=backend, middlewares=mw),
+        ]
+    else:
+        print(
+            "acp_example: client lacks fs.readTextFile/writeTextFile — "
+            "Read/Write/Edit are disabled in shell mode.",
+            file=sys.stderr,
+        )
+    tools += [
+        Grep(backend=backend, middlewares=mw),
+        Glob(backend=backend, middlewares=mw),
+        Bash(cwd=cwd, backend=backend, middlewares=mw),
+    ]
+    return tools
+
+
+def build_agent(
+    *,
+    cwd: str,
+    state: "AgentState",
+    conn: "Client",
+    caps: "ClientCapabilities | None",
+    ops: OpRegistry,
+    config: Config,
+) -> Agent:
+    """Construct the example's fixed default agent.
+
+    Args:
+        cwd: The session working directory (absolute, from
+            ``session/new``).
+        state: The fresh ``AgentState`` whose ``session_id`` doubles as
+            the ACP sessionId.
+        conn: The ACP client-side connection (``acp.interfaces.Client``).
+        caps: The initialize-time client capability snapshot.
+        ops: The session's operation registry (receipt invariant c).
+        config: The resolved environment configuration.
+    """
+    middleware = OpBindingMiddleware(ops)
+
+    if config.is_shell_authority:
+        # DEFAULT: shell delegation. ONE ClientBackend implements ALL
+        # THREE BackendBase primitives: read_file/write_file -> fs/*,
+        # exec_shell -> terminal/*.
+        from .bridge import ClientBackend
+
+        backend: BackendBase = ClientBackend(
+            conn=conn,
+            session_id=state.session_id,
+            cwd=cwd,
+            ops=ops,
+        )
+        tools = _shell_tools(backend, cwd, caps, middleware)
+    else:
+        # OPT-IN sandbox: one workspace backend implements all three
+        # primitives natively; no client fs/terminal capability needed.
+        backend = _make_workspace_backend(config)
+        mw = [middleware]
+        tools = [
+            Read(backend=backend, middlewares=mw),
+            Write(backend=backend, middlewares=mw),
+            Edit(backend=backend, middlewares=mw),
+            Grep(backend=backend, middlewares=mw),
+            Glob(backend=backend, middlewares=mw),
+            Bash(cwd=cwd, backend=backend, middlewares=mw),
+        ]
+
+    # Permission posture. DEFAULT gates Write/Edit/Bash behind ASK (with
+    # a read-only fast path for Read/Grep/Glob), so no side effect ever
+    # happens without exactly one client prompt (§12). Rules are
+    # editable here by a forker.
+    state.permission_context.mode = PermissionMode(config.permission_mode)
+
+    return Agent(
+        name=config.agent_name,
+        system_prompt=_SYSTEM_PROMPT.format(name=config.agent_name, cwd=cwd),
+        model=_make_model(config),
+        toolkit=Toolkit(tools=tools),
+        state=state,
+    )

--- a/examples/acp/acp_example/bridge.py
+++ b/examples/acp/acp_example/bridge.py
@@ -345,7 +345,9 @@ _PERMISSION_OPTIONS = [
         kind="allow_always",
     ),
     PermissionOption(
-        option_id="reject_once", name="Reject", kind="reject_once"
+        option_id="reject_once",
+        name="Reject",
+        kind="reject_once",
     ),
     PermissionOption(
         option_id="reject_always",

--- a/examples/acp/acp_example/bridge.py
+++ b/examples/acp/acp_example/bridge.py
@@ -1,0 +1,437 @@
+# -*- coding: utf-8 -*-
+"""fs / terminal / permission bridge (DESIGN.md §12, §13, §14).
+
+Three pieces live here:
+
+- :class:`OpRegistry` + :class:`OpBindingMiddleware` — bind every
+  backend-level ``fs/*`` / ``terminal/*`` client call to the AgentScope
+  ``tool_call_id`` of the enclosing tool call (receipt invariant c).
+  The middleware runs *inside* the tool's own task context, so the
+  binding survives AgentScope's concurrent tool batches (where a
+  ContextVar set from the event-consumer side would not propagate).
+- :class:`ClientBackend` — the single ``BackendBase`` implementation
+  for shell delegation: ``read_file``/``write_file`` route to the ACP
+  client's ``fs/read_text_file``/``fs/write_text_file``, ``exec_shell``
+  routes to the client's ``terminal/*`` create→wait→output→release
+  cycle.
+- :func:`request_permission_for` — converts a
+  ``RequireUserConfirmEvent`` into one ``session/request_permission``
+  round-trip per gated tool call and maps the outcome back to
+  ``ConfirmResult`` objects (receipt invariant d).
+"""
+import asyncio
+import json
+import os
+import posixpath
+import sys
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any, AsyncGenerator, Callable, TYPE_CHECKING
+
+from acp import RequestError
+from acp.schema import AllowedOutcome, PermissionOption, ToolCallUpdate
+
+from agentscope.event import ConfirmResult, RequireUserConfirmEvent
+from agentscope.message import ToolCallBlock
+from agentscope.permission import (
+    PermissionBehavior,
+    PermissionRule,
+)
+from agentscope.tool import BackendBase, ExecResult, ToolMiddlewareBase
+
+if TYPE_CHECKING:
+    from acp.interfaces import Client
+
+    from agentscope.tool import ToolBase, ToolChunk
+
+    from .session import Session
+
+# The tool_call_id of the tool call currently executing in this task
+# context, set by OpBindingMiddleware. Read by ClientBackend to stamp
+# every outbound fs/terminal client call with its operation id.
+_CURRENT_TOOL_CALL_ID: ContextVar[str | None] = ContextVar(
+    "acp_example_current_tool_call_id",
+    default=None,
+)
+
+# Default byte cap for terminal output requested from the client. Keeps
+# a runaway command from flooding the JSON-RPC channel; AgentScope's own
+# ContextConfig.tool_result_limit caps what re-enters model context.
+_TERMINAL_OUTPUT_BYTE_LIMIT = 1024 * 1024
+
+
+@dataclass
+class OpRecord:
+    """One receipt-ready record of a client-delegated operation."""
+
+    kind: str
+    """``"fs/read"``, ``"fs/write"`` or ``"terminal"``."""
+
+    detail: str
+    """The path (fs ops) or the command line (terminal ops)."""
+
+    tool_call_id: str | None
+    """The AgentScope tool call this operation belongs to, or ``None``
+    for a call made outside any tool."""
+
+    terminal_id: str | None = None
+    """The client-side terminal id, for terminal ops."""
+
+    exit_code: int | None = None
+    """The exit code, for terminal ops."""
+
+
+class OpRegistry:
+    """Per-session registry binding client calls to tool-call ids.
+
+    ``pending`` holds tool calls whose arguments are complete but whose
+    execution has not been claimed by the middleware yet; ``records``
+    accumulates the receipt-ready operation log (invariant c).
+    """
+
+    def __init__(self) -> None:
+        self.pending: dict[str, tuple[str, str]] = {}
+        """tool_call_id -> (tool_name, raw JSON input)."""
+        self.records: list[OpRecord] = []
+
+    def register_pending(
+        self,
+        tool_call_id: str,
+        tool_name: str,
+        raw_input: str,
+    ) -> None:
+        """Register a fully-streamed tool call awaiting execution."""
+        self.pending[tool_call_id] = (tool_name, raw_input)
+
+    def discard_pending(self, tool_call_id: str) -> None:
+        """Drop a pending entry (tool finished, was denied, …)."""
+        self.pending.pop(tool_call_id, None)
+
+    def claim(self, tool_name: str, input_kwargs: dict) -> str | None:
+        """Match a starting tool invocation back to its tool_call_id.
+
+        Called by :class:`OpBindingMiddleware` from inside the tool's
+        task. Matching is by tool name first; when several calls to the
+        same tool are pending in one batch, the parsed inputs
+        disambiguate. The claimed entry is removed so a twin invocation
+        cannot bind to the same id twice.
+        """
+        candidates = [
+            (tc_id, raw)
+            for tc_id, (name, raw) in self.pending.items()
+            if name == tool_name
+        ]
+        if not candidates:
+            return None
+        if len(candidates) > 1:
+            # Disambiguate by comparing the tool's actual kwargs against
+            # each pending call's parsed JSON input. Internal kwargs
+            # injected by the framework (e.g. _agent_state) are ignored.
+            visible = {
+                k: v for k, v in input_kwargs.items() if not k.startswith("_")
+            }
+            for tc_id, raw in candidates:
+                try:
+                    if json.loads(raw) == visible:
+                        candidates = [(tc_id, raw)]
+                        break
+                except (TypeError, ValueError):
+                    continue
+        tc_id = candidates[0][0]
+        del self.pending[tc_id]
+        return tc_id
+
+    def record(self, op: OpRecord) -> None:
+        """Append one operation record."""
+        self.records.append(op)
+
+
+class OpBindingMiddleware(ToolMiddlewareBase):
+    """Stamps the enclosing tool_call_id into the task context.
+
+    Runs inside the tool's own asyncio task (AgentScope executes
+    concurrency-safe tools in parallel worker tasks), so the ContextVar
+    value is visible to every backend call the tool makes — including
+    the ``file_exists``/``is_dir``/``mkdir -p`` helpers that go through
+    ``exec_shell``.
+    """
+
+    def __init__(self, ops: OpRegistry) -> None:
+        self._ops = ops
+
+    async def on_tool_call(
+        self,
+        tool: "ToolBase",
+        input_kwargs: dict[str, Any],
+        next_handler: Callable[..., AsyncGenerator["ToolChunk", None]],
+    ) -> AsyncGenerator["ToolChunk", None]:
+        """Bind this invocation to its tool_call_id, then run the tool."""
+        tc_id = self._ops.claim(tool.name, input_kwargs)
+        token = _CURRENT_TOOL_CALL_ID.set(tc_id)
+        try:
+            async for chunk in next_handler(**input_kwargs):
+                yield chunk
+        finally:
+            _CURRENT_TOOL_CALL_ID.reset(token)
+
+
+class ClientBackend(BackendBase):
+    """The one shell-delegation backend (DESIGN.md §13).
+
+    Implements all three ``BackendBase`` primitives against the ACP
+    client:
+
+    - ``read_file``  → ``fs/read_text_file`` (sees unsaved buffers),
+    - ``write_file`` → ``fs/write_text_file``,
+    - ``exec_shell`` → ``terminal/create`` → ``wait_for_exit`` →
+      ``output`` → ``release``.
+
+    The builtin file tools call ``exec_shell`` for existence/dir/mkdir
+    checks, ripgrep and the Glob helper, so shell delegation requires
+    the client ``terminal`` capability in addition to ``fs.*``.
+
+    ACP mandates absolute paths: every path is resolved against the
+    session ``cwd`` before leaving the process.
+    """
+
+    def __init__(
+        self,
+        conn: "Client",
+        session_id: str,
+        cwd: str,
+        ops: OpRegistry,
+    ) -> None:
+        self._conn = conn
+        self._session_id = session_id
+        self._cwd = cwd
+        self._ops = ops
+
+    # ── path helpers ──────────────────────────────────────────────
+
+    def _abs(self, path: str) -> str:
+        """Resolve ``path`` against the session cwd, POSIX-normalized."""
+        if not posixpath.isabs(path) and not os.path.isabs(path):
+            path = posixpath.join(self._cwd, path)
+        return posixpath.normpath(path)
+
+    async def getcwd(self) -> str:
+        """The session working directory, with no client round-trip."""
+        return self._cwd
+
+    # ── the three primitives ──────────────────────────────────────
+
+    async def read_file(self, path: str) -> bytes:
+        """Read a text file through the client (unsaved buffers incl.)."""
+        abs_path = self._abs(path)
+        resp = await self._conn.read_text_file(
+            session_id=self._session_id,
+            path=abs_path,
+        )
+        self._ops.record(
+            OpRecord(
+                kind="fs/read",
+                detail=abs_path,
+                tool_call_id=_CURRENT_TOOL_CALL_ID.get(),
+            ),
+        )
+        return resp.content.encode("utf-8")
+
+    async def write_file(self, path: str, data: bytes) -> None:
+        """Write a text file through the client."""
+        abs_path = self._abs(path)
+        await self._conn.write_text_file(
+            session_id=self._session_id,
+            path=abs_path,
+            content=data.decode("utf-8"),
+        )
+        self._ops.record(
+            OpRecord(
+                kind="fs/write",
+                detail=abs_path,
+                tool_call_id=_CURRENT_TOOL_CALL_ID.get(),
+            ),
+        )
+
+    async def exec_shell(
+        self,
+        command: list[str],
+        *,
+        cwd: str | None = None,
+        timeout: float | None = None,
+    ) -> ExecResult:
+        """Run a command in a client-owned terminal.
+
+        The ACP terminal merges stdout and stderr into one stream; the
+        merged output is returned as ``stdout``. A timeout kills the
+        terminal and reports exit code ``-1`` (the ``ExecResult``
+        convention for internal failures).
+        """
+        run_cwd = self._abs(cwd) if cwd else self._cwd
+        create = await self._conn.create_terminal(
+            session_id=self._session_id,
+            command=command[0],
+            args=list(command[1:]),
+            cwd=run_cwd,
+            output_byte_limit=_TERMINAL_OUTPUT_BYTE_LIMIT,
+        )
+        terminal_id = create.terminal_id
+        record = OpRecord(
+            kind="terminal",
+            detail=" ".join(command),
+            tool_call_id=_CURRENT_TOOL_CALL_ID.get(),
+            terminal_id=terminal_id,
+        )
+        try:
+            timed_out = False
+            exit_code: int | None = None
+            try:
+                exit_resp = await asyncio.wait_for(
+                    self._conn.wait_for_terminal_exit(
+                        session_id=self._session_id,
+                        terminal_id=terminal_id,
+                    ),
+                    timeout=timeout,
+                )
+                exit_code = exit_resp.exit_code
+            except asyncio.TimeoutError:
+                timed_out = True
+                await self._conn.kill_terminal(
+                    session_id=self._session_id,
+                    terminal_id=terminal_id,
+                )
+            out = await self._conn.terminal_output(
+                session_id=self._session_id,
+                terminal_id=terminal_id,
+            )
+            if exit_code is None and out.exit_status is not None:
+                exit_code = out.exit_status.exit_code
+            if timed_out or exit_code is None:
+                # Timeout, or terminated by a signal: ExecResult uses -1
+                # for internal failures.
+                exit_code = -1
+            record.exit_code = exit_code
+            return ExecResult(
+                exit_code=exit_code,
+                stdout=out.output.encode("utf-8"),
+                stderr=b"",
+            )
+        finally:
+            self._ops.record(record)
+            try:
+                await self._conn.release_terminal(
+                    session_id=self._session_id,
+                    terminal_id=terminal_id,
+                )
+            except (RequestError, ConnectionError):
+                # Releasing a terminal the client already dropped (e.g.
+                # after a cancelled turn) is not an error worth surfacing.
+                print(
+                    f"acp_example: release_terminal({terminal_id}) failed",
+                    file=sys.stderr,
+                )
+
+
+# ── permission bridge (DESIGN.md §12) ─────────────────────────────────
+
+_PERMISSION_OPTIONS = [
+    PermissionOption(option_id="allow_once", name="Allow", kind="allow_once"),
+    PermissionOption(
+        option_id="allow_always",
+        name="Always allow",
+        kind="allow_always",
+    ),
+    PermissionOption(
+        option_id="reject_once", name="Reject", kind="reject_once"
+    ),
+    PermissionOption(
+        option_id="reject_always",
+        name="Always reject",
+        kind="reject_always",
+    ),
+]
+
+
+def _parse_raw_input(raw: str) -> Any:
+    """Best-effort JSON parse of a streamed tool input for display."""
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        return raw
+
+
+def _rules_for(
+    tool_call: ToolCallBlock,
+    behavior: PermissionBehavior,
+) -> list[PermissionRule]:
+    """The rules an ``*_always`` decision installs in the kernel.
+
+    For ALLOW, core's own ``suggested_rules`` (attached to the ASKING
+    tool call) are preferred — they carry the tool-specific
+    ``rule_content`` (a path glob, a command prefix, …). Bypass-immune
+    safety ASKs are never silenced by these rules (see #2117), so a
+    client may still be prompted again for dangerous operations.
+    """
+    suggested = getattr(tool_call, "suggested_rules", None) or []
+    if behavior == PermissionBehavior.ALLOW and suggested:
+        return list(suggested)
+    return [
+        PermissionRule(
+            tool_name=tool_call.name,
+            behavior=behavior,
+            source="acp-client",
+        ),
+    ]
+
+
+async def request_permission_for(
+    conn: "Client",
+    sess: "Session",
+    event: RequireUserConfirmEvent,
+) -> list[ConfirmResult] | None:
+    """Resolve one ``RequireUserConfirmEvent`` at the ACP client.
+
+    Sends one ``session/request_permission`` per gated tool call, bound
+    to the exact ``toolCallId`` (invariant d), and maps each outcome to
+    a ``ConfirmResult``. Returns ``None`` when the client reports the
+    prompt was cancelled (``{"outcome": "cancelled"}``) — the caller
+    then aborts the turn.
+    """
+    results: list[ConfirmResult] = []
+    for tool_call in event.tool_calls:
+        resp = await conn.request_permission(
+            session_id=sess.id,
+            tool_call=ToolCallUpdate(
+                tool_call_id=tool_call.id,
+                title=tool_call.name,
+                raw_input=_parse_raw_input(tool_call.input),
+            ),
+            options=_PERMISSION_OPTIONS,
+        )
+        outcome = resp.outcome
+        if not isinstance(outcome, AllowedOutcome):
+            # DeniedOutcome — the client cancelled the prompt (turn
+            # aborted, client shutdown, …). Per spec the whole turn
+            # resolves to stopReason "cancelled".
+            return None
+        confirmed = outcome.option_id in ("allow_once", "allow_always")
+        rules: list[PermissionRule] | None = None
+        if outcome.option_id == "allow_always":
+            rules = _rules_for(tool_call, PermissionBehavior.ALLOW)
+        elif outcome.option_id == "reject_always":
+            rules = _rules_for(tool_call, PermissionBehavior.DENY)
+        results.append(
+            ConfirmResult(
+                confirmed=confirmed,
+                tool_call=ToolCallBlock(
+                    id=tool_call.id,
+                    name=tool_call.name,
+                    input=tool_call.input,
+                ),
+                rules=rules,
+            ),
+        )
+        if not confirmed:
+            # A denied call never executes: nothing will claim its
+            # pending entry, so drop it here.
+            sess.ops.discard_pending(tool_call.id)
+    return results

--- a/examples/acp/acp_example/bridge.py
+++ b/examples/acp/acp_example/bridge.py
@@ -310,10 +310,14 @@ class ClientBackend(BackendBase):
                 # for internal failures.
                 exit_code = -1
             record.exit_code = exit_code
+            # The builtin tools detect timeouts via the LocalBackend
+            # convention: exit_code == -1 with stderr == b"timed out"
+            # (e.g. Bash reports "Command timed out after Nms"). Honor
+            # it so shell-delegated timeouts are not misreported.
             return ExecResult(
                 exit_code=exit_code,
                 stdout=out.output.encode("utf-8"),
-                stderr=b"",
+                stderr=b"timed out" if timed_out else b"",
             )
         finally:
             self._ops.record(record)
@@ -374,13 +378,31 @@ def _rules_for(
     suggested = getattr(tool_call, "suggested_rules", None) or []
     if behavior == PermissionBehavior.ALLOW and suggested:
         return list(suggested)
+    # rule_content=None means "match every invocation of this tool" —
+    # the right semantics for an unqualified always-allow/always-reject.
     return [
         PermissionRule(
             tool_name=tool_call.name,
+            rule_content=None,
             behavior=behavior,
             source="acp-client",
         ),
     ]
+
+
+def _install_deny_rules(sess: "Session", rules: list[PermissionRule]) -> None:
+    """Install persistent DENY rules on the session's agent.
+
+    ``ConfirmResult.rules`` is only applied by the core when
+    ``confirmed=True``, so a *reject_always* rule cannot ride the
+    confirmation. The engine evaluates the public
+    ``agent.state.permission_context`` live, so appending there (in the
+    same shape as ``PermissionEngine.add_rule``) makes the rejection
+    stick without touching any private attribute.
+    """
+    context = sess.agent.state.permission_context
+    for rule in rules:
+        context.deny_rules.setdefault(rule.tool_name, []).append(rule)
 
 
 async def request_permission_for(
@@ -416,9 +438,17 @@ async def request_permission_for(
         confirmed = outcome.option_id in ("allow_once", "allow_always")
         rules: list[PermissionRule] | None = None
         if outcome.option_id == "allow_always":
+            # ALLOW rules ride the confirmation; the core applies them
+            # on resume (only honored when confirmed=True).
             rules = _rules_for(tool_call, PermissionBehavior.ALLOW)
         elif outcome.option_id == "reject_always":
-            rules = _rules_for(tool_call, PermissionBehavior.DENY)
+            # DENY rules would be silently dropped on a confirmed=False
+            # ConfirmResult, so install them directly on the public
+            # permission context instead.
+            _install_deny_rules(
+                sess,
+                _rules_for(tool_call, PermissionBehavior.DENY),
+            )
         results.append(
             ConfirmResult(
                 confirmed=confirmed,

--- a/examples/acp/acp_example/config.py
+++ b/examples/acp/acp_example/config.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""Environment-based configuration for the ACP example.
+
+Everything a user can tune without editing code is read from environment
+variables here (the "EXPOSED" column of the fixed-vs-exposed matrix in
+DESIGN.md §7). Everything else is fixed by the example.
+"""
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Config:
+    """Resolved environment configuration."""
+
+    model_provider: str
+    model_name: str | None
+    authority: str
+    permission_mode: str
+    agent_name: str
+    workspace_backend: str
+
+    @property
+    def is_shell_authority(self) -> bool:
+        """Whether fs/terminal operations are delegated to the ACP client."""
+        return self.authority == "shell"
+
+
+def load_config() -> Config:
+    """Read the example's configuration from environment variables."""
+    authority = os.environ.get("ACP_AUTHORITY", "shell").lower()
+    if authority not in ("shell", "workspace"):
+        raise ValueError(
+            f"ACP_AUTHORITY must be 'shell' or 'workspace', got {authority!r}",
+        )
+    return Config(
+        model_provider=os.environ.get(
+            "ACP_MODEL_PROVIDER",
+            "dashscope",
+        ).lower(),
+        model_name=os.environ.get("ACP_MODEL_NAME") or None,
+        authority=authority,
+        permission_mode=os.environ.get("ACP_PERMISSION_MODE", "default"),
+        agent_name=os.environ.get("ACP_AGENT_NAME", "agentscope-acp"),
+        workspace_backend=os.environ.get(
+            "ACP_WORKSPACE_BACKEND",
+            "local",
+        ).lower(),
+    )

--- a/examples/acp/acp_example/server.py
+++ b/examples/acp/acp_example/server.py
@@ -1,0 +1,328 @@
+# -*- coding: utf-8 -*-
+"""ACP Agent-role handlers and the stdio entrypoint (DESIGN.md §16).
+
+One ACP turn == one (possibly resumed) ``Agent.reply_stream`` run,
+driven in a *child* asyncio task so that ``session/cancel`` cancels the
+turn, never the ``session/prompt`` request handler. Since #1995 the
+core converts that cancellation into a graceful ending — interrupted
+tool-result events plus ``ReplyEndEvent(finished_reason=INTERRUPTED)``
+— so the stop reason is derived from ``finished_reason`` rather than
+from exception plumbing.
+"""
+import asyncio
+import contextlib
+import posixpath
+import sys
+from typing import Any
+
+from acp import (
+    PROTOCOL_VERSION,
+    Agent as AcpAgentBase,
+    InitializeResponse,
+    NewSessionResponse,
+    PromptResponse,
+    RequestError,
+    run_agent,
+)
+from acp.schema import (
+    AgentCapabilities,
+    ClientCapabilities,
+    Implementation,
+)
+
+from agentscope.event import (
+    ReplyEndEvent,
+    ReplyStartEvent,
+    RequireExternalExecutionEvent,
+    RequireUserConfirmEvent,
+    UserConfirmResultEvent,
+    UserInterruptEvent,
+)
+from agentscope.message import DataBlock, Base64Source, TextBlock, UserMsg
+from agentscope.state import AgentState
+from agentscope.types import ReplyFinishedReason
+
+from . import __version__
+from .agent import build_agent
+from .bridge import OpRegistry, request_permission_for
+from .config import Config, load_config
+from .session import Session, SessionManager
+
+
+def _prompt_to_msg(prompt: list[Any]) -> UserMsg:
+    """Map ACP prompt ContentBlocks to an AgentScope user message (§11).
+
+    PR1 advertises ``promptCapabilities`` all-false, so conforming
+    clients send only ``text`` and ``resource_link`` blocks; the other
+    shapes are still handled defensively rather than crashing the turn.
+    """
+    blocks: list[TextBlock | DataBlock] = []
+    for block in prompt:
+        block_type = getattr(block, "type", None)
+        if block_type == "text":
+            blocks.append(TextBlock(text=block.text))
+        elif block_type == "resource_link":
+            mime = f", {block.mime_type}" if block.mime_type else ""
+            blocks.append(
+                TextBlock(
+                    text=f"[Linked resource: {block.name}{mime}]"
+                    f"({block.uri})",
+                ),
+            )
+        elif block_type == "resource":
+            contents = block.resource
+            text = getattr(contents, "text", None)
+            if text is not None:
+                blocks.append(
+                    TextBlock(
+                        text=f"<resource uri={contents.uri!r}>\n{text}\n"
+                        "</resource>",
+                    ),
+                )
+        elif block_type in ("image", "audio"):
+            blocks.append(
+                DataBlock(
+                    source=Base64Source(
+                        data=block.data,
+                        media_type=block.mime_type,
+                    ),
+                ),
+            )
+    if not blocks:
+        blocks = [TextBlock(text="")]
+    return UserMsg(name="user", content=blocks)
+
+
+def _stop_reason(finished: ReplyFinishedReason | None) -> str:
+    """Map ``ReplyEndEvent.finished_reason`` onto an ACP stopReason."""
+    if finished == ReplyFinishedReason.EXCEED_MAX_ITERS:
+        return "max_turn_requests"
+    if finished == ReplyFinishedReason.INTERRUPTED:
+        return "cancelled"
+    # COMPLETED, or a defensive fallback if the stream ended without a
+    # terminal event.
+    return "end_turn"
+
+
+class AgentScopeAcpAgent(AcpAgentBase):
+    """The ACP Agent role wrapping AgentScope agents."""
+
+    def __init__(self, config: Config | None = None) -> None:
+        self._conn: Any = None
+        self._client_caps: ClientCapabilities | None = None
+        self._sessions = SessionManager()
+        self._config = config or load_config()
+
+    # ── lifecycle ─────────────────────────────────────────────────
+
+    def on_connect(self, conn: Any) -> None:
+        """Store the client-side connection handle."""
+        self._conn = conn
+
+    async def initialize(
+        self,
+        protocol_version: int,
+        client_capabilities: ClientCapabilities | None = None,
+        client_info: Implementation | None = None,
+        **kwargs: Any,
+    ) -> InitializeResponse:
+        """Advertise capabilities; snapshot the client's (invariant b)."""
+        self._client_caps = client_capabilities
+        return InitializeResponse(
+            protocol_version=PROTOCOL_VERSION,
+            # Minimal capabilities (§8): no session/load yet, prompt
+            # capabilities all-false (text + resource_link baseline
+            # only), no auth methods.
+            agent_capabilities=AgentCapabilities(),
+            agent_info=Implementation(
+                name="agentscope-acp",
+                title="AgentScope ACP Agent",
+                version=__version__,
+            ),
+        )
+
+    async def authenticate(self, method_id: str, **kwargs: Any) -> None:
+        """Defensive no-op: no authMethods are advertised (§8)."""
+        return None
+
+    async def new_session(
+        self,
+        cwd: str,
+        additional_directories: list | None = None,
+        mcp_servers: list | None = None,
+        **kwargs: Any,
+    ) -> NewSessionResponse:
+        """Mint a session; ACP sessionId == AgentState.session_id."""
+        if not posixpath.isabs(cwd):
+            raise RequestError.invalid_params(
+                {"cwd": f"cwd must be an absolute path, got {cwd!r}"},
+            )
+        # mcp_servers: stdio MCP wiring into Toolkit(mcps=...) is a
+        # follow-on within the example (DESIGN.md §20); ignored in PR1.
+        state = AgentState()
+        ops = OpRegistry()
+        agent = build_agent(
+            cwd=cwd,
+            state=state,
+            conn=self._conn,
+            caps=self._client_caps,
+            ops=ops,
+            config=self._config,
+        )
+        self._sessions.add(
+            Session(
+                id=state.session_id,
+                agent=agent,
+                state=state,
+                cwd=cwd,
+                caps=self._client_caps,
+                authority=self._config.authority,
+                ops=ops,
+            ),
+        )
+        return NewSessionResponse(session_id=state.session_id)
+
+    # ── the turn ──────────────────────────────────────────────────
+
+    async def prompt(
+        self,
+        session_id: str,
+        prompt: list,
+        **kwargs: Any,
+    ) -> PromptResponse:
+        """Run one turn; the request stays open until the turn ends."""
+        sess = self._sessions.get(session_id)
+        if not sess.try_begin_turn():
+            # Single-active-turn-per-session (§18): one Agent/AgentState
+            # must not be driven by two concurrent reply_streams.
+            raise RequestError(
+                code=-32603,
+                message="a turn is already in progress for this session",
+            )
+        try:
+            user_msg = _prompt_to_msg(prompt)
+            # Child task, so session/cancel cancels the *turn*, not this
+            # request handler.
+            sess.turn_task = asyncio.create_task(
+                self._run_turn(sess, user_msg),
+            )
+            try:
+                stop = await sess.turn_task
+            except asyncio.CancelledError:
+                if sess.turn_task.cancelled():
+                    # session/cancel won the race before the turn could
+                    # end gracefully; the stop reason MUST still be
+                    # returned (never a JSON-RPC error).
+                    stop = "cancelled"
+                else:
+                    raise
+        finally:
+            sess.end_turn()
+        return PromptResponse(stop_reason=stop)
+
+    async def _run_turn(self, sess: Session, inputs: Any) -> str:
+        """One ACP turn: a reply_stream, resumed across permission gates."""
+        stream = None
+        try:
+            while True:
+                pending_confirm: RequireUserConfirmEvent | None = None
+                finished: ReplyFinishedReason | None = None
+                stream = sess.agent.reply_stream(inputs)
+                async for event in stream:
+                    if isinstance(event, ReplyStartEvent):
+                        sess.last_reply_id = event.reply_id
+                    if isinstance(event, RequireUserConfirmEvent):
+                        pending_confirm = event
+                        break
+                    if isinstance(event, RequireExternalExecutionEvent):
+                        # The fixed tool set has no external tools; a
+                        # forker who adds one must extend this handler.
+                        print(
+                            "acp_example: external tool execution is not "
+                            "supported by this example; interrupting.",
+                            file=sys.stderr,
+                        )
+                        return await self._abort_parked(
+                            sess,
+                            event.reply_id,
+                        )
+                    if isinstance(event, ReplyEndEvent):
+                        finished = event.finished_reason
+                        if event.error is not None:
+                            raise RequestError.internal_error(
+                                {"error": str(event.error)},
+                            )
+                    for update in sess.translator.translate(event):
+                        await self._conn.session_update(
+                            session_id=sess.id,
+                            update=update,
+                        )
+                stream = None
+                if pending_confirm is None:
+                    return _stop_reason(finished)
+                # Resolve the gate at the client, bound to the exact
+                # toolCallId (invariant d).
+                confirm_results = await request_permission_for(
+                    self._conn,
+                    sess,
+                    pending_confirm,
+                )
+                if confirm_results is None:
+                    # Client answered {"outcome": "cancelled"}.
+                    return await self._abort_parked(
+                        sess,
+                        pending_confirm.reply_id,
+                    )
+                inputs = UserConfirmResultEvent(
+                    reply_id=pending_confirm.reply_id,
+                    confirm_results=confirm_results,
+                )
+        except asyncio.CancelledError:
+            # The cancellation landed while awaiting something *other*
+            # than reply_stream (a session/update write, a permission
+            # round-trip) — otherwise the agent itself would have ended
+            # the stream gracefully with finished_reason=INTERRUPTED.
+            if stream is not None:
+                with contextlib.suppress(Exception):
+                    await stream.aclose()
+            elif sess.last_reply_id is not None:
+                # Parked (awaiting permission): close the ASKING tool
+                # calls through the public interrupt input.
+                with contextlib.suppress(Exception):
+                    await self._drain_interrupt(sess, sess.last_reply_id)
+            return "cancelled"
+
+    async def _abort_parked(self, sess: Session, reply_id: str) -> str:
+        """Abort a parked reply and surface its close-out updates."""
+        await self._drain_interrupt(sess, reply_id)
+        return "cancelled"
+
+    async def _drain_interrupt(self, sess: Session, reply_id: str) -> None:
+        """Feed ``UserInterruptEvent`` and forward the close-out events.
+
+        The core closes pending ASKING/SUBMITTED tool calls with
+        INTERRUPTED results and ends the reply; the client sees the
+        corresponding ``tool_call_update`` notifications.
+        """
+        async for event in sess.agent.reply_stream(
+            UserInterruptEvent(reply_id=reply_id),
+        ):
+            for update in sess.translator.translate(event):
+                await self._conn.session_update(
+                    session_id=sess.id,
+                    update=update,
+                )
+
+    async def cancel(self, session_id: str, **kwargs: Any) -> None:
+        """``session/cancel``: cancel the child turn task (§18)."""
+        sess = self._sessions.get(session_id)
+        task = sess.turn_task
+        if task is not None and not task.done():
+            task.cancel()
+
+
+async def main() -> None:
+    """Serve the agent over stdio until the client disconnects."""
+    # The kernel MUST NOT write non-ACP text to stdout; all logging in
+    # this example goes to stderr.
+    await run_agent(AgentScopeAcpAgent())

--- a/examples/acp/acp_example/server.py
+++ b/examples/acp/acp_example/server.py
@@ -1,23 +1,31 @@
 # -*- coding: utf-8 -*-
 """ACP Agent-role handlers and the stdio entrypoint (DESIGN.md §16).
 
-One ACP turn == one (possibly resumed) ``Agent.reply_stream`` run,
-driven in a *child* asyncio task so that ``session/cancel`` cancels the
-turn, never the ``session/prompt`` request handler. Since #1995 the
-core converts that cancellation into a graceful ending — interrupted
-tool-result events plus ``ReplyEndEvent(finished_reason=INTERRUPTED)``
-— so the stop reason is derived from ``finished_reason`` rather than
-from exception plumbing.
+One ACP turn == one (possibly resumed) ``Agent.reply_stream`` run.
+
+Cancellation architecture: the generator is consumed by a dedicated
+**driver task** whose only awaits are the generator's ``__anext__``
+steps; events are handed to the request handler through a queue. A
+``session/cancel`` therefore cancels the *driver*, which guarantees the
+``CancelledError`` is delivered *inside* ``reply_stream`` — where the
+core (#1995) catches it, closes running tools with ``INTERRUPTED``
+results, and ends the stream with
+``ReplyEndEvent(finished_reason=INTERRUPTED)``. Cancelling the
+forwarding coroutine instead (or closing the generator with
+``aclose()``, which raises ``GeneratorExit``) would bypass that cleanup
+and orphan concurrent tool workers. The stop reason is then derived
+from ``finished_reason`` rather than from exception plumbing.
 """
+# pylint: disable=unused-argument  # the ACP handler signatures are fixed
 import asyncio
 import contextlib
+import os
 import posixpath
 import sys
-from typing import Any
+from typing import Any, AsyncGenerator
 
 from acp import (
     PROTOCOL_VERSION,
-    Agent as AcpAgentBase,
     InitializeResponse,
     NewSessionResponse,
     PromptResponse,
@@ -31,6 +39,7 @@ from acp.schema import (
 )
 
 from agentscope.event import (
+    AgentEvent,
     ReplyEndEvent,
     ReplyStartEvent,
     RequireExternalExecutionEvent,
@@ -47,6 +56,9 @@ from .agent import build_agent
 from .bridge import OpRegistry, request_permission_for
 from .config import Config, load_config
 from .session import Session, SessionManager
+
+# Queue sentinel marking the end of one reply_stream run.
+_STREAM_END = object()
 
 
 def _prompt_to_msg(prompt: list[Any]) -> UserMsg:
@@ -104,8 +116,20 @@ def _stop_reason(finished: ReplyFinishedReason | None) -> str:
     return "end_turn"
 
 
-class AgentScopeAcpAgent(AcpAgentBase):
-    """The ACP Agent role wrapping AgentScope agents."""
+def _is_abs(path: str) -> bool:
+    """Absolute on either POSIX or the host platform (Windows drives)."""
+    return posixpath.isabs(path) or os.path.isabs(path)
+
+
+class AgentScopeAcpAgent:
+    """The ACP Agent role wrapping AgentScope agents.
+
+    Deliberately NOT a subclass of ``acp.Agent``: the SDK dispatches
+    handlers structurally via ``getattr``, and inheriting the Protocol's
+    placeholder method bodies would turn every unimplemented optional
+    method (``session/load``, ``session/list``, …) into a bogus no-op
+    success instead of the correct ``-32601`` method-not-found error.
+    """
 
     def __init__(self, config: Config | None = None) -> None:
         self._conn: Any = None
@@ -153,7 +177,7 @@ class AgentScopeAcpAgent(AcpAgentBase):
         **kwargs: Any,
     ) -> NewSessionResponse:
         """Mint a session; ACP sessionId == AgentState.session_id."""
-        if not posixpath.isabs(cwd):
+        if not _is_abs(cwd):
             raise RequestError.invalid_params(
                 {"cwd": f"cwd must be an absolute path, got {cwd!r}"},
             )
@@ -201,8 +225,8 @@ class AgentScopeAcpAgent(AcpAgentBase):
             )
         try:
             user_msg = _prompt_to_msg(prompt)
-            # Child task, so session/cancel cancels the *turn*, not this
-            # request handler.
+            # Child task, so a cancel aimed at the parked-permission
+            # window cancels the *turn*, not this request handler.
             sess.turn_task = asyncio.create_task(
                 self._run_turn(sess, user_msg),
             )
@@ -210,8 +234,8 @@ class AgentScopeAcpAgent(AcpAgentBase):
                 stop = await sess.turn_task
             except asyncio.CancelledError:
                 if sess.turn_task.cancelled():
-                    # session/cancel won the race before the turn could
-                    # end gracefully; the stop reason MUST still be
+                    # The cancel won a race before the turn could end
+                    # gracefully; the stop reason MUST still be
                     # returned (never a JSON-RPC error).
                     stop = "cancelled"
                 else:
@@ -220,46 +244,99 @@ class AgentScopeAcpAgent(AcpAgentBase):
             sess.end_turn()
         return PromptResponse(stop_reason=stop)
 
+    @staticmethod
+    async def _drive_stream(
+        stream: AsyncGenerator[AgentEvent, None],
+        queue: "asyncio.Queue[Any]",
+    ) -> None:
+        """Consume one reply_stream run in a task of its own.
+
+        This task's only awaits are the generator's ``__anext__`` steps
+        (``put_nowait`` never suspends), so cancelling it delivers the
+        ``CancelledError`` inside the generator, triggering the core's
+        graceful INTERRUPTED close-out. The close-out events still flow
+        into the queue before the sentinel.
+        """
+        try:
+            async for event in stream:
+                queue.put_nowait(event)
+        finally:
+            queue.put_nowait(_STREAM_END)
+
     async def _run_turn(self, sess: Session, inputs: Any) -> str:
         """One ACP turn: a reply_stream, resumed across permission gates."""
-        stream = None
         try:
             while True:
                 pending_confirm: RequireUserConfirmEvent | None = None
+                pending_external = False
                 finished: ReplyFinishedReason | None = None
+                error: Any = None
+                queue: asyncio.Queue = asyncio.Queue()
                 stream = sess.agent.reply_stream(inputs)
-                async for event in stream:
-                    if isinstance(event, ReplyStartEvent):
-                        sess.last_reply_id = event.reply_id
-                    if isinstance(event, RequireUserConfirmEvent):
-                        pending_confirm = event
-                        break
-                    if isinstance(event, RequireExternalExecutionEvent):
-                        # The fixed tool set has no external tools; a
-                        # forker who adds one must extend this handler.
-                        print(
-                            "acp_example: external tool execution is not "
-                            "supported by this example; interrupting.",
-                            file=sys.stderr,
-                        )
-                        return await self._abort_parked(
-                            sess,
-                            event.reply_id,
-                        )
-                    if isinstance(event, ReplyEndEvent):
-                        finished = event.finished_reason
-                        if event.error is not None:
-                            raise RequestError.internal_error(
-                                {"error": str(event.error)},
+                sess.driver_task = asyncio.create_task(
+                    self._drive_stream(stream, queue),
+                )
+                try:
+                    while True:
+                        event = await queue.get()
+                        if event is _STREAM_END:
+                            break
+                        if isinstance(event, ReplyStartEvent):
+                            sess.last_reply_id = event.reply_id
+                        elif isinstance(event, RequireUserConfirmEvent):
+                            # The reply is parking; the stream ends
+                            # right after this event.
+                            pending_confirm = event
+                            continue
+                        elif isinstance(
+                            event,
+                            RequireExternalExecutionEvent,
+                        ):
+                            # The fixed tool set has no external tools;
+                            # a forker who adds one must extend this.
+                            print(
+                                "acp_example: external tool execution "
+                                "is not supported by this example; "
+                                "interrupting.",
+                                file=sys.stderr,
                             )
-                    for update in sess.translator.translate(event):
-                        await self._conn.session_update(
-                            session_id=sess.id,
-                            update=update,
-                        )
-                stream = None
+                            pending_external = True
+                            continue
+                        elif isinstance(event, ReplyEndEvent):
+                            finished = event.finished_reason
+                            error = event.error
+                        for update in sess.translator.translate(event):
+                            await self._conn.session_update(
+                                session_id=sess.id,
+                                update=update,
+                            )
+                finally:
+                    driver = sess.driver_task
+                    sess.driver_task = None
+                    if driver is not None:
+                        if not driver.done():
+                            driver.cancel()
+                        with contextlib.suppress(asyncio.CancelledError):
+                            # Surfaces agent-side exceptions; a
+                            # cancelled driver is the graceful path.
+                            await driver
+                if error is not None:
+                    raise RequestError.internal_error(
+                        {"error": str(error)},
+                    )
+                if pending_external:
+                    return await self._abort_parked(
+                        sess,
+                        sess.last_reply_id,
+                    )
                 if pending_confirm is None:
                     return _stop_reason(finished)
+                if sess.cancel_requested:
+                    # session/cancel raced the park: don't prompt.
+                    return await self._abort_parked(
+                        sess,
+                        pending_confirm.reply_id,
+                    )
                 # Resolve the gate at the client, bound to the exact
                 # toolCallId (invariant d).
                 confirm_results = await request_permission_for(
@@ -278,23 +355,40 @@ class AgentScopeAcpAgent(AcpAgentBase):
                     confirm_results=confirm_results,
                 )
         except asyncio.CancelledError:
-            # The cancellation landed while awaiting something *other*
-            # than reply_stream (a session/update write, a permission
-            # round-trip) — otherwise the agent itself would have ended
-            # the stream gracefully with finished_reason=INTERRUPTED.
-            if stream is not None:
-                with contextlib.suppress(Exception):
-                    await stream.aclose()
-            elif sess.last_reply_id is not None:
-                # Parked (awaiting permission): close the ASKING tool
-                # calls through the public interrupt input.
-                with contextlib.suppress(Exception):
-                    await self._drain_interrupt(sess, sess.last_reply_id)
+            # Only reachable when cancel() targeted the turn task: the
+            # reply was parked (permission round-trip) or the cancel
+            # raced a forwarding await after the stream had ended. The
+            # generator itself is never suspended here (the driver owns
+            # it), so closing out the parked state is safe.
+            await self._close_out_cancelled(sess)
             return "cancelled"
+        except Exception:
+            # Never leave a parked reply behind — it would brick every
+            # subsequent prompt on this session ("Agent is waiting for
+            # N tool calls..."). Interrupting an idle agent is a no-op.
+            await self._close_out_cancelled(sess)
+            raise
 
-    async def _abort_parked(self, sess: Session, reply_id: str) -> str:
+    async def _close_out_cancelled(self, sess: Session) -> None:
+        """Best-effort close-out of a parked reply after an abort.
+
+        Runs under ``asyncio.shield`` so a repeated ``session/cancel``
+        (or the surrounding task's cancellation) cannot abort the
+        close-out halfway and leave dangling ASKING tool calls in the
+        agent context. ``cancel()`` is additionally idempotent per
+        turn, so no second cancellation targets this path.
+        """
+        if sess.last_reply_id is None:
+            return
+        with contextlib.suppress(Exception, asyncio.CancelledError):
+            await asyncio.shield(
+                self._drain_interrupt(sess, sess.last_reply_id),
+            )
+
+    async def _abort_parked(self, sess: Session, reply_id: str | None) -> str:
         """Abort a parked reply and surface its close-out updates."""
-        await self._drain_interrupt(sess, reply_id)
+        if reply_id is not None:
+            await self._drain_interrupt(sess, reply_id)
         return "cancelled"
 
     async def _drain_interrupt(self, sess: Session, reply_id: str) -> None:
@@ -302,7 +396,8 @@ class AgentScopeAcpAgent(AcpAgentBase):
 
         The core closes pending ASKING/SUBMITTED tool calls with
         INTERRUPTED results and ends the reply; the client sees the
-        corresponding ``tool_call_update`` notifications.
+        corresponding ``tool_call_update`` notifications. On an idle
+        agent (nothing parked) this yields nothing.
         """
         async for event in sess.agent.reply_stream(
             UserInterruptEvent(reply_id=reply_id),
@@ -314,8 +409,27 @@ class AgentScopeAcpAgent(AcpAgentBase):
                 )
 
     async def cancel(self, session_id: str, **kwargs: Any) -> None:
-        """``session/cancel``: cancel the child turn task (§18)."""
-        sess = self._sessions.get(session_id)
+        """``session/cancel``: cancel the in-flight turn (§18).
+
+        Prefers cancelling the stream **driver** (the graceful path:
+        the core converts it into INTERRUPTED results and the turn
+        resolves through the normal event flow). Only when no driver is
+        running — the reply is parked at the permission round-trip —
+        is the turn task itself cancelled. Idempotent per turn: repeated
+        cancels while the close-out is in flight are no-ops, so they
+        cannot abort the cleanup halfway.
+        """
+        try:
+            sess = self._sessions.get(session_id)
+        except RequestError:
+            return  # cancelling an unknown session is a no-op
+        if sess.cancel_requested:
+            return
+        sess.cancel_requested = True
+        driver = sess.driver_task
+        if driver is not None and not driver.done():
+            driver.cancel()
+            return
         task = sess.turn_task
         if task is not None and not task.done():
             task.cancel()

--- a/examples/acp/acp_example/session.py
+++ b/examples/acp/acp_example/session.py
@@ -47,6 +47,17 @@ class Session:
     turn_task: asyncio.Task | None = None
     """The child task running the current turn, if any."""
 
+    driver_task: asyncio.Task | None = None
+    """The task consuming the current reply_stream run, if any.
+    ``session/cancel`` targets this first — cancelling the driver
+    delivers the CancelledError inside the generator, the core's
+    graceful-interruption path."""
+
+    cancel_requested: bool = False
+    """Set once a ``session/cancel`` has been processed for the current
+    turn; makes repeated cancels no-ops so they cannot abort the
+    close-out halfway."""
+
     last_reply_id: str | None = None
     """The reply_id of the most recent turn (for interrupt-on-parked)."""
 
@@ -64,12 +75,14 @@ class Session:
         if self._turn_active:
             return False
         self._turn_active = True
+        self.cancel_requested = False
         return True
 
     def end_turn(self) -> None:
         """Release the single-active-turn guard."""
         self._turn_active = False
         self.turn_task = None
+        self.driver_task = None
 
 
 class SessionManager:

--- a/examples/acp/acp_example/session.py
+++ b/examples/acp/acp_example/session.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""In-process session bookkeeping (DESIGN.md §9, §14, §18).
+
+One :class:`Session` per ACP ``sessionId``. The ACP session id *is*
+``AgentState.session_id`` (receipt invariant a) — one stable id shared
+end-to-end. There is deliberately no multi-tenant session manager here:
+the whole registry is a dict on the connection.
+"""
+import asyncio
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from acp import RequestError
+
+from .bridge import OpRegistry
+from .translate import Translator
+
+if TYPE_CHECKING:
+    from acp.schema import ClientCapabilities
+
+    from agentscope.agent import Agent
+    from agentscope.state import AgentState
+
+
+@dataclass
+class Session:
+    """Everything the kernel tracks for one ACP session."""
+
+    id: str
+    """The ACP sessionId == ``AgentState.session_id`` (invariant a)."""
+
+    agent: "Agent"
+    state: "AgentState"
+    cwd: str
+
+    caps: "ClientCapabilities | None"
+    """The initialize-time client capability snapshot (invariant b)."""
+
+    authority: str
+    """``"shell"`` or ``"workspace"`` — part of the snapshot."""
+
+    ops: OpRegistry
+    """Per-session operation registry (invariant c)."""
+
+    translator: Translator = field(init=False)
+
+    turn_task: asyncio.Task | None = None
+    """The child task running the current turn, if any."""
+
+    last_reply_id: str | None = None
+    """The reply_id of the most recent turn (for interrupt-on-parked)."""
+
+    _turn_active: bool = False
+
+    def __post_init__(self) -> None:
+        self.translator = Translator(self.ops)
+
+    def try_begin_turn(self) -> bool:
+        """Acquire the single-active-turn guard (DESIGN.md §18).
+
+        One ``Agent``/``AgentState`` must never be driven by two
+        concurrent ``reply_stream`` runs.
+        """
+        if self._turn_active:
+            return False
+        self._turn_active = True
+        return True
+
+    def end_turn(self) -> None:
+        """Release the single-active-turn guard."""
+        self._turn_active = False
+        self.turn_task = None
+
+
+class SessionManager:
+    """The connection-scoped ``dict[SessionId, Session]``."""
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, Session] = {}
+
+    def add(self, session: Session) -> None:
+        """Register a freshly minted session."""
+        self._sessions[session.id] = session
+
+    def get(self, session_id: str) -> Session:
+        """Look up a session or fail with a JSON-RPC error."""
+        session = self._sessions.get(session_id)
+        if session is None:
+            raise RequestError.invalid_params(
+                {"sessionId": f"unknown session: {session_id}"},
+            )
+        return session

--- a/examples/acp/acp_example/translate.py
+++ b/examples/acp/acp_example/translate.py
@@ -22,6 +22,7 @@ from typing import Any, TypeAlias
 from acp import (
     audio_block,
     image_block,
+    resource_link_block,
     text_block,
     tool_content,
 )
@@ -84,6 +85,7 @@ class _ToolCallBuffer:
     result_text: str = ""
     data_blocks: dict[str, list[str]] = field(default_factory=dict)
     data_media_types: dict[str, str] = field(default_factory=dict)
+    data_urls: dict[str, str] = field(default_factory=dict)
 
 
 def _parse_args(raw: str) -> Any:
@@ -255,6 +257,13 @@ class Translator:
         buf = self._tool_calls.get(event.tool_call_id)
         if buf is None:
             return []
+        # ``data`` and ``url`` are mutually exclusive: the core emits
+        # data=None with url=... for URL-sourced DataBlocks. URLs are
+        # one-shot, base64 payloads stream in chunks.
+        if event.data is None:
+            if event.url is not None:
+                buf.data_urls[event.block_id] = event.url
+            return []
         buf.data_blocks.setdefault(event.block_id, []).append(event.data)
         buf.data_media_types[event.block_id] = event.media_type
         return []
@@ -282,6 +291,10 @@ class Translator:
                 )
                 if block is not None:
                     content.append(tool_content(block))
+            for url in buf.data_urls.values():
+                content.append(
+                    tool_content(resource_link_block(name=url, uri=url)),
+                )
         return [
             ToolCallProgress(
                 session_update="tool_call_update",
@@ -310,6 +323,7 @@ class Translator:
 
 def _data_to_content(chunks: list[str], media_type: str) -> Any:
     """Assemble buffered base64 chunks into an ACP content block."""
+    chunks = [c for c in chunks if c is not None]
     if not chunks:
         return None
     data = "".join(chunks)

--- a/examples/acp/acp_example/translate.py
+++ b/examples/acp/acp_example/translate.py
@@ -1,0 +1,326 @@
+# -*- coding: utf-8 -*-
+"""AgentEvent → ACP ``session/update`` translation (DESIGN.md §10, §11).
+
+One :class:`Translator` per session. Correlation is carried by ids the
+core already mints (receipt invariants a/c):
+
+- streamed text/thinking/data blocks: ``block_id`` → ``messageId``,
+- tool call/result lifecycle: ``tool_call_id`` → ``toolCallId``,
+- the turn: ``reply_id`` (no direct ACP field — the turn *is* the open
+  ``session/prompt`` request).
+
+Events with no clean ACP mapping (model-call boundaries, hint blocks,
+custom events) translate to nothing; ``usage_update`` is omitted
+entirely because ACP requires both ``used`` and ``size`` (context
+window) and AgentScope only reports per-call token counts.
+"""
+import base64
+import json
+from dataclasses import dataclass, field
+from typing import Any, TypeAlias
+
+from acp import (
+    audio_block,
+    image_block,
+    text_block,
+    tool_content,
+)
+from acp.schema import (
+    AgentMessageChunk,
+    AgentThoughtChunk,
+    ToolCallStart,
+    ToolCallProgress,
+)
+
+from agentscope.event import (
+    DataBlockDeltaEvent,
+    DataBlockEndEvent,
+    TextBlockDeltaEvent,
+    ThinkingBlockDeltaEvent,
+    ToolCallDeltaEvent,
+    ToolCallEndEvent,
+    ToolCallStartEvent,
+    ToolResultDataDeltaEvent,
+    ToolResultEndEvent,
+    ToolResultStartEvent,
+    ToolResultTextDeltaEvent,
+)
+from agentscope.message import ToolResultState
+
+from .bridge import OpRegistry
+
+SessionUpdate: TypeAlias = (
+    AgentMessageChunk | AgentThoughtChunk | ToolCallStart | ToolCallProgress
+)
+
+# Presentation hint only: AgentScope builtin tool name → ACP ToolKind.
+_TOOL_KIND = {
+    "Read": "read",
+    "Grep": "search",
+    "Glob": "search",
+    "Write": "edit",
+    "Edit": "edit",
+    "Bash": "execute",
+    "PowerShell": "execute",
+}
+
+# ToolResultState → (ACP ToolCallStatus, receipt taxonomy label).
+# ACP only has completed/failed; the finer-grained taxonomy label
+# (invariant e) rides along in _meta.
+_RESULT_STATUS = {
+    ToolResultState.SUCCESS: ("completed", "completed"),
+    ToolResultState.ERROR: ("failed", "failed"),
+    ToolResultState.INTERRUPTED: ("failed", "interrupted"),
+    ToolResultState.DENIED: ("failed", "denied"),
+}
+
+
+@dataclass
+class _ToolCallBuffer:
+    """Streaming state for one in-flight tool call."""
+
+    name: str
+    args: str = ""
+    result_text: str = ""
+    data_blocks: dict[str, list[str]] = field(default_factory=dict)
+    data_media_types: dict[str, str] = field(default_factory=dict)
+
+
+def _parse_args(raw: str) -> Any:
+    """Best-effort JSON parse of accumulated tool arguments."""
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        return raw
+
+
+class Translator:
+    """Stateful AgentEvent → session/update mapper for one session."""
+
+    def __init__(self, ops: OpRegistry) -> None:
+        self._ops = ops
+        self._tool_calls: dict[str, _ToolCallBuffer] = {}
+        # Streamed assistant-level data blocks (images/audio), buffered
+        # until DATA_BLOCK_END because partial base64 is not renderable.
+        self._data: dict[str, list[str]] = {}
+        self._data_media_types: dict[str, str] = {}
+
+    def translate(self, event: Any) -> list[SessionUpdate]:
+        """Map one AgentEvent to zero or more session updates.
+
+        Events with no handler have no per-event ACP mapping:
+
+        - ReplyStart/ReplyEnd, ExceedMaxIters: turn boundaries — the
+          server derives the stopReason from
+          ``ReplyEndEvent.finished_reason``.
+        - ModelCallStart/End: no faithful ``usage_update`` possible (no
+          context-window size signal), so nothing is emitted.
+        - HintBlockEvent: runtime-state injection hints are internal
+          system-reminder text; rendering them would leak into the UI.
+        - RequireUserConfirm/RequireExternalExecution and the resume
+          inputs: handled by the server's permission bridge.
+        - CustomEvent: no stable mapping.
+        """
+        handler = self._HANDLERS.get(type(event))
+        if handler is None:
+            return []
+        return handler(self, event)
+
+    def _text_delta(self, event: TextBlockDeltaEvent) -> list[SessionUpdate]:
+        return [
+            AgentMessageChunk(
+                session_update="agent_message_chunk",
+                content=text_block(event.delta),
+                message_id=event.block_id,
+            ),
+        ]
+
+    def _thinking_delta(
+        self,
+        event: ThinkingBlockDeltaEvent,
+    ) -> list[SessionUpdate]:
+        return [
+            AgentThoughtChunk(
+                session_update="agent_thought_chunk",
+                content=text_block(event.delta),
+                message_id=event.block_id,
+            ),
+        ]
+
+    def _data_delta(self, event: DataBlockDeltaEvent) -> list[SessionUpdate]:
+        self._data.setdefault(event.block_id, []).append(event.data)
+        self._data_media_types[event.block_id] = event.media_type
+        return []
+
+    def _data_end(self, event: DataBlockEndEvent) -> list[SessionUpdate]:
+        chunks = self._data.pop(event.block_id, [])
+        media_type = self._data_media_types.pop(event.block_id, "")
+        block = _data_to_content(chunks, media_type)
+        if block is None:
+            return []
+        return [
+            AgentMessageChunk(
+                session_update="agent_message_chunk",
+                content=block,
+                message_id=event.block_id,
+            ),
+        ]
+
+    def _tool_call_start(
+        self,
+        event: ToolCallStartEvent,
+    ) -> list[SessionUpdate]:
+        self._tool_calls[event.tool_call_id] = _ToolCallBuffer(
+            name=event.tool_call_name,
+        )
+        return [
+            ToolCallStart(
+                session_update="tool_call",
+                tool_call_id=event.tool_call_id,
+                title=event.tool_call_name,
+                kind=_TOOL_KIND.get(event.tool_call_name, "other"),
+                status="pending",
+            ),
+        ]
+
+    def _tool_call_delta(
+        self,
+        event: ToolCallDeltaEvent,
+    ) -> list[SessionUpdate]:
+        buf = self._tool_calls.get(event.tool_call_id)
+        if buf is not None:
+            buf.args += event.delta
+        # ACP has no argument-delta update; hold until TOOL_CALL_END.
+        return []
+
+    def _tool_call_end(self, event: ToolCallEndEvent) -> list[SessionUpdate]:
+        buf = self._tool_calls.get(event.tool_call_id)
+        if buf is None:
+            return []
+        # Arguments are complete: register the pending operation so
+        # the OpBindingMiddleware can claim it at execution time
+        # (invariant c), and surface the final rawInput.
+        self._ops.register_pending(
+            event.tool_call_id,
+            buf.name,
+            buf.args,
+        )
+        return [
+            ToolCallProgress(
+                session_update="tool_call_update",
+                tool_call_id=event.tool_call_id,
+                raw_input=_parse_args(buf.args),
+            ),
+        ]
+
+    def _tool_result_start(
+        self,
+        event: ToolResultStartEvent,
+    ) -> list[SessionUpdate]:
+        # Execution began (permission, if any, was resolved).
+        self._tool_calls.setdefault(
+            event.tool_call_id,
+            _ToolCallBuffer(name=event.tool_call_name),
+        )
+        return [
+            ToolCallProgress(
+                session_update="tool_call_update",
+                tool_call_id=event.tool_call_id,
+                status="in_progress",
+            ),
+        ]
+
+    def _tool_result_text_delta(
+        self,
+        event: ToolResultTextDeltaEvent,
+    ) -> list[SessionUpdate]:
+        buf = self._tool_calls.get(event.tool_call_id)
+        if buf is None:
+            return []
+        buf.result_text += event.delta
+        # ``content`` replaces the collection on every update, so
+        # each update carries the accumulated text.
+        return [
+            ToolCallProgress(
+                session_update="tool_call_update",
+                tool_call_id=event.tool_call_id,
+                content=[tool_content(text_block(buf.result_text))],
+            ),
+        ]
+
+    def _tool_result_data_delta(
+        self,
+        event: ToolResultDataDeltaEvent,
+    ) -> list[SessionUpdate]:
+        buf = self._tool_calls.get(event.tool_call_id)
+        if buf is None:
+            return []
+        buf.data_blocks.setdefault(event.block_id, []).append(event.data)
+        buf.data_media_types[event.block_id] = event.media_type
+        return []
+
+    def _tool_result_end(
+        self,
+        event: ToolResultEndEvent,
+    ) -> list[SessionUpdate]:
+        buf = self._tool_calls.pop(event.tool_call_id, None)
+        self._ops.discard_pending(event.tool_call_id)
+        status, taxonomy = _RESULT_STATUS.get(
+            event.state,
+            ("failed", "failed"),
+        )
+        content = []
+        raw_output: Any = None
+        if buf is not None:
+            if buf.result_text:
+                content.append(tool_content(text_block(buf.result_text)))
+                raw_output = buf.result_text
+            for block_id, chunks in buf.data_blocks.items():
+                block = _data_to_content(
+                    chunks,
+                    buf.data_media_types.get(block_id, ""),
+                )
+                if block is not None:
+                    content.append(tool_content(block))
+        return [
+            ToolCallProgress(
+                session_update="tool_call_update",
+                tool_call_id=event.tool_call_id,
+                status=status,
+                content=content or None,
+                raw_output=raw_output,
+                field_meta={"agentscope": {"result_state": taxonomy}},
+            ),
+        ]
+
+    _HANDLERS: dict[type, Any] = {
+        TextBlockDeltaEvent: _text_delta,
+        ThinkingBlockDeltaEvent: _thinking_delta,
+        DataBlockDeltaEvent: _data_delta,
+        DataBlockEndEvent: _data_end,
+        ToolCallStartEvent: _tool_call_start,
+        ToolCallDeltaEvent: _tool_call_delta,
+        ToolCallEndEvent: _tool_call_end,
+        ToolResultStartEvent: _tool_result_start,
+        ToolResultTextDeltaEvent: _tool_result_text_delta,
+        ToolResultDataDeltaEvent: _tool_result_data_delta,
+        ToolResultEndEvent: _tool_result_end,
+    }
+
+
+def _data_to_content(chunks: list[str], media_type: str) -> Any:
+    """Assemble buffered base64 chunks into an ACP content block."""
+    if not chunks:
+        return None
+    data = "".join(chunks)
+    if media_type.startswith("image/"):
+        return image_block(data, media_type)
+    if media_type.startswith("audio/"):
+        return audio_block(data, media_type)
+    # Other media: degrade to a short textual stand-in rather than
+    # dropping the information entirely.
+    try:
+        size = len(base64.b64decode(data, validate=False))
+    except (ValueError, TypeError):
+        size = len(data)
+    return text_block(f"[{media_type or 'binary'} data, {size} bytes]")

--- a/examples/acp/pyproject.toml
+++ b/examples/acp/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "acp-example"
+version = "0.1.0"
+description = "ACP Agent (stdio) example for AgentScope"
+requires-python = ">=3.11"
+dependencies = [
+    # The ACP stdio peer. Pinned: the SDK is pre-1.0 and its schema moves.
+    "agent-client-protocol==0.12.0",
+    # The kernel. The example only uses public API.
+    "agentscope>=2.0.5",
+]
+
+[project.optional-dependencies]
+test = ["pytest", "pytest-asyncio"]
+
+[tool.setuptools]
+packages = ["acp_example"]

--- a/examples/acp/pytest.ini
+++ b/examples/acp/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/examples/acp/requirements.txt
+++ b/examples/acp/requirements.txt
@@ -1,0 +1,11 @@
+# The ACP stdio peer. Pinned: the SDK is pre-1.0 and its schema moves.
+agent-client-protocol==0.12.0
+
+# The kernel. The example only uses public API (agentscope.agent/event/
+# permission/tool/message/state); any model-provider SDK it needs comes
+# with the core install (dashscope/openai/anthropic are core deps).
+agentscope>=2.0.5
+
+# For the example's test suite only.
+pytest
+pytest-asyncio

--- a/examples/acp/tests/conftest.py
+++ b/examples/acp/tests/conftest.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+"""Make the example package importable when running pytest from
+``examples/acp/``."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/examples/acp/tests/mock_client.py
+++ b/examples/acp/tests/mock_client.py
@@ -5,7 +5,7 @@ Implements the ``acp.interfaces.Client`` protocol surface the kernel
 uses: it records every ``session/update``, answers
 ``session/request_permission`` from a script, serves ``fs/*`` against
 the real filesystem, and backs ``terminal/*`` with real subprocesses —
-so Read/Write/Edit/Grep/Bash execute end-to-end against a temp dir.
+so Read/Write/Edit/Bash execute end-to-end against a temp dir.
 """
 # pylint: disable=unused-argument  # the Client protocol fixes signatures
 import asyncio

--- a/examples/acp/tests/mock_client.py
+++ b/examples/acp/tests/mock_client.py
@@ -1,0 +1,233 @@
+# -*- coding: utf-8 -*-
+"""An in-process mock ACP client for the example tests (DESIGN.md §19).
+
+Implements the ``acp.interfaces.Client`` protocol surface the kernel
+uses: it records every ``session/update``, answers
+``session/request_permission`` from a script, serves ``fs/*`` against
+the real filesystem, and backs ``terminal/*`` with real subprocesses —
+so Read/Write/Edit/Grep/Bash execute end-to-end against a temp dir.
+"""
+# pylint: disable=unused-argument  # the Client protocol fixes signatures
+import asyncio
+from typing import Any
+
+from acp import RequestError
+from acp.schema import (
+    AllowedOutcome,
+    CreateTerminalResponse,
+    DeniedOutcome,
+    KillTerminalResponse,
+    PermissionOption,
+    ReadTextFileResponse,
+    ReleaseTerminalResponse,
+    RequestPermissionResponse,
+    TerminalExitStatus,
+    TerminalOutputResponse,
+    ToolCallUpdate,
+    WaitForTerminalExitResponse,
+    WriteTextFileResponse,
+)
+
+
+class _FakeTerminal:
+    """One client-owned terminal backed by a real subprocess."""
+
+    def __init__(self) -> None:
+        self.proc: asyncio.subprocess.Process | None = None
+        self.output = b""
+        self._collector: asyncio.Task | None = None
+
+    async def start(
+        self,
+        command: str,
+        args: list[str],
+        cwd: str | None,
+    ) -> None:
+        """Spawn the subprocess and start collecting output."""
+        self.proc = await asyncio.create_subprocess_exec(
+            command,
+            *args,
+            cwd=cwd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+
+        async def _collect() -> None:
+            assert self.proc is not None and self.proc.stdout is not None
+            self.output = await self.proc.stdout.read()
+
+        self._collector = asyncio.create_task(_collect())
+
+    async def wait(self) -> int | None:
+        """Wait for exit and the output collector."""
+        assert self.proc is not None
+        code = await self.proc.wait()
+        if self._collector is not None:
+            await self._collector
+        return code
+
+    def kill(self) -> None:
+        """Kill the subprocess if still running."""
+        if self.proc is not None and self.proc.returncode is None:
+            self.proc.kill()
+
+
+class FakeClient:
+    """Scripted, filesystem-backed mock of the ACP client side."""
+
+    def __init__(
+        self,
+        permission_answers: list[str] | None = None,
+    ) -> None:
+        # Recorded traffic, for assertions.
+        self.updates: list[tuple[str, Any]] = []
+        self.permission_requests: list[ToolCallUpdate] = []
+        # Each entry answers one request_permission call: an option id
+        # ("allow_once", ...) or "cancelled" for a DeniedOutcome.
+        self.permission_answers = list(permission_answers or [])
+        # Set when a permission request arrives and, if present, awaited
+        # before answering — lets tests park a turn at the gate.
+        self.permission_gate: asyncio.Event | None = None
+        self.terminals: dict[str, _FakeTerminal] = {}
+        self._terminal_seq = 0
+        self.terminal_started = asyncio.Event()
+
+    # ── session/update ────────────────────────────────────────────
+
+    async def session_update(
+        self,
+        session_id: str,
+        update: Any,
+        **kwargs: Any,
+    ) -> None:
+        """Record one session/update notification."""
+        self.updates.append((session_id, update))
+
+    def updates_of(self, kind: str) -> list[Any]:
+        """All recorded updates of one sessionUpdate discriminator."""
+        return [u for _, u in self.updates if u.session_update == kind]
+
+    # ── permission ────────────────────────────────────────────────
+
+    async def request_permission(
+        self,
+        session_id: str,
+        tool_call: ToolCallUpdate,
+        options: list[PermissionOption],
+        **kwargs: Any,
+    ) -> RequestPermissionResponse:
+        """Answer a permission request from the script."""
+        self.permission_requests.append(tool_call)
+        if self.permission_gate is not None:
+            await self.permission_gate.wait()
+        answer = (
+            self.permission_answers.pop(0)
+            if self.permission_answers
+            else "allow_once"
+        )
+        if answer == "cancelled":
+            outcome: Any = DeniedOutcome(outcome="cancelled")
+        else:
+            outcome = AllowedOutcome(outcome="selected", option_id=answer)
+        return RequestPermissionResponse(outcome=outcome)
+
+    # ── fs/* ──────────────────────────────────────────────────────
+
+    async def read_text_file(
+        self,
+        session_id: str,
+        path: str,
+        line: int | None = None,
+        limit: int | None = None,
+        **kwargs: Any,
+    ) -> ReadTextFileResponse:
+        """Serve fs/read_text_file from the real filesystem."""
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return ReadTextFileResponse(content=f.read())
+        except FileNotFoundError as e:
+            raise RequestError.resource_not_found(path) from e
+
+    async def write_text_file(
+        self,
+        session_id: str,
+        path: str,
+        content: str,
+        **kwargs: Any,
+    ) -> WriteTextFileResponse:
+        """Serve fs/write_text_file onto the real filesystem."""
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content)
+        return WriteTextFileResponse()
+
+    # ── terminal/* ────────────────────────────────────────────────
+
+    async def create_terminal(
+        self,
+        session_id: str,
+        command: str,
+        args: list[str] | None = None,
+        env: list | None = None,
+        cwd: str | None = None,
+        output_byte_limit: int | None = None,
+        **kwargs: Any,
+    ) -> CreateTerminalResponse:
+        """Spawn a real subprocess as the client-owned terminal."""
+        self._terminal_seq += 1
+        terminal_id = f"term-{self._terminal_seq}"
+        terminal = _FakeTerminal()
+        await terminal.start(command, list(args or []), cwd)
+        self.terminals[terminal_id] = terminal
+        self.terminal_started.set()
+        return CreateTerminalResponse(terminal_id=terminal_id)
+
+    async def wait_for_terminal_exit(
+        self,
+        session_id: str,
+        terminal_id: str,
+        **kwargs: Any,
+    ) -> WaitForTerminalExitResponse:
+        """Wait for the terminal subprocess to exit."""
+        code = await self.terminals[terminal_id].wait()
+        return WaitForTerminalExitResponse(exit_code=code)
+
+    async def terminal_output(
+        self,
+        session_id: str,
+        terminal_id: str,
+        **kwargs: Any,
+    ) -> TerminalOutputResponse:
+        """Return the merged output collected so far."""
+        terminal = self.terminals[terminal_id]
+        exit_status = None
+        if terminal.proc is not None and terminal.proc.returncode is not None:
+            exit_status = TerminalExitStatus(
+                exit_code=terminal.proc.returncode,
+            )
+        return TerminalOutputResponse(
+            output=terminal.output.decode("utf-8", errors="replace"),
+            truncated=False,
+            exit_status=exit_status,
+        )
+
+    async def kill_terminal(
+        self,
+        session_id: str,
+        terminal_id: str,
+        **kwargs: Any,
+    ) -> KillTerminalResponse:
+        """Kill the terminal subprocess."""
+        self.terminals[terminal_id].kill()
+        return KillTerminalResponse()
+
+    async def release_terminal(
+        self,
+        session_id: str,
+        terminal_id: str,
+        **kwargs: Any,
+    ) -> ReleaseTerminalResponse:
+        """Release (and kill, if needed) the terminal."""
+        terminal = self.terminals.get(terminal_id)
+        if terminal is not None:
+            terminal.kill()
+        return ReleaseTerminalResponse()

--- a/examples/acp/tests/mock_model.py
+++ b/examples/acp/tests/mock_model.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+"""A minimal scripted chat model for the example tests.
+
+Mirrors the pattern of the repository's own ``tests/utils.py`` MockModel
+but stays self-contained so the example tests do not depend on repo test
+internals.
+"""
+from typing import Any, AsyncGenerator, Type
+
+from pydantic import BaseModel
+
+from agentscope.credential import CredentialBase
+from agentscope.formatter import OpenAIChatFormatter
+from agentscope.model import ChatModelBase, ChatResponse
+
+
+class MockCredential(CredentialBase):
+    """A do-nothing credential."""
+
+    @classmethod
+    def get_chat_model_class(cls) -> Type["ChatModelBase"]:
+        """Return the mock model class."""
+        return MockModel
+
+
+class MockModel(ChatModelBase):
+    """Replays scripted responses; each entry answers one model call.
+
+    An entry that is a list is served as a streaming call (each element
+    yielded, or raised if it is an exception); a bare ``ChatResponse``
+    is served as a non-stream call.
+    """
+
+    class Parameters(BaseModel):
+        """No parameters."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            credential=MockCredential(),
+            model="mock-model",
+            stream=True,
+            parameters=MockModel.Parameters(),
+            context_size=100000,
+        )
+        self.formatter = OpenAIChatFormatter()
+        self.responses: list = []
+        self.cnt = 0
+
+    def set_responses(self, responses: list) -> None:
+        """Script the upcoming model calls."""
+        self.responses = responses
+        self.cnt = 0
+        self.stream = all(isinstance(r, list) for r in responses)
+
+    async def _call_api(  # pylint: disable=unused-argument
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> ChatResponse | AsyncGenerator[ChatResponse, None]:
+        """Serve the next scripted response."""
+        scripted = self.responses[self.cnt]
+        self.cnt += 1
+        if isinstance(scripted, BaseException):
+            raise scripted
+        if isinstance(scripted, list):
+
+            async def _stream() -> AsyncGenerator[ChatResponse, None]:
+                for item in scripted:
+                    if isinstance(item, BaseException):
+                        raise item
+                    yield item
+
+            return _stream()
+        return scripted

--- a/examples/acp/tests/mock_model.py
+++ b/examples/acp/tests/mock_model.py
@@ -45,6 +45,9 @@ class MockModel(ChatModelBase):
         self.formatter = OpenAIChatFormatter()
         self.responses: list = []
         self.cnt = 0
+        # Re-declared here (the base __init__ also sets it) so that
+        # set_responses' toggling is visibly an attribute update.
+        self.stream = True
 
     def set_responses(self, responses: list) -> None:
         """Script the upcoming model calls."""

--- a/examples/acp/tests/test_regressions.py
+++ b/examples/acp/tests/test_regressions.py
@@ -15,18 +15,18 @@ import pytest
 
 from acp import text_block
 
+from acp_example.bridge import ClientBackend, OpRegistry
+from acp_example.translate import Translator
+
+from mock_client import FakeClient
+from test_server import setup, text_script, tool_call_script
+
 from agentscope.event import (
     ToolResultDataDeltaEvent,
     ToolResultEndEvent,
     ToolResultStartEvent,
 )
 from agentscope.message import ToolResultState
-
-from acp_example.bridge import ClientBackend, OpRegistry
-from acp_example.translate import Translator
-
-from mock_client import FakeClient
-from test_server import setup, text_script, tool_call_script
 
 REPLY = "reply-1"
 

--- a/examples/acp/tests/test_regressions.py
+++ b/examples/acp/tests/test_regressions.py
@@ -1,0 +1,394 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for defects found in adversarial review (§19).
+
+Covers: the ``*_always`` permission options (rule construction and
+persistence), the Edit end-to-end path, URL-sourced tool-result data,
+the exec_shell timeout sentinel, repeated ``session/cancel``, and a
+cancel landing while the turn is blocked forwarding a session/update.
+"""
+# pylint: disable=protected-access
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from acp import text_block
+
+from agentscope.event import (
+    ToolResultDataDeltaEvent,
+    ToolResultEndEvent,
+    ToolResultStartEvent,
+)
+from agentscope.message import ToolResultState
+
+from acp_example.bridge import ClientBackend, OpRegistry
+from acp_example.translate import Translator
+
+from mock_client import FakeClient
+from test_server import setup, text_script, tool_call_script
+
+REPLY = "reply-1"
+
+
+# ── *_always permission options ───────────────────────────────────────
+
+
+async def test_allow_always_installs_rule_no_reprompt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """allow_always must not crash, and the installed rule suppresses
+    the prompt for an identical operation in the next turn."""
+    server, client, model, session_id = await setup(
+        tmp_path,
+        monkeypatch,
+        permission_answers=["allow_always"],
+    )
+    target = tmp_path / "out.txt"
+    write_call = tool_call_script(
+        "Write",
+        {"file_path": str(target), "content": "v1"},
+    )
+    model.set_responses([write_call, text_script("done")])
+    resp = await server.prompt(
+        session_id=session_id,
+        prompt=[text_block("write")],
+    )
+    assert resp.stop_reason == "end_turn"
+    assert target.read_text() == "v1"
+    assert len(client.permission_requests) == 1
+
+    # Second turn: Read (required before overwriting), then the same
+    # Write — covered by the installed rule, so no second prompt.
+    model.set_responses(
+        [
+            tool_call_script(
+                "Read",
+                {"file_path": str(target)},
+                call_id="call-r",
+            ),
+            tool_call_script(
+                "Write",
+                {"file_path": str(target), "content": "v2"},
+                call_id="call-2",
+            ),
+            text_script("done again"),
+        ],
+    )
+    resp = await server.prompt(
+        session_id=session_id,
+        prompt=[text_block("write again")],
+    )
+    assert resp.stop_reason == "end_turn"
+    assert target.read_text() == "v2"
+    assert len(client.permission_requests) == 1  # no second prompt
+
+
+async def test_reject_always_installs_deny_rule(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """reject_always must not crash; the DENY rule goes onto the public
+    permission context (ConfirmResult.rules is ignored for denials) and
+    auto-denies the identical operation next turn without a prompt."""
+    server, client, model, session_id = await setup(
+        tmp_path,
+        monkeypatch,
+        permission_answers=["reject_always"],
+    )
+    target = tmp_path / "out.txt"
+    model.set_responses(
+        [
+            tool_call_script(
+                "Write",
+                {"file_path": str(target), "content": "nope"},
+            ),
+            text_script("okay"),
+        ],
+    )
+    resp = await server.prompt(
+        session_id=session_id,
+        prompt=[text_block("write")],
+    )
+    assert resp.stop_reason == "end_turn"
+    assert not target.exists()
+    assert len(client.permission_requests) == 1
+    sess = server._sessions.get(session_id)
+    deny = sess.agent.state.permission_context.deny_rules.get("Write")
+    assert deny, "reject_always must install a DENY rule"
+
+    # Second turn: the deny rule resolves without prompting the client.
+    model.set_responses(
+        [
+            tool_call_script(
+                "Write",
+                {"file_path": str(target), "content": "still no"},
+                call_id="call-2",
+            ),
+            text_script("understood"),
+        ],
+    )
+    resp = await server.prompt(
+        session_id=session_id,
+        prompt=[text_block("write again")],
+    )
+    assert resp.stop_reason == "end_turn"
+    assert not target.exists()
+    assert len(client.permission_requests) == 1  # no second prompt
+    denied = [
+        u
+        for u in client.updates_of("tool_call_update")
+        if u.tool_call_id == "call-2"
+        and u.field_meta
+        and u.field_meta.get("agentscope", {}).get("result_state") == "denied"
+    ]
+    assert len(denied) == 1
+
+
+# ── Edit end-to-end ───────────────────────────────────────────────────
+
+
+async def test_edit_tool_end_to_end(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Edit composes fs/read + fs/write + exec existence checks."""
+    server, client, model, session_id = await setup(
+        tmp_path,
+        monkeypatch,
+        permission_answers=["allow_once"],
+    )
+    target = tmp_path / "code.py"
+    target.write_text("x = 1\ny = 2\n")
+    model.set_responses(
+        [
+            tool_call_script(
+                "Read",
+                {"file_path": str(target)},
+                call_id="call-r",
+            ),
+            tool_call_script(
+                "Edit",
+                {
+                    "file_path": str(target),
+                    "old_string": "x = 1",
+                    "new_string": "x = 42",
+                },
+            ),
+            text_script("edited"),
+        ],
+    )
+    resp = await server.prompt(
+        session_id=session_id,
+        prompt=[text_block("bump x")],
+    )
+    assert resp.stop_reason == "end_turn"
+    assert target.read_text() == "x = 42\ny = 2\n"
+    assert len(client.permission_requests) == 1
+    statuses = [
+        u.status for u in client.updates_of("tool_call_update") if u.status
+    ]
+    assert statuses[-1] == "completed"
+
+
+# ── URL-sourced tool-result data ──────────────────────────────────────
+
+
+def test_url_data_delta_does_not_crash_translator() -> None:
+    """The URL variant (data=None) must not crash; the URL surfaces as
+    a resource_link content block on the final update."""
+    tr = Translator(OpRegistry())
+    tr.translate(
+        ToolResultStartEvent(
+            reply_id=REPLY,
+            tool_call_id="tc",
+            tool_call_name="fetch_image",
+        ),
+    )
+    assert not tr.translate(
+        ToolResultDataDeltaEvent(
+            reply_id=REPLY,
+            tool_call_id="tc",
+            block_id="b1",
+            media_type="image/png",
+            url="https://example.com/pic.png",
+        ),
+    )
+    done = tr.translate(
+        ToolResultEndEvent(
+            reply_id=REPLY,
+            tool_call_id="tc",
+            state=ToolResultState.SUCCESS,
+        ),
+    )
+    assert done[0].status == "completed"
+    links = [
+        c.content
+        for c in done[0].content
+        if getattr(c.content, "type", None) == "resource_link"
+    ]
+    assert len(links) == 1
+    assert links[0].uri == "https://example.com/pic.png"
+
+
+# ── exec_shell timeout sentinel ───────────────────────────────────────
+
+
+async def test_exec_timeout_returns_timed_out_sentinel(
+    tmp_path: Path,
+) -> None:
+    """A timed-out command must report the LocalBackend convention
+    (exit_code -1, stderr b"timed out") that Bash/Grep key on."""
+    client = FakeClient()
+    backend = ClientBackend(
+        conn=client,
+        session_id="s",
+        cwd=str(tmp_path),
+        ops=OpRegistry(),
+    )
+    result = await backend.exec_shell(["sleep", "30"], timeout=0.3)
+    assert result.exit_code == -1
+    assert result.stderr == b"timed out"
+
+
+# ── cancellation robustness ───────────────────────────────────────────
+
+
+async def test_repeated_cancel_does_not_brick_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A flurry of session/cancel while parked at the permission gate
+    must close out cleanly and leave the session usable."""
+    server, client, model, session_id = await setup(
+        tmp_path,
+        monkeypatch,
+    )
+    client.permission_gate = asyncio.Event()  # never released
+    model.set_responses(
+        [
+            tool_call_script(
+                "Write",
+                {"file_path": str(tmp_path / "x.txt"), "content": "x"},
+            ),
+        ],
+    )
+    turn = asyncio.create_task(
+        server.prompt(session_id=session_id, prompt=[text_block("go")]),
+    )
+    while not client.permission_requests:
+        await asyncio.sleep(0.01)
+    # Users mash Escape: several cancels in quick succession.
+    await server.cancel(session_id=session_id)
+    await server.cancel(session_id=session_id)
+    await asyncio.sleep(0)
+    await server.cancel(session_id=session_id)
+    resp = await asyncio.wait_for(turn, timeout=10)
+    assert resp.stop_reason == "cancelled"
+    # The parked ASKING call was closed out as interrupted.
+    interrupted = [
+        u
+        for u in client.updates_of("tool_call_update")
+        if u.field_meta
+        and u.field_meta.get("agentscope", {}).get("result_state")
+        == "interrupted"
+    ]
+    assert len(interrupted) == 1
+    # The session accepts and completes a fresh turn.
+    client.permission_gate = None
+    model.set_responses([text_script("alive")])
+    resp = await server.prompt(
+        session_id=session_id,
+        prompt=[text_block("hi")],
+    )
+    assert resp.stop_reason == "end_turn"
+
+
+class _BlockingUpdateClient(FakeClient):
+    """FakeClient whose session_update stalls once, like a backpressured
+    transport, so a cancel can land mid-forward."""
+
+    def __init__(self) -> None:
+        super().__init__(permission_answers=["allow_once"])
+        self.block_on_status: str | None = "in_progress"
+        self.blocked = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def session_update(
+        self,
+        session_id: str,
+        update: Any,
+        **kwargs: Any,
+    ) -> None:
+        await super().session_update(session_id, update, **kwargs)
+        if (
+            self.block_on_status is not None
+            and getattr(update, "status", None) == self.block_on_status
+        ):
+            self.block_on_status = None
+            self.blocked.set()
+            await self.release.wait()
+
+
+async def test_cancel_while_forwarding_update_still_closes_out(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancel landing while the turn is blocked in session_update must
+    still produce the core's graceful INTERRUPTED close-out (the driver
+    owns the generator, so the cancellation reaches reply_stream)."""
+    import acp_example.agent as agent_mod
+    from acp_example.server import AgentScopeAcpAgent
+    from mock_model import MockModel
+    from test_server import make_config
+
+    model = MockModel()
+    monkeypatch.setattr(agent_mod, "_make_model", lambda config: model)
+    client = _BlockingUpdateClient()
+    server = AgentScopeAcpAgent(config=make_config())
+    server.on_connect(client)
+    from acp.schema import ClientCapabilities, FileSystemCapabilities
+
+    await server.initialize(
+        protocol_version=1,
+        client_capabilities=ClientCapabilities(
+            fs=FileSystemCapabilities(
+                read_text_file=True,
+                write_text_file=True,
+            ),
+            terminal=True,
+        ),
+    )
+    session_id = (await server.new_session(cwd=str(tmp_path))).session_id
+    model.set_responses(
+        [tool_call_script("Bash", {"command": "sleep 30"})],
+    )
+    turn = asyncio.create_task(
+        server.prompt(session_id=session_id, prompt=[text_block("go")]),
+    )
+    # The forwarder is now stalled on the in_progress update while the
+    # tool runs in a worker; fire the cancel into that window.
+    await asyncio.wait_for(client.blocked.wait(), timeout=10)
+    await server.cancel(session_id=session_id)
+    await asyncio.sleep(0.05)
+    client.release.set()
+    resp = await asyncio.wait_for(turn, timeout=10)
+    assert resp.stop_reason == "cancelled"
+    # The graceful close-out reached the wire: the running tool call
+    # ended as interrupted, not stuck at in_progress.
+    interrupted = [
+        u
+        for u in client.updates_of("tool_call_update")
+        if u.field_meta
+        and u.field_meta.get("agentscope", {}).get("result_state")
+        == "interrupted"
+    ]
+    assert len(interrupted) == 1
+    # And the agent context was repaired: a fresh turn works.
+    model.set_responses([text_script("alive")])
+    resp = await server.prompt(
+        session_id=session_id,
+        prompt=[text_block("hi")],
+    )
+    assert resp.stop_reason == "end_turn"

--- a/examples/acp/tests/test_server.py
+++ b/examples/acp/tests/test_server.py
@@ -1,0 +1,429 @@
+# -*- coding: utf-8 -*-
+"""End-to-end tests driving the ACP handlers with a mock client (§19).
+
+The mock client serves fs/* against a temp dir and terminal/* with real
+subprocesses, so the builtin tools execute the full shell-delegation
+path: content via fs/*, existence/dir/mkdir checks via terminal/*.
+"""
+# pylint: disable=protected-access
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from acp import RequestError, text_block
+from acp.schema import ClientCapabilities, FileSystemCapabilities
+
+from agentscope.message import TextBlock, ToolCallBlock
+from agentscope.model import ChatResponse
+from agentscope.types import ReplyFinishedReason
+
+import acp_example.agent as agent_mod
+from acp_example.config import Config
+from acp_example.server import AgentScopeAcpAgent, _stop_reason
+
+from mock_client import FakeClient
+from mock_model import MockModel
+
+FULL_CAPS = ClientCapabilities(
+    fs=FileSystemCapabilities(read_text_file=True, write_text_file=True),
+    terminal=True,
+)
+
+
+def make_config() -> Config:
+    """A shell-authority config that never reads the environment."""
+    return Config(
+        model_provider="dashscope",
+        model_name=None,
+        authority="shell",
+        permission_mode="default",
+        agent_name="agentscope-acp",
+        workspace_backend="local",
+    )
+
+
+async def setup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    permission_answers: list[str] | None = None,
+    caps: ClientCapabilities = FULL_CAPS,
+) -> tuple[AgentScopeAcpAgent, FakeClient, MockModel, str]:
+    """Build a server+mock-client pair with one fresh session."""
+    model = MockModel()
+    monkeypatch.setattr(agent_mod, "_make_model", lambda config: model)
+    client = FakeClient(permission_answers)
+    server = AgentScopeAcpAgent(config=make_config())
+    server.on_connect(client)
+    await server.initialize(protocol_version=1, client_capabilities=caps)
+    resp = await server.new_session(cwd=str(tmp_path))
+    return server, client, model, resp.session_id
+
+
+def tool_call_script(
+    name: str,
+    arguments: dict,
+    call_id: str = "call-1",
+) -> list[Any]:
+    """One scripted model call that emits a single tool call."""
+    block = ToolCallBlock(id=call_id, name=name, input=json.dumps(arguments))
+    return [
+        ChatResponse(content=[block], is_last=False),
+        ChatResponse(content=[block], is_last=True),
+    ]
+
+
+def text_script(text: str) -> list[Any]:
+    """One scripted model call that streams a text answer."""
+    return [
+        ChatResponse(content=[TextBlock(text=text)], is_last=False),
+        ChatResponse(content=[TextBlock(text=text)], is_last=True),
+    ]
+
+
+# ── session lifecycle ─────────────────────────────────────────────────
+
+
+async def test_session_id_is_agent_state_session_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invariants a and b: stable session id + stored snapshot."""
+    server, _, _, session_id = await setup(tmp_path, monkeypatch)
+    sess = server._sessions.get(session_id)
+    # Receipt invariant a: one stable id shared end-to-end.
+    assert session_id == sess.state.session_id
+    # Invariant b: the capability/authority snapshot is stored.
+    assert sess.caps is FULL_CAPS
+    assert sess.authority == "shell"
+
+
+async def test_new_session_rejects_relative_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ACP mandates absolute cwd paths."""
+    server, _, _, _ = await setup(tmp_path, monkeypatch)
+    with pytest.raises(RequestError):
+        await server.new_session(cwd="relative/path")
+
+
+# ── plain turns ───────────────────────────────────────────────────────
+
+
+async def test_text_only_turn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A streamed text answer maps to correlated message chunks."""
+    server, client, model, session_id = await setup(tmp_path, monkeypatch)
+    model.set_responses([text_script("Hello world")])
+    resp = await server.prompt(
+        session_id=session_id,
+        prompt=[text_block("Hi")],
+    )
+    assert resp.stop_reason == "end_turn"
+    chunks = client.updates_of("agent_message_chunk")
+    assert "".join(c.content.text for c in chunks) == "Hello world"
+    # All chunks of one streamed block share one messageId.
+    assert len({c.message_id for c in chunks}) == 1
+
+
+async def test_busy_session_rejects_second_prompt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Single-active-turn guard: a busy session rejects prompts."""
+    server, client, model, session_id = await setup(
+        tmp_path,
+        monkeypatch,
+        permission_answers=["allow_once"],
+    )
+    # Park the turn at the permission gate so it stays in flight.
+    client.permission_gate = asyncio.Event()
+    (tmp_path / "f.txt").write_text("x")
+    model.set_responses(
+        [
+            tool_call_script(
+                "Write",
+                {"file_path": str(tmp_path / "f.txt"), "content": "y"},
+            ),
+            text_script("done"),
+        ],
+    )
+    turn = asyncio.create_task(
+        server.prompt(session_id=session_id, prompt=[text_block("go")]),
+    )
+    # Wait until the turn is parked at the permission request.
+    while not client.permission_requests:
+        await asyncio.sleep(0.01)
+    with pytest.raises(RequestError):
+        await server.prompt(session_id=session_id, prompt=[text_block("2nd")])
+    client.permission_gate.set()
+    resp = await turn
+    assert resp.stop_reason == "end_turn"
+
+
+# ── tool calls: read-only fast path ───────────────────────────────────
+
+
+async def test_read_tool_shell_delegation_no_prompt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Read runs under DEFAULT with no permission prompt (#2117 fast
+    path) and its content flows through fs/read_text_file."""
+    server, client, model, session_id = await setup(tmp_path, monkeypatch)
+    target = tmp_path / "notes.txt"
+    target.write_text("the answer is 42\n")
+    model.set_responses(
+        [
+            tool_call_script("Read", {"file_path": str(target)}),
+            text_script("It says 42."),
+        ],
+    )
+    resp = await server.prompt(
+        session_id=session_id,
+        prompt=[text_block("read notes.txt")],
+    )
+    assert resp.stop_reason == "end_turn"
+    # The read-only fast path means no client prompt was raised.
+    assert client.permission_requests == []
+
+    starts = client.updates_of("tool_call")
+    assert len(starts) == 1
+    assert starts[0].tool_call_id == "call-1"
+    assert starts[0].kind == "read"
+    assert starts[0].status == "pending"
+
+    progress = client.updates_of("tool_call_update")
+    statuses = [u.status for u in progress if u.status]
+    assert statuses[0] == "in_progress"
+    assert statuses[-1] == "completed"
+    final = [u for u in progress if u.status == "completed"][-1]
+    assert "42" in final.raw_output
+
+    # Receipt invariant c: the fs read (and the exec_shell existence
+    # checks) are bound to the tool call id by the middleware.
+    sess = server._sessions.get(session_id)
+    fs_reads = [r for r in sess.ops.records if r.kind == "fs/read"]
+    assert fs_reads and all(r.tool_call_id == "call-1" for r in fs_reads)
+    term_ops = [r for r in sess.ops.records if r.kind == "terminal"]
+    assert term_ops and all(r.tool_call_id == "call-1" for r in term_ops)
+
+
+# ── permission round-trip ─────────────────────────────────────────────
+
+
+async def test_write_permission_allow_roundtrip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """allow_once lets the write land through fs/write_text_file."""
+    server, client, model, session_id = await setup(
+        tmp_path,
+        monkeypatch,
+        permission_answers=["allow_once"],
+    )
+    target = tmp_path / "out.txt"
+    model.set_responses(
+        [
+            tool_call_script(
+                "Write",
+                {
+                    "file_path": str(target),
+                    "content": "written by the kernel",
+                },
+            ),
+            text_script("done"),
+        ],
+    )
+    resp = await server.prompt(
+        session_id=session_id,
+        prompt=[text_block("write out.txt")],
+    )
+    assert resp.stop_reason == "end_turn"
+    # Invariant d: the permission request is bound to the toolCallId.
+    assert len(client.permission_requests) == 1
+    assert client.permission_requests[0].tool_call_id == "call-1"
+    assert client.permission_requests[0].raw_input["file_path"] == str(target)
+    # The write went through the client's fs/write_text_file.
+    assert target.read_text() == "written by the kernel"
+    statuses = [
+        u.status for u in client.updates_of("tool_call_update") if u.status
+    ]
+    assert statuses[-1] == "completed"
+
+
+async def test_write_permission_reject_marks_denied(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """reject_once denies the call; the turn continues."""
+    server, client, model, session_id = await setup(
+        tmp_path,
+        monkeypatch,
+        permission_answers=["reject_once"],
+    )
+    target = tmp_path / "out.txt"
+    model.set_responses(
+        [
+            tool_call_script(
+                "Write",
+                {
+                    "file_path": str(target),
+                    "content": "nope",
+                },
+            ),
+            text_script("okay, not writing"),
+        ],
+    )
+    resp = await server.prompt(
+        session_id=session_id,
+        prompt=[text_block("write out.txt")],
+    )
+    # The turn continues after a denial (the model sees the DENIED
+    # result and answers in text).
+    assert resp.stop_reason == "end_turn"
+    assert not target.exists()
+    denied = [
+        u
+        for u in client.updates_of("tool_call_update")
+        if u.field_meta
+        and u.field_meta.get("agentscope", {}).get("result_state") == "denied"
+    ]
+    assert len(denied) == 1
+    assert denied[0].status == "failed"
+
+
+async def test_permission_cancelled_outcome_cancels_turn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancelled permission prompt aborts the parked reply."""
+    server, client, model, session_id = await setup(
+        tmp_path,
+        monkeypatch,
+        permission_answers=["cancelled"],
+    )
+    model.set_responses(
+        [
+            tool_call_script(
+                "Write",
+                {
+                    "file_path": str(tmp_path / "x.txt"),
+                    "content": "x",
+                },
+            ),
+        ],
+    )
+    resp = await server.prompt(
+        session_id=session_id,
+        prompt=[text_block("write")],
+    )
+    assert resp.stop_reason == "cancelled"
+    # The parked ASKING call was closed out as interrupted.
+    interrupted = [
+        u
+        for u in client.updates_of("tool_call_update")
+        if u.field_meta
+        and u.field_meta.get("agentscope", {}).get("result_state")
+        == "interrupted"
+    ]
+    assert len(interrupted) == 1
+
+
+# ── cancellation ──────────────────────────────────────────────────────
+
+
+async def test_session_cancel_mid_tool(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """session/cancel during a running Bash tool yields stopReason
+    cancelled (never a JSON-RPC error) and an interrupted tool result."""
+    server, client, model, session_id = await setup(
+        tmp_path,
+        monkeypatch,
+        permission_answers=["allow_once"],
+    )
+    model.set_responses(
+        [
+            tool_call_script("Bash", {"command": "sleep 30"}),
+        ],
+    )
+    turn = asyncio.create_task(
+        server.prompt(session_id=session_id, prompt=[text_block("sleep")]),
+    )
+    # Wait for the client-owned terminal to actually start, then cancel.
+    await asyncio.wait_for(client.terminal_started.wait(), timeout=10)
+    await server.cancel(session_id=session_id)
+    resp = await asyncio.wait_for(turn, timeout=10)
+    assert resp.stop_reason == "cancelled"
+    interrupted = [
+        u
+        for u in client.updates_of("tool_call_update")
+        if u.field_meta
+        and u.field_meta.get("agentscope", {}).get("result_state")
+        == "interrupted"
+    ]
+    assert len(interrupted) == 1
+    # A fresh turn works after the cancelled one.
+    model.set_responses([text_script("still alive")])
+    resp = await server.prompt(
+        session_id=session_id,
+        prompt=[text_block("hi")],
+    )
+    assert resp.stop_reason == "end_turn"
+
+
+# ── capability gating ─────────────────────────────────────────────────
+
+
+async def test_no_terminal_capability_disables_all_tools(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without terminal, no client-delegated tool can run (§13)."""
+    caps = ClientCapabilities(
+        fs=FileSystemCapabilities(read_text_file=True, write_text_file=True),
+        terminal=False,
+    )
+    server, _, _, session_id = await setup(tmp_path, monkeypatch, caps=caps)
+    sess = server._sessions.get(session_id)
+    assert await sess.agent.toolkit.get_tool_schemas() == []
+
+
+async def test_no_fs_capability_keeps_exec_tools(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without fs.*, only the exec-backed tools survive (§13)."""
+    caps = ClientCapabilities(
+        fs=FileSystemCapabilities(
+            read_text_file=False,
+            write_text_file=False,
+        ),
+        terminal=True,
+    )
+    server, _, _, session_id = await setup(tmp_path, monkeypatch, caps=caps)
+    sess = server._sessions.get(session_id)
+    schemas = await sess.agent.toolkit.get_tool_schemas()
+    names = {s["function"]["name"] for s in schemas}
+    assert names == {"Grep", "Glob", "Bash"}
+
+
+# ── stop-reason mapping ───────────────────────────────────────────────
+
+
+def test_stop_reason_mapping() -> None:
+    """finished_reason maps onto the ACP stopReason values."""
+    assert _stop_reason(ReplyFinishedReason.COMPLETED) == "end_turn"
+    assert (
+        _stop_reason(ReplyFinishedReason.EXCEED_MAX_ITERS)
+        == "max_turn_requests"
+    )
+    assert _stop_reason(ReplyFinishedReason.INTERRUPTED) == "cancelled"
+    assert _stop_reason(None) == "end_turn"

--- a/examples/acp/tests/test_server.py
+++ b/examples/acp/tests/test_server.py
@@ -16,16 +16,16 @@ import pytest
 from acp import RequestError, text_block
 from acp.schema import ClientCapabilities, FileSystemCapabilities
 
-from agentscope.message import TextBlock, ToolCallBlock
-from agentscope.model import ChatResponse
-from agentscope.types import ReplyFinishedReason
-
 import acp_example.agent as agent_mod
 from acp_example.config import Config
 from acp_example.server import AgentScopeAcpAgent, _stop_reason
 
 from mock_client import FakeClient
 from mock_model import MockModel
+
+from agentscope.message import TextBlock, ToolCallBlock
+from agentscope.model import ChatResponse
+from agentscope.types import ReplyFinishedReason
 
 FULL_CAPS = ClientCapabilities(
     fs=FileSystemCapabilities(read_text_file=True, write_text_file=True),

--- a/examples/acp/tests/test_stdio_rpc.py
+++ b/examples/acp/tests/test_stdio_rpc.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""Wire-level smoke test: the real JSON-RPC layer over a socket pair.
+
+Runs the kernel through ``acp.run_agent`` and drives it with the SDK's
+own client-side connection, so framing, request routing and response
+serialization are exercised exactly as they are over stdio.
+"""
+import asyncio
+import contextlib
+import socket
+from pathlib import Path
+
+import pytest
+
+from acp import connect_to_agent, text_block
+from acp.schema import ClientCapabilities, FileSystemCapabilities
+from acp import run_agent
+
+from agentscope.message import TextBlock
+from agentscope.model import ChatResponse
+
+import acp_example.agent as agent_mod
+from acp_example.server import AgentScopeAcpAgent
+
+from mock_client import FakeClient
+from mock_model import MockModel
+from test_server import make_config
+
+
+async def test_full_turn_over_socketpair(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """initialize → session/new → prompt over the real RPC layer."""
+    model = MockModel()
+    model.set_responses(
+        [
+            [
+                ChatResponse(content=[TextBlock(text="Hi ")], is_last=False),
+                ChatResponse(content=[TextBlock(text="there")], is_last=False),
+                ChatResponse(
+                    content=[TextBlock(text="Hi there")], is_last=True
+                ),
+            ],
+        ],
+    )
+    monkeypatch.setattr(agent_mod, "_make_model", lambda config: model)
+
+    sock_agent, sock_client = socket.socketpair()
+    agent_reader, agent_writer = await asyncio.open_connection(
+        sock=sock_agent,
+    )
+    client_reader, client_writer = await asyncio.open_connection(
+        sock=sock_client,
+    )
+
+    server_task = asyncio.create_task(
+        run_agent(
+            AgentScopeAcpAgent(config=make_config()),
+            agent_writer,
+            agent_reader,
+        ),
+    )
+    client = FakeClient()
+    conn = connect_to_agent(client, client_writer, client_reader)
+    try:
+        init = await asyncio.wait_for(
+            conn.initialize(
+                protocol_version=1,
+                client_capabilities=ClientCapabilities(
+                    fs=FileSystemCapabilities(
+                        read_text_file=True,
+                        write_text_file=True,
+                    ),
+                    terminal=True,
+                ),
+            ),
+            timeout=10,
+        )
+        assert init.protocol_version == 1
+        assert init.agent_info.name == "agentscope-acp"
+
+        new = await asyncio.wait_for(
+            conn.new_session(cwd=str(tmp_path)),
+            timeout=10,
+        )
+        assert new.session_id
+
+        resp = await asyncio.wait_for(
+            conn.prompt(
+                session_id=new.session_id,
+                prompt=[text_block("hello")],
+            ),
+            timeout=10,
+        )
+        assert resp.stop_reason == "end_turn"
+        chunks = client.updates_of("agent_message_chunk")
+        assert "".join(c.content.text for c in chunks) == "Hi there"
+    finally:
+        server_task.cancel()
+        with contextlib.suppress(
+            asyncio.CancelledError,
+            asyncio.IncompleteReadError,
+        ):
+            await server_task
+        client_writer.close()
+        agent_writer.close()

--- a/examples/acp/tests/test_stdio_rpc.py
+++ b/examples/acp/tests/test_stdio_rpc.py
@@ -16,15 +16,15 @@ from acp import connect_to_agent, text_block
 from acp.schema import ClientCapabilities, FileSystemCapabilities
 from acp import run_agent
 
-from agentscope.message import TextBlock
-from agentscope.model import ChatResponse
-
 import acp_example.agent as agent_mod
 from acp_example.server import AgentScopeAcpAgent
 
 from mock_client import FakeClient
 from mock_model import MockModel
 from test_server import make_config
+
+from agentscope.message import TextBlock
+from agentscope.model import ChatResponse
 
 
 async def test_full_turn_over_socketpair(
@@ -39,7 +39,8 @@ async def test_full_turn_over_socketpair(
                 ChatResponse(content=[TextBlock(text="Hi ")], is_last=False),
                 ChatResponse(content=[TextBlock(text="there")], is_last=False),
                 ChatResponse(
-                    content=[TextBlock(text="Hi there")], is_last=True
+                    content=[TextBlock(text="Hi there")],
+                    is_last=True,
                 ),
             ],
         ],

--- a/examples/acp/tests/test_translate.py
+++ b/examples/acp/tests/test_translate.py
@@ -7,6 +7,9 @@ from acp.schema import (
     ToolCallStart,
 )
 
+from acp_example.bridge import OpRegistry
+from acp_example.translate import Translator
+
 from agentscope.event import (
     HintBlockEvent,
     ModelCallEndEvent,
@@ -24,9 +27,6 @@ from agentscope.event import (
     ToolResultTextDeltaEvent,
 )
 from agentscope.message import ToolResultState
-
-from acp_example.bridge import OpRegistry
-from acp_example.translate import Translator
 
 REPLY = "reply-1"
 

--- a/examples/acp/tests/test_translate.py
+++ b/examples/acp/tests/test_translate.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the AgentEvent → session/update translator (§19.2)."""
+from acp.schema import (
+    AgentMessageChunk,
+    AgentThoughtChunk,
+    ToolCallProgress,
+    ToolCallStart,
+)
+
+from agentscope.event import (
+    HintBlockEvent,
+    ModelCallEndEvent,
+    ModelCallStartEvent,
+    ReplyEndEvent,
+    TextBlockDeltaEvent,
+    TextBlockEndEvent,
+    TextBlockStartEvent,
+    ThinkingBlockDeltaEvent,
+    ToolCallDeltaEvent,
+    ToolCallEndEvent,
+    ToolCallStartEvent,
+    ToolResultEndEvent,
+    ToolResultStartEvent,
+    ToolResultTextDeltaEvent,
+)
+from agentscope.message import ToolResultState
+
+from acp_example.bridge import OpRegistry
+from acp_example.translate import Translator
+
+REPLY = "reply-1"
+
+
+def make() -> tuple[Translator, OpRegistry]:
+    """Build a fresh translator + registry pair."""
+    ops = OpRegistry()
+    return Translator(ops), ops
+
+
+def test_text_deltas_map_to_message_chunks_with_block_id() -> None:
+    """Text deltas become agent_message_chunks keyed by block id."""
+    tr, _ = make()
+    assert not tr.translate(
+        TextBlockStartEvent(reply_id=REPLY, block_id="b1"),
+    )
+    updates = tr.translate(
+        TextBlockDeltaEvent(reply_id=REPLY, block_id="b1", delta="Hello"),
+    )
+    assert len(updates) == 1
+    upd = updates[0]
+    assert isinstance(upd, AgentMessageChunk)
+    assert upd.content.text == "Hello"
+    assert upd.message_id == "b1"
+    assert not tr.translate(
+        TextBlockEndEvent(reply_id=REPLY, block_id="b1"),
+    )
+
+
+def test_thinking_deltas_map_to_thought_chunks() -> None:
+    """Thinking deltas become agent_thought_chunks."""
+    tr, _ = make()
+    updates = tr.translate(
+        ThinkingBlockDeltaEvent(reply_id=REPLY, block_id="t1", delta="hmm"),
+    )
+    assert isinstance(updates[0], AgentThoughtChunk)
+    assert updates[0].message_id == "t1"
+
+
+def test_tool_call_lifecycle_and_pending_registration() -> None:
+    """The full tool lifecycle maps to tool_call/_update events."""
+    tr, ops = make()
+    start = tr.translate(
+        ToolCallStartEvent(
+            reply_id=REPLY,
+            tool_call_id="tc1",
+            tool_call_name="Read",
+        ),
+    )
+    assert isinstance(start[0], ToolCallStart)
+    assert start[0].tool_call_id == "tc1"
+    assert start[0].kind == "read"
+    assert start[0].status == "pending"
+
+    assert not tr.translate(
+        ToolCallDeltaEvent(
+            reply_id=REPLY,
+            tool_call_id="tc1",
+            delta='{"file_path": ',
+        ),
+    )
+    end = tr.translate(
+        ToolCallDeltaEvent(
+            reply_id=REPLY,
+            tool_call_id="tc1",
+            delta='"/tmp/x"}',
+        ),
+    ) + tr.translate(ToolCallEndEvent(reply_id=REPLY, tool_call_id="tc1"))
+    assert len(end) == 1
+    assert end[0].raw_input == {"file_path": "/tmp/x"}
+    # Args complete → the op is registered for middleware claiming.
+    assert ops.pending == {"tc1": ("Read", '{"file_path": "/tmp/x"}')}
+
+    running = tr.translate(
+        ToolResultStartEvent(
+            reply_id=REPLY,
+            tool_call_id="tc1",
+            tool_call_name="Read",
+        ),
+    )
+    assert running[0].status == "in_progress"
+
+    delta = tr.translate(
+        ToolResultTextDeltaEvent(
+            reply_id=REPLY,
+            tool_call_id="tc1",
+            delta="line 1\n",
+        ),
+    )
+    assert delta[0].content[0].content.text == "line 1\n"
+
+    done = tr.translate(
+        ToolResultEndEvent(
+            reply_id=REPLY,
+            tool_call_id="tc1",
+            state=ToolResultState.SUCCESS,
+        ),
+    )
+    assert isinstance(done[0], ToolCallProgress)
+    assert done[0].status == "completed"
+    assert done[0].raw_output == "line 1\n"
+    assert done[0].field_meta == {"agentscope": {"result_state": "completed"}}
+    # Executed or not, the pending entry must be cleaned up.
+    assert not ops.pending
+
+
+def test_result_state_taxonomy() -> None:
+    """ToolResultState maps to ACP status plus a _meta taxonomy."""
+    for state, status, taxonomy in [
+        (ToolResultState.ERROR, "failed", "failed"),
+        (ToolResultState.INTERRUPTED, "failed", "interrupted"),
+        (ToolResultState.DENIED, "failed", "denied"),
+    ]:
+        tr, _ = make()
+        tr.translate(
+            ToolResultStartEvent(
+                reply_id=REPLY,
+                tool_call_id="tc",
+                tool_call_name="Write",
+            ),
+        )
+        done = tr.translate(
+            ToolResultEndEvent(
+                reply_id=REPLY,
+                tool_call_id="tc",
+                state=state,
+            ),
+        )
+        assert done[0].status == status
+        assert done[0].field_meta == {
+            "agentscope": {"result_state": taxonomy},
+        }
+
+
+def test_noise_events_translate_to_nothing() -> None:
+    """Hints, model-call boundaries and reply ends emit nothing."""
+    tr, _ = make()
+    # Hint blocks are runtime-state injection noise — never rendered.
+    assert not tr.translate(
+        HintBlockEvent(
+            reply_id=REPLY,
+            block_id="h1",
+            source="tasks",
+            hint="<system-reminder>internal</system-reminder>",
+        ),
+    )
+    # No faithful usage_update is possible (no context-window size), so
+    # model-call boundaries emit nothing.
+    assert not tr.translate(
+        ModelCallStartEvent(reply_id=REPLY, model_name="m"),
+    )
+    assert not tr.translate(
+        ModelCallEndEvent(
+            reply_id=REPLY,
+            input_tokens=3,
+            output_tokens=5,
+        ),
+    )
+    assert not tr.translate(
+        ReplyEndEvent(reply_id=REPLY, session_id="s1"),
+    )


### PR DESCRIPTION
## AgentScope Version

2.0.6dev (branched from `main` @ efba74ed)

## Description

Implements **PR1 of the plan in `examples/acp/DESIGN.md`** — the design RFC discussed in #1948 and hosted for review in #1973 (the doc in this PR is the v2 revision, re-audited against `main` as of 2026-08-06).

**What it is.** A fully runnable Agent Client Protocol (**ACP**) *Agent-role, stdio* example under `examples/acp/`: a desktop editor (ACP Client, e.g. **Zed**) spawns the AgentScope kernel as a subprocess, drives it over newline-delimited JSON-RPC (`initialize` / `session/new` / `session/prompt`), and receives streamed `session/update` notifications translated from `Agent.reply_stream`'s `AgentEvent` stream. Built **only on public API — zero `agentscope/` core changes**, per @DavdGao's guidance in #1948.

Highlights:

- **Shell delegation by default**: one `ClientBackend(BackendBase)` routes `read_file`/`write_file` → client `fs/*` (so the agent sees unsaved editor buffers) and `exec_shell` → client `terminal/*` — including the builtin tools' internal existence/dir/mkdir checks, ripgrep and the Glob helper. Opt-in Workspace sandbox mode (`ACP_AUTHORITY=workspace`).
- **Permission bridge**: `RequireUserConfirmEvent` ↔ `session/request_permission`, bound to the exact `toolCallId`; `allow_always` installs core's `suggested_rules` via `ConfirmResult.rules`, `reject_always` installs a DENY rule on the public `agent.state.permission_context`. Exactly one prompt per gated side effect under `PermissionMode.DEFAULT` (read-only fast path applies).
- **Cancellation done through core's graceful path (#1995)**: the reply stream is consumed by a dedicated driver task, so `session/cancel` is always delivered *inside* `reply_stream` — interrupted tool results, `ReplyEndEvent(finished_reason=interrupted)`, `stopReason:"cancelled"`. Repeated cancels are idempotent; parked replies are closed via `UserInterruptEvent`.
- **Receipt-ready invariants** (DESIGN.md §14) enforced by tests: stable session/turn/operation ids, capability snapshot, permission-to-op binding, result-state taxonomy. Op-id binding uses a `ToolMiddlewareBase` claim-matching mechanism that survives concurrent tool batches.
- **Fork seam**: all agent construction lives in one `build_agent()` function; the ACP plumbing is generic.

**How to test.**

```bash
cd examples/acp
python -m venv .venv && source .venv/bin/activate
pip install -e ".[test]"   # or: pip install -e ../..  + agent-client-protocol==0.12.0
pytest                     # 25 tests
```

The suite drives the kernel with a mock ACP client (fs served from a temp dir, terminals backed by **real subprocesses**) plus a wire-level JSON-RPC smoke test over a socket pair. Covered: turn lifecycle, permission round-trips (all four option kinds + cancelled outcome), mid-tool cancellation and staged cancel races, capability gating, Read/Write/Edit/Bash end-to-end. Manual e2e against Zed is documented in the README. Lint matches the repo pre-commit suite (black 79 / flake8 / pylint / mypy strict flags).

The code was additionally hardened by an adversarial review pass (16 confirmed findings fixed, each with a regression test — see the second commit's message for the list).

**Follow-ons within the example** (DESIGN.md §20): receipt emitter, `session/load`, MCP pass-through, additional sandbox backends, session modes, prompt capabilities.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  An issue has been created for this PR — tracked via discussion #1948 and RFC PR #1973
- [x]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [x]  Code is ready for review
