### PR TITLE
fix(app): persist workspace bindings for scheduled sessions

### DIFF
--- a/src/agentscope/app/_lifespan.py
+++ b/src/agentscope/app/_lifespan.py
@@ -89,6 +89,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             SchedulerManager(
                 storage=storage,
                 message_bus=message_bus,
+                workspace_manager=workspace_manager,
             ),
         )
         app.state.scheduler_manager = scheduler

--- a/src/agentscope/app/_manager/_scheduler/_scheduler_manager.py
+++ b/src/agentscope/app/_manager/_scheduler/_scheduler_manager.py
@@ -10,6 +10,7 @@ from ....permission import PermissionContext
 from ....state import AgentState
 from ....tool import ToolBase
 from ...._logging import logger
+from ...._utils._common import _generate_id
 from ._tools import ScheduleCreate, ScheduleDelete, ScheduleList, ScheduleView
 from ...message_bus import MessageBus, MessageBusKeys
 from ..._bus_ops import enqueue_run_trigger
@@ -20,6 +21,7 @@ from ...storage import (
     SessionConfig,
     SessionSource,
 )
+from ...workspace_manager import WorkspaceManagerBase
 
 
 class SchedulerManager:
@@ -39,6 +41,7 @@ class SchedulerManager:
         self,
         storage: StorageBase,
         message_bus: MessageBus,
+        workspace_manager: WorkspaceManagerBase | None = None,
     ) -> None:
         """Initialize the scheduler manager.
 
@@ -50,11 +53,16 @@ class SchedulerManager:
                 The application message bus. Each scheduled fire pushes
                 a :class:`HintBlock` to the target session's inbox and
                 enqueues a wakeup via this bus.
+            workspace_manager (`WorkspaceManagerBase | None`, optional):
+                Resolves stable workspace bindings for sessions that cannot
+                inherit one from the schedule's source session. When omitted,
+                a fresh isolated workspace id is generated.
         """
         from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
         self._storage = storage
         self._message_bus = message_bus
+        self._workspace_manager = workspace_manager
         self._scheduler = AsyncIOScheduler()
 
     # ------------------------------------------------------------------
@@ -92,6 +100,35 @@ class SchedulerManager:
     # Trigger construction
     # ------------------------------------------------------------------
 
+    async def _resolve_workspace_id(
+        self,
+        record: ScheduleRecord,
+        session_id: str,
+    ) -> str:
+        """Resolve the workspace binding for a scheduled session.
+
+        Agent-created schedules inherit their source session's workspace so
+        files and other workspace resources remain available when they fire.
+        Schedules without a live source session fall back to the configured
+        workspace isolation policy.
+        """
+        if record.data.source_session_id:
+            source_session = await self._storage.get_session(
+                record.user_id,
+                record.agent_id,
+                record.data.source_session_id,
+            )
+            if source_session and source_session.config.workspace_id:
+                return source_session.config.workspace_id
+
+        if self._workspace_manager is not None:
+            return self._workspace_manager.assign_workspace_id(
+                user_id=record.user_id,
+                agent_id=record.agent_id,
+                session_id=session_id,
+            )
+        return _generate_id()
+
     def _build_trigger(
         self,
         record: ScheduleRecord,
@@ -121,6 +158,7 @@ class SchedulerManager:
         # re-look these up on every fire.
         storage = self._storage
         message_bus = self._message_bus
+        resolve_workspace_id = self._resolve_workspace_id
 
         async def _trigger() -> None:
             logger.info(
@@ -163,8 +201,12 @@ class SchedulerManager:
                         state.permission_context = PermissionContext(
                             mode=record.data.permission_mode,
                         )
+                        workspace_id = await resolve_workspace_id(
+                            record,
+                            stateful_session_id,
+                        )
                         session_config = SessionConfig(
-                            workspace_id="",
+                            workspace_id=workspace_id,
                             chat_model_config=record.data.chat_model_config,
                         )
                         session = await storage.upsert_session(
@@ -195,14 +237,20 @@ class SchedulerManager:
                     state.permission_context = PermissionContext(
                         mode=record.data.permission_mode,
                     )
+                    session_id = _generate_id()
+                    workspace_id = await resolve_workspace_id(
+                        record,
+                        session_id,
+                    )
                     session = await storage.upsert_session(
                         user_id=record.user_id,
                         agent_id=record.agent_id,
                         config=SessionConfig(
-                            workspace_id="",
+                            workspace_id=workspace_id,
                             chat_model_config=record.data.chat_model_config,
                         ),
                         state=state,
+                        session_id=session_id,
                         source=SessionSource.SCHEDULE,
                         source_schedule_id=record.id,
                     )

--- a/tests/service_scheduler_test.py
+++ b/tests/service_scheduler_test.py
@@ -21,7 +21,7 @@ from unittest import IsolatedAsyncioTestCase
 
 import fakeredis.aioredis
 
-from utils import AnyString
+from utils import AnyString, FakeWorkspaceManager
 
 from agentscope.app._manager import SchedulerManager
 from agentscope.app.message_bus import RedisMessageBus
@@ -30,6 +30,9 @@ from agentscope.app.storage import (
     RedisStorage,
     ScheduleData,
     ScheduleRecord,
+    ScheduleSource,
+    SessionConfig,
+    SessionRecord,
     SessionSource,
 )
 from agentscope.permission import PermissionMode
@@ -76,6 +79,7 @@ def _make_record(
     enabled: bool = True,
     stateful: bool = False,
     description: str = "run nightly summary",
+    source_session_id: str = "",
 ) -> ScheduleRecord:
     """Build a minimal :class:`ScheduleRecord` for the trigger test."""
     return ScheduleRecord(
@@ -95,6 +99,12 @@ def _make_record(
             ),
             stateful=stateful,
             permission_mode=PermissionMode.DONT_ASK,
+            source=(
+                ScheduleSource.AGENT
+                if source_session_id
+                else ScheduleSource.USER
+            ),
+            source_session_id=source_session_id,
         ),
     )
 
@@ -115,6 +125,7 @@ class _SchedulerFireTestBase(IsolatedAsyncioTestCase):
         self.manager = SchedulerManager(
             storage=self.storage,
             message_bus=self.bus,
+            workspace_manager=FakeWorkspaceManager(),
         )
 
     async def asyncTearDown(self) -> None:
@@ -149,6 +160,7 @@ class TestSchedulerFireDelivery(_SchedulerFireTestBase):
                 "source_schedule_id": record.id,
             },
         )
+        self.assertTrue(session.config.workspace_id)
 
         # Inbox has the wrapped HintBlock.
         inbox = await self.bus.inbox_drain(session.id, max_count=10)
@@ -182,6 +194,110 @@ class TestSchedulerFireDelivery(_SchedulerFireTestBase):
                 "kind": "wake",
                 "input": None,
             },
+        )
+
+
+class TestSchedulerWorkspaceBinding(_SchedulerFireTestBase):
+    """Scheduled sessions always persist a stable workspace binding."""
+
+    async def _create_source_session(
+        self,
+        record: ScheduleRecord,
+        workspace_id: str,
+    ) -> None:
+        """Persist the session from which an agent created a schedule."""
+        await self.storage.upsert_session(
+            user_id=record.user_id,
+            agent_id=record.agent_id,
+            session_id=record.data.source_session_id,
+            config=SessionConfig(
+                workspace_id=workspace_id,
+                chat_model_config=record.data.chat_model_config,
+            ),
+        )
+
+    async def _scheduled_sessions(
+        self,
+        record: ScheduleRecord,
+    ) -> list[SessionRecord]:
+        """Return only the sessions created by the schedule."""
+        sessions = await self.storage.list_sessions(
+            record.user_id,
+            record.agent_id,
+        )
+        return [s for s in sessions if s.source == SessionSource.SCHEDULE]
+
+    async def test_inherits_source_session_workspace(self) -> None:
+        """An agent-created schedule keeps access to its source workspace."""
+        record = _make_record(source_session_id="source-session")
+        await self._create_source_session(record, "source-workspace")
+
+        await self.manager._build_trigger(record)()
+
+        sessions = await self._scheduled_sessions(record)
+        self.assertEqual(len(sessions), 1)
+        self.assertEqual(
+            sessions[0].config.workspace_id,
+            "source-workspace",
+        )
+
+    async def test_missing_source_uses_workspace_isolation_policy(
+        self,
+    ) -> None:
+        """A deleted source session falls back to a stable assigned id."""
+        record = _make_record(source_session_id="missing-session")
+
+        await self.manager._build_trigger(record)()
+
+        sessions = await self._scheduled_sessions(record)
+        self.assertEqual(len(sessions), 1)
+        session = sessions[0]
+        self.assertEqual(
+            session.config.workspace_id,
+            self.manager._workspace_manager.assign_workspace_id(
+                user_id=record.user_id,
+                agent_id=record.agent_id,
+                session_id=session.id,
+            ),
+        )
+        self.assertTrue(session.config.workspace_id)
+
+    async def test_without_workspace_manager_generates_workspace_id(
+        self,
+    ) -> None:
+        """The existing two-argument constructor remains supported."""
+        manager = SchedulerManager(
+            storage=self.storage,
+            message_bus=self.bus,
+        )
+        record = _make_record(source_session_id="missing-session")
+
+        await manager._build_trigger(record)()
+
+        sessions = await self._scheduled_sessions(record)
+        self.assertEqual(len(sessions), 1)
+        self.assertTrue(sessions[0].config.workspace_id)
+
+    async def test_stateful_session_keeps_initial_workspace_binding(
+        self,
+    ) -> None:
+        """Later fires reuse the workspace persisted on the first fire."""
+        record = _make_record(
+            stateful=True,
+            source_session_id="source-session",
+        )
+        await self._create_source_session(record, "initial-workspace")
+        trigger = self.manager._build_trigger(record)
+        await trigger()
+
+        await self._create_source_session(record, "changed-workspace")
+        await trigger()
+
+        sessions = await self._scheduled_sessions(record)
+        self.assertEqual(len(sessions), 1)
+        self.assertEqual(
+            sessions[0].config.workspace_id,
+            "initial-workspace",
         )
 
 


### PR DESCRIPTION
## AgentScope Version

2.0.6

## Description

Scheduled sessions currently persist an empty `workspace_id`, while workspace managers treat that value as a cache key and runtime workspaces may replace it with a generated identifier. This leaves the persisted binding inconsistent and can make unrelated scheduled sessions reuse the empty cache key.

This change:

- inherits a non-empty workspace binding from the schedule source session when it is available
- falls back to the configured workspace isolation policy when the source session is missing or has no binding
- generates a non-empty isolated binding when `SchedulerManager` is constructed without a workspace manager, preserving the existing constructor usage
- assigns the stateless session ID before resolving and persisting its workspace binding

Regression tests cover source inheritance, missing-source fallback, backwards-compatible construction, stateful binding reuse, and non-empty scheduled-session bindings.

Fixes #2282

## Testing

- `pytest tests/service_scheduler_test.py tests/service_toolkit_test.py tests/app_lifespan_dedicated_test.py -q` (13 passed)
- pre-commit checks on all changed and affected files

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the contributing guide
- [x] Docstrings are in Google style
- [x] No documentation update is required for this internal persistence fix
- [x] Code is ready for review