### PR TITLE
fix(service): preserve busy background wakeups

### DIFF
--- a/src/agentscope/app/_bus_ops.py
+++ b/src/agentscope/app/_bus_ops.py
@@ -90,9 +90,9 @@ async def enqueue_run_trigger(
 
     ``kind`` selects how the dispatcher handles the entry:
 
-    - ``wake`` — idle-session wake-up.  The dispatcher skips the entry
-      when the session is already running (the live run drains the inbox
-      itself).  ``inputs`` must be ``None``.
+    - ``wake`` — idle-session wake-up.  The dispatcher re-queues the entry
+      while the session is already running, then skips the deferred run if
+      the inbox has already been drained.  ``inputs`` must be ``None``.
     - ``resume`` — resume a HITL-parked session with a user confirmation,
       an external execution result, or a user interrupt.  The dispatcher
       waits (with backoff) until the parked run releases its lock, then

--- a/src/agentscope/app/_manager/_wakeup_dispatcher.py
+++ b/src/agentscope/app/_manager/_wakeup_dispatcher.py
@@ -12,8 +12,9 @@ funnels through this one serial consumer.
 Each queue entry carries a ``kind`` that selects how a busy session is
 handled:
 
-- ``wake`` (idle-session wake-up, ``input_msg=None``): skipped while the
-  session is already running — the live run will drain the inbox.
+- ``wake`` (idle-session wake-up, ``input_msg=None``): re-queued while the
+  session is already running so inbox entries that arrive after the live
+  run's final drain are not stranded.
 - ``resume`` (a parked HITL run being fed its result): must *not* be
   skipped while running, because the session is typically still running
   the parked tail at trigger time. It is re-queued after a short backoff
@@ -54,21 +55,20 @@ _RESUME_INPUT_ADAPTER: TypeAdapter = TypeAdapter(
     UserConfirmResultEvent | ExternalExecutionResultEvent | UserInterruptEvent,
 )
 
-# Delay before re-queuing a ``resume`` trigger whose target session is
-# still running (the parked run is finishing and about to free its
-# lock). Short enough to feel instant to the user, long enough to avoid
-# a hot re-enqueue loop while the lock is held.
-_RESUME_RETRY_BACKOFF_SECS = 0.1
+# Delay before re-queuing a trigger whose target session is still running.
+# Short enough to feel instant to the user, long enough to avoid a hot
+# re-enqueue loop while the lock is held.
+_TRIGGER_RETRY_BACKOFF_SECS = 0.1
 
 
 class WakeupDispatcher:
     """One asyncio task per process, draining the shared trigger queue.
 
     Args:
-        message_bus (`MessageBus`):
-            Application message bus. Used for signal subscription,
-            queue drain, ``session_is_running`` checks, and re-queuing
-            deferred ``resume`` triggers.
+            message_bus (`MessageBus`):
+                Application message bus. Used for signal subscription,
+                queue drain, ``session_is_running`` checks, and re-queuing
+                deferred triggers.
         storage (`StorageBase`):
             Persistent storage backend. Consulted before spawning a
             run so triggers whose target session has been deleted are
@@ -104,7 +104,7 @@ class WakeupDispatcher:
         self._chat_service = chat_service
         self._registry = chat_run_registry
         self._task: asyncio.Task | None = None
-        # Detached backoff timers for deferred ``resume`` re-enqueues.
+        # Detached backoff timers for deferred trigger re-enqueues.
         # Held so they are not garbage-collected mid-sleep and can be
         # cancelled on shutdown.
         self._retry_tasks: set[asyncio.Task] = set()
@@ -274,19 +274,16 @@ class WakeupDispatcher:
         if await self._bus.is_locked(
             MessageBusKeys.session_lock(session_id),
         ):
-            if carries_input:
-                # The session is busy. Do NOT drop input-carrying triggers
-                # — re-queue after a short backoff so they land once the
-                # running turn releases its lock.
-                self._schedule_input_retry(
-                    user_id,
-                    session_id,
-                    agent_id,
-                    kind,
-                    input_msg,
-                )
-            # ``wake`` triggers are safe to drop while running — the
-            # live run drains the inbox itself.
+            # The session may already have completed its final inbox drain.
+            # Keep every trigger alive until the running turn releases its
+            # lock; empty wake-ups are discarded inside ChatService.
+            self._schedule_trigger_retry(
+                user_id,
+                session_id,
+                agent_id,
+                kind,
+                input_msg,
+            )
             return
 
         # Orphan guard: the queue is unaware of session lifecycle. A
@@ -337,25 +334,18 @@ class WakeupDispatcher:
                 name=f"{kind}-run:{session_id}",
             )
         except RuntimeError:
-            # A local run was registered between the running-check and
-            # the spawn. For ``wake`` that run will drain the inbox; for
-            # input-carrying kinds re-queue so the input is not lost.
-            if carries_input:
-                self._schedule_input_retry(
-                    user_id,
-                    session_id,
-                    agent_id,
-                    kind,
-                    input_msg,
-                )
-            else:
-                logger.debug(
-                    "WakeupDispatcher: skipping wake trigger for session "
-                    "%s; a local run is already registered.",
-                    session_id,
-                )
+            # A local run was registered between the running-check and the
+            # spawn. Re-queue after it finishes for the same reason as the
+            # distributed-lock path above.
+            self._schedule_trigger_retry(
+                user_id,
+                session_id,
+                agent_id,
+                kind,
+                input_msg,
+            )
 
-    def _schedule_input_retry(
+    def _schedule_trigger_retry(
         self,
         user_id: str,
         session_id: str,
@@ -367,8 +357,7 @@ class WakeupDispatcher:
         | Msg
         | None,
     ) -> None:
-        """Re-enqueue an input-carrying (``resume``/``message``) trigger
-        after a short backoff.
+        """Re-enqueue a trigger after a short backoff.
 
         Spawns a detached timer that sleeps, then re-enqueues the trigger
         (which re-fires the signal, re-driving the drain). This keeps the
@@ -383,20 +372,20 @@ class WakeupDispatcher:
             agent_id (`str`):
                 The agent that owns the session.
             kind (`str`):
-                The trigger kind to re-enqueue (``resume`` / ``message``).
+                The trigger kind to re-enqueue.
             input_msg:
                 The parsed input to redeliver.
         """
 
         async def _retry() -> None:
             try:
-                await asyncio.sleep(_RESUME_RETRY_BACKOFF_SECS)
+                await asyncio.sleep(_TRIGGER_RETRY_BACKOFF_SECS)
                 await enqueue_run_trigger(
                     self._bus,
                     user_id=user_id,
                     session_id=session_id,
                     agent_id=agent_id,
-                    kind=kind,  # type: ignore[arg-type]  # resume | message
+                    kind=kind,  # type: ignore[arg-type]  # all trigger kinds
                     inputs=input_msg,
                 )
             except asyncio.CancelledError:

--- a/src/agentscope/app/_service/_chat.py
+++ b/src/agentscope/app/_service/_chat.py
@@ -500,6 +500,39 @@ optional):
         )
         return True
 
+    async def _skip_empty_wakeup(
+        self,
+        session_id: str,
+        input_msg: object,
+    ) -> bool:
+        """Whether a wake-only run has no pending inbox work.
+
+        The check must run under the distributed session lock. A deferred or
+        duplicate wake may arrive after another run already drained the
+        inbox; returning early avoids an unprompted LLM turn in that case.
+
+        Args:
+            session_id (`str`):
+                Session whose inbox should be inspected.
+            input_msg (`object`):
+                Run input; only ``None`` represents a plain wake.
+
+        Returns:
+            `bool`:
+                ``True`` when the run should finish without invoking the
+                agent.
+        """
+        if input_msg is not None:
+            return False
+        if await self._message_bus.inbox_len(session_id) != 0:
+            return False
+        logger.info(
+            "Skipping empty wake-up for session %s: inbox has already "
+            "been drained.",
+            session_id,
+        )
+        return True
+
     async def _run_impl(
         # pylint: disable=too-many-statements,too-many-branches
         self,
@@ -799,6 +832,9 @@ optional):
             lock_key,
             ttl_secs=MessageBusKeys.SESSION_RUN_TTL_SECS,
         ):
+            if await self._skip_empty_wakeup(session_id, input_msg):
+                return
+
             # Channel-bound run: signal the output forwarder so the reply
             # is streamed back to the platform chat. Covers scheduled /
             # background wakes, not just inbound channel messages.

--- a/src/agentscope/app/message_bus/_base.py
+++ b/src/agentscope/app/message_bus/_base.py
@@ -167,6 +167,28 @@ class MessageBus(ABC):  # pylint: disable=too-many-public-methods
                 Queue identifier.
         """
 
+    async def queue_len(  # pylint: disable=unused-argument
+        self,
+        key: str,
+    ) -> int | None:
+        """Return the number of pending entries without consuming them.
+
+        Transports that cannot inspect a queue non-destructively may return
+        ``None``. This default keeps custom message-bus implementations
+        compatible while allowing built-in transports to suppress duplicate
+        empty wake-ups.
+
+        Args:
+            key (`str`):
+                Queue identifier.
+
+        Returns:
+            `int | None`:
+                Number of entries currently stored in the queue, or ``None``
+                when the transport cannot determine it non-destructively.
+        """
+        return None
+
     # ------------------------------------------------------------------
     # Mode C — replay log (multi-consumer, externally bounded)
     # ------------------------------------------------------------------
@@ -680,6 +702,20 @@ class MessageBus(ABC):  # pylint: disable=too-many-public-methods
             self._INBOX_KEY.format(sid=session_id),
             max_count=max_count,
         )
+
+    async def inbox_len(self, session_id: str) -> int | None:
+        """Return the number of pending inbox entries for a session.
+
+        Args:
+            session_id (`str`):
+                Session whose inbox should be inspected.
+
+        Returns:
+            `int | None`:
+                Number of entries currently waiting in the inbox, or
+                ``None`` when the transport cannot determine it.
+        """
+        return await self.queue_len(self._INBOX_KEY.format(sid=session_id))
 
     # Wakeup ----------------------------------------------------------
 

--- a/src/agentscope/app/message_bus/_in_memory_message_bus.py
+++ b/src/agentscope/app/message_bus/_in_memory_message_bus.py
@@ -193,6 +193,26 @@ class InMemoryMessageBus(MessageBus):
         """
         self._queues.pop(key, None)
 
+    async def queue_len(self, key: str) -> int:
+        """Return the number of pending entries without consuming them.
+
+        Args:
+            key (`str`):
+                Queue identifier.
+
+        Returns:
+            `int`:
+                Number of unexpired entries currently stored under ``key``.
+        """
+        queue = self._queues.get(key)
+        if not queue:
+            return 0
+        now = time.monotonic()
+        queue[:] = [
+            entry for entry in queue if entry[2] is None or entry[2] > now
+        ]
+        return len(queue)
+
     # ------------------------------------------------------------------
     # Mode C — replay log
     # ------------------------------------------------------------------

--- a/src/agentscope/app/message_bus/_keys.py
+++ b/src/agentscope/app/message_bus/_keys.py
@@ -33,7 +33,7 @@ class MessageBusKeys:  # pylint: disable=too-many-public-methods
     WAKEUP_KIND_WAKE: Final = "wake"
     """Trigger kind: wake an *idle* session to drain pending inbox
     content. The dispatcher spawns the run with ``input_msg=None`` and
-    skips the session entirely while it is already running."""
+    re-queues it while the session is already running."""
 
     WAKEUP_KIND_RESUME: Final = "resume"
     """Trigger kind: resume a session parked on an awaiting tool call by
@@ -47,8 +47,7 @@ class MessageBusKeys:  # pylint: disable=too-many-public-methods
     inbound channel message). The dispatcher spawns the run with the
     carried message as ``input_msg`` so it is persisted and reasoned over
     as a real user turn. Like ``resume`` (and unlike ``wake``) it carries
-    input, so it is re-queued rather than dropped while the session is
-    running."""
+    input, so it is re-queued while the session is running."""
 
     # ------------------------------------------------------------------
     # Cross-session UI projection — a generic per-session Redis-hash

--- a/src/agentscope/app/message_bus/_redis_message_bus.py
+++ b/src/agentscope/app/message_bus/_redis_message_bus.py
@@ -16,7 +16,7 @@ else:
     Redis = Any
 
 
-class RedisMessageBus(MessageBus):
+class RedisMessageBus(MessageBus):  # pylint: disable=too-many-public-methods
     """Redis-backed implementation of :class:`MessageBus`.
 
     Mapping of bus modes to Redis primitives:
@@ -275,6 +275,19 @@ class RedisMessageBus(MessageBus):
                 when the key does not exist.
         """
         await self._client.delete(key)
+
+    async def queue_len(self, key: str) -> int:
+        """Return the number of pending entries without consuming them.
+
+        Args:
+            key (`str`):
+                Stream key for the drain queue.
+
+        Returns:
+            `int`:
+                Number of entries currently stored in the stream.
+        """
+        return int(await self._client.xlen(key))
 
     # ------------------------------------------------------------------
     # Mode C — replay log

--- a/tests/in_memory_message_bus_test.py
+++ b/tests/in_memory_message_bus_test.py
@@ -79,6 +79,16 @@ class TestQueuePrimitive(IsolatedAsyncioTestCase):
         self.assertEqual([p for _id, p in a], [{"x": 1}])
         self.assertEqual([p for _id, p in b], [{"x": 2}])
 
+    async def test_queue_len_is_non_destructive(self) -> None:
+        """Queue length reports pending entries without consuming them."""
+        self.assertEqual(await self.bus.queue_len("k"), 0)
+        await self.bus.queue_push("k", {"i": 1})
+        await self.bus.queue_push("k", {"i": 2})
+
+        self.assertEqual(await self.bus.queue_len("k"), 2)
+        entries = await self.bus.queue_drain("k", max_count=10)
+        self.assertEqual([payload["i"] for _, payload in entries], [1, 2])
+
 
 class TestLogPrimitive(IsolatedAsyncioTestCase):
     """Mode C — replay log: append / read with cursor / trim."""

--- a/tests/service_chat_wakeup_test.py
+++ b/tests/service_chat_wakeup_test.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Tests for wake-driven :class:`ChatService` runs."""
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+
+from agentscope.app._service._chat import ChatService
+
+
+def _service(message_bus: object) -> ChatService:
+    """Build a chat service with only the dependency under test."""
+    return ChatService(
+        storage=None,
+        workspace_manager=None,
+        scheduler_manager=None,
+        background_task_manager=None,
+        message_bus=message_bus,
+        resource_access_service=None,
+    )
+
+
+class TestEmptyWakeupGuard(IsolatedAsyncioTestCase):
+    """Wake-only runs should execute only when inbox work remains."""
+
+    async def test_empty_wakeup_is_skipped(self) -> None:
+        """A wake with no pending inbox entries does not need an agent run."""
+        bus = SimpleNamespace(inbox_len=AsyncMock(return_value=0))
+
+        skipped = await _service(bus)._skip_empty_wakeup("session-1", None)
+
+        self.assertTrue(skipped)
+        bus.inbox_len.assert_awaited_once_with("session-1")
+
+    async def test_wakeup_with_pending_inbox_is_not_skipped(self) -> None:
+        """A pending completion result must be delivered to the agent."""
+        bus = SimpleNamespace(inbox_len=AsyncMock(return_value=1))
+
+        skipped = await _service(bus)._skip_empty_wakeup("session-1", None)
+
+        self.assertFalse(skipped)
+
+    async def test_unknown_inbox_length_is_not_skipped(self) -> None:
+        """Custom transports without queue inspection preserve delivery."""
+        bus = SimpleNamespace(inbox_len=AsyncMock(return_value=None))
+
+        skipped = await _service(bus)._skip_empty_wakeup("session-1", None)
+
+        self.assertFalse(skipped)
+
+    async def test_input_message_bypasses_empty_wakeup_guard(self) -> None:
+        """Real run inputs are never suppressed by inbox state."""
+        bus = SimpleNamespace(inbox_len=AsyncMock(return_value=0))
+
+        skipped = await _service(bus)._skip_empty_wakeup(
+            "session-1",
+            object(),
+        )
+
+        self.assertFalse(skipped)
+        bus.inbox_len.assert_not_awaited()

--- a/tests/service_message_bus_test.py
+++ b/tests/service_message_bus_test.py
@@ -83,6 +83,16 @@ class TestQueuePrimitive(IsolatedAsyncioTestCase):
         self.assertEqual([p["i"] for _id, p in first], [0, 1, 2])
         self.assertEqual([p["i"] for _id, p in rest], [3, 4])
 
+    async def test_queue_len_is_non_destructive(self) -> None:
+        """Queue length reports pending entries without consuming them."""
+        self.assertEqual(await self.bus.queue_len("k"), 0)
+        await self.bus.queue_push("k", {"i": 1})
+        await self.bus.queue_push("k", {"i": 2})
+
+        self.assertEqual(await self.bus.queue_len("k"), 2)
+        entries = await self.bus.queue_drain("k", max_count=10)
+        self.assertEqual([payload["i"] for _, payload in entries], [1, 2])
+
 
 class TestLogPrimitive(IsolatedAsyncioTestCase):
     """Mode C — replay log: append / read with cursor / trim."""

--- a/tests/service_wakeup_dispatcher_test.py
+++ b/tests/service_wakeup_dispatcher_test.py
@@ -288,12 +288,12 @@ class TestWakeupDispatcherDispatch(IsolatedAsyncioTestCase):
             ],
         )
 
-    async def test_active_session_skipped(self) -> None:
-        """If the target session is already running, no chat run is
-        spawned for it."""
+    async def test_wake_running_session_requeues_until_free(self) -> None:
+        """A plain wake remains pending until the running session exits."""
         bus = _FakeBus()
         chat = _FakeChatService()
-        bus._locks.add(MessageBus._SESSION_LOCK_KEY.format(sid="busy"))
+        lock_key = MessageBus._SESSION_LOCK_KEY.format(sid="busy")
+        bus._locks.add(lock_key)
 
         async with WakeupDispatcher(
             message_bus=bus,
@@ -306,9 +306,14 @@ class TestWakeupDispatcherDispatch(IsolatedAsyncioTestCase):
                 {"user_id": "u", "session_id": "busy", "agent_id": "a"},
             )
             await bus.publish(MessageBusKeys.wakeup_signal(), {})
-            await asyncio.sleep(0.05)
+            await asyncio.sleep(0.25)
+            self.assertEqual(chat.calls, [])
 
-        self.assertEqual(chat.calls, [])
+            bus._locks.discard(lock_key)
+            await asyncio.wait_for(chat.notify.wait(), timeout=2.0)
+
+        self.assertEqual(len(chat.calls), 1)
+        self.assertEqual(chat.calls[0]["session_id"], "busy")
 
     async def test_malformed_entry_skipped(self) -> None:
         """A wake-up entry missing required fields is logged and skipped,


### PR DESCRIPTION
## Summary

- defer plain wake triggers while their target session still holds the run lock instead of dropping them
- check the inbox under the session lock before a wake-only run, so a deferred or duplicate wake cannot start an empty model turn on built-in transports
- add non-destructive queue length support for the in-memory and Redis message buses, with a backward-compatible fallback for custom transports

## Why

A background completion can enqueue its inbox entry and wake trigger after the live run has performed its final inbox drain but just before that run releases the session lock. The dispatcher previously dropped the wake because the session was still busy, leaving the inbox entry stranded with no later trigger.

Retrying the wake closes that timing window. Pairing the retry with an inbox check under the same distributed lock prevents a delayed or duplicate wake from invoking the model after another run has already consumed the inbox entry.

## Scope

Refs #1711 and #1868. This is a focused fix for wake delivery during normal session completion. It does not change offloaded-tool result semantics, and it does not implement Redis consumer groups or crash recovery for in-flight wake triggers. Custom message-bus transports that do not implement non-destructive queue inspection preserve delivery but cannot suppress duplicate empty wakes.

## Validation

- `pre-commit run --all-files`
- `pytest tests`: 1832 passed, 89 skipped
- focused wake-up and message-bus suites: 102 passed
