### PR TITLE
fix(gemini): remove unsupported $schema from tool parameters

### DIFF
--- a/src/agentscope/model/_gemini/_model.py
+++ b/src/agentscope/model/_gemini/_model.py
@@ -28,6 +28,7 @@ def _sanitize_schema_for_gemini(schema: Any) -> Any:
     Gemini API does not support certain JSON Schema constructs. This
     function removes or rewrites the following:
 
+    - ``$schema``: removed entirely.
     - ``additionalProperties``: removed entirely.
     - ``const``: converted to an equivalent single-value ``enum``,
       since Gemini's ``Schema`` model does not support ``const``.
@@ -54,6 +55,9 @@ def _sanitize_schema_for_gemini(schema: Any) -> Any:
         return schema
 
     schema = dict(schema)
+
+    # Gemini's Schema model does not support the JSON Schema dialect marker.
+    schema.pop("$schema", None)
 
     # Gemini (and many third-party proxies) reject `null` as a standalone
     # functionDeclaration property type. Some MCP servers emit

--- a/tests/model_gemini_test.py
+++ b/tests/model_gemini_test.py
@@ -578,6 +578,30 @@ class TestGeminiFormatTools(unittest.TestCase):
         self.assertEqual(fmt_tools, _FT_TOOLS_GEMINI)
         self.assertIsNone(fmt_choice)
 
+    def test_schema_keyword_removed_from_parameters(self) -> None:
+        """The unsupported `$schema` keyword is removed before the call."""
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "Search for text",
+                    "parameters": {
+                        "$schema": "https://example.com/schema.json",
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string"},
+                        },
+                    },
+                },
+            },
+        ]
+
+        fmt_tools, _ = self.model._format_tools(tools, None)
+        parameters = fmt_tools[0]["function_declarations"][0]["parameters"]
+
+        self.assertNotIn("$schema", parameters)
+
 
 # ---------------------------------------------------------------------------
 # Tests for _sanitize_schema_for_gemini and _flatten_json_schema
@@ -586,6 +610,31 @@ class TestGeminiFormatTools(unittest.TestCase):
 
 class TestGeminiSchemaUtils(unittest.TestCase):
     """Tests for _sanitize_schema_for_gemini and _flatten_json_schema."""
+
+    def test_sanitize_removes_schema_keyword_recursively(self) -> None:
+        """The unsupported `$schema` keyword is removed recursively."""
+        result = _sanitize_schema_for_gemini(
+            {
+                "$schema": "https://example.com/schema.json",
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "$schema": "https://example.com/schema.json",
+                        "type": "string",
+                    },
+                },
+            },
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                },
+            },
+        )
 
     def test_sanitize_removes_additional_properties_and_inlines_optional(
         self,


### PR DESCRIPTION
## AgentScope Version

2.0.6

## Description

Remove the unsupported `$schema` keyword recursively from Gemini tool parameter schemas before API calls. Add regression tests covering both top-level and nested occurrences.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review