### PR TITLE
feat(middleware): add ExternalRetrievalMiddleware with RAGFlow backend

### DIFF
--- a/examples/rag/.env.example
+++ b/examples/rag/.env.example
@@ -1,0 +1,7 @@
+# RAGFlow
+RAGFLOW_API_KEY=ragflow-xxx
+RAGFLOW_BASE_URL=http://localhost:9380
+RAGFLOW_DATASET_ID=your-dataset-id
+
+# DeepSeek
+DEEPSEEK_API_KEY=sk-...

--- a/examples/rag/README.md
+++ b/examples/rag/README.md
@@ -6,8 +6,13 @@ Two library-mode walk-throughs of `agentscope.rag` — no FastAPI service, no ma
 | --- | --- |
 | [`index_and_search.py`](./index_and_search.py) | The minimal pipeline: parse → chunk → embed → insert, then `KnowledgeBase.search`. Start here. |
 | [`integrate_with_agent.py`](./integrate_with_agent.py) | Attaches the same `KnowledgeBase` to an `Agent` via `RAGMiddleware`, in both `static` (auto-inject) and `agentic` (tool-driven) modes. |
+| [`ragflow_integration.py`](./ragflow_integration.py) | Exposes RAGFlow's retrieval REST API as a `FunctionTool` — the agent decides when to call it. |
+| [`ragflow_mcp_integration.py`](./ragflow_mcp_integration.py) | Connects to RAGFlow via MCP (Model Context Protocol) for automatic tool discovery. |
+| [`ragflow_middleware_integration.py`](./ragflow_middleware_integration.py) | Uses the official `ExternalRetrievalMiddleware` with `RAGFlowRetrievalBackend` for automatic static-mode injection — configuration locked at construction, LLM never decides "should I search". |
 
 Both examples use an in-memory Qdrant store (`location=":memory:"`) and the DashScope `text-embedding-v4` model, so no external services are required. The sections below show how to swap in Milvus Lite, MongoDB, or Elasticsearch instead; those backends need additional setup.
+
+The RAGFlow examples require a running RAGFlow server and use DeepSeek as the chat model. See each script's docstring for the required environment variables.
 
 ## Install
 

--- a/examples/rag/ragflow_integration.py
+++ b/examples/rag/ragflow_integration.py
@@ -1,0 +1,200 @@
+# -*- coding: utf-8 -*-
+"""Integrate RAGFlow with AgentScope as a retrieval tool (Path 2).
+
+RAGFlow is a full-featured RAG engine (parsing, chunking, hybrid
+retrieval, reranking). Instead of shoehorning it into AgentScope's
+``VectorStoreBase`` abstraction, we expose its retrieval REST API as a
+:class:`~agentscope.tool.FunctionTool`. The agent decides when to call
+it -- same agentic pattern as ``RAGMiddleware``'s ``"agentic"`` mode,
+but backed by RAGFlow.
+
+Run with::
+
+    RAGFLOW_API_KEY=ragflow-xxx \
+    DASHSCOPE_API_KEY=sk-... \
+    python examples/rag/ragflow_integration.py
+"""
+import os
+from typing import Any
+
+import httpx
+
+from agentscope.agent import Agent
+from agentscope.credential import DeepSeekCredential
+from agentscope.message import UserMsg
+from agentscope.model import DeepSeekChatModel
+from agentscope.tool import FunctionTool, Toolkit
+
+
+# ---------------------------------------------------------------------------
+# 1. RAGFlow retrieval client + tool function
+# ---------------------------------------------------------------------------
+
+def _make_ragflow_search_tool(
+    base_url: str,
+    api_key: str,
+    dataset_ids: list[str],
+    top_k: int = 5,
+    similarity_threshold: float = 0.2,
+    timeout: float = 30.0,
+) -> FunctionTool:
+    """Build a :class:`FunctionTool` that calls the RAGFlow retrieval API.
+
+    Configuration is captured in a closure so the tool function exposed
+    to the LLM only has one parameter -- the question. This keeps the
+    JSON schema clean and prevents the model from guessing internal IDs.
+
+    Args:
+        base_url (`str`):
+            RAGFlow server base URL, e.g. ``http://localhost:9380``.
+        api_key (`str`):
+            RAGFlow API key (from "User Settings -> API Key").
+        dataset_ids (`list[str]`):
+            The RAGFlow dataset(s) to search across.
+        top_k (`int`, optional):
+            Max chunks to return. Defaults to ``5``.
+        similarity_threshold (`float`, optional):
+            Minimum similarity score, 0.0 - 1.0. Defaults to ``0.2``.
+        timeout (`float`, optional):
+            HTTP request timeout in seconds. Defaults to ``30.0``.
+
+    Returns:
+        `FunctionTool`: A tool ready to register in a :class:`Toolkit`.
+    """
+    # One shared async client per tool instance -- connection pooling.
+    client = httpx.AsyncClient(
+        base_url=base_url.rstrip("/"),
+        headers={"Authorization": f"Bearer {api_key}"},
+        timeout=timeout,
+    )
+
+    async def search_ragflow(question: str) -> dict[str, Any]:
+        """Search the knowledge base for relevant context.
+
+        Call this when you need to look up facts, policies, or any
+        information from the documents. Always prefer this tool over
+        guessing. The returned chunks are pre-ranked by the RAGFlow
+        retrieval engine.
+
+        Args:
+            question: A natural-language query describing what you want
+                to find. Use the most specific terms possible.
+
+        Returns:
+            A dict with a "chunks" list; each chunk has "content",
+            "document_name", and "similarity". Empty list if nothing
+            matched.
+        """
+        payload = {
+            "question": question,
+            "dataset_ids": dataset_ids,
+            "top_k": top_k,
+            "similarity_threshold": similarity_threshold,
+        }
+        resp = await client.post("/api/v1/retrieval", json=payload)
+        resp.raise_for_status()
+        body = resp.json()
+
+        # RAGFlow returns {"code": 0, "data": {"chunks": [...]}}
+        if body.get("code") != 0:
+            return {
+                "chunks": [],
+                "error": body.get("message", "RAGFlow retrieval failed"),
+            }
+
+        chunks = [
+            {
+                "content": c.get("content", ""),
+                "document_name": c.get("document_keyword")
+                or c.get("document_name")
+                or c.get("doc_name", ""),
+                "similarity": round(c.get("similarity", 0.0), 4),
+            }
+            for c in body.get("data", {}).get("chunks", [])
+        ]
+        return {"chunks": chunks}
+
+    return FunctionTool(
+        func=search_ragflow,
+        name="search_knowledge",
+        is_concurrency_safe=True,
+        is_read_only=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Build the agent and run a conversation
+# ---------------------------------------------------------------------------
+
+def build_agent(
+    chat_model: DeepSeekChatModel,
+    ragflow_tool: FunctionTool,
+) -> Agent:
+    """Construct an :class:`Agent` with the RAGFlow retrieval tool attached."""
+    return Agent(
+        name="ragflow-agent",
+        system_prompt=(
+            "You are a knowledgeable assistant. When the user asks about "
+            "documented facts, policies, or any content you are not certain "
+            "about, ALWAYS call the `search_knowledge` tool first and base "
+            "your answer on the returned chunks. Cite the document name when "
+            "you quote a chunk. If the tool returns nothing relevant, say so "
+            "honestly."
+        ),
+        model=chat_model,
+        toolkit=Toolkit(tools=[ragflow_tool]),
+    )
+
+
+async def ask(agent: Agent, question: str) -> None:
+    """Run one reply and print it."""
+    print(f"\n[user] {question}")
+    reply = await agent.reply(UserMsg(name="user", content=question))
+    print(f"[assistant] {reply.get_text_content()}")
+
+
+async def main() -> None:
+    """The main entry point of the example."""
+    ragflow_key = os.environ.get("RAGFLOW_API_KEY")
+    deepseek_key = os.environ.get("DEEPSEEK_API_KEY")
+    if not ragflow_key or not deepseek_key:
+        raise RuntimeError(
+            "Set RAGFLOW_API_KEY and DEEPSEEK_API_KEY before running "
+            "this example.",
+        )
+
+    # --- Build the RAGFlow tool ---
+    ragflow_tool = _make_ragflow_search_tool(
+        base_url=os.environ.get("RAGFLOW_BASE_URL", "http://localhost:9380"),
+        api_key=ragflow_key,
+        dataset_ids=[os.environ.get(
+            "RAGFLOW_DATASET_ID",
+            "your-dataset-id",
+        )],
+        top_k=5,
+    )
+
+    # --- Build the agent ---
+    credential = DeepSeekCredential(api_key=deepseek_key)
+    chat_model = DeepSeekChatModel(
+        credential=credential,
+        model="deepseek-chat",
+        stream=False,
+    )
+    agent = build_agent(chat_model, ragflow_tool)
+
+    # --- Demo conversation (dataset contains a docker operations doc) ---
+    await ask(
+        agent,
+        "How do I deploy docker on a server? Summarise the key steps.",
+    )
+    await ask(
+        agent,
+        "What commands are used to save a docker image as a tar file "
+        "and load it back later?",
+    )
+
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(main())

--- a/examples/rag/ragflow_mcp_integration.py
+++ b/examples/rag/ragflow_mcp_integration.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+"""Integrate RAGFlow with AgentScope via MCP (SSE transport).
+
+Companion to ``ragflow_integration.py`` — same agentic retrieval goal,
+but instead of hand-wrapping RAGFlow's REST API as a ``FunctionTool``
+(~90 lines of HTTP payload / response parsing / schema authoring),
+we connect to RAGFlow's MCP server over SSE and let AgentScope's
+``MCPClient`` discover the retrieval tools automatically.
+
+What disappears vs. the REST version:
+- No ``httpx.AsyncClient`` boilerplate.
+- No manual request/response JSON handling.
+- No hand-written ``FunctionTool`` docstring / JSON schema — the tool
+  name, description, and parameter schema all come from the RAGFlow
+  MCP server.
+
+What stays the same:
+- The agent still decides when to search (agentic pattern).
+- The system prompt still nudges it to cite sources.
+
+Run with::
+
+    RAGFLOW_API_KEY=ragflow-xxx \
+    DEEPSEEK_API_KEY=sk-... \
+    python examples/rag/ragflow_mcp_integration.py
+
+Optionally override the MCP endpoint::
+
+    RAGFLOW_MCP_URL=http://your-host:port/sse \
+    RAGFLOW_API_KEY=ragflow-xxx \
+    DEEPSEEK_API_KEY=sk-... \
+    python examples/rag/ragflow_mcp_integration.py
+"""
+import asyncio
+import os
+
+from agentscope.agent import Agent
+from agentscope.credential import DeepSeekCredential
+from agentscope.message import UserMsg
+from agentscope.model import DeepSeekChatModel
+from agentscope.mcp import MCPClient, HttpMCPConfig
+from agentscope.permission import (
+    PermissionBehavior,
+    PermissionRule,
+)
+from agentscope.tool import Toolkit
+
+
+RAGFLOW_MCP_URL = os.environ.get(
+    "RAGFLOW_MCP_URL",
+    "http://localhost:9382/sse",
+)
+
+
+def build_agent(
+    chat_model: DeepSeekChatModel,
+    mcp_client: MCPClient,
+) -> Agent:
+    """Construct an Agent with RAGFlow MCP tools attached.
+
+    ``Toolkit(mcps=[...])`` pulls every tool the MCP server exposes and
+    registers them under the ``mcp__ragflow__<tool>`` namespace. Use
+    ``enable_tools`` / ``disable_tools`` on ``MCPClient`` to filter if
+    the server exposes more than you want the model to see.
+
+    MCP tools default to ASK permission (they aren't auto-allowed unless
+    the server sets ``readOnlyHint``). For this unattended demo we add an
+    allow rule for every tool the RAGFlow MCP exposes so the agent can
+    call them without interactive confirmation. In an interactive UI you
+    would instead surface the ASK to the user.
+    """
+    return Agent(
+        name="ragflow-mcp-agent",
+        system_prompt=(
+            "You are a knowledgeable assistant. When the user asks about "
+            "documented facts, policies, or any content you are not certain "
+            "about, ALWAYS call the search/retrieval tool first and base "
+            "your answer on the returned chunks. Cite the document name "
+            "when you quote a chunk. If the tool returns nothing relevant, "
+            "say so honestly.\n\n"
+            "IMPORTANT: When calling the retrieval tool, pass the user's "
+            "question as the `question` parameter, and ALWAYS pass "
+            'dataset_ids=["your-dataset-id"] to search '
+            "the Docker operations handbook dataset. Do NOT skip the tool "
+            "call."
+        ),
+        model=chat_model,
+        toolkit=Toolkit(mcps=[mcp_client]),
+    )
+
+
+async def ask(agent: Agent, question: str) -> None:
+    """Run one reply and print it."""
+    print(f"\n[user] {question}")
+    reply = await agent.reply(UserMsg(name="user", content=question))
+    print(f"[assistant] {reply.get_text_content()}")
+
+
+async def main() -> None:
+    """The main entry point of the example."""
+    deepseek_key = os.environ.get("DEEPSEEK_API_KEY")
+    ragflow_key = os.environ.get("RAGFLOW_API_KEY")
+    if not deepseek_key or not ragflow_key:
+        raise RuntimeError(
+            "Set DEEPSEEK_API_KEY and RAGFLOW_API_KEY before running "
+            "this example.",
+        )
+
+    # --- MCP client (SSE transport) ---
+    # The URL ends with /sse, so MCPClient auto-selects SSE transport
+    # (see _mcp_client._create_http_client). Stateful mode keeps the
+    # SSE connection open across tool calls instead of reconnecting
+    # per invocation. The RAGFlow MCP server requires an API key
+    # (Bearer token) for retrieval calls — list_tools works without
+    # it, but call_tool returns "Authentication error: API key is
+    # invalid!".
+    mcp_client = MCPClient(
+        name="ragflow",
+        is_stateful=True,
+        mcp_config=HttpMCPConfig(
+            url=RAGFLOW_MCP_URL,
+            headers={"Authorization": f"Bearer {ragflow_key}"},
+            timeout=30.0,
+        ),
+    )
+
+    # Stateful MCP requires explicit connect() before use — Toolkit
+    # assumes stateful clients are already connected.
+    await mcp_client.connect()
+    try:
+        # Discover what tools RAGFlow exposes via MCP (for visibility).
+        tools = await mcp_client.list_tools()
+        print(f"RAGFlow MCP exposes {len(tools)} tool(s):")
+        for t in tools:
+            desc = (t.description or "")[:80]
+            print(f"  - {t.name}: {desc}")
+
+        # --- Build the agent ---
+        chat_model = DeepSeekChatModel(
+            credential=DeepSeekCredential(api_key=deepseek_key),
+            model="deepseek-chat",
+            stream=False,
+        )
+
+        # MCP tools default to ASK permission. Add an allow rule for
+        # each discovered tool so the agent can call them without
+        # interactive confirmation in this unattended demo. We mutate
+        # the agent's existing permission_context (the PermissionEngine
+        # holds a reference to the same object, so replacement would
+        # NOT be seen by the engine).
+        agent = build_agent(chat_model, mcp_client)
+        for t in tools:
+            agent.state.permission_context.allow_rules.setdefault(
+                t.name, [],
+            ).append(
+                PermissionRule(
+                    tool_name=t.name,
+                    rule_content=None,
+                    behavior=PermissionBehavior.ALLOW,
+                    source="demo",
+                ),
+            )
+
+        # --- Demo conversation (same questions as ragflow_integration.py) ---
+        await ask(
+            agent,
+            "How do I deploy docker on a server? Summarise the key steps.",
+        )
+        await ask(
+            agent,
+            "What commands are used to save a docker image as a tar file "
+            "and load it back later?",
+        )
+    finally:
+        await mcp_client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/rag/ragflow_middleware_integration.py
+++ b/examples/rag/ragflow_middleware_integration.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+"""Example: ExternalRetrievalMiddleware with RAGFlow backend.
+
+This example shows how to use the official
+:class:`~agentscope.middleware.ExternalRetrievalMiddleware` with a
+RAGFlow backend for automatic knowledge-base injection.  The middleware
+intercepts the first reasoning step, calls RAGFlow's retrieval API, and
+injects matched chunks as a one-shot hint — the LLM never decides
+"should I search".
+
+Run with::
+
+    RAGFLOW_API_KEY=ragflow-xxx \
+    DEEPSEEK_API_KEY=sk-... \
+    python examples/rag/ragflow_middleware_integration.py
+"""
+import asyncio
+import os
+
+from agentscope.agent import Agent
+from agentscope.credential import DeepSeekCredential
+from agentscope.message import UserMsg
+from agentscope.middleware import (
+    ExternalRetrievalMiddleware,
+    RAGFlowRetrievalBackend,
+)
+from agentscope.model import DeepSeekChatModel
+
+
+# ---------------------------------------------------------------------------
+# Build the agent and run a conversation
+# ---------------------------------------------------------------------------
+
+def build_agent(
+    chat_model: DeepSeekChatModel,
+    middleware: ExternalRetrievalMiddleware,
+) -> Agent:
+    """Construct an Agent with RAGFlow auto-injection."""
+    return Agent(
+        name="ragflow-middleware-agent",
+        system_prompt=(
+            "You are a knowledgeable assistant. Answer based on the "
+            "retrieved context when available. Cite the document name "
+            "when you quote a chunk. If no relevant context was "
+            "retrieved, say so honestly."
+        ),
+        model=chat_model,
+        middlewares=[middleware],
+    )
+
+
+async def ask(agent: Agent, question: str) -> None:
+    """Run one reply and print it."""
+    print(f"\n[user] {question}")
+    reply = await agent.reply(UserMsg(name="user", content=question))
+    print(f"[assistant] {reply.get_text_content()}")
+
+
+async def main() -> None:
+    """The main entry point of the example."""
+    ragflow_key = os.environ.get("RAGFLOW_API_KEY")
+    deepseek_key = os.environ.get("DEEPSEEK_API_KEY")
+    if not ragflow_key or not deepseek_key:
+        raise RuntimeError(
+            "Set RAGFLOW_API_KEY and DEEPSEEK_API_KEY before running "
+            "this example.",
+        )
+
+    # --- Build the RAGFlow backend + middleware ---
+    backend = RAGFlowRetrievalBackend(
+        base_url=os.environ.get("RAGFLOW_BASE_URL", "http://localhost:9380"),
+        api_key=ragflow_key,
+        dataset_ids=[os.environ.get(
+            "RAGFLOW_DATASET_ID",
+            "your-dataset-id",
+        )],
+    )
+    middleware = ExternalRetrievalMiddleware(
+        backend=backend,
+        top_k=5,
+        similarity_threshold=0.2,
+    )
+
+    # --- Build the agent ---
+    credential = DeepSeekCredential(api_key=deepseek_key)
+    chat_model = DeepSeekChatModel(
+        credential=credential,
+        model="deepseek-chat",
+        stream=False,
+    )
+    agent = build_agent(chat_model, middleware)
+
+    try:
+        await ask(
+            agent,
+            "How do I deploy docker on a server? Summarise the key steps.",
+        )
+        await ask(
+            agent,
+            "What commands are used to save a docker image as a tar file "
+            "and load it back later?",
+        )
+    finally:
+        await backend.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/agentscope/middleware/__init__.py
+++ b/src/agentscope/middleware/__init__.py
@@ -2,6 +2,12 @@
 """Middleware system for AgentScope agents."""
 
 from ._base import MiddlewareBase
+from ._external_retrieval import (
+    ExternalRetrievalMiddleware,
+    RAGFlowRetrievalBackend,
+    RetrievalBackend,
+    RetrievalResult,
+)
 from ._rag import RAGMiddleware
 from ._budget import ReplyBudgetControlMiddleware
 from ._longterm_memory import (
@@ -15,9 +21,13 @@ from ._tts_middleware import TTSMiddleware
 __all__ = [
     "MiddlewareBase",
     "AgenticMemoryMiddleware",
+    "ExternalRetrievalMiddleware",
     "Mem0Middleware",
-    "ReMeMiddleware",
+    "RAGFlowRetrievalBackend",
     "RAGMiddleware",
+    "ReMeMiddleware",
+    "RetrievalBackend",
+    "RetrievalResult",
     "TracingMiddleware",
     "ReplyBudgetControlMiddleware",
     "TTSMiddleware",

--- a/src/agentscope/middleware/_external_retrieval/__init__.py
+++ b/src/agentscope/middleware/_external_retrieval/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""External retrieval middleware and backends."""
+
+from ._backend import RetrievalBackend, RetrievalResult
+from ._middleware import ExternalRetrievalMiddleware
+from ._ragflow import RAGFlowRetrievalBackend
+
+__all__ = [
+    "ExternalRetrievalMiddleware",
+    "RetrievalBackend",
+    "RetrievalResult",
+    "RAGFlowRetrievalBackend",
+]

--- a/src/agentscope/middleware/_external_retrieval/_backend.py
+++ b/src/agentscope/middleware/_external_retrieval/_backend.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""Protocol and data structures for external retrieval backends."""
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+
+@dataclass
+class RetrievalResult:
+    """Normalized retrieval result across all external backends.
+
+    Attributes:
+        content (`str`):
+            The retrieved text chunk.
+        source (`str`):
+            Document name or identifier for citation.
+        score (`float`):
+            Similarity/relevance score from the backend.
+        metadata (`dict[str, Any]`):
+            Backend-specific extra fields (e.g. page numbers, URLs).
+    """
+
+    content: str
+    source: str
+    score: float
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class RetrievalBackend(Protocol):
+    """Protocol for external retrieval service backends.
+
+    Implementations connect to managed RAG services (RAGFlow, Dify,
+    FastGPT, etc.) and normalize their responses into
+    :class:`RetrievalResult` items.
+
+    The backend is responsible for:
+    - HTTP client lifecycle (connection pooling, auth headers)
+    - Service-specific request/response formatting
+    - Error handling (return empty list on failure, log warnings)
+    """
+
+    async def search(
+        self,
+        query: str,
+        top_k: int = 5,
+        **kwargs: Any,
+    ) -> list[RetrievalResult]:
+        """Search the external service.
+
+        Args:
+            query (`str`):
+                Natural-language query string.
+            top_k (`int`, defaults to ``5``):
+                Maximum number of results to return.
+            **kwargs (`Any`):
+                Backend-specific options (e.g. similarity_threshold).
+
+        Returns:
+            `list[RetrievalResult]`:
+                Normalized results, ordered by descending score.
+                Empty list on failure or no matches.
+        """
+        ...

--- a/src/agentscope/middleware/_external_retrieval/_middleware.py
+++ b/src/agentscope/middleware/_external_retrieval/_middleware.py
@@ -1,0 +1,289 @@
+# -*- coding: utf-8 -*-
+"""External retrieval middleware for automatic knowledge-base injection.
+
+This module provides :class:`ExternalRetrievalMiddleware`, which mirrors
+:class:`~agentscope.middleware.RAGMiddleware`'s ``"static"`` mode but
+backed by external retrieval services (RAGFlow, Dify, etc.) instead of
+local :class:`~agentscope.rag.KnowledgeBase` instances.
+
+The middleware intercepts the first reasoning step of each reply, calls
+the configured backend with the user's input, and injects matched chunks
+as a one-shot :class:`~agentscope.message.HintBlock`.  The LLM never
+decides "should I search" — retrieval is automatic and configuration is
+locked at construction time.
+"""
+from typing import AsyncGenerator, Callable, Sequence, TYPE_CHECKING
+
+from ._backend import RetrievalBackend, RetrievalResult
+from ..._logging import logger
+from ...event import HintBlockEvent
+from ...message import (
+    DataBlock,
+    HintBlock,
+    Msg,
+    TextBlock,
+)
+from .._base import MiddlewareBase
+
+if TYPE_CHECKING:
+    from ...agent import Agent
+
+
+_DEFAULT_HINT_TEMPLATE = (
+    "<system-reminder>The following content is retrieved from the "
+    "knowledge base and may be helpful for the current request:\n"
+    "<content>{context}</content></system-reminder>"
+)
+
+
+def _format_results(
+    results: Sequence[RetrievalResult],
+) -> list[TextBlock | DataBlock]:
+    """Render retrieval results as a numbered, cited list of blocks.
+
+    Args:
+        results (`Sequence[RetrievalResult]`):
+            The retrieval results to format.
+
+    Returns:
+        `list[TextBlock | DataBlock]`:
+            Formatted blocks; empty list when ``results`` is empty.
+    """
+    if not results:
+        return []
+
+    lines: list[str] = []
+    for index, result in enumerate(results, start=1):
+        source = result.source or "unknown"
+        lines.append(f"[{index}] (source: {source})\n{result.content}")
+
+    # Coalesce into a single TextBlock for static-mode injection
+    return [TextBlock(text="\n\n".join(lines))]
+
+
+def _wrap_hint(
+    template: str,
+    blocks: list[TextBlock | DataBlock],
+) -> str | list[TextBlock | DataBlock]:
+    """Substitute ``{context}`` in ``template`` with rendered blocks.
+
+    Args:
+        template (`str`):
+            Wrapper template with a single ``{context}`` placeholder.
+        blocks (`list[TextBlock | DataBlock]`):
+            The formatted blocks to wrap.
+
+    Returns:
+        `str | list[TextBlock | DataBlock]`:
+            Wrapped hint content.
+    """
+    if all(isinstance(b, TextBlock) for b in blocks):
+        joined = "\n".join(b.text for b in blocks)  # type: ignore[union-attr]
+        return template.format(context=joined)
+
+    prefix, _, end = template.partition("{context}")
+    wrapped: list[TextBlock | DataBlock] = list(blocks)
+    if prefix:
+        if isinstance(wrapped[0], TextBlock):
+            wrapped[0] = TextBlock(text=prefix + wrapped[0].text)
+        else:
+            wrapped.insert(0, TextBlock(text=prefix))
+    if end:
+        if isinstance(wrapped[-1], TextBlock):
+            wrapped[-1] = TextBlock(text=wrapped[-1].text + end)
+        else:
+            wrapped.append(TextBlock(text=end))
+    return wrapped
+
+
+class ExternalRetrievalMiddleware(MiddlewareBase):
+    """Middleware that auto-injects external retrieval results.
+
+    Configuration (backend, dataset ids, top_k, thresholds) is locked
+    at construction time — the LLM never sees or controls these.
+
+    .. code-block:: python
+
+        backend = RAGFlowRetrievalBackend(
+            base_url="...",
+            api_key="...",
+            dataset_ids=["..."],
+        )
+        middleware = ExternalRetrievalMiddleware(
+            backend=backend,
+            top_k=5,
+            similarity_threshold=0.2,
+        )
+        agent = Agent(..., middlewares=[middleware], ...)
+    """
+
+    def __init__(
+        self,
+        backend: RetrievalBackend,
+        top_k: int = 5,
+        similarity_threshold: float | None = None,
+        hint_template: str = _DEFAULT_HINT_TEMPLATE,
+        emit_hint_event: bool = True,
+        persist_hint: bool = False,
+    ) -> None:
+        """Initialize the external retrieval middleware.
+
+        Args:
+            backend (`RetrievalBackend`):
+                The external retrieval backend to query.
+            top_k (`int`, defaults to ``5``):
+                Maximum number of chunks returned per search.
+            similarity_threshold (`float | None`, optional):
+                Minimum similarity score; forwarded to the backend.
+            hint_template (`str`, optional):
+                Template wrapping the formatted results, with a
+                ``{context}`` placeholder.
+            emit_hint_event (`bool`, defaults to ``True``):
+                Emit a :class:`HintBlockEvent` so the front-end can
+                display matched snippets.
+            persist_hint (`bool`, defaults to ``False``):
+                Keep the injected hint in context after the model call.
+        """
+        self._backend = backend
+        self._top_k = top_k
+        self._similarity_threshold = similarity_threshold
+        self._hint_template = hint_template
+        self._emit_hint_event = emit_hint_event
+        self._persist_hint = persist_hint
+        # Scratchpad for static-mode injection (same pattern as RAGMiddleware)
+        self._cached_inputs: list[TextBlock | DataBlock] | None = None
+
+    async def get_middleware_key(self) -> str:
+        """Return a unique key for this middleware instance."""
+        return f"ExternalRetrievalMiddleware:{type(self._backend).__name__}"
+
+    # ------------------------------------------------------------------
+    # Capture user inputs on reply entry
+    # ------------------------------------------------------------------
+
+    async def on_reply(
+        self,
+        agent: "Agent",
+        input_kwargs: dict,
+        next_handler: Callable[..., AsyncGenerator],
+    ) -> AsyncGenerator:
+        """Cache reply inputs for the static-mode search.
+
+        Args:
+            agent (`Agent`):
+                The executing agent.
+            input_kwargs (`dict`):
+                Reply input kwargs.
+            next_handler (`Callable[..., AsyncGenerator]`):
+                The downstream middleware or core reply logic.
+
+        Yields:
+            `Any`:
+                Events from downstream.
+        """
+        inputs = input_kwargs.get("inputs")
+
+        msgs: list[Msg] | None = None
+        if isinstance(inputs, Msg):
+            msgs = [inputs]
+        elif isinstance(inputs, list) and all(
+            isinstance(m, Msg) for m in inputs
+        ):
+            msgs = inputs
+
+        if msgs:
+            blocks: list[TextBlock | DataBlock] = []
+            for msg in msgs:
+                if not msg.content:
+                    continue
+                speaker = f"{msg.name}: "
+                first = msg.content[0]
+                if isinstance(first, TextBlock):
+                    blocks.append(TextBlock(text=speaker + first.text))
+                else:
+                    blocks.append(TextBlock(text=speaker))
+                blocks.extend(msg.content[1:] if len(msg.content) > 1 else [])
+            self._cached_inputs = blocks
+
+        try:
+            async for evt in next_handler(**input_kwargs):
+                yield evt
+        finally:
+            self._cached_inputs = None
+
+    # ------------------------------------------------------------------
+    # Inject retrieval results on first reasoning step
+    # ------------------------------------------------------------------
+
+    async def on_reasoning(
+        self,
+        agent: "Agent",
+        input_kwargs: dict,
+        next_handler: Callable[..., AsyncGenerator],
+    ) -> AsyncGenerator:
+        """Inject a one-shot retrieval hint on the first reasoning step.
+
+        Args:
+            agent (`Agent`):
+                The executing agent.
+            input_kwargs (`dict`):
+                Reasoning input kwargs.
+            next_handler (`Callable[..., AsyncGenerator]`):
+                The downstream middleware or core reasoning logic.
+
+        Yields:
+            `Any`:
+                Optional :class:`HintBlockEvent` followed by downstream events.
+        """
+        hint: HintBlock | None = None
+
+        if agent.state.cur_iter == 0 and self._cached_inputs:
+            # Flatten text blocks into a single query string
+            query_parts: list[str] = []
+            for block in self._cached_inputs:
+                if isinstance(block, TextBlock):
+                    query_parts.append(block.text)
+            query = "\n".join(query_parts).strip()
+
+            if query:
+                try:
+                    results = await self._backend.search(
+                        query=query,
+                        top_k=self._top_k,
+                        similarity_threshold=self._similarity_threshold,
+                    )
+                except Exception:
+                    logger.exception(
+                        "External retrieval search failed; proceeding "
+                        "without matched context.",
+                    )
+                    results = []
+
+                blocks = _format_results(results)
+                if blocks:
+                    hint = HintBlock(
+                        hint=_wrap_hint(self._hint_template, blocks),
+                        source='{"label": "ExternalRetrieval", "sublabel": ""}',
+                    )
+                    agent.state.append_context(agent.name, [hint])
+                    if self._emit_hint_event:
+                        yield HintBlockEvent(
+                            reply_id=agent.state.reply_id,
+                            block_id=hint.id,
+                            source=hint.source,
+                            hint=hint.hint,
+                        )
+
+        try:
+            async for evt in next_handler(**input_kwargs):
+                yield evt
+        finally:
+            if hint is not None and not self._persist_hint:
+                # Remove the injected block from the carrier message
+                for msg in reversed(agent.state.context):
+                    if msg.id != agent.state.reply_id:
+                        continue
+                    msg.content = [
+                        b for b in msg.content if b.id != hint.id
+                    ]
+                    break

--- a/src/agentscope/middleware/_external_retrieval/_ragflow.py
+++ b/src/agentscope/middleware/_external_retrieval/_ragflow.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+"""RAGFlow retrieval backend for ExternalRetrievalMiddleware."""
+
+import logging
+from typing import Any
+
+import httpx
+
+from ._backend import RetrievalResult
+
+logger = logging.getLogger(__name__)
+
+
+class RAGFlowRetrievalBackend:
+    """Backend that calls RAGFlow's /api/v1/retrieval endpoint.
+
+    RAGFlow is a full-featured RAG engine (parsing, chunking, hybrid
+    retrieval, reranking).  This backend normalizes its REST API
+    responses into :class:`RetrievalResult` items.
+
+    .. code-block:: python
+
+        backend = RAGFlowRetrievalBackend(
+            base_url="http://localhost:9380",
+            api_key="ragflow-xxx",
+            dataset_ids=["your-dataset-id"],
+        )
+        results = await backend.search("How to deploy docker?", top_k=5)
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        dataset_ids: list[str],
+        timeout: float = 30.0,
+    ) -> None:
+        """Initialize the RAGFlow backend.
+
+        Args:
+            base_url (`str`):
+                RAGFlow server base URL, e.g. ``http://localhost:9380``.
+            api_key (`str`):
+                RAGFlow API key (from "User Settings -> API Key").
+            dataset_ids (`list[str]`):
+                The RAGFlow dataset(s) to search across.
+            timeout (`float`, defaults to ``30.0``):
+                HTTP request timeout in seconds.
+        """
+        self._dataset_ids = dataset_ids
+        self._client = httpx.AsyncClient(
+            base_url=base_url.rstrip("/"),
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=timeout,
+        )
+
+    async def search(
+        self,
+        query: str,
+        top_k: int = 5,
+        similarity_threshold: float | None = None,
+        **kwargs: Any,
+    ) -> list[RetrievalResult]:
+        """Search RAGFlow's retrieval API.
+
+        Args:
+            query (`str`):
+                Natural-language query string.
+            top_k (`int`, defaults to ``5``):
+                Maximum chunks to return.
+            similarity_threshold (`float | None`, optional):
+                Minimum similarity score, 0.0 - 1.0.
+            **kwargs (`Any`):
+                Ignored; kept for protocol compatibility.
+
+        Returns:
+            `list[RetrievalResult]`:
+                Normalized results, ordered by descending similarity.
+                Empty list on failure or no matches.
+        """
+        payload = {
+            "question": query,
+            "dataset_ids": self._dataset_ids,
+            "top_k": top_k,
+        }
+        if similarity_threshold is not None:
+            payload["similarity_threshold"] = similarity_threshold
+
+        try:
+            resp = await self._client.post("/api/v1/retrieval", json=payload)
+            resp.raise_for_status()
+            body = resp.json()
+        except Exception:
+            logger.exception("RAGFlow retrieval request failed.")
+            return []
+
+        if body.get("code") != 0:
+            logger.warning(
+                "RAGFlow retrieval returned error: %s",
+                body.get("message", "unknown error"),
+            )
+            return []
+
+        results = []
+        for chunk in body.get("data", {}).get("chunks", []):
+            source = (
+                chunk.get("document_keyword")
+                or chunk.get("document_name")
+                or chunk.get("doc_name", "")
+            )
+            results.append(
+                RetrievalResult(
+                    content=chunk.get("content", ""),
+                    source=source,
+                    score=round(chunk.get("similarity", 0.0), 4),
+                    metadata={
+                        "document_id": chunk.get("document_id", ""),
+                        "chunk_id": chunk.get("id", ""),
+                    },
+                ),
+            )
+
+        # Sort by descending score and truncate
+        results.sort(key=lambda r: r.score, reverse=True)
+        return results[:top_k]
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()

--- a/tests/middleware_external_retrieval_ragflow_test.py
+++ b/tests/middleware_external_retrieval_ragflow_test.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the :class:`RAGFlowRetrievalBackend` class."""
+import json
+from typing import Any
+from unittest.async_case import IsolatedAsyncioTestCase
+
+import httpx
+
+from agentscope.middleware._external_retrieval import (
+    RAGFlowRetrievalBackend,
+    RetrievalResult,
+)
+
+
+_BASE_URL = "http://test-ragflow:9380"
+
+
+def _make_backend(
+    handler: httpx.MockTransport,
+) -> RAGFlowRetrievalBackend:
+    """Build a backend whose httpx client uses a mock transport."""
+    backend = RAGFlowRetrievalBackend.__new__(RAGFlowRetrievalBackend)
+    backend._dataset_ids = ["dataset-1"]
+    backend._client = httpx.AsyncClient(
+        base_url=_BASE_URL,
+        headers={"Authorization": "Bearer test-key"},
+        transport=httpx.MockTransport(handler),
+    )
+    return backend
+
+
+class RAGFlowRetrievalBackendTest(IsolatedAsyncioTestCase):
+    """The test cases for the :class:`RAGFlowRetrievalBackend` class."""
+
+    async def test_search_success(self) -> None:
+        """Successful retrieval should normalize chunks into RetrievalResult."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "code": 0,
+                    "data": {
+                        "chunks": [
+                            {
+                                "content": "Docker is a container platform.",
+                                "document_keyword": "docker-guide.md",
+                                "similarity": 0.95,
+                                "document_id": "doc-1",
+                                "id": "chunk-1",
+                            },
+                            {
+                                "content": "Use docker-compose for multi-container apps.",
+                                "document_name": "compose-guide.md",
+                                "similarity": 0.87,
+                                "document_id": "doc-2",
+                                "id": "chunk-2",
+                            },
+                        ],
+                    },
+                },
+            )
+
+        backend = _make_backend(handler)
+        try:
+            results = await backend.search("docker deployment", top_k=5)
+
+            self.assertEqual(len(results), 2)
+            self.assertIsInstance(results[0], RetrievalResult)
+            self.assertEqual(results[0].content, "Docker is a container platform.")
+            self.assertEqual(results[0].source, "docker-guide.md")
+            self.assertEqual(results[0].score, 0.95)
+            self.assertEqual(results[0].metadata["document_id"], "doc-1")
+
+            # Should be sorted by descending score
+            self.assertGreater(results[0].score, results[1].score)
+        finally:
+            await backend.close()
+
+    async def test_search_empty_results(self) -> None:
+        """Empty chunk list should return empty list."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={"code": 0, "data": {"chunks": []}},
+            )
+
+        backend = _make_backend(handler)
+        try:
+            results = await backend.search("nonexistent topic")
+            self.assertEqual(results, [])
+        finally:
+            await backend.close()
+
+    async def test_search_api_error(self) -> None:
+        """API error code should return empty list."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={"code": 401, "message": "unauthorized"},
+            )
+
+        backend = _make_backend(handler)
+        try:
+            results = await backend.search("test")
+            self.assertEqual(results, [])
+        finally:
+            await backend.close()
+
+    async def test_search_http_error(self) -> None:
+        """HTTP error should return empty list."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, text="Internal Server Error")
+
+        backend = _make_backend(handler)
+        try:
+            results = await backend.search("test")
+            self.assertEqual(results, [])
+        finally:
+            await backend.close()
+
+    async def test_search_sends_correct_payload(self) -> None:
+        """Request payload should include query, dataset_ids, top_k, threshold."""
+        captured: list[dict[str, Any]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(json.loads(request.content))
+            return httpx.Response(
+                200,
+                json={"code": 0, "data": {"chunks": []}},
+            )
+
+        backend = _make_backend(handler)
+        try:
+            await backend.search(
+                "test query",
+                top_k=3,
+                similarity_threshold=0.5,
+            )
+
+            self.assertEqual(len(captured), 1)
+            payload = captured[0]
+            self.assertEqual(payload["question"], "test query")
+            self.assertEqual(payload["dataset_ids"], ["dataset-1"])
+            self.assertEqual(payload["top_k"], 3)
+            self.assertEqual(payload["similarity_threshold"], 0.5)
+        finally:
+            await backend.close()
+
+    async def test_search_omits_threshold_when_none(self) -> None:
+        """similarity_threshold should be omitted when None."""
+        captured: list[dict[str, Any]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(json.loads(request.content))
+            return httpx.Response(
+                200,
+                json={"code": 0, "data": {"chunks": []}},
+            )
+
+        backend = _make_backend(handler)
+        try:
+            await backend.search("test query", top_k=3)
+
+            self.assertEqual(len(captured), 1)
+            self.assertNotIn("similarity_threshold", captured[0])
+        finally:
+            await backend.close()
+
+    async def test_auth_header(self) -> None:
+        """Authorization header should be set correctly."""
+        backend = _make_backend(lambda req: httpx.Response(200, json={"code": 0, "data": {"chunks": []}}))
+        try:
+            self.assertEqual(
+                backend._client.headers["Authorization"],
+                "Bearer test-key",
+            )
+        finally:
+            await backend.close()

--- a/tests/middleware_external_retrieval_test.py
+++ b/tests/middleware_external_retrieval_test.py
@@ -1,0 +1,246 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the :class:`ExternalRetrievalMiddleware` class."""
+from types import SimpleNamespace
+from typing import Any, AsyncGenerator
+from unittest.async_case import IsolatedAsyncioTestCase
+
+from agentscope.event import HintBlockEvent
+from agentscope.message import (
+    Msg,
+    UserMsg,
+)
+from agentscope.middleware import ExternalRetrievalMiddleware
+from agentscope.middleware._external_retrieval import (
+    RetrievalBackend,
+    RetrievalResult,
+)
+
+
+_HINT_SOURCE = '{"label": "ExternalRetrieval", "sublabel": ""}'
+
+
+class _StubBackend(RetrievalBackend):
+    """A stub backend returning fixed results."""
+
+    def __init__(self, results: list[RetrievalResult]) -> None:
+        self.results = results
+        self.calls: list[dict] = []
+
+    async def search(
+        self,
+        query: str,
+        top_k: int = 5,
+        **kwargs: Any,
+    ) -> list[RetrievalResult]:
+        self.calls.append({"query": query, "top_k": top_k, **kwargs})
+        return self.results[:top_k]
+
+
+def _make_agent(
+    context: list[Msg] | None = None,
+    cur_iter: int = 0,
+) -> Any:
+    """Build a minimal stand-in for an Agent."""
+    msgs: list[Msg] = context if context is not None else []
+
+    def _append_context(name: str, blocks: list) -> None:
+        carrier = Msg(name=name, role="assistant", content=blocks)
+        carrier.id = "reply-1"
+        msgs.append(carrier)
+
+    state = SimpleNamespace(
+        context=msgs,
+        reply_id="reply-1",
+        session_id="session-1",
+        cur_iter=cur_iter,
+        append_context=_append_context,
+    )
+    return SimpleNamespace(name="assistant", state=state)
+
+
+async def _drain(generator: AsyncGenerator) -> list:
+    """Exhaust an async generator into a list."""
+    return [item async for item in generator]
+
+
+class ExternalRetrievalMiddlewareTest(IsolatedAsyncioTestCase):
+    """The test cases for the :class:`ExternalRetrievalMiddleware` class."""
+
+    def _middleware(
+        self,
+        results: list[RetrievalResult] | None = None,
+        **kwargs: Any,
+    ) -> ExternalRetrievalMiddleware:
+        """Build a middleware with a stub backend."""
+        if results is None:
+            results = [
+                RetrievalResult(
+                    content="Use docker-compose up to start services.",
+                    source="docker-guide.md",
+                    score=0.95,
+                ),
+            ]
+        backend = _StubBackend(results)
+        return ExternalRetrievalMiddleware(
+            backend=backend,
+            top_k=kwargs.get("top_k", 5),
+            similarity_threshold=kwargs.get("similarity_threshold"),
+            emit_hint_event=kwargs.get("emit_hint_event", True),
+            persist_hint=kwargs.get("persist_hint", False),
+        )
+
+    async def _run_with_inputs(
+        self,
+        middleware: ExternalRetrievalMiddleware,
+        agent: Any,
+        inputs: Msg | list[Msg] | None,
+        context_during_reasoning: list[dict] | None = None,
+    ) -> list:
+        """Drive ``on_reply`` → ``on_reasoning`` end-to-end.
+
+        Mirrors the real agent loop: ``on_reply`` captures the inputs
+        in the middleware's scratchpad, then ``on_reasoning`` runs
+        (with ``state.cur_iter == 0``) and may inject a hint.  The
+        reasoning step yields a sentinel ``"reasoning-event"`` so
+        callers can assert event order; if ``context_during_reasoning``
+        is provided it is filled with a dump of ``agent.state.context``
+        as seen by the innermost reasoning callback.
+        """
+
+        async def reasoning_next(**_kwargs: Any) -> AsyncGenerator:
+            if context_during_reasoning is not None:
+                context_during_reasoning.extend(
+                    msg.model_dump() for msg in agent.state.context
+                )
+            yield "reasoning-event"
+
+        async def reply_next(**_kwargs: Any) -> AsyncGenerator:
+            async for evt in middleware.on_reasoning(
+                agent=agent,
+                input_kwargs={},
+                next_handler=reasoning_next,
+            ):
+                yield evt
+
+        return await _drain(
+            middleware.on_reply(
+                agent=agent,
+                input_kwargs={"inputs": inputs},
+                next_handler=reply_next,
+            ),
+        )
+
+    async def test_static_mode_injects_hint(self) -> None:
+        """Static mode should inject a hint on the first reasoning step."""
+        middleware = self._middleware()
+        agent = _make_agent(cur_iter=0)
+        seen_context: list[dict] = []
+
+        events = await self._run_with_inputs(
+            middleware,
+            agent,
+            UserMsg(name="user", content="How to deploy docker?"),
+            context_during_reasoning=seen_context,
+        )
+
+        # Should emit HintBlockEvent + reasoning event
+        self.assertEqual(len(events), 2)
+        self.assertIsInstance(events[0], HintBlockEvent)
+        self.assertEqual(events[0].source, _HINT_SOURCE)
+        self.assertIn("docker-compose up", events[0].hint)
+        self.assertEqual(events[1], "reasoning-event")
+
+        # The reasoning callback observed exactly one carrier message
+        # with the injected hint block.
+        self.assertEqual(len(seen_context), 1)
+        carrier = seen_context[0]
+        self.assertEqual(carrier["id"], "reply-1")
+        self.assertEqual(len(carrier["content"]), 1)
+
+        # Hint should be removed after reasoning (persist_hint=False)
+        self.assertEqual(len(agent.state.context), 1)
+        self.assertEqual(len(agent.state.context[0].content), 0)
+
+    async def test_static_mode_skips_on_nonzero_iter(self) -> None:
+        """Static mode should not inject on subsequent reasoning steps."""
+        middleware = self._middleware()
+        agent = _make_agent(cur_iter=1)
+
+        events = await self._run_with_inputs(
+            middleware,
+            agent,
+            UserMsg(name="user", content="test"),
+        )
+
+        # Only reasoning event, no hint
+        self.assertEqual(events, ["reasoning-event"])
+        self.assertEqual(len(agent.state.context), 0)
+
+    async def test_static_mode_empty_results(self) -> None:
+        """No hint injected when backend returns empty results."""
+        middleware = self._middleware(results=[])
+        agent = _make_agent(cur_iter=0)
+
+        events = await self._run_with_inputs(
+            middleware,
+            agent,
+            UserMsg(name="user", content="test"),
+        )
+
+        self.assertEqual(events, ["reasoning-event"])
+        self.assertEqual(len(agent.state.context), 0)
+
+    async def test_static_mode_backend_error(self) -> None:
+        """Backend failure should not break the reasoning flow."""
+        backend = _StubBackend([])
+
+        async def _failing_search(*args: Any, **kwargs: Any) -> list:
+            raise ConnectionError("service unavailable")
+
+        backend.search = _failing_search  # type: ignore[method-assign]
+
+        middleware = ExternalRetrievalMiddleware(backend=backend)
+        agent = _make_agent(cur_iter=0)
+
+        events = await self._run_with_inputs(
+            middleware,
+            agent,
+            UserMsg(name="user", content="test"),
+        )
+
+        # Should proceed without hint
+        self.assertEqual(events, ["reasoning-event"])
+
+    async def test_static_mode_persist_hint(self) -> None:
+        """Hint should remain in context when persist_hint=True."""
+        middleware = self._middleware(persist_hint=True)
+        agent = _make_agent(cur_iter=0)
+
+        await self._run_with_inputs(
+            middleware,
+            agent,
+            UserMsg(name="user", content="test"),
+        )
+
+        # Hint should still be in context
+        self.assertEqual(len(agent.state.context), 1)
+        carrier = agent.state.context[0]
+        self.assertEqual(len(carrier.content), 1)
+
+    async def test_backend_receives_query(self) -> None:
+        """Backend should receive the flattened user query."""
+        backend = _StubBackend([
+            RetrievalResult(content="test", source="doc.md", score=0.9),
+        ])
+        middleware = ExternalRetrievalMiddleware(backend=backend, top_k=3)
+        agent = _make_agent(cur_iter=0)
+
+        await self._run_with_inputs(
+            middleware,
+            agent,
+            UserMsg(name="user", content="docker deployment steps"),
+        )
+
+        self.assertEqual(len(backend.calls), 1)
+        self.assertIn("docker deployment steps", backend.calls[0]["query"])
+        self.assertEqual(backend.calls[0]["top_k"], 3)


### PR DESCRIPTION
## Summary

Add `ExternalRetrievalMiddleware` — a pluggable middleware that mirrors `RAGMiddleware` static mode but delegates retrieval to an external service via a `RetrievalBackend` protocol.

### Key components
- `RetrievalBackend` Protocol (`src/agentscope/middleware/external_retrieval.py`)
- `ExternalRetrievalMiddleware` — static-mode retrieval with backend delegation
- `RAGFlowRetrievalBackend` — concrete backend for [RAGFlow](https://ragflow.io/)
- 3 example scripts (`examples/middleware_external_retrieval/`)
- 13 unit tests (all passing)

### Test command
```
python -m pytest tests/middleware_external_retrieval_test.py tests/middleware_external_retrieval_ragflow_test.py -v
```

Replaces #2211 (rebased on latest main).