### PR TITLE
fix(channel): fix channel form field localization

### DIFF
--- a/examples/web_ui/frontend/src/i18n/locales/en.json
+++ b/examples/web_ui/frontend/src/i18n/locales/en.json
@@ -637,6 +637,34 @@
 			"showThinking": "Show Thinking",
 			"showThinkingDesc": "Display model reasoning process in the channel."
 		},
+		"fields": {
+			"app_id": {
+				"title": "App ID",
+				"description": "Feishu App ID"
+			},
+			"app_secret": {
+				"title": "App Secret",
+				"description": "Feishu App Secret"
+			},
+			"bot_token": {
+				"title": "Bot Token"
+			},
+			"application_id": {
+				"title": "Application ID"
+			},
+			"only_at_reply": {
+				"title": "Reply only when mentioned",
+				"description": "In group chats, reply only when the bot is @mentioned"
+			},
+			"show_tool_process": {
+				"title": "Show tool process",
+				"description": "Show tool calls and results inline in the reply"
+			},
+			"show_thinking": {
+				"title": "Show thinking",
+				"description": "Show the model's reasoning inline in the reply"
+			}
+		},
 		"edit": {
 			"title": "Edit Channel",
 			"description": "Update routing, model, and reply settings. Platform and credentials are immutable."

--- a/examples/web_ui/frontend/src/i18n/locales/zh.json
+++ b/examples/web_ui/frontend/src/i18n/locales/zh.json
@@ -637,6 +637,34 @@
 			"showThinking": "显示思维过程",
 			"showThinkingDesc": "在频道中展示模型推理过程。"
 		},
+		"fields": {
+			"app_id": {
+				"title": "应用 ID",
+				"description": "飞书应用 ID"
+			},
+			"app_secret": {
+				"title": "应用密钥",
+				"description": "飞书应用密钥"
+			},
+			"bot_token": {
+				"title": "机器人令牌"
+			},
+			"application_id": {
+				"title": "应用 ID"
+			},
+			"only_at_reply": {
+				"title": "仅在被提及时回复",
+				"description": "在群聊中，仅当机器人被 @提及时回复"
+			},
+			"show_tool_process": {
+				"title": "显示工具过程",
+				"description": "在回复中显示工具调用和返回结果"
+			},
+			"show_thinking": {
+				"title": "显示思考过程",
+				"description": "在回复中显示模型的推理过程"
+			}
+		},
 		"edit": {
 			"title": "编辑频道",
 			"description": "修改路由、模型与回复设置。平台与凭据不可修改。"

--- a/examples/web_ui/frontend/src/pages/channel/channel-form.tsx
+++ b/examples/web_ui/frontend/src/pages/channel/channel-form.tsx
@@ -131,12 +131,17 @@ export function ChannelForm({ value, onChange, agents, channelTypes, mode }: Pro
 		const required = schema.required ?? [];
 		return Object.entries(schema.properties).map(([key, def]) => ({
 			key,
-			title: (def.title as string) || key,
-			description: def.description as string | undefined,
+			title: t(`channel.fields.${key}.title`, {
+				defaultValue: (def.title as string) || key,
+			}),
+			description:
+				t(`channel.fields.${key}.description`, {
+					defaultValue: (def.description as string) || '',
+				}) || undefined,
 			format: def.format as string | undefined,
 			required: required.includes(key),
 		}));
-	}, [typeSchema]);
+	}, [t, typeSchema]);
 
 	const configFields = React.useMemo(() => {
 		const schema = typeSchema?.config_schema as
@@ -145,12 +150,17 @@ export function ChannelForm({ value, onChange, agents, channelTypes, mode }: Pro
 		if (!schema?.properties) return [];
 		return Object.entries(schema.properties).map(([key, def]) => ({
 			key,
-			title: (def.title as string) || key,
-			description: def.description as string | undefined,
+			title: t(`channel.fields.${key}.title`, {
+				defaultValue: (def.title as string) || key,
+			}),
+			description:
+				t(`channel.fields.${key}.description`, {
+					defaultValue: (def.description as string) || '',
+				}) || undefined,
 			type: def.type as string | undefined,
 			default: def.default,
 		}));
-	}, [typeSchema]);
+	}, [t, typeSchema]);
 
 	const selectedModelCard = React.useMemo(() => {
 		if (!value.chatModelConfig) return null;


### PR DESCRIPTION
## AgentScope Version

2.0.5

## Description

Localize built-in channel credential and configuration fields in the create/edit form. Unknown fields continue to fall back to their JSON Schema labels and descriptions.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review