### PR TITLE
fix(memory): isolate agentic memory retrieval tasks

### DIFF
--- a/src/agentscope/middleware/_longterm_memory/_agentic_memory/_middleware.py
+++ b/src/agentscope/middleware/_longterm_memory/_agentic_memory/_middleware.py
@@ -479,7 +479,7 @@ class AgenticMemoryMiddleware(MiddlewareBase):
         # In-flight asynchronous retrieval tasks started in ``on_reply`` and
         # consumed in ``on_reasoning``. Keyed per session/agent so a shared
         # middleware instance never lets one concurrent reply clobber another.
-        self._retrieval_tasks: dict[object, asyncio.Task] = {}
+        self._retrieval_tasks: dict[tuple[str | None, int], asyncio.Task] = {}
 
     @staticmethod
     def _truncate_if_needed(content: str, max_length: int) -> str:
@@ -683,10 +683,10 @@ class AgenticMemoryMiddleware(MiddlewareBase):
     # ========================================================================
 
     @staticmethod
-    def _retrieval_key_of(agent: "Agent") -> object:
+    def _retrieval_key_of(agent: "Agent") -> tuple[str | None, int]:
         """Return the key used to isolate one in-flight retrieval task."""
         session_id = getattr(getattr(agent, "state", None), "session_id", None)
-        return session_id if session_id is not None else id(agent)
+        return (session_id, id(agent))
 
     @staticmethod
     def _format_manifest(headers: list[_MemoryFileHeader]) -> str:

--- a/src/agentscope/middleware/_longterm_memory/_agentic_memory/_middleware.py
+++ b/src/agentscope/middleware/_longterm_memory/_agentic_memory/_middleware.py
@@ -476,11 +476,10 @@ class AgenticMemoryMiddleware(MiddlewareBase):
         self._parameters = parameters or self.Parameters()
         self._backend = backend or LocalBackend()
 
-        self._cached_input: str | None = None
-        # The in-flight asynchronous retrieval task started in ``on_reply``
-        # and consumed in ``on_reasoning``. Kept on the instance so the
-        # reasoning hook can poll for completion across iterations.
-        self._retrieval_task: asyncio.Task | None = None
+        # In-flight asynchronous retrieval tasks started in ``on_reply`` and
+        # consumed in ``on_reasoning``. Keyed per session/agent so a shared
+        # middleware instance never lets one concurrent reply clobber another.
+        self._retrieval_tasks: dict[object, asyncio.Task] = {}
 
     @staticmethod
     def _truncate_if_needed(content: str, max_length: int) -> str:
@@ -587,6 +586,7 @@ class AgenticMemoryMiddleware(MiddlewareBase):
                 Items yielded by ``next_handler``.
         """
 
+        retrieval_key = self._retrieval_key_of(agent)
         if self._parameters.retrieval_async:
             inputs = input_kwargs.get("inputs")
 
@@ -598,8 +598,9 @@ class AgenticMemoryMiddleware(MiddlewareBase):
             elif isinstance(inputs, Msg):
                 msgs = [inputs]
 
+            cached_input = None
             if msgs is not None:
-                self._cached_input = "\n".join(
+                cached_input = "\n".join(
                     [
                         f"{_.name}: " + _.get_text_content()
                         for _ in msgs
@@ -607,12 +608,16 @@ class AgenticMemoryMiddleware(MiddlewareBase):
                     ],
                 )
 
+            stale = self._retrieval_tasks.pop(retrieval_key, None)
+            if stale is not None and not stale.done():
+                stale.cancel()
+
             # Start an asynchronous retrieval task that uses an LLM to decide
             # which memory files are relevant to the current user input. The
             # result is consumed by ``on_reasoning``.
-            if self._cached_input:
-                self._retrieval_task = asyncio.create_task(
-                    self._retrieve_relevant_files(agent, self._cached_input),
+            if cached_input:
+                self._retrieval_tasks[retrieval_key] = asyncio.create_task(
+                    self._retrieve_relevant_files(agent, cached_input),
                 )
 
         try:
@@ -620,17 +625,13 @@ class AgenticMemoryMiddleware(MiddlewareBase):
                 yield _
         finally:
             # Ensure the retrieval task does not outlive the reply.
-            if (
-                self._retrieval_task is not None
-                and not self._retrieval_task.done()
-            ):
-                self._retrieval_task.cancel()
+            retrieval_task = self._retrieval_tasks.pop(retrieval_key, None)
+            if retrieval_task is not None and not retrieval_task.done():
+                retrieval_task.cancel()
                 try:
-                    await self._retrieval_task
+                    await retrieval_task
                 except (asyncio.CancelledError, Exception):  # noqa: BLE001
                     pass
-            self._retrieval_task = None
-            self._cached_input = None
 
     async def on_reasoning(
         self,
@@ -655,9 +656,10 @@ class AgenticMemoryMiddleware(MiddlewareBase):
         """
         # Poll the in-flight retrieval task; if it has finished, consume its
         # result and inject it into the agent context exactly once.
-        if self._retrieval_task is not None and self._retrieval_task.done():
-            task = self._retrieval_task
-            self._retrieval_task = None
+        retrieval_key = self._retrieval_key_of(agent)
+        task = self._retrieval_tasks.get(retrieval_key)
+        if task is not None and task.done():
+            self._retrieval_tasks.pop(retrieval_key, None)
             try:
                 retrieval_result = task.result()
             except (asyncio.CancelledError, Exception):
@@ -679,6 +681,12 @@ class AgenticMemoryMiddleware(MiddlewareBase):
     # ========================================================================
     # Helper functions
     # ========================================================================
+
+    @staticmethod
+    def _retrieval_key_of(agent: "Agent") -> object:
+        """Return the key used to isolate one in-flight retrieval task."""
+        session_id = getattr(getattr(agent, "state", None), "session_id", None)
+        return session_id if session_id is not None else id(agent)
 
     @staticmethod
     def _format_manifest(headers: list[_MemoryFileHeader]) -> str:

--- a/tests/middleware_filesystem_memory_test.py
+++ b/tests/middleware_filesystem_memory_test.py
@@ -836,3 +836,66 @@ class AgenticMemoryMiddlewareTest(IsolatedAsyncioTestCase):
         self.assertNotIn("sess-b", cancelled_after_a)
         self.assertEqual(set(cancelled), {"sess-a", "sess-b"})
         self.assertEqual(getattr(middleware, "_retrieval_tasks"), {})
+
+    async def test_concurrent_replies_isolate_same_session_agents(
+        self,
+    ) -> None:
+        """A shared middleware must isolate agents in the same session."""
+        middleware = AgenticMemoryMiddleware(workdir=self.temp_dir)
+        started = {
+            "agent-a": asyncio.Event(),
+            "agent-b": asyncio.Event(),
+        }
+        release_b_handler = asyncio.Event()
+        cancelled: list[str] = []
+
+        async def fake_retrieve(agent: Any, query: str) -> None:
+            del query
+            started[agent.name].set()
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                cancelled.append(agent.name)
+                raise
+
+        async def handler_a(**kwargs: Any) -> Any:
+            del kwargs
+            await started["agent-b"].wait()
+            yield "done-a"
+
+        async def handler_b(**kwargs: Any) -> Any:
+            del kwargs
+            await release_b_handler.wait()
+            yield "done-b"
+
+        async def drive(agent: Any, handler: Any) -> None:
+            async for _ in middleware.on_reply(
+                agent,
+                {"inputs": UserMsg("user", "remember this")},
+                handler,
+            ):
+                pass
+
+        setattr(middleware, "_retrieve_relevant_files", fake_retrieve)
+        agent_a = SimpleNamespace(
+            name="agent-a",
+            state=SimpleNamespace(session_id="same-session"),
+        )
+        agent_b = SimpleNamespace(
+            name="agent-b",
+            state=SimpleNamespace(session_id="same-session"),
+        )
+
+        task_a = asyncio.create_task(drive(agent_a, handler_a))
+        await started["agent-a"].wait()
+        task_b = asyncio.create_task(drive(agent_b, handler_b))
+        await started["agent-b"].wait()
+
+        await task_a
+        cancelled_after_a = list(cancelled)
+        release_b_handler.set()
+        await task_b
+
+        self.assertNotIn("agent-b", cancelled_after_a)
+        self.assertEqual(set(cancelled), {"agent-a", "agent-b"})
+        self.assertEqual(getattr(middleware, "_retrieval_tasks"), {})

--- a/tests/middleware_filesystem_memory_test.py
+++ b/tests/middleware_filesystem_memory_test.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 """Unit tests for AgenticMemoryMiddleware with real Agent execution."""
+import asyncio
 import os
 import shutil
 import tempfile
+from types import SimpleNamespace
 from typing import Any, Type
 from unittest.async_case import IsolatedAsyncioTestCase
 
@@ -774,3 +776,63 @@ class AgenticMemoryMiddlewareTest(IsolatedAsyncioTestCase):
                 "structured_call_count": 0,
             },
         )
+
+    async def test_concurrent_replies_isolate_retrieval_tasks(self) -> None:
+        """A shared middleware must not cancel another session's retrieval."""
+        middleware = AgenticMemoryMiddleware(workdir=self.temp_dir)
+        started = {
+            "sess-a": asyncio.Event(),
+            "sess-b": asyncio.Event(),
+        }
+        release_b_handler = asyncio.Event()
+        cancelled: list[str] = []
+
+        async def fake_retrieve(agent: Any, query: str) -> None:
+            del query
+            session_id = agent.state.session_id
+            started[session_id].set()
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                cancelled.append(session_id)
+                raise
+
+        async def handler_a(**kwargs: Any) -> Any:
+            del kwargs
+            await started["sess-b"].wait()
+            yield "done-a"
+
+        async def handler_b(**kwargs: Any) -> Any:
+            del kwargs
+            await release_b_handler.wait()
+            yield "done-b"
+
+        async def drive(agent: Any, handler: Any) -> None:
+            async for _ in middleware.on_reply(
+                agent,
+                {"inputs": UserMsg("user", "remember this")},
+                handler,
+            ):
+                pass
+
+        setattr(middleware, "_retrieve_relevant_files", fake_retrieve)
+        agent_a = SimpleNamespace(
+            state=SimpleNamespace(session_id="sess-a"),
+        )
+        agent_b = SimpleNamespace(
+            state=SimpleNamespace(session_id="sess-b"),
+        )
+
+        task_a = asyncio.create_task(drive(agent_a, handler_a))
+        await started["sess-a"].wait()
+        task_b = asyncio.create_task(drive(agent_b, handler_b))
+        await started["sess-b"].wait()
+
+        await task_a
+        cancelled_after_a = list(cancelled)
+        release_b_handler.set()
+        await task_b
+
+        self.assertNotIn("sess-b", cancelled_after_a)
+        self.assertEqual(set(cancelled), {"sess-a", "sess-b"})
+        self.assertEqual(getattr(middleware, "_retrieval_tasks"), {})


### PR DESCRIPTION
## Summary

- isolate `AgenticMemoryMiddleware` async retrieval tasks by session/agent identity instead of one shared instance slot
- make `on_reasoning` consume only the matching retrieval task and make `on_reply` cleanup cancel only the matching task
- add regression tests for concurrent replies sharing one middleware instance across different sessions and different agents in the same session

## Root cause

`AgenticMemoryMiddleware` stored the in-flight retrieval task in a single `_retrieval_task` attribute. When the same middleware instance was shared across concurrent agents/sessions, a later reply could overwrite that slot, and an earlier reply's cleanup could cancel the later session's retrieval task.

The first fix keyed tasks by `session_id`, but that still aliased distinct agents that share the same session. The retrieval task map now keys by `(session_id, id(agent))`, which matches the in-process lifetime of the async task and keeps same-session agents isolated.

Closes #2274

## Test plan

- `PYTHONPATH=src;tests python -m unittest tests.middleware_filesystem_memory_test.AgenticMemoryMiddlewareTest.test_concurrent_replies_isolate_retrieval_tasks`
- `PYTHONPATH=src;tests python -m unittest tests.middleware_filesystem_memory_test.AgenticMemoryMiddlewareTest.test_concurrent_replies_isolate_same_session_agents`
- `PYTHONPATH=src;tests python -m unittest tests.middleware_filesystem_memory_test`
- `pre-commit run --files src/agentscope/middleware/_longterm_memory/_agentic_memory/_middleware.py tests/middleware_filesystem_memory_test.py`