### PR TITLE
feat(app): pass the resolved workspace to extra_agent_middlewares

### DIFF
--- a/examples/agent_service/main.py
+++ b/examples/agent_service/main.py
@@ -14,8 +14,10 @@ from agentscope.app.rag.knowledge_base_manager import CollectionPerKbManager
 from agentscope.app.storage import RedisStorage
 from agentscope.app.workspace_manager import LocalWorkspaceManager
 from agentscope.mcp import MCPClient, StdioMCPConfig, HttpMCPConfig
+from agentscope.middleware import AgenticMemoryMiddleware, MiddlewareBase
 from agentscope.permission import PermissionContext, PermissionMode
 from agentscope.rag import QdrantStore
+from agentscope.workspace import WorkspaceBase
 
 default_mcps = [
     MCPClient(
@@ -46,6 +48,24 @@ storage = RedisStorage(
 )
 
 vector_store = QdrantStore(location=":memory:")
+
+
+async def longterm_memory_factory(
+    user_id: str,
+    agent_id: str,
+    session_id: str,
+    workspace: WorkspaceBase,
+) -> list[MiddlewareBase]:
+    """Attach Markdown-file long-term memory, stored under the session's
+    workspace so it is reachable through whichever backend is bound."""
+    del user_id, agent_id, session_id
+    return [
+        AgenticMemoryMiddleware(
+            workdir=workspace.workdir,
+            backend=workspace.get_backend(),
+        ),
+    ]
+
 
 app = create_app(
     storage=storage,
@@ -118,6 +138,9 @@ so anything you want them to see MUST be sent through `TeamSay`.""",
             ),
         ),
     ],
+    # Long-term memory. The default PER_AGENT workspace isolation makes
+    # the memory survive across sessions of the same agent.
+    extra_agent_middlewares=longterm_memory_factory,
     extra_middlewares=[
         Middleware(
             CORSMiddleware,

--- a/src/agentscope/app/_app.py
+++ b/src/agentscope/app/_app.py
@@ -197,14 +197,21 @@ def create_app(
         extra_middlewares (`list[Middleware] | None`, optional):
             Additional ASGI middlewares to add to the application.
         extra_agent_middlewares (`AgentMiddlewareFactory | None`, optional):
-            An async factory ``(user_id, agent_id, session_id) -> awaitable
-            of list[MiddlewareBase]`` that produces extra
+            An async factory ``(user_id, agent_id, session_id, workspace) ->
+            awaitable of list[MiddlewareBase]`` that produces extra
             :class:`~agentscope.middleware.MiddlewareBase` instances to
             attach to the agent on each invocation.  Called once per agent
             assembly (i.e. per chat turn / scheduled trigger), so it can
             return user/session-specific middleware (auth, audit logging,
-            tenant isolation, etc.).  The returned middlewares are appended
-            to the framework-supplied ones (e.g. ``ToolOffloadMiddleware``).
+            tenant isolation, etc.).  ``workspace`` is the session's
+            resolved :class:`~agentscope.workspace.WorkspaceBase`, exposing
+            ``workdir`` and ``get_backend()`` for filesystem-backed
+            middleware such as
+            :class:`~agentscope.middleware.AgenticMemoryMiddleware`.
+            Factories written against the older three-argument signature
+            keep working — the fourth argument is only passed to factories
+            that accept it.  The returned middlewares are appended to the
+            framework-supplied ones (e.g. ``ToolOffloadMiddleware``).
         extra_agent_tools (`AgentToolFactory | None`, optional):
             An async factory ``(user_id, agent_id, session_id) -> awaitable
             of list[ToolBase]`` that produces extra

--- a/src/agentscope/app/_service/_chat.py
+++ b/src/agentscope/app/_service/_chat.py
@@ -12,6 +12,7 @@ that wants them subscribes through the
 ``GET /sessions/{sid}/stream`` SSE endpoint.
 """
 import asyncio
+import inspect
 from typing import TYPE_CHECKING
 
 from fastapi import HTTPException
@@ -137,6 +138,9 @@ class ChatService:
              optional):
                 Async factory invoked at every chat turn to produce
                 user/session-specific middlewares to attach to the agent.
+                Called as ``(user_id, agent_id, session_id, workspace)``,
+                falling back to the legacy three-argument call when the
+                factory does not accept ``workspace``.
             extra_agent_tools (`AgentToolFactory | None`, optional):
                 Async factory invoked at every chat turn to produce
                 user/session-specific tools to register in the toolkit.
@@ -169,6 +173,20 @@ optional):
         self._access = resource_access_service
         self._knowledge_base_manager = knowledge_base_manager
         self._extra_agent_middlewares = extra_agent_middlewares
+        # Probed once (the service is built once per lifespan) so legacy
+        # three-argument factories keep working without the per-turn cost.
+        self._middlewares_take_workspace = False
+        if extra_agent_middlewares is not None:
+            try:
+                inspect.signature(extra_agent_middlewares).bind(
+                    "",
+                    "",
+                    "",
+                    None,
+                )
+                self._middlewares_take_workspace = True
+            except (TypeError, ValueError):
+                pass
         self._extra_agent_tools = extra_agent_tools
         self._channel_dispatcher = channel_dispatcher
         self._sub_agent_templates = custom_subagent_templates
@@ -575,12 +593,11 @@ optional):
                 ),
             ]
             if self._extra_agent_middlewares is not None:
+                factory_args: tuple = (user_id, agent_id, session_id)
+                if self._middlewares_take_workspace:
+                    factory_args += (workspace,)
                 middlewares.extend(
-                    await self._extra_agent_middlewares(
-                        user_id,
-                        agent_id,
-                        session_id,
-                    ),
+                    await self._extra_agent_middlewares(*factory_args),
                 )
 
             # ----------------------------------------------------------------

--- a/src/agentscope/app/_types.py
+++ b/src/agentscope/app/_types.py
@@ -11,18 +11,24 @@ from ..middleware import MiddlewareBase
 from ..permission import PermissionContext
 from ..state import TaskContext
 from ..tool import ToolBase
+from ..workspace import WorkspaceBase
 
 if TYPE_CHECKING:
     from ._service._session_projection import SessionProjection
     from .storage import AgentRecord, SessionRecord
 
 
-AgentMiddlewareFactory = Callable[
-    [str, str, str],
-    Awaitable[list[MiddlewareBase]],
-]
-# Async factory signature: ``(user_id, agent_id, session_id)`` →
-# awaitable of :class:`~agentscope.middleware.MiddlewareBase` instances.
+AgentMiddlewareFactory = (
+    Callable[[str, str, str], Awaitable[list[MiddlewareBase]]]
+    | Callable[
+        [str, str, str, WorkspaceBase],
+        Awaitable[list[MiddlewareBase]],
+    ]
+)
+# Async factory: ``(user_id, agent_id, session_id, workspace)`` → awaitable
+# of :class:`~agentscope.middleware.MiddlewareBase` instances. The legacy
+# three-argument form stays supported — ``ChatService`` probes the signature
+# and only passes ``workspace`` to factories that accept it.
 
 AgentToolFactory = Callable[
     [str, str, str],

--- a/tests/service_chat_middleware_factory_test.py
+++ b/tests/service_chat_middleware_factory_test.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Back-compat probe for the ``extra_agent_middlewares`` factory.
+
+The factory gained a fourth ``workspace`` argument. ``ChatService`` probes
+each factory's signature once at construction so factories written against
+the original three-argument shape keep being called with three arguments.
+"""
+import functools
+from unittest import TestCase
+
+from agentscope.app._service._chat import ChatService
+
+
+def _probe(factory: object) -> bool:
+    """Return whether ``ChatService`` would pass ``workspace`` to
+    ``factory``.
+
+    Args:
+        factory (`object`):
+            The candidate ``extra_agent_middlewares`` factory.
+
+    Returns:
+        `bool`:
+            ``True`` when the service resolved the four-argument shape.
+    """
+    service = ChatService(
+        storage=None,
+        workspace_manager=None,
+        scheduler_manager=None,
+        background_task_manager=None,
+        message_bus=None,
+        resource_access_service=None,
+        extra_agent_middlewares=factory,
+    )
+    return service._middlewares_take_workspace
+
+
+async def _legacy(user_id: str, agent_id: str, session_id: str) -> list:
+    """A factory written before ``workspace`` existed."""
+    del user_id, agent_id, session_id
+    return []
+
+
+async def _with_workspace(
+    user_id: str,
+    agent_id: str,
+    session_id: str,
+    workspace: object,
+) -> list:
+    """A factory that opted into the fourth argument."""
+    del user_id, agent_id, session_id, workspace
+    return []
+
+
+class _CallableLegacy:
+    """A callable object using the three-argument shape."""
+
+    async def __call__(self, user_id: str, agent_id: str, sid: str) -> list:
+        """Return no middlewares."""
+        del user_id, agent_id, sid
+        return []
+
+
+class ExtraMiddlewareFactoryProbeTest(TestCase):
+    """The probe must classify every callable shape correctly."""
+
+    def test_legacy_factory_is_called_without_workspace(self) -> None:
+        """A three-argument factory must not receive ``workspace``."""
+        self.assertFalse(_probe(_legacy))
+
+    def test_new_factory_receives_workspace(self) -> None:
+        """A four-argument factory must receive ``workspace``."""
+        self.assertTrue(_probe(_with_workspace))
+
+    def test_no_factory_is_inert(self) -> None:
+        """``None`` must not be probed as if it were callable."""
+        self.assertFalse(_probe(None))
+
+    def test_var_positional_factory_receives_workspace(self) -> None:
+        """``*args`` absorbs the fourth argument, so pass it."""
+
+        async def factory(*args: object) -> list:
+            del args
+            return []
+
+        self.assertTrue(_probe(factory))
+
+    def test_callable_object_is_probed_on_its_call(self) -> None:
+        """``__call__`` is what gets invoked, so it is what is measured."""
+        self.assertFalse(_probe(_CallableLegacy()))
+
+    def test_partial_keeps_the_underlying_shape(self) -> None:
+        """``functools.partial`` must not be mistaken for a legacy shape."""
+        self.assertTrue(_probe(functools.partial(_with_workspace)))
+        self.assertFalse(_probe(functools.partial(_legacy)))

--- a/tests/service_workspace_files_test.py
+++ b/tests/service_workspace_files_test.py
@@ -578,11 +578,16 @@ class WorkspaceFileEndpointTests(IsolatedAsyncioTestCase):
     async def test_tampered_token_raises_401(self) -> None:
         """An edited signature must not pass."""
         token, _ = self._service.sign_download_token("u", "notes.txt")
+        # Edit the signature's first character, not its last: a 32-byte
+        # digest ends on a base64 char carrying only 4 significant bits,
+        # so editing that one can decode back to the same digest.
+        expiry, user, signature = token.split(".")
+        tampered = ("A" if signature[0] != "A" else "B") + signature[1:]
         with self.assertRaises(HTTPException) as ctx:
             await self._read(
                 path="notes.txt",
                 download=True,
-                token=token[:-1] + ("A" if token[-1] != "A" else "B"),
+                token=f"{expiry}.{user}.{tampered}",
                 x_user_id=None,
             )
         self.assertEqual(


### PR DESCRIPTION
Filesystem-backed middleware such as `AgenticMemoryMiddleware` needs both a `workdir` and the backend bound to it. The pair only makes sense together — `workdir` is a host path under `LocalWorkspaceManager` but a container-side path under Docker/E2B, so only the matching backend can interpret it.

The middleware factory received neither. A caller wanting long-term memory had to re-resolve the workspace itself: read the session record for its `workspace_id`, then call `get_workspace` and duplicate the manager's `assign_workspace_id` fallback rules — which would silently drift the moment those rules changed.

`ChatService` already resolves the workspace a few lines above middleware assembly, so this hands it over as a fourth factory argument.

## Backward compatibility

Factories written against the three-argument signature keep working. `ChatService` probes each factory once at construction — the service is built once per lifespan, so there is no per-turn `inspect` cost — and only passes the fourth argument to factories that accept it. `inspect.signature` handles bound methods, callable objects, `functools.partial`, and `*args`; an unreadable signature falls back to the legacy call.

## Also in this PR

- **`examples/agent_service`** now wires `AgenticMemoryMiddleware`, storing memory under the session workspace. The default `PER_AGENT` isolation makes it survive across sessions of the same agent.
- **Flaky test fix** (`test_tampered_token_raises_401`). A 32-byte HMAC encodes to 43 base64 characters whose last one carries only 4 significant bits; the trailing 2 bits are discarded on decode. The test tampered with exactly that character, so for 1 in 16 tokens the "tampered" token decoded back to the same digest, the HMAC matched, and no `HTTPException` was raised. Measured 6.14% failure rate over 100k tokens. The test now edits the signature's first character. `verify_download_token` itself is correct — this was never a forgery risk, only a broken test.

## Testing

- New `tests/service_chat_middleware_factory_test.py` covers the probe across legacy, four-argument, `*args`, callable-object, and `partial` shapes.
- `test_tampered_token_raises_401` passes 40/40 runs.
- `pre-commit run --files <changed>` passes every hook. The pre-existing `--all-files` failures are confined to files this PR does not touch and stem from the hook interpreter not knowing 3.11 builtins (`StrEnum`, `Self`, `ExceptionGroup`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)