### PR TITLE
fix(utils): honor Python attribute lookup semantics

### DIFF
--- a/src/agentscope/_utils/_mixin.py
+++ b/src/agentscope/_utils/_mixin.py
@@ -1,9 +1,16 @@
 # -*- coding: utf-8 -*-
 """The mixin for agentscope."""
+from typing import Any
 
 
 class DictMixin(dict):
     """The dictionary mixin that allows attribute-style access."""
 
     __setattr__ = dict.__setitem__
-    __getattr__ = dict.__getitem__
+
+    def __getattr__(self, name: str) -> Any:
+        """Return a mapped value or signal a missing attribute."""
+        try:
+            return self[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc

--- a/tests/model_response_test.py
+++ b/tests/model_response_test.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Unit tests for :class:`agentscope.model.ChatResponse` and its
 ``append_*`` helpers."""
+from copy import deepcopy
+from unittest import TestCase
 from unittest.async_case import IsolatedAsyncioTestCase
 
 from utils import AnyString
@@ -45,6 +47,33 @@ def _expected(
         "finished_reason": finished_reason,
         "metadata": {},
     }
+
+
+class DictMixinAttributeTest(TestCase):
+    """Test attribute access on dictionary-backed model responses."""
+
+    def setUp(self) -> None:
+        """Create a response used by the attribute protocol tests."""
+        self.response = ChatResponse(content=[], is_last=True)
+
+    def test_deepcopy_works_with_missing_special_attributes(self) -> None:
+        """``deepcopy`` should work when ``__deepcopy__`` is not a key."""
+        copied = deepcopy(self.response)
+
+        self.assertIsNot(copied, self.response)
+        self.assertDictEqual(dict(copied), dict(self.response))
+
+    def test_missing_attribute_uses_python_attribute_protocol(self) -> None:
+        """Missing attributes should raise ``AttributeError``."""
+        self.assertFalse(hasattr(self.response, "missing"))
+        self.assertEqual(
+            getattr(self.response, "missing", "fallback"),
+            "fallback",
+        )
+
+    def test_missing_mapping_key_still_raises_key_error(self) -> None:
+        """Mapping-style access should keep its existing ``KeyError``."""
+        self.assertRaises(KeyError, self.response.__getitem__, "missing")
 
 
 class ChatResponseAppendTest(IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary

Fixes #2239.

`DictMixin` uses dictionary keys for attribute-style access, but a missing key currently raises `KeyError`. That breaks Python's attribute lookup contract: `hasattr()` and `getattr(..., default)` cannot handle the missing attribute, and `copy.deepcopy()` fails while probing for `__deepcopy__`.

This change translates missing mapped attributes into `AttributeError` while keeping direct mapping access unchanged, so `response["missing"]` still raises `KeyError`.

## Tests

- `uv run pre-commit run --files src/agentscope/_utils/_mixin.py tests/model_response_test.py`
- `uv run pytest tests/model_response_test.py -q` (19 passed)
- `uv run pytest tests -q` (1764 passed, 147 skipped; one pre-existing failure in `tests/mcp_sse_client_test.py::SseSchemaDefsPreservationTest::test_defs_preserved_and_titles_stripped`, also reproduced on `origin/main`)

## Notes

No public API names or serialized response fields change; this only restores standard Python behavior for missing attributes.
