### PR TITLE
fix(hub): accept owner-scoped skill card ids

### DIFF
--- a/src/agentscope/app/_router/_hub.py
+++ b/src/agentscope/app/_router/_hub.py
@@ -290,8 +290,8 @@ async def install_skill(
 
 
 # Keep this catch-all path route after the more specific ``/install`` route.
-# Starlette resolves routes in declaration order, so placing it first would
-# turn owner-scoped install requests into 405 responses.
+# This keeps route precedence explicit and protects specific routes from
+# accidental shadowing as more card actions are added.
 @hub_router.get("/skill/{hub_id}/cards/{card_id:path}")
 async def get_skill_card(
     hub_id: str,

--- a/src/agentscope/app/_router/_hub.py
+++ b/src/agentscope/app/_router/_hub.py
@@ -231,27 +231,8 @@ async def list_skill_cards(
     return await hub.list_skills(user_id, q=q, cursor=cursor, limit=limit)
 
 
-@hub_router.get("/skill/{hub_id}/cards/{card_id}")
-async def get_skill_card(
-    hub_id: str,
-    card_id: str,
-    *,
-    user_id: str = Depends(get_current_user_id),
-    hubs: dict[str, SkillHubBase] = Depends(get_skill_hubs),
-) -> SkillCard:
-    """Return one skill card, including its ``SKILL.md`` body."""
-    hub = _pick_hub(hubs, hub_id)
-    try:
-        return await hub.get_skill(user_id, card_id)
-    except KeyError as e:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Hub {hub_id!r} has no skill {card_id!r}.",
-        ) from e
-
-
 @hub_router.post(
-    "/skill/{hub_id}/cards/{card_id}/install",
+    "/skill/{hub_id}/cards/{card_id:path}/install",
     status_code=status.HTTP_201_CREATED,
 )
 async def install_skill(
@@ -306,3 +287,25 @@ async def install_skill(
         ) from e
 
     return SkillView.from_record(record)
+
+
+# Keep this catch-all path route after the more specific ``/install`` route.
+# Starlette resolves routes in declaration order, so placing it first would
+# turn owner-scoped install requests into 405 responses.
+@hub_router.get("/skill/{hub_id}/cards/{card_id:path}")
+async def get_skill_card(
+    hub_id: str,
+    card_id: str,
+    *,
+    user_id: str = Depends(get_current_user_id),
+    hubs: dict[str, SkillHubBase] = Depends(get_skill_hubs),
+) -> SkillCard:
+    """Return one skill card, including its ``SKILL.md`` body."""
+    hub = _pick_hub(hubs, hub_id)
+    try:
+        return await hub.get_skill(user_id, card_id)
+    except KeyError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Hub {hub_id!r} has no skill {card_id!r}.",
+        ) from e

--- a/tests/hub_router_test.py
+++ b/tests/hub_router_test.py
@@ -6,6 +6,7 @@ import json
 import tempfile
 import zipfile
 from typing import Any, AsyncIterator
+from urllib.parse import quote
 from unittest import IsolatedAsyncioTestCase
 
 import fakeredis.aioredis
@@ -131,6 +132,12 @@ class FakeSkillHub(SkillHubBase):
             url="https://hub.invalid/skills/gifgrep",
             markdown=SKILL_MD,
         )
+        self.owner_scoped_card = SkillCard(
+            hub_id="fakeskills",
+            id="runware/music",
+            name="music",
+            markdown=SKILL_MD,
+        )
         self.download_users: list[str] = []
 
     async def list_skills(
@@ -145,6 +152,8 @@ class FakeSkillHub(SkillHubBase):
 
     async def get_skill(self, user_id: str, card_id: str) -> SkillCard:
         """Return the fixture card, or raise for anything else."""
+        if card_id == self.owner_scoped_card.id:
+            return self.owner_scoped_card
         if card_id != "gifgrep":
             raise KeyError(card_id)
         return self.card
@@ -277,6 +286,18 @@ class HubRouterTest(IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(response.status_code, 404)
+
+    def test_gets_owner_scoped_skill_card(self) -> None:
+        """A slash in an opaque card id stays inside the path parameter."""
+        card_id = quote("runware/music", safe="")
+
+        response = self._client.get(
+            f"/hub/skill/fakeskills/cards/{card_id}",
+            headers=HEADERS,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["id"], "runware/music")
 
     # ── install: MCP ──────────────────────────────────────────────
 
@@ -635,6 +656,15 @@ class HubRouterTest(IsolatedAsyncioTestCase):
         self.assertEqual(len(listed), 1)
         self.assertEqual(listed[0]["hub_id"], "fakeskills")
         self.assertEqual(listed[0]["card_id"], "gifgrep")
+
+    def test_installs_owner_scoped_skill_card(self) -> None:
+        """An owner-scoped card id is accepted by the install route."""
+        card_id = quote("runware/music", safe="")
+
+        response = self._install_skill(card_id)
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()["card_id"], "runware/music")
 
     def test_install_snapshots_the_display_identity(self) -> None:
         """Author, icon and link survive the install, so the library


### PR DESCRIPTION
## AgentScope Version

2.0.6 (`main` at `1d97e964`)

## Description

Fixes #2290.

ClawHub search results use owner-scoped card IDs such as `runware/music`. Although the Web UI URL-encodes these IDs, ASGI decodes `%2F` before Starlette matches a normal path parameter, so the detail and install routes returned 404 before reaching the hub.

This PR:
- accepts slash-containing opaque skill card IDs with FastAPI's `path` converter;
- declares the more specific install route before the catch-all detail route to keep route precedence explicit and protect future card actions from shadowing;
- adds HTTP-level regression coverage for both detail and install flows.

No public API shape, dependencies, or documentation are changed.

## Verification

- `pre-commit run --files src/agentscope/app/_router/_hub.py tests/hub_router_test.py`
- `pytest -q tests/hub_router_test.py tests/hub_claw_test.py tests/hub_github_test.py tests/hub_card_test.py` — 80 passed
- Full suite — 1769 passed, 147 skipped; one pre-existing unrelated Alembic locale failure remains

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation has been updated (not applicable; no user-facing API or docs change)
- [x] Code is ready for review
