### PR TITLE
fix(formatter): normalize OpenAI audio input formats

### DIFF
--- a/src/agentscope/formatter/_openai_formatter.py
+++ b/src/agentscope/formatter/_openai_formatter.py
@@ -4,7 +4,6 @@ import base64
 from abc import ABC
 from fnmatch import fnmatch
 from typing import Any
-from urllib.parse import urlparse
 
 import requests
 from pydantic import Field
@@ -22,6 +21,13 @@ from ..message import (
     HintBlock,
     ThinkingBlock,
 )
+
+
+_OPENAI_AUDIO_FORMATS = {
+    "audio/wav": "wav",
+    "audio/mp3": "mp3",
+    "audio/mpeg": "mp3",
+}
 
 
 class _OpenAIFormatterBase(FormatterBase, ABC):
@@ -124,7 +130,9 @@ class _OpenAIFormatterBase(FormatterBase, ABC):
         """Convert an audio source to OpenAI input_audio format.
 
         Local ``file://`` URLs are read from disk. Remote URLs are downloaded.
-        Only ``wav`` and ``mp3`` formats are supported by the OpenAI API.
+        The OpenAI format is derived from the source media type, so URLs do
+        not need a filename extension. Only ``wav`` and ``mp3`` formats are
+        supported by the OpenAI API.
 
         Args:
             source (`URLSource | Base64Source`):
@@ -134,56 +142,46 @@ class _OpenAIFormatterBase(FormatterBase, ABC):
             `dict[str, Any]`:
                 A dictionary with ``"type": "input_audio"`` in OpenAI format.
         """
+        if not isinstance(source, (URLSource, Base64Source)):
+            raise TypeError(f"Unsupported audio source type: {type(source)}.")
+
+        media_type = source.media_type.partition(";")[0].strip().lower()
+        audio_format = _OPENAI_AUDIO_FORMATS.get(media_type)
+        if audio_format is None:
+            supported_types = ", ".join(_OPENAI_AUDIO_FORMATS)
+            raise TypeError(
+                f"Unsupported audio media type: {source.media_type}, "
+                f"only {supported_types} are supported.",
+            )
+
         if isinstance(source, Base64Source):
-            media_type = source.media_type
-            if media_type not in ["audio/wav", "audio/mp3"]:
-                raise TypeError(
-                    f"Unsupported audio media type: {media_type}, "
-                    "only audio/wav and audio/mp3 are supported.",
-                )
             return {
                 "type": "input_audio",
                 "input_audio": {
                     "data": source.data,
-                    "format": media_type.split("/")[-1],
+                    "format": audio_format,
                 },
             }
 
-        if isinstance(source, URLSource):
-            url_str = str(source.url)
-            if url_str.startswith("file://"):
-                # Local file
-                local_path = url_str.removeprefix("file://")
-                extension = local_path.rsplit(".", 1)[-1].lower()
-                if extension not in ["wav", "mp3"]:
-                    raise TypeError(
-                        f"Unsupported audio file extension: {extension}, "
-                        "wav and mp3 are supported.",
-                    )
-                with open(local_path, "rb") as f:
-                    data = base64.b64encode(f.read()).decode("utf-8")
-            else:
-                # Remote URL — download and encode
-                parsed = urlparse(url_str)
-                extension = parsed.path.rsplit(".", 1)[-1].lower()
-                if extension not in ["wav", "mp3"]:
-                    raise TypeError(
-                        f"Unsupported audio file extension: {extension}, "
-                        "wav and mp3 are supported.",
-                    )
-                response = requests.get(url_str, timeout=30)
-                response.raise_for_status()
-                data = base64.b64encode(response.content).decode("utf-8")
+        url_str = str(source.url)
+        if url_str.startswith("file://"):
+            # Local file
+            local_path = url_str.removeprefix("file://")
+            with open(local_path, "rb") as f:
+                data = base64.b64encode(f.read()).decode("utf-8")
+        else:
+            # Remote URL — download and encode
+            response = requests.get(url_str, timeout=30)
+            response.raise_for_status()
+            data = base64.b64encode(response.content).decode("utf-8")
 
-            return {
-                "type": "input_audio",
-                "input_audio": {
-                    "data": data,
-                    "format": extension,
-                },
-            }
-
-        raise TypeError(f"Unsupported audio source type: {type(source)}.")
+        return {
+            "type": "input_audio",
+            "input_audio": {
+                "data": data,
+                "format": audio_format,
+            },
+        }
 
 
 class OpenAIChatFormatter(_OpenAIFormatterBase):

--- a/src/agentscope/model/_openai_chat/_models/gpt-audio-mini.yaml
+++ b/src/agentscope/model/_openai_chat/_models/gpt-audio-mini.yaml
@@ -7,6 +7,7 @@ input_types:
   - text/plain
   - audio/wav
   - audio/mp3
+  - audio/mpeg
 
 output_types:
   - text/plain

--- a/tests/formatter_openai_chat_test.py
+++ b/tests/formatter_openai_chat_test.py
@@ -4,7 +4,7 @@ OpenAIMultiAgentFormatter, following the reference test style with exact
 ground-truth comparisons.
 """
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from agentscope.formatter import (
     OpenAIChatFormatter,
@@ -347,6 +347,83 @@ class TestOpenAIFormatter(IsolatedAsyncioTestCase):
                 },
             ],
             res,
+        )
+
+    async def test_chat_formatter_base64_mpeg_audio(self) -> None:
+        """Standard MP3 MIME type is normalized to OpenAI's format."""
+        fmt = OpenAIChatFormatter(input_types=["audio/mpeg"])
+        res = await fmt.format(
+            [
+                UserMsg(
+                    name="user",
+                    content=[
+                        DataBlock(
+                            source=Base64Source(
+                                data="bXAzIGRhdGE=",
+                                media_type="audio/mpeg",
+                            ),
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        self.assertListEqual(
+            [
+                {
+                    "role": "user",
+                    "name": "user",
+                    "content": [
+                        {
+                            "type": "input_audio",
+                            "input_audio": {
+                                "data": "bXAzIGRhdGE=",
+                                "format": "mp3",
+                            },
+                        },
+                    ],
+                },
+            ],
+            res,
+        )
+
+    @patch("agentscope.formatter._openai_formatter.requests.get")
+    async def test_chat_formatter_audio_url_without_extension(
+        self,
+        mock_get: MagicMock,
+    ) -> None:
+        """Audio URL format is derived from MIME type, not URL suffix."""
+        mock_get.return_value.content = b"wav data"
+        fmt = OpenAIChatFormatter()
+        audio_url = "https://example.com/download?token=abc"
+
+        res = await fmt.format(
+            [
+                UserMsg(
+                    name="user",
+                    content=[
+                        DataBlock(
+                            source=URLSource(
+                                url=audio_url,
+                                media_type="audio/wav",
+                            ),
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        mock_get.assert_called_once_with(audio_url, timeout=30)
+        mock_get.return_value.raise_for_status.assert_called_once_with()
+        self.assertEqual(
+            res[0]["content"][0],
+            {
+                "type": "input_audio",
+                "input_audio": {
+                    "data": "d2F2IGRhdGE=",
+                    "format": "wav",
+                },
+            },
         )
 
     async def test_chat_formatter_thinking_dropped(self) -> None:


### PR DESCRIPTION
Fixes #2293

## AgentScope Version

2.0.6 (based on commit `1d97e964` from `main`)

## Description

### Background

`OpenAIChatFormatter` rejected MP3 audio using the standard `audio/mpeg` MIME type because it only recognized `audio/mp3`. This was inconsistent with AgentScope's OpenAI TTS implementation, which emits MP3 data as `audio/mpeg`.

For `URLSource`, the formatter also inferred the audio format from the URL suffix. Signed or extensionless download URLs therefore failed even when `DataBlock.source.media_type` explicitly declared a supported format.

### Changes

- normalize `audio/mpeg` to OpenAI's `mp3` input format
- preserve compatibility with `audio/mp3` and `audio/wav`
- derive URL audio format from `DataBlock.source.media_type`
- support signed and extensionless audio URLs
- update the `gpt-audio-mini` model card
- add regression tests for `audio/mpeg` and extensionless URLs

### Testing

- 45 related tests passed
- Black passed
- Flake8 passed
- Mypy passed
- Pylint passed
- model card YAML parsing passed

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated (not applicable: no public API or user-facing documentation change)
- [x] Code is ready for review