### PR TITLE
feat(tts): add MiniMax speech synthesis

### DIFF
--- a/src/agentscope/app/_router/_model.py
+++ b/src/agentscope/app/_router/_model.py
@@ -36,5 +36,5 @@ async def list_models(
             detail=f"Provider '{body.provider}' not found.",
         )
 
-    models = credential_cls.get_chat_model_class().list_models()
+    models = credential_cls.list_models()
     return ListModelsResponse(models=models, total=len(models))

--- a/src/agentscope/credential/__init__.py
+++ b/src/agentscope/credential/__init__.py
@@ -6,6 +6,7 @@ from ._anthropic import AnthropicCredential
 from ._dashscope import DashScopeCredential
 from ._deepseek import DeepSeekCredential
 from ._gemini import GeminiCredential
+from ._minimax import MiniMaxCredential
 from ._moonshot import MoonshotCredential
 from ._ollama import OllamaCredential
 from ._openai import OpenAICredential
@@ -19,6 +20,7 @@ __all__ = [
     "DashScopeCredential",
     "DeepSeekCredential",
     "GeminiCredential",
+    "MiniMaxCredential",
     "MoonshotCredential",
     "OllamaCredential",
     "OpenAICredential",

--- a/src/agentscope/credential/_factory.py
+++ b/src/agentscope/credential/_factory.py
@@ -8,6 +8,7 @@ from ._anthropic import AnthropicCredential
 from ._dashscope import DashScopeCredential
 from ._deepseek import DeepSeekCredential
 from ._gemini import GeminiCredential
+from ._minimax import MiniMaxCredential
 from ._moonshot import MoonshotCredential
 from ._ollama import OllamaCredential
 from ._openai import OpenAICredential
@@ -38,6 +39,7 @@ class CredentialFactory:
         DashScopeCredential,
         DeepSeekCredential,
         GeminiCredential,
+        MiniMaxCredential,
         MoonshotCredential,
         OllamaCredential,
         OpenAICredential,

--- a/src/agentscope/credential/_minimax.py
+++ b/src/agentscope/credential/_minimax.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from ..tts import TTSModelBase
 
 
-class MiniMaxCredential(CredentialBase):
+class MiniMaxCredential(CredentialBase):  # pylint: disable=abstract-method
     """The credential for MiniMax APIs."""
 
     model_config = ConfigDict(

--- a/src/agentscope/credential/_minimax.py
+++ b/src/agentscope/credential/_minimax.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""The MiniMax credential."""
+from typing import Literal, Type, TYPE_CHECKING
+
+from pydantic import ConfigDict, Field, SecretStr
+
+from ._base import CredentialBase
+
+if TYPE_CHECKING:
+    from ..tts import TTSModelBase
+
+
+class MiniMaxCredential(CredentialBase):
+    """The credential for MiniMax APIs."""
+
+    model_config = ConfigDict(
+        title="MiniMax API",
+    )
+
+    type: Literal["minimax_credential"] = "minimax_credential"
+    """The credential type."""
+
+    api_key: SecretStr = Field(
+        description="The MiniMax API key.",
+        title="API Key",
+    )
+    """The API key."""
+
+    @classmethod
+    def get_tts_model_classes(cls) -> list[Type["TTSModelBase"]]:
+        """Return the MiniMax TTS model classes."""
+        from ..tts import MiniMaxTTSModel
+
+        return [MiniMaxTTSModel]

--- a/src/agentscope/credential/_minimax.py
+++ b/src/agentscope/credential/_minimax.py
@@ -7,7 +7,11 @@ from pydantic import ConfigDict, Field, SecretStr
 from ._base import CredentialBase
 
 if TYPE_CHECKING:
+    from ..model import ModelCard
     from ..tts import TTSModelBase
+
+
+_MINIMAX_GLOBAL_BASE_URL = "https://api.minimax.io"
 
 
 class MiniMaxCredential(CredentialBase):  # pylint: disable=abstract-method
@@ -25,6 +29,20 @@ class MiniMaxCredential(CredentialBase):  # pylint: disable=abstract-method
         title="API Key",
     )
     """The API key."""
+
+    base_url: Literal[
+        "https://api.minimax.io",
+        "https://api.minimaxi.com",
+    ] = Field(
+        default=_MINIMAX_GLOBAL_BASE_URL,
+        description="The regional base URL for the MiniMax API.",
+    )
+    """The regional base URL for the MiniMax API."""
+
+    @classmethod
+    def list_models(cls) -> list["ModelCard"]:
+        """Return no chat models for this TTS-only credential."""
+        return []
 
     @classmethod
     def get_tts_model_classes(cls) -> list[Type["TTSModelBase"]]:

--- a/src/agentscope/tts/__init__.py
+++ b/src/agentscope/tts/__init__.py
@@ -10,6 +10,7 @@ from ._dashscope import (
     DashScopeRealtimeTTSModel,
 )
 from ._gemini import GeminiTTSModel
+from ._minimax import MiniMaxTTSModel
 from ._openai import OpenAITTSModel
 
 __all__ = [
@@ -21,5 +22,6 @@ __all__ = [
     "DashScopeTTSModel",
     "DashScopeRealtimeTTSModel",
     "GeminiTTSModel",
+    "MiniMaxTTSModel",
     "OpenAITTSModel",
 ]

--- a/src/agentscope/tts/_minimax/__init__.py
+++ b/src/agentscope/tts/_minimax/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""The MiniMax TTS module."""
+
+from ._model import MiniMaxTTSModel
+
+__all__ = [
+    "MiniMaxTTSModel",
+]

--- a/src/agentscope/tts/_minimax/_model.py
+++ b/src/agentscope/tts/_minimax/_model.py
@@ -1,0 +1,295 @@
+# -*- coding: utf-8 -*-
+"""MiniMax TTS model implementation using the T2A HTTP API."""
+import base64
+import json
+from typing import Any, AsyncGenerator, Literal, TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from .._tts_base import TTSModelBase
+from .._tts_response import TTSResponse
+from ...credential import MiniMaxCredential
+from ...message import Base64Source, DataBlock
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+
+
+_DEFAULT_API_URL = "https://api.minimax.io/v1/t2a_v2"
+_MEDIA_TYPES = {
+    "mp3": "audio/mpeg",
+    "wav": "audio/wav",
+    "flac": "audio/flac",
+    "pcm": "audio/pcm",
+}
+
+
+def _raise_for_api_error(payload: dict[str, Any]) -> None:
+    """Raise when the API reports an unsuccessful status code."""
+    base_response = payload.get("base_resp") or {}
+    status_code = base_response.get("status_code", 0)
+    if status_code != 0:
+        status_message = base_response.get("status_msg", "unknown error")
+        raise RuntimeError(
+            f"MiniMax TTS API error {status_code}: {status_message}",
+        )
+
+
+class MiniMaxTTSModel(TTSModelBase):
+    """MiniMax TTS model implementation using the T2A HTTP API.
+
+    For more details, see the `official documentation
+    <https://platform.minimax.io/docs/api-reference/speech-t2a-http>`_.
+    """
+
+    class Parameters(BaseModel):
+        """Frontend-exposed parameters for MiniMax TTS models."""
+
+        voice: str = Field(
+            default="English_expressive_narrator",
+            title="Voice",
+            description="The voice ID to use for synthesis.",
+        )
+
+        speed: float = Field(
+            default=1.0,
+            title="Speed",
+            description="The speech speed multiplier.",
+        )
+
+        volume: float = Field(
+            default=1.0,
+            title="Volume",
+            description="The output volume multiplier.",
+        )
+
+        pitch: int = Field(
+            default=0,
+            title="Pitch",
+            description="The voice pitch adjustment.",
+        )
+
+        response_format: Literal["mp3", "wav", "flac", "pcm"] = Field(
+            default="mp3",
+            title="Response Format",
+            description="The audio format of the synthesized speech.",
+        )
+
+        sample_rate: int = Field(
+            default=32000,
+            title="Sample Rate",
+            description="The audio sample rate in hertz.",
+        )
+
+        bitrate: int = Field(
+            default=128000,
+            title="Bitrate",
+            description="The audio bitrate in bits per second.",
+        )
+
+        channel: int = Field(
+            default=1,
+            title="Channels",
+            description="The number of audio channels.",
+        )
+
+        language_boost: str | None = Field(
+            default="auto",
+            title="Language Boost",
+            description="The language or dialect optimization mode.",
+        )
+
+        api_url: str = Field(
+            default=_DEFAULT_API_URL,
+            title="API URL",
+            description=(
+                "The T2A HTTP endpoint. Use the regional endpoint that "
+                "matches the API key."
+            ),
+        )
+
+    type: Literal["minimax_tts"] = "minimax_tts"
+    """The type of the TTS model."""
+
+    realtime: bool = False
+
+    def __init__(
+        self,
+        credential: MiniMaxCredential,
+        model: str = "speech-2.8-hd",
+        parameters: "MiniMaxTTSModel.Parameters | None" = None,
+        stream: bool = True,
+    ) -> None:
+        """Initialize the MiniMax TTS model.
+
+        Args:
+            credential (`MiniMaxCredential`):
+                The credential used to authenticate the API call.
+            model (`str`, defaults to ``"speech-2.8-hd"``):
+                The TTS model name.
+            parameters (`MiniMaxTTSModel.Parameters | None`, defaults to \
+            `None`):
+                The voice, audio, language, and endpoint parameters.
+            stream (`bool`, defaults to `True`):
+                Whether to stream incremental audio responses.
+        """
+        super().__init__(
+            credential=credential,
+            model=model,
+            parameters=parameters,
+            stream=stream,
+        )
+
+        import httpx
+
+        self.client: AsyncClient = httpx.AsyncClient(
+            headers={
+                "Authorization": (
+                    "Bearer " + self.credential.api_key.get_secret_value()
+                ),
+                "Content-Type": "application/json",
+            },
+            timeout=httpx.Timeout(60.0, connect=10.0),
+        )
+
+    async def synthesize(
+        self,
+        text: str | None = None,
+        **kwargs: Any,
+    ) -> TTSResponse | AsyncGenerator[TTSResponse, None]:
+        """Synthesize speech through the T2A HTTP endpoint.
+
+        Args:
+            text (`str | None`, optional):
+                The text to synthesize.
+            **kwargs (`Any`):
+                Additional fields to include in the API request.
+
+        Returns:
+            `TTSResponse | AsyncGenerator[TTSResponse, None]`:
+                A single response or a stream of incremental audio chunks.
+        """
+        if not text:
+            return TTSResponse(content=None)
+
+        payload: dict[str, Any] = {
+            "voice_setting": {
+                "voice_id": self.parameters.voice,
+                "speed": self.parameters.speed,
+                "vol": self.parameters.volume,
+                "pitch": self.parameters.pitch,
+            },
+            "audio_setting": {
+                "sample_rate": self.parameters.sample_rate,
+                "bitrate": self.parameters.bitrate,
+                "format": self.parameters.response_format,
+                "channel": self.parameters.channel,
+            },
+            **kwargs,
+            "model": self.model,
+            "text": text,
+            "stream": self.stream,
+            "output_format": "hex",
+        }
+        if self.parameters.language_boost is not None:
+            payload.setdefault(
+                "language_boost",
+                self.parameters.language_boost,
+            )
+
+        audio_setting = payload.get("audio_setting")
+        response_format = self.parameters.response_format
+        if isinstance(audio_setting, dict):
+            response_format = audio_setting.get("format", response_format)
+        media_type = _MEDIA_TYPES.get(
+            response_format,
+            f"audio/{response_format}",
+        )
+
+        if self.stream:
+            return self._stream(payload, media_type)
+
+        return await self._aggregate(payload, media_type)
+
+    async def _aggregate(
+        self,
+        payload: dict[str, Any],
+        media_type: str,
+    ) -> TTSResponse:
+        """Return the complete audio from a non-streaming response."""
+        response = await self.client.post(
+            self.parameters.api_url,
+            json=payload,
+        )
+        response.raise_for_status()
+        result = response.json()
+        _raise_for_api_error(result)
+
+        data = result.get("data") or {}
+        audio = data.get("audio")
+        if not audio:
+            return TTSResponse(content=None)
+
+        return TTSResponse(
+            content=DataBlock(
+                source=Base64Source(
+                    data=base64.b64encode(bytes.fromhex(audio)).decode(
+                        "ascii",
+                    ),
+                    media_type=media_type,
+                ),
+            ),
+        )
+
+    async def _stream(
+        self,
+        payload: dict[str, Any],
+        media_type: str,
+    ) -> AsyncGenerator[TTSResponse, None]:
+        """Yield incremental audio chunks from a streaming response."""
+        pending: TTSResponse | None = None
+
+        async with self.client.stream(
+            "POST",
+            self.parameters.api_url,
+            json=payload,
+        ) as response:
+            response.raise_for_status()
+            async for line in response.aiter_lines():
+                line = line.strip()
+                if line.startswith("data:"):
+                    line = line.removeprefix("data:").strip()
+                if not line or line == "[DONE]":
+                    continue
+                try:
+                    result = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                _raise_for_api_error(result)
+                data = result.get("data") or {}
+                audio = data.get("audio")
+                if not audio:
+                    continue
+
+                if pending is not None:
+                    yield pending
+                pending = TTSResponse(
+                    content=DataBlock(
+                        source=Base64Source(
+                            data=base64.b64encode(
+                                bytes.fromhex(audio),
+                            ).decode("ascii"),
+                            media_type=media_type,
+                        ),
+                    ),
+                    is_last=False,
+                )
+                if data.get("status") == 2:
+                    break
+
+        if pending is not None:
+            pending.is_last = True
+            yield pending
+        else:
+            yield TTSResponse(content=None, is_last=True)

--- a/src/agentscope/tts/_minimax/_model.py
+++ b/src/agentscope/tts/_minimax/_model.py
@@ -15,13 +15,8 @@ if TYPE_CHECKING:
     from httpx import AsyncClient
 
 
-_DEFAULT_API_URL = "https://api.minimax.io/v1/t2a_v2"
-_MEDIA_TYPES = {
-    "mp3": "audio/mpeg",
-    "wav": "audio/wav",
-    "flac": "audio/flac",
-    "pcm": "audio/pcm",
-}
+_TTS_PATH = "/v1/t2a_v2"
+_MEDIA_TYPE = "audio/mpeg"
 
 
 def _raise_for_api_error(payload: dict[str, Any]) -> None:
@@ -69,12 +64,6 @@ class MiniMaxTTSModel(TTSModelBase):
             description="The voice pitch adjustment.",
         )
 
-        response_format: Literal["mp3", "wav", "flac", "pcm"] = Field(
-            default="mp3",
-            title="Response Format",
-            description="The audio format of the synthesized speech.",
-        )
-
         sample_rate: int = Field(
             default=32000,
             title="Sample Rate",
@@ -99,15 +88,6 @@ class MiniMaxTTSModel(TTSModelBase):
             description="The language or dialect optimization mode.",
         )
 
-        api_url: str = Field(
-            default=_DEFAULT_API_URL,
-            title="API URL",
-            description=(
-                "The T2A HTTP endpoint. Use the regional endpoint that "
-                "matches the API key."
-            ),
-        )
-
     type: Literal["minimax_tts"] = "minimax_tts"
     """The type of the TTS model."""
 
@@ -129,7 +109,7 @@ class MiniMaxTTSModel(TTSModelBase):
                 The TTS model name.
             parameters (`MiniMaxTTSModel.Parameters | None`, defaults to \
             `None`):
-                The voice, audio, language, and endpoint parameters.
+                The voice, audio, and language parameters.
             stream (`bool`, defaults to `True`):
                 Whether to stream incremental audio responses.
         """
@@ -182,7 +162,7 @@ class MiniMaxTTSModel(TTSModelBase):
             "audio_setting": {
                 "sample_rate": self.parameters.sample_rate,
                 "bitrate": self.parameters.bitrate,
-                "format": self.parameters.response_format,
+                "format": "mp3",
                 "channel": self.parameters.channel,
             },
             **kwargs,
@@ -198,27 +178,33 @@ class MiniMaxTTSModel(TTSModelBase):
             )
 
         audio_setting = payload.get("audio_setting")
-        response_format = self.parameters.response_format
         if isinstance(audio_setting, dict):
-            response_format = audio_setting.get("format", response_format)
-        media_type = _MEDIA_TYPES.get(
-            response_format,
-            f"audio/{response_format}",
-        )
+            payload["audio_setting"] = {
+                **audio_setting,
+                "format": "mp3",
+            }
+        else:
+            payload["audio_setting"] = {"format": "mp3"}
 
         if self.stream:
-            return self._stream(payload, media_type)
+            stream_options = payload.get("stream_options")
+            if not isinstance(stream_options, dict):
+                stream_options = {}
+            payload["stream_options"] = {
+                **stream_options,
+                "exclude_aggregated_audio": True,
+            }
+            return self._stream(payload)
 
-        return await self._aggregate(payload, media_type)
+        return await self._aggregate(payload)
 
     async def _aggregate(
         self,
         payload: dict[str, Any],
-        media_type: str,
     ) -> TTSResponse:
         """Return the complete audio from a non-streaming response."""
         response = await self.client.post(
-            self.parameters.api_url,
+            self.credential.base_url.rstrip("/") + _TTS_PATH,
             json=payload,
         )
         response.raise_for_status()
@@ -236,7 +222,7 @@ class MiniMaxTTSModel(TTSModelBase):
                     data=base64.b64encode(bytes.fromhex(audio)).decode(
                         "ascii",
                     ),
-                    media_type=media_type,
+                    media_type=_MEDIA_TYPE,
                 ),
             ),
         )
@@ -244,14 +230,14 @@ class MiniMaxTTSModel(TTSModelBase):
     async def _stream(
         self,
         payload: dict[str, Any],
-        media_type: str,
     ) -> AsyncGenerator[TTSResponse, None]:
         """Yield incremental audio chunks from a streaming response."""
-        pending: TTSResponse | None = None
+        pending: bytes | None = None
+        emitted = bytearray()
 
         async with self.client.stream(
             "POST",
-            self.parameters.api_url,
+            self.credential.base_url.rstrip("/") + _TTS_PATH,
             json=payload,
         ) as response:
             response.raise_for_status()
@@ -272,24 +258,45 @@ class MiniMaxTTSModel(TTSModelBase):
                 if not audio:
                     continue
 
+                audio_bytes = bytes.fromhex(audio)
+                if data.get("status") != 2:
+                    if pending is not None:
+                        emitted.extend(pending)
+                        yield self._audio_response(pending, is_last=False)
+                    pending = audio_bytes
+                    continue
+
+                received = bytes(emitted) + (pending or b"")
+                if audio_bytes.startswith(received):
+                    final_audio = audio_bytes[len(received) :]
+                else:
+                    final_audio = audio_bytes
+
                 if pending is not None:
-                    yield pending
-                pending = TTSResponse(
-                    content=DataBlock(
-                        source=Base64Source(
-                            data=base64.b64encode(
-                                bytes.fromhex(audio),
-                            ).decode("ascii"),
-                            media_type=media_type,
-                        ),
-                    ),
-                    is_last=False,
-                )
-                if data.get("status") == 2:
-                    break
+                    yield self._audio_response(
+                        pending,
+                        is_last=not final_audio,
+                    )
+                if final_audio:
+                    yield self._audio_response(final_audio, is_last=True)
+                elif pending is None:
+                    yield TTSResponse(content=None, is_last=True)
+                return
 
         if pending is not None:
-            pending.is_last = True
-            yield pending
+            yield self._audio_response(pending, is_last=True)
         else:
             yield TTSResponse(content=None, is_last=True)
+
+    @staticmethod
+    def _audio_response(audio: bytes, is_last: bool) -> TTSResponse:
+        """Build a response for an MP3 audio chunk."""
+        return TTSResponse(
+            content=DataBlock(
+                source=Base64Source(
+                    data=base64.b64encode(audio).decode("ascii"),
+                    media_type=_MEDIA_TYPE,
+                ),
+            ),
+            is_last=is_last,
+        )

--- a/src/agentscope/tts/_minimax/_models/speech-01-hd.yaml
+++ b/src/agentscope/tts/_minimax/_models/speech-01-hd.yaml
@@ -1,0 +1,14 @@
+name: speech-01-hd
+label: MiniMax Speech 01 HD
+status: active
+
+input_types:
+  - text/plain
+
+output_types:
+  - audio/mpeg
+  - audio/wav
+  - audio/flac
+  - audio/pcm
+
+parameter_overrides: {}

--- a/src/agentscope/tts/_minimax/_models/speech-01-hd.yaml
+++ b/src/agentscope/tts/_minimax/_models/speech-01-hd.yaml
@@ -7,8 +7,5 @@ input_types:
 
 output_types:
   - audio/mpeg
-  - audio/wav
-  - audio/flac
-  - audio/pcm
 
 parameter_overrides: {}

--- a/src/agentscope/tts/_minimax/_models/speech-01-turbo.yaml
+++ b/src/agentscope/tts/_minimax/_models/speech-01-turbo.yaml
@@ -1,0 +1,14 @@
+name: speech-01-turbo
+label: MiniMax Speech 01 Turbo
+status: active
+
+input_types:
+  - text/plain
+
+output_types:
+  - audio/mpeg
+  - audio/wav
+  - audio/flac
+  - audio/pcm
+
+parameter_overrides: {}

--- a/src/agentscope/tts/_minimax/_models/speech-01-turbo.yaml
+++ b/src/agentscope/tts/_minimax/_models/speech-01-turbo.yaml
@@ -7,8 +7,5 @@ input_types:
 
 output_types:
   - audio/mpeg
-  - audio/wav
-  - audio/flac
-  - audio/pcm
 
 parameter_overrides: {}

--- a/src/agentscope/tts/_minimax/_models/speech-02-hd.yaml
+++ b/src/agentscope/tts/_minimax/_models/speech-02-hd.yaml
@@ -1,0 +1,14 @@
+name: speech-02-hd
+label: MiniMax Speech 02 HD
+status: active
+
+input_types:
+  - text/plain
+
+output_types:
+  - audio/mpeg
+  - audio/wav
+  - audio/flac
+  - audio/pcm
+
+parameter_overrides: {}

--- a/src/agentscope/tts/_minimax/_models/speech-02-hd.yaml
+++ b/src/agentscope/tts/_minimax/_models/speech-02-hd.yaml
@@ -7,8 +7,5 @@ input_types:
 
 output_types:
   - audio/mpeg
-  - audio/wav
-  - audio/flac
-  - audio/pcm
 
 parameter_overrides: {}

--- a/src/agentscope/tts/_minimax/_models/speech-02-turbo.yaml
+++ b/src/agentscope/tts/_minimax/_models/speech-02-turbo.yaml
@@ -7,8 +7,5 @@ input_types:
 
 output_types:
   - audio/mpeg
-  - audio/wav
-  - audio/flac
-  - audio/pcm
 
 parameter_overrides: {}

--- a/src/agentscope/tts/_minimax/_models/speech-02-turbo.yaml
+++ b/src/agentscope/tts/_minimax/_models/speech-02-turbo.yaml
@@ -1,0 +1,14 @@
+name: speech-02-turbo
+label: MiniMax Speech 02 Turbo
+status: active
+
+input_types:
+  - text/plain
+
+output_types:
+  - audio/mpeg
+  - audio/wav
+  - audio/flac
+  - audio/pcm
+
+parameter_overrides: {}

--- a/src/agentscope/tts/_minimax/_models/speech-2.6-hd.yaml
+++ b/src/agentscope/tts/_minimax/_models/speech-2.6-hd.yaml
@@ -7,8 +7,5 @@ input_types:
 
 output_types:
   - audio/mpeg
-  - audio/wav
-  - audio/flac
-  - audio/pcm
 
 parameter_overrides: {}

--- a/src/agentscope/tts/_minimax/_models/speech-2.6-hd.yaml
+++ b/src/agentscope/tts/_minimax/_models/speech-2.6-hd.yaml
@@ -1,0 +1,14 @@
+name: speech-2.6-hd
+label: MiniMax Speech 2.6 HD
+status: active
+
+input_types:
+  - text/plain
+
+output_types:
+  - audio/mpeg
+  - audio/wav
+  - audio/flac
+  - audio/pcm
+
+parameter_overrides: {}

--- a/src/agentscope/tts/_minimax/_models/speech-2.6-turbo.yaml
+++ b/src/agentscope/tts/_minimax/_models/speech-2.6-turbo.yaml
@@ -1,0 +1,14 @@
+name: speech-2.6-turbo
+label: MiniMax Speech 2.6 Turbo
+status: active
+
+input_types:
+  - text/plain
+
+output_types:
+  - audio/mpeg
+  - audio/wav
+  - audio/flac
+  - audio/pcm
+
+parameter_overrides: {}

--- a/src/agentscope/tts/_minimax/_models/speech-2.6-turbo.yaml
+++ b/src/agentscope/tts/_minimax/_models/speech-2.6-turbo.yaml
@@ -7,8 +7,5 @@ input_types:
 
 output_types:
   - audio/mpeg
-  - audio/wav
-  - audio/flac
-  - audio/pcm
 
 parameter_overrides: {}

--- a/src/agentscope/tts/_minimax/_models/speech-2.8-hd.yaml
+++ b/src/agentscope/tts/_minimax/_models/speech-2.8-hd.yaml
@@ -1,0 +1,14 @@
+name: speech-2.8-hd
+label: MiniMax Speech 2.8 HD
+status: active
+
+input_types:
+  - text/plain
+
+output_types:
+  - audio/mpeg
+  - audio/wav
+  - audio/flac
+  - audio/pcm
+
+parameter_overrides: {}

--- a/src/agentscope/tts/_minimax/_models/speech-2.8-hd.yaml
+++ b/src/agentscope/tts/_minimax/_models/speech-2.8-hd.yaml
@@ -7,8 +7,5 @@ input_types:
 
 output_types:
   - audio/mpeg
-  - audio/wav
-  - audio/flac
-  - audio/pcm
 
 parameter_overrides: {}

--- a/src/agentscope/tts/_minimax/_models/speech-2.8-turbo.yaml
+++ b/src/agentscope/tts/_minimax/_models/speech-2.8-turbo.yaml
@@ -7,8 +7,5 @@ input_types:
 
 output_types:
   - audio/mpeg
-  - audio/wav
-  - audio/flac
-  - audio/pcm
 
 parameter_overrides: {}

--- a/src/agentscope/tts/_minimax/_models/speech-2.8-turbo.yaml
+++ b/src/agentscope/tts/_minimax/_models/speech-2.8-turbo.yaml
@@ -1,0 +1,14 @@
+name: speech-2.8-turbo
+label: MiniMax Speech 2.8 Turbo
+status: active
+
+input_types:
+  - text/plain
+
+output_types:
+  - audio/mpeg
+  - audio/wav
+  - audio/flac
+  - audio/pcm
+
+parameter_overrides: {}

--- a/tests/tts_minimax_test.py
+++ b/tests/tts_minimax_test.py
@@ -1,0 +1,213 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Unit tests for the MiniMax TTS model."""
+import base64
+import json
+from typing import Any
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+from agentscope.credential import CredentialFactory, MiniMaxCredential
+from agentscope.tts import MiniMaxTTSModel, TTSResponse
+
+
+_GLOBAL_API_URL = "https://api.minimax.io/v1/t2a_v2"
+_CHINA_API_URL = "https://api.minimaxi.com/v1/t2a_v2"
+
+
+class _StreamResponse:
+    """Mock streaming response with newline-delimited payloads."""
+
+    def __init__(self, lines: list[str]) -> None:
+        self.lines = lines
+
+    @staticmethod
+    def raise_for_status() -> None:
+        """Simulate a successful HTTP response."""
+
+    async def aiter_lines(self) -> Any:
+        """Yield mock response lines."""
+        for line in self.lines:
+            yield line
+
+
+class TestMiniMaxTTSModel(IsolatedAsyncioTestCase):
+    """The unit tests for MiniMax TTS synthesis."""
+
+    def setUp(self) -> None:
+        """Replace the HTTP client with a mock."""
+        self.client = MagicMock()
+        self.client_patcher = patch(
+            "httpx.AsyncClient",
+            return_value=self.client,
+        )
+        self.client_patcher.start()
+
+    def tearDown(self) -> None:
+        """Restore the HTTP client constructor."""
+        self.client_patcher.stop()
+
+    @staticmethod
+    def _make_model(
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> MiniMaxTTSModel:
+        """Create a model with test credentials."""
+        return MiniMaxTTSModel(
+            credential=MiniMaxCredential(api_key="test"),
+            stream=stream,
+            **kwargs,
+        )
+
+    async def test_non_streaming_synthesis(self) -> None:
+        """The non-streaming response contains the decoded audio."""
+        audio = b"complete audio"
+        response = Mock()
+        response.raise_for_status = Mock()
+        response.json.return_value = {
+            "data": {"audio": audio.hex(), "status": 2},
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        }
+        self.client.post = AsyncMock(return_value=response)
+        model = self._make_model(stream=False)
+
+        result = await model.synthesize(
+            "Hello world",
+            pronunciation_dict={"tone": ["world/wɜːrld"]},
+            voice_modify={"pitch": 1},
+            subtitle_enable=True,
+        )
+
+        self.assertIsInstance(result, TTSResponse)
+        self.assertEqual(result.content.source.media_type, "audio/mpeg")
+        self.assertEqual(
+            base64.b64decode(result.content.source.data),
+            audio,
+        )
+        self.client.post.assert_awaited_once()
+        api_url, call_kwargs = self.client.post.call_args
+        self.assertEqual(api_url[0], _GLOBAL_API_URL)
+        payload = call_kwargs["json"]
+        self.assertEqual(payload["model"], "speech-2.8-hd")
+        self.assertEqual(payload["text"], "Hello world")
+        self.assertFalse(payload["stream"])
+        self.assertEqual(payload["output_format"], "hex")
+        self.assertEqual(
+            payload["voice_setting"]["voice_id"],
+            "English_expressive_narrator",
+        )
+        self.assertEqual(payload["audio_setting"]["format"], "mp3")
+        self.assertIn("pronunciation_dict", payload)
+        self.assertIn("voice_modify", payload)
+        self.assertTrue(payload["subtitle_enable"])
+
+    async def test_regional_endpoint_and_audio_format(self) -> None:
+        """A regional endpoint and audio format are configurable."""
+        response = Mock()
+        response.raise_for_status = Mock()
+        response.json.return_value = {
+            "data": {"audio": b"wave".hex(), "status": 2},
+            "base_resp": {"status_code": 0},
+        }
+        self.client.post = AsyncMock(return_value=response)
+        parameters = MiniMaxTTSModel.Parameters(
+            api_url=_CHINA_API_URL,
+            response_format="wav",
+        )
+        model = self._make_model(stream=False, parameters=parameters)
+
+        result = await model.synthesize("Hello")
+
+        api_url, _ = self.client.post.call_args
+        self.assertEqual(api_url[0], _CHINA_API_URL)
+        self.assertEqual(result.content.source.media_type, "audio/wav")
+
+    async def test_streaming_synthesis(self) -> None:
+        """Streaming accepts SSE and plain JSON response lines."""
+        first = b"first"
+        second = b"second"
+        lines = [
+            "data: "
+            + json.dumps(
+                {
+                    "data": {"audio": first.hex(), "status": 1},
+                    "base_resp": {"status_code": 0},
+                },
+            ),
+            json.dumps(
+                {
+                    "data": {"audio": second.hex(), "status": 2},
+                    "base_resp": {"status_code": 0},
+                },
+            ),
+            "data: [DONE]",
+        ]
+        stream_response = _StreamResponse(lines)
+        stream_context = MagicMock()
+        stream_context.__aenter__ = AsyncMock(return_value=stream_response)
+        stream_context.__aexit__ = AsyncMock(return_value=None)
+        self.client.stream = Mock(return_value=stream_context)
+        model = self._make_model(stream=True)
+
+        generator = await model.synthesize("Hello")
+        chunks = [chunk async for chunk in generator]
+
+        self.assertEqual(
+            [base64.b64decode(chunk.content.source.data) for chunk in chunks],
+            [first, second],
+        )
+        self.assertEqual([chunk.is_last for chunk in chunks], [False, True])
+        _, _, call_kwargs = self.client.stream.mock_calls[0]
+        self.assertTrue(call_kwargs["json"]["stream"])
+
+    async def test_api_error(self) -> None:
+        """An unsuccessful API status raises a clear error."""
+        response = Mock()
+        response.raise_for_status = Mock()
+        response.json.return_value = {
+            "base_resp": {
+                "status_code": 1001,
+                "status_msg": "invalid parameter",
+            },
+        }
+        self.client.post = AsyncMock(return_value=response)
+        model = self._make_model(stream=False)
+
+        with self.assertRaisesRegex(RuntimeError, "invalid parameter"):
+            await model.synthesize("Hello")
+
+    async def test_empty_input_short_circuits(self) -> None:
+        """Empty input returns without sending an API request."""
+        model = self._make_model(stream=False)
+        self.client.post = AsyncMock()
+
+        result = await model.synthesize("")
+
+        self.assertIsNone(result.content)
+        self.client.post.assert_not_awaited()
+
+    async def test_model_cards_and_credential_wiring(self) -> None:
+        """All supported models are discoverable from the credential."""
+        expected_names = {
+            "speech-2.8-hd",
+            "speech-2.8-turbo",
+            "speech-2.6-hd",
+            "speech-2.6-turbo",
+            "speech-02-hd",
+            "speech-02-turbo",
+            "speech-01-hd",
+            "speech-01-turbo",
+        }
+
+        self.assertIs(
+            CredentialFactory.get_credential_class("minimax_credential"),
+            MiniMaxCredential,
+        )
+        self.assertEqual(
+            {card.name for card in MiniMaxCredential.list_tts_models()},
+            expected_names,
+        )
+        self.assertEqual(
+            MiniMaxCredential.get_tts_model_classes(),
+            [MiniMaxTTSModel],
+        )

--- a/tests/tts_minimax_test.py
+++ b/tests/tts_minimax_test.py
@@ -11,8 +11,9 @@ from agentscope.credential import CredentialFactory, MiniMaxCredential
 from agentscope.tts import MiniMaxTTSModel, TTSResponse
 
 
-_GLOBAL_API_URL = "https://api.minimax.io/v1/t2a_v2"
-_CHINA_API_URL = "https://api.minimaxi.com/v1/t2a_v2"
+_GLOBAL_BASE_URL = "https://api.minimax.io"
+_CHINA_BASE_URL = "https://api.minimaxi.com"
+_TTS_PATH = "/v1/t2a_v2"
 
 
 class _StreamResponse:
@@ -86,7 +87,7 @@ class TestMiniMaxTTSModel(IsolatedAsyncioTestCase):
         )
         self.client.post.assert_awaited_once()
         api_url, call_kwargs = self.client.post.call_args
-        self.assertEqual(api_url[0], _GLOBAL_API_URL)
+        self.assertEqual(api_url[0], _GLOBAL_BASE_URL + _TTS_PATH)
         payload = call_kwargs["json"]
         self.assertEqual(payload["model"], "speech-2.8-hd")
         self.assertEqual(payload["text"], "Hello world")
@@ -101,8 +102,8 @@ class TestMiniMaxTTSModel(IsolatedAsyncioTestCase):
         self.assertIn("voice_modify", payload)
         self.assertTrue(payload["subtitle_enable"])
 
-    async def test_regional_endpoint_and_audio_format(self) -> None:
-        """A regional endpoint and audio format are configurable."""
+    async def test_regional_endpoint_is_credential_owned(self) -> None:
+        """The credential selects an allowlisted regional endpoint."""
         response = Mock()
         response.raise_for_status = Mock()
         response.json.return_value = {
@@ -110,17 +111,25 @@ class TestMiniMaxTTSModel(IsolatedAsyncioTestCase):
             "base_resp": {"status_code": 0},
         }
         self.client.post = AsyncMock(return_value=response)
-        parameters = MiniMaxTTSModel.Parameters(
-            api_url=_CHINA_API_URL,
-            response_format="wav",
+        model = MiniMaxTTSModel(
+            credential=MiniMaxCredential(
+                api_key="test",
+                base_url=_CHINA_BASE_URL,
+            ),
+            stream=False,
         )
-        model = self._make_model(stream=False, parameters=parameters)
 
         result = await model.synthesize("Hello")
 
         api_url, _ = self.client.post.call_args
-        self.assertEqual(api_url[0], _CHINA_API_URL)
-        self.assertEqual(result.content.source.media_type, "audio/wav")
+        self.assertEqual(api_url[0], _CHINA_BASE_URL + _TTS_PATH)
+        self.assertEqual(result.content.source.media_type, "audio/mpeg")
+
+        with self.assertRaises(ValueError):
+            MiniMaxCredential(
+                api_key="test",
+                base_url="https://example.com",
+            )
 
     async def test_streaming_synthesis(self) -> None:
         """Streaming accepts SSE and plain JSON response lines."""
@@ -136,7 +145,10 @@ class TestMiniMaxTTSModel(IsolatedAsyncioTestCase):
             ),
             json.dumps(
                 {
-                    "data": {"audio": second.hex(), "status": 2},
+                    "data": {
+                        "audio": (first + second).hex(),
+                        "status": 2,
+                    },
                     "base_resp": {"status_code": 0},
                 },
             ),
@@ -149,7 +161,10 @@ class TestMiniMaxTTSModel(IsolatedAsyncioTestCase):
         self.client.stream = Mock(return_value=stream_context)
         model = self._make_model(stream=True)
 
-        generator = await model.synthesize("Hello")
+        generator = await model.synthesize(
+            "Hello",
+            audio_setting={"format": "wav", "sample_rate": 32000},
+        )
         chunks = [chunk async for chunk in generator]
 
         self.assertEqual(
@@ -159,6 +174,14 @@ class TestMiniMaxTTSModel(IsolatedAsyncioTestCase):
         self.assertEqual([chunk.is_last for chunk in chunks], [False, True])
         _, _, call_kwargs = self.client.stream.mock_calls[0]
         self.assertTrue(call_kwargs["json"]["stream"])
+        self.assertEqual(call_kwargs["json"]["audio_setting"]["format"], "mp3")
+        self.assertEqual(
+            call_kwargs["json"]["audio_setting"]["sample_rate"],
+            32000,
+        )
+        self.assertTrue(
+            call_kwargs["json"]["stream_options"]["exclude_aggregated_audio"],
+        )
 
     async def test_api_error(self) -> None:
         """An unsuccessful API status raises a clear error."""
@@ -210,4 +233,10 @@ class TestMiniMaxTTSModel(IsolatedAsyncioTestCase):
         self.assertEqual(
             MiniMaxCredential.get_tts_model_classes(),
             [MiniMaxTTSModel],
+        )
+        self.assertEqual(MiniMaxCredential.list_models(), [])
+        self.assertNotIn("api_url", MiniMaxTTSModel.Parameters.model_fields)
+        self.assertNotIn(
+            "response_format",
+            MiniMaxTTSModel.Parameters.model_fields,
         )


### PR DESCRIPTION
Reason: Add native MiniMax T2A support to AgentScope's TTS framework.

This change:

- registers MiniMax credentials and TTS model discovery;
- supports streaming and non-streaming T2A responses across configurable regional endpoints;
- exposes voice, audio, language, and endpoint parameters;
- adds model cards for the supported speech models and focused unit coverage.

Checks:

- `.venv312/bin/python -m pytest tests/tts_*_test.py -q` (77 passed, 5 skipped)
- `.venv312/bin/python -m black --check --line-length 79 src/agentscope/tts/_minimax/_model.py tests/tts_minimax_test.py`
- `.venv312/bin/python -m flake8 --extend-ignore=E203 src/agentscope/credential/__init__.py src/agentscope/credential/_factory.py src/agentscope/credential/_minimax.py src/agentscope/tts/__init__.py src/agentscope/tts/_minimax/__init__.py src/agentscope/tts/_minimax/_model.py tests/tts_minimax_test.py`
- `.venv312/bin/python -m mypy --disallow-untyped-defs --disallow-incomplete-defs --ignore-missing-imports --follow-imports=skip --explicit-package-bases src/agentscope/credential/_minimax.py src/agentscope/tts/_minimax/_model.py tests/tts_minimax_test.py`
