### PR TITLE
feat(channel): enable channels for scheduled tasks

### DIFF
--- a/examples/web_ui/frontend/src/api/types.ts
+++ b/examples/web_ui/frontend/src/api/types.ts
@@ -747,6 +747,7 @@ export interface ScheduleData {
 	permission_mode: PermissionMode;
 	source: ScheduleSource;
 	source_session_id: string;
+	channel_id: string | null;
 }
 
 export interface ScheduleRecord extends RecordBase {
@@ -765,6 +766,7 @@ export interface CreateScheduleRequest {
 	enabled?: boolean;
 	stateful?: boolean;
 	permission_mode?: PermissionMode;
+	channel_id?: string | null;
 }
 
 export interface CreateScheduleResponse {
@@ -779,6 +781,7 @@ export interface UpdateScheduleRequest {
 	enabled?: boolean;
 	stateful?: boolean;
 	permission_mode?: PermissionMode;
+	channel_id?: string | null;
 }
 
 export interface ScheduleListResponse {
@@ -1168,6 +1171,7 @@ export interface ChannelRecord {
 	name: string | null;
 	user_id: string;
 	platform_bot_id: string;
+	supports_scheduled_tools: boolean;
 	enabled: boolean;
 	platform_config: Record<string, unknown>;
 	routing: RoutingConfig;

--- a/examples/web_ui/frontend/src/i18n/locales/en.json
+++ b/examples/web_ui/frontend/src/i18n/locales/en.json
@@ -503,6 +503,14 @@
 	"schedule": {
 		"subtitle": "Schedule recurring or one-off tasks for your agents",
 		"calendar": "Calendar",
+		"channelSelector": {
+			"description": "Selecting a channel authorizes this unattended task to use its proactive tools without another confirmation. Other tools still follow the permission mode.",
+			"empty": "No channels support scheduled delivery",
+			"label": "Channel",
+			"loadError": "Could not load channels",
+			"none": "None (no channel)",
+			"triggerLabel": "Select the channel used by this schedule"
+		},
 		"createSchedule": {
 			"description": "Set up a recurring or one-time scheduled task for an agent.",
 			"descriptionLabel": "Description",

--- a/examples/web_ui/frontend/src/i18n/locales/zh.json
+++ b/examples/web_ui/frontend/src/i18n/locales/zh.json
@@ -503,6 +503,14 @@
 	"schedule": {
 		"subtitle": "为智能体设置定时或一次性的计划任务",
 		"calendar": "日历",
+		"channelSelector": {
+			"description": "选择频道即授权该无人值守任务无需再次确认即可使用其主动发送工具；其他工具仍遵循权限模式。",
+			"empty": "暂无支持定时发送的频道",
+			"label": "频道",
+			"loadError": "频道加载失败",
+			"none": "不使用频道",
+			"triggerLabel": "选择定时任务使用的频道"
+		},
 		"createSchedule": {
 			"description": "为智能体设置定时或一次性的计划任务。",
 			"descriptionLabel": "描述",

--- a/examples/web_ui/frontend/src/pages/schedule/create-schedule-dialog.tsx
+++ b/examples/web_ui/frontend/src/pages/schedule/create-schedule-dialog.tsx
@@ -1,12 +1,20 @@
 import { format } from 'date-fns';
-import { ChevronDownIcon, CircleAlert, Loader2, PlusCircle } from 'lucide-react';
+import {
+	Cable,
+	ChevronDown,
+	ChevronDownIcon,
+	CircleAlert,
+	Loader2,
+	PlusCircle,
+} from 'lucide-react';
 import * as React from 'react';
 
-import type { ChatModelConfig, PermissionMode } from '@/api';
+import type { ChannelRecord, ChatModelConfig, PermissionMode } from '@/api';
 import { AgentSelect } from '@/components/select/AgentSelect';
 import { LlmSelect } from '@/components/select/LlmSelect';
 import { PermissionModeSelect } from '@/components/select/PermissionModeSelect';
 import { TimezoneSelect } from '@/components/select/TimezoneSelect';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import {
@@ -17,6 +25,16 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from '@/components/ui/dialog';
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Field, FieldGroup, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
@@ -30,6 +48,7 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 import { useAgents } from '@/hooks/useAgents';
+import { useChannels } from '@/hooks/useChannels';
 import { useSchedules } from '@/hooks/useSchedules';
 import { useTranslation } from '@/i18n/useI18n';
 
@@ -57,7 +76,94 @@ function getDefaultForm() {
 		permissionMode: 'dont_ask' as PermissionMode,
 		timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 		stateful: false,
+		channelId: null as string | null,
 	};
+}
+
+const NO_CHANNEL_VALUE = '__none__';
+
+function channelLabel(channel: ChannelRecord): string {
+	const name = channel.name?.trim();
+	return name || `${channel.channel_type} · ${channel.id.slice(0, 8)}`;
+}
+
+function ChannelSelect({
+	channels,
+	value,
+	loading,
+	error,
+	onChange,
+}: {
+	channels: ChannelRecord[];
+	value: string | null;
+	loading: boolean;
+	error: Error | null;
+	onChange: (channelId: string | null) => void;
+}) {
+	const { t } = useTranslation();
+	const selected = channels.find((channel) => channel.id === value) ?? null;
+	const displayLabel = selected ? channelLabel(selected) : t('schedule.channelSelector.none');
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button
+					variant="outline"
+					size="default"
+					className="w-48 justify-between gap-1 font-normal"
+					aria-label={t('schedule.channelSelector.triggerLabel')}
+				>
+					<span className="flex min-w-0 items-center gap-2">
+						<Cable className="size-3.5 shrink-0 text-muted-foreground" />
+						<span className="truncate">{displayLabel}</span>
+					</span>
+					<ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="start" className="min-w-64 max-h-72 overflow-y-auto">
+				<DropdownMenuLabel>{t('schedule.channelSelector.label')}</DropdownMenuLabel>
+				<DropdownMenuRadioGroup
+					value={value ?? NO_CHANNEL_VALUE}
+					onValueChange={(next) => onChange(next === NO_CHANNEL_VALUE ? null : next)}
+				>
+					<DropdownMenuRadioItem value={NO_CHANNEL_VALUE}>
+						{t('schedule.channelSelector.none')}
+					</DropdownMenuRadioItem>
+
+					{channels.length > 0 && <DropdownMenuSeparator />}
+					{channels.map((channel) => (
+						<DropdownMenuRadioItem key={channel.id} value={channel.id}>
+							<span className="min-w-0 flex-1">
+								<span className="block truncate" title={channelLabel(channel)}>
+									{channelLabel(channel)}
+								</span>
+								{channel.name?.trim() && (
+									<span className="block truncate text-xs text-muted-foreground">
+										{channel.channel_type}
+									</span>
+								)}
+							</span>
+							{!channel.enabled && (
+								<Badge variant="secondary" className="mr-5 text-[10px]">
+									{t('common.disabled')}
+								</Badge>
+							)}
+						</DropdownMenuRadioItem>
+					))}
+				</DropdownMenuRadioGroup>
+
+				{channels.length === 0 && (
+					<DropdownMenuItem disabled>
+						{loading
+							? t('common.loading')
+							: error
+								? t('schedule.channelSelector.loadError')
+								: t('schedule.channelSelector.empty')}
+					</DropdownMenuItem>
+				)}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
 }
 
 function buildCronExpr(freq: FreqType, time: string, date: Date | undefined): string {
@@ -117,6 +223,11 @@ export function CreateScheduleDialog({ open, onOpenChange, onCreated }: Props) {
 	const { t } = useTranslation();
 	const { create } = useSchedules();
 	const { agents } = useAgents();
+	const { channels, loading: channelsLoading, error: channelsError } = useChannels();
+	const schedulableChannels = React.useMemo(
+		() => channels.filter((channel) => channel.supports_scheduled_tools),
+		[channels],
+	);
 	const [form, setForm] = React.useState(getDefaultForm);
 	const [loading, setLoading] = React.useState(false);
 	const [error, setError] = React.useState('');
@@ -169,6 +280,7 @@ export function CreateScheduleDialog({ open, onOpenChange, onCreated }: Props) {
 				enabled: true,
 				stateful: form.stateful,
 				permission_mode: form.permissionMode,
+				...(form.channelId ? { channel_id: form.channelId } : {}),
 			});
 			onCreated?.();
 			onOpenChange(false);
@@ -301,6 +413,22 @@ export function CreateScheduleDialog({ open, onOpenChange, onCreated }: Props) {
 								size="default"
 								value={form.permissionMode}
 								onChange={(v) => set('permissionMode', v)}
+							/>
+						</Field>
+
+						<Field orientation="horizontal" className="items-start">
+							<div className="flex flex-1 flex-col gap-0.5">
+								<FieldLabel>{t('schedule.channelSelector.label')}</FieldLabel>
+								<span className="text-xs text-muted-foreground">
+									{t('schedule.channelSelector.description')}
+								</span>
+							</div>
+							<ChannelSelect
+								channels={schedulableChannels}
+								value={form.channelId}
+								loading={channelsLoading}
+								error={channelsError}
+								onChange={(channelId) => set('channelId', channelId)}
 							/>
 						</Field>
 

--- a/src/agentscope/app/_router/_channel.py
+++ b/src/agentscope/app/_router/_channel.py
@@ -74,12 +74,16 @@ def _to_response(
         )
     except ValueError:
         bot_id = ""
+    channel_cls = registry.get(record.channel_type)
     return ChannelResponse(
         id=record.id,
         channel_type=record.channel_type,
         name=record.name,
         user_id=record.user_id,
         platform_bot_id=bot_id,
+        supports_scheduled_tools=(
+            channel_cls is not None and channel_cls.supports_scheduled_tools
+        ),
         enabled=record.enabled,
         platform_config=record.platform_config,
         routing=record.routing,

--- a/src/agentscope/app/_router/_schedule.py
+++ b/src/agentscope/app/_router/_schedule.py
@@ -6,7 +6,9 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from ..access import ResourceKind
 from .._manager import SchedulerManager
+from ..channel import ChannelTypeRegistry
 from ..deps import (
+    get_channel_type_registry,
     get_current_user_id,
     get_resource_access_service,
     get_scheduler_manager,
@@ -33,6 +35,47 @@ schedule_router = APIRouter(
     tags=["schedule"],
     responses={404: {"description": "Not found"}},
 )
+
+
+async def _validate_owned_channel(
+    channel_id: str,
+    user_id: str,
+    storage: StorageBase,
+    registry: ChannelTypeRegistry,
+) -> None:
+    """Ensure an owned channel supports unattended scheduled tools.
+
+    Args:
+        channel_id (`str`): Channel to validate.
+        user_id (`str`): Authenticated user ID.
+        storage (`StorageBase`): Storage instance.
+        registry (`ChannelTypeRegistry`): Registered adapter capabilities.
+
+    Raises:
+        `HTTPException`: 404 if the channel does not exist, or 403 if it
+            belongs to another user, or 400 if its adapter does not opt in to
+            scheduled tools.
+    """
+    channel = await storage.get_channel(channel_id)
+    if channel is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Channel '{channel_id}' not found.",
+        )
+    if channel.user_id != user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied.",
+        )
+    channel_cls = registry.get(channel.channel_type)
+    if channel_cls is None or not channel_cls.supports_scheduled_tools:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Channel type '{channel.channel_type}' does not support "
+                "scheduled tools."
+            ),
+        )
 
 
 @schedule_router.get(
@@ -68,6 +111,7 @@ async def create_schedule(
     body: CreateScheduleRequest,
     user_id: str = Depends(get_current_user_id),
     storage: StorageBase = Depends(get_storage),
+    registry: ChannelTypeRegistry = Depends(get_channel_type_registry),
     access: ResourceAccessService = Depends(get_resource_access_service),
     scheduler: SchedulerManager = Depends(get_scheduler_manager),
 ) -> CreateScheduleResponse:
@@ -81,6 +125,7 @@ async def create_schedule(
         body (`CreateScheduleRequest`): Schedule configuration.
         user_id (`str`): Authenticated user ID.
         storage (`StorageBase`): Storage instance.
+        registry (`ChannelTypeRegistry`): Registered channel capabilities.
         access (`ResourceAccessService`): Access service.
         scheduler (`SchedulerManager`): Scheduler manager.
 
@@ -89,10 +134,10 @@ async def create_schedule(
             The ID of the newly created schedule.
 
     Raises:
-        `HTTPException`: 404 if the specified agent or the credential
-            referenced by ``chat_model_config`` is not visible to the
-            caller; 422 if the cron expression, timezone or activation
-            window is invalid.
+        `HTTPException`: 404 if the specified agent, credential, or channel
+            does not exist; 403 if the channel belongs to another user; 400
+            if the channel adapter does not support scheduled tools; 422 if
+            the cron expression, timezone, or activation window is invalid.
     """
     # Visibility checks — raise 404 when neither owned nor shared. The
     # schedule fires under the owner's user_id, so re-validating the
@@ -104,6 +149,13 @@ async def create_schedule(
         ResourceKind.CREDENTIAL,
         body.chat_model_config.credential_id,
     )
+    if body.channel_id is not None:
+        await _validate_owned_channel(
+            body.channel_id,
+            user_id,
+            storage,
+            registry,
+        )
 
     record = ScheduleRecord(
         user_id=user_id,
@@ -119,6 +171,7 @@ async def create_schedule(
             chat_model_config=body.chat_model_config,
             source=ScheduleSource.USER,
             started_at=datetime.now(),
+            channel_id=body.channel_id,
         ),
     )
 
@@ -146,6 +199,7 @@ async def update_schedule(
     body: UpdateScheduleRequest,
     user_id: str = Depends(get_current_user_id),
     storage: StorageBase = Depends(get_storage),
+    registry: ChannelTypeRegistry = Depends(get_channel_type_registry),
     scheduler: SchedulerManager = Depends(get_scheduler_manager),
 ) -> ScheduleRecord:
     """Partially update a schedule.
@@ -160,6 +214,7 @@ async def update_schedule(
         body (`UpdateScheduleRequest`): Fields to update.
         user_id (`str`): Authenticated user ID.
         storage (`StorageBase`): Storage instance.
+        registry (`ChannelTypeRegistry`): Registered channel capabilities.
         scheduler (`SchedulerManager`): Scheduler manager.
 
     Returns:
@@ -167,9 +222,11 @@ async def update_schedule(
             The updated schedule record.
 
     Raises:
-        `HTTPException`: 404 if the schedule does not exist; 422 if the
-            update leaves an invalid cron expression, timezone or
-            activation window.
+        `HTTPException`: 404 if the schedule or selected channel does not
+            exist, 403 if the channel belongs to another user, or 400 if the
+            channel adapter does not support scheduled tools; 422 if the
+            update leaves an invalid cron expression, timezone, or activation
+            window.
     """
     existing = await storage.get_schedule(user_id, schedule_id)
     if existing is None:
@@ -178,7 +235,20 @@ async def update_schedule(
             detail=f"Schedule '{schedule_id}' not found.",
         )
 
+    if body.channel_id is not None:
+        await _validate_owned_channel(
+            body.channel_id,
+            user_id,
+            storage,
+            registry,
+        )
+
     updates = body.model_dump(exclude_none=True)
+    # Unlike the existing optional fields, channel_id supports an explicit
+    # null to remove the association. Omission still preserves the stored
+    # value, while null for every other field retains the legacy behaviour.
+    if "channel_id" in body.model_fields_set:
+        updates["channel_id"] = body.channel_id
     updated_data = existing.data.model_copy(update=updates)
     updated_record = existing.model_copy(
         update={"data": updated_data, "updated_at": datetime.now()},

--- a/src/agentscope/app/_router/_schema/_channel.py
+++ b/src/agentscope/app/_router/_schema/_channel.py
@@ -56,6 +56,7 @@ class ChannelResponse(BaseModel):
     name: str | None
     user_id: str
     platform_bot_id: str
+    supports_scheduled_tools: bool
     enabled: bool
     platform_config: dict
     routing: RoutingConfig

--- a/src/agentscope/app/_router/_schema/_schedule.py
+++ b/src/agentscope/app/_router/_schema/_schedule.py
@@ -29,6 +29,12 @@ class CreateScheduleRequest(BaseModel):
 
     agent_id: str = Field(description="Agent to run when the schedule fires.")
 
+    channel_id: str | None = Field(
+        default=None,
+        description="Optional channel whose scheduled tools are explicitly "
+        "authorized for this unattended task.",
+    )
+
     chat_model_config: ChatModelConfig = Field(
         description="Model configuration for the auto-created session.",
     )
@@ -99,6 +105,12 @@ class UpdateScheduleRequest(BaseModel):
     permission_mode: PermissionMode | None = Field(
         default=None,
         description="New permission mode.",
+    )
+
+    channel_id: str | None = Field(
+        default=None,
+        description="New explicitly authorized scheduled-tool channel, or "
+        "null to remove the association.",
     )
 
 

--- a/src/agentscope/app/_service/_chat.py
+++ b/src/agentscope/app/_service/_chat.py
@@ -37,6 +37,7 @@ from ..storage import (
     SessionNaming,
     SessionRecord,
     ChannelOrigin,
+    ScheduleOrigin,
 )
 from ..storage._utils import _resolve_team_leader
 from .._manager import BackgroundTaskManager, SchedulerManager
@@ -893,8 +894,10 @@ class ChatService:
                     )
 
                 # -------------------------------------------------------------
-                # 1c. Resolve the channel binding ONCE; the toolkit and the
-                # system-prompt attachment share it.
+                # 1c. Resolve channel tools ONCE; interactive channel sessions
+                # also share the client with the system-prompt attachment.
+                # Scheduled sessions resolve their current schedule on every
+                # run, but are never treated as conversation-bound.
                 # -------------------------------------------------------------
                 channel_origin = (
                     session_record.origin
@@ -928,6 +931,64 @@ class ChatService:
                     if channel is not None and channel_origin is not None
                     else []
                 )
+                if (
+                    isinstance(session_record.origin, ScheduleOrigin)
+                    and self._channel_clients is not None
+                ):
+                    clients = self._channel_clients
+                    schedule_id = session_record.origin.schedule_id
+                    try:
+                        schedule = await self._storage.get_schedule(
+                            user_id,
+                            schedule_id,
+                        )
+                        selected_channel_id = (
+                            schedule.data.channel_id
+                            if schedule is not None
+                            and schedule.agent_id == agent_id
+                            and schedule.data.enabled
+                            else None
+                        )
+                        if selected_channel_id is not None:
+                            channel = await clients.get_scheduled(
+                                selected_channel_id,
+                                user_id,
+                            )
+                        if channel is not None:
+                            assert selected_channel_id is not None
+                            channel_tools = await channel.list_scheduled_tools(
+                                workspace,
+                            )
+                            latest = await self._storage.get_schedule(
+                                user_id,
+                                schedule_id,
+                            )
+                            schedule_is_current = (
+                                latest is not None
+                                and latest.data.enabled
+                                and latest.agent_id == agent_id
+                                and latest.data.channel_id
+                                == selected_channel_id
+                            )
+                            channel_is_current = False
+                            if schedule_is_current:
+                                is_current = clients.is_scheduled_current
+                                channel_is_current = await is_current(
+                                    selected_channel_id,
+                                    user_id,
+                                    channel,
+                                )
+                            if not channel_is_current:
+                                channel = None
+                                channel_tools = []
+                    except Exception:  # pylint: disable=broad-except
+                        logger.warning(
+                            "Schedule %r: selected channel could not be "
+                            "resolved for this run",
+                            schedule_id,
+                        )
+                        channel = None
+                        channel_tools = []
 
                 # -------------------------------------------------------------
                 # 2. Middlewares — framework-supplied first, then caller
@@ -1082,7 +1143,7 @@ class ChatService:
                 # -------------------------------------------------------------
                 attachment = f"You're within a session (id={session_id})."
 
-                # Channel-bound sessions: tell the agent which chat it serves.
+                # Only a true channel-originated session is conversation-bound.
                 if channel is not None and channel_origin is not None:
                     tools = ", ".join(t.name for t in channel_tools)
                     chat_id = channel_origin.chat_id

--- a/src/agentscope/app/channel/_base.py
+++ b/src/agentscope/app/channel/_base.py
@@ -335,6 +335,13 @@ class ChannelBase(ABC):
     """Brand icon URL for the management UI; empty falls back to a
     generated avatar."""
 
+    supports_scheduled_tools: bool = False
+    """Whether this adapter exposes tools to unattended scheduled runs.
+
+    This is deliberately opt-in. Scheduled tools use an unconnected REST
+    client, so adapters must also provide an explicit scheduled-tool list.
+    """
+
     class Credentials(BaseModel):
         """Secret connection fields (app id, tokens, ...). Subclasses
         override with their own fields; mark a field secret with
@@ -652,6 +659,18 @@ class ChannelBase(ABC):
             message naming what the operator has to fix.
         """
         return None
+
+    async def list_scheduled_tools(  # pylint: disable=unused-argument
+        self,
+        workspace: "WorkspaceBase",
+    ) -> list["ToolBase"]:
+        """Tools explicitly authorised for an unattended scheduled run.
+
+        The default is empty even when :meth:`list_tools` is implemented;
+        adapters must opt in so ordinary interactive permission semantics are
+        not silently reused for an unattended execution.
+        """
+        return []
 
     def _split_long_message(self, text: str) -> list[str]:
         """Split text into chunks within the platform length limit.

--- a/src/agentscope/app/channel/_clients.py
+++ b/src/agentscope/app/channel/_clients.py
@@ -125,10 +125,103 @@ class ChannelClients:
             `ChannelBase | None`: The instance, or ``None`` when the
             record is gone, disabled, or its type is not registered.
         """
+        return await self._get(channel_id)
+
+    async def get_scheduled(
+        self,
+        channel_id: str,
+        user_id: str,
+    ) -> ChannelBase | None:
+        """Return a schedule-authorised REST client for ``channel_id``.
+
+        Unlike :meth:`get`, this accepts a disabled record: no long
+        connection is opened, so using its explicit scheduled-tool whitelist
+        does not re-enable inbound traffic. Ownership and adapter capability
+        are revalidated for stale or legacy schedule records.
+
+        Args:
+            channel_id (`str`): The selected channel.
+            user_id (`str`): Owner of the scheduled run.
+
+        Returns:
+            `ChannelBase | None`: A capable owned client, otherwise ``None``.
+        """
+        return await self._get(
+            channel_id,
+            allow_disabled=True,
+            expected_user_id=user_id,
+            require_scheduled_tools=True,
+        )
+
+    async def is_scheduled_current(
+        self,
+        channel_id: str,
+        user_id: str,
+        channel: ChannelBase,
+    ) -> bool:
+        """Revalidate a borrowed schedule client before exposing its tools.
+
+        Args:
+            channel_id (`str`): Selected channel id.
+            user_id (`str`): Owner of the scheduled run.
+            channel (`ChannelBase`): Client returned by
+                :meth:`get_scheduled` earlier in the same assembly.
+
+        Returns:
+            `bool`: Whether the record, owner, capability, version, and cached
+            client identity still match.
+        """
+        try:
+            record = await self._storage.get_channel(channel_id)
+        except Exception:  # pylint: disable=broad-except
+            return False
+        if record is None or record.user_id != user_id:
+            return False
+        channel_cls = self._types.get(record.channel_type)
+        if channel_cls is None or not channel_cls.supports_scheduled_tools:
+            return False
+        cached = self._cache.get(channel_id)
+        return (
+            cached is not None
+            and cached[0] == str(record.updated_at)
+            and cached[1] is channel
+        )
+
+    async def _get(
+        self,
+        channel_id: str,
+        *,
+        allow_disabled: bool = False,
+        expected_user_id: str | None = None,
+        require_scheduled_tools: bool = False,
+    ) -> ChannelBase | None:
+        """Build one cached client after applying access/capability gates.
+
+        Args:
+            channel_id (`str`): Channel record to resolve.
+            allow_disabled (`bool`): Whether a disabled record is usable.
+            expected_user_id (`str | None`): Required owner when provided.
+            require_scheduled_tools (`bool`): Require the adapter's explicit
+                scheduled-tool capability.
+
+        Returns:
+            `ChannelBase | None`: A matching client, otherwise ``None``.
+        """
         record = await self._storage.get_channel(channel_id)
-        if record is None or not record.enabled:
+        if record is None:
             self._retire(channel_id)
             return None
+        if not allow_disabled and not record.enabled:
+            self._retire(channel_id)
+            return None
+        if expected_user_id is not None and record.user_id != expected_user_id:
+            self._retire(channel_id)
+            return None
+        if require_scheduled_tools:
+            channel_cls = self._types.get(record.channel_type)
+            if channel_cls is None or not channel_cls.supports_scheduled_tools:
+                self._retire(channel_id)
+                return None
 
         version = str(record.updated_at)
         cached = self._cache.get(channel_id)

--- a/src/agentscope/app/channel/_feishu/_channel.py
+++ b/src/agentscope/app/channel/_feishu/_channel.py
@@ -97,6 +97,7 @@ class FeishuChannel(ChannelBase):
     icon_url = "https://www.google.com/s2/favicons?domain=feishu.cn&sz=128"
     platform_bot_id_field = "app_id"
     credential_binding = FeishuCredentialBinding
+    supports_scheduled_tools = True
 
     class Credentials(BaseModel):
         """Feishu bot application credentials."""
@@ -971,6 +972,31 @@ class FeishuChannel(ChannelBase):
             SendFile(self, backend),
             SendImage(self, backend),
         ] + await super().list_tools(workspace, channel_user_id)
+
+    async def list_scheduled_tools(
+        self,
+        workspace: "WorkspaceBase",
+    ) -> list["ToolBase"]:
+        """Expose the narrow Feishu whitelist authorised by a schedule.
+
+        File/image tools are intentionally excluded because they can read and
+        transmit workspace content. Text send is explicitly authorised by the
+        selected channel; discovery tools remain read-only.
+
+        Args:
+            workspace (`WorkspaceBase`): Calling session workspace.
+
+        Returns:
+            `list[ToolBase]`: Chat discovery and text-send tools only.
+        """
+        from ._tools import ListChatMembers, ListChats, SendMessage
+
+        backend = workspace.get_backend()
+        return [
+            ListChats(self, backend),
+            ListChatMembers(self, backend),
+            SendMessage(self, backend, allow_scheduled_actions=True),
+        ]
 
     # -- Agent-tool operations (act on chats/users other than the current) --
 

--- a/src/agentscope/app/channel/_feishu/_tools/_base.py
+++ b/src/agentscope/app/channel/_feishu/_tools/_base.py
@@ -44,6 +44,8 @@ class _FeishuToolBase(ToolBase):
         self,
         channel: "FeishuChannel",
         backend: BackendBase,
+        *,
+        allow_scheduled_actions: bool = False,
     ) -> None:
         """Bind the live channel and the session's workspace backend.
 
@@ -51,10 +53,13 @@ class _FeishuToolBase(ToolBase):
             channel (`FeishuChannel`): The live channel to send / query.
             backend (`BackendBase`): The session workspace backend; the
                 file tools read their payload from it (others ignore it).
+            allow_scheduled_actions (`bool`): Whether explicit schedule
+                channel selection authorises unattended mutating calls.
         """
         super().__init__()
         self._channel = channel
         self._backend = backend
+        self._allow_scheduled_actions = allow_scheduled_actions
 
     async def check_permissions(
         self,
@@ -71,6 +76,12 @@ class _FeishuToolBase(ToolBase):
             return PermissionDecision(
                 behavior=PermissionBehavior.ALLOW,
                 message=f"{self.name} is a read-only lookup.",
+            )
+        if self._allow_scheduled_actions:
+            return PermissionDecision(
+                behavior=PermissionBehavior.ALLOW,
+                message="This action was authorised by the schedule's "
+                "selected Feishu output channel.",
             )
         return PermissionDecision(
             behavior=PermissionBehavior.ASK,

--- a/src/agentscope/app/channel/_feishu/_tools/_send_message.py
+++ b/src/agentscope/app/channel/_feishu/_tools/_send_message.py
@@ -37,7 +37,9 @@ automatically. Never use this tool for the current conversation.
 ## How to Use
 Obtain ``receive_id`` first: a group's via ``ListChats``, a person's via \
 ``ListChatMembers``. Pass ``receive_id`` and ``receive_id_type`` exactly as \
-returned. Sending requires the user's confirmation."""
+returned. Sending normally requires the user's confirmation; an unattended \
+schedule that explicitly selects this channel is already authorised to send \
+text messages."""
     is_read_only: bool = False
     input_schema: dict = _SendMessageParams.model_json_schema()
 

--- a/src/agentscope/app/storage/_model/_schedule.py
+++ b/src/agentscope/app/storage/_model/_schedule.py
@@ -104,6 +104,12 @@ class ScheduleData(BaseModel):
         "retrieval.",
     )
 
+    channel_id: str | None = Field(
+        default=None,
+        description="Optional channel whose schedule-specific tools are "
+        "explicitly authorized for this unattended task.",
+    )
+
 
 class ScheduleRecord(_RecordBase):
     """Persisted schedule record."""

--- a/tests/channel_clients_test.py
+++ b/tests/channel_clients_test.py
@@ -40,6 +40,7 @@ class _FakeChannel(ChannelBase):
     channel_type = "fake"
     display_name = "Fake"
     platform_bot_id_field = "bot_id"
+    supports_scheduled_tools = True
 
     class Credentials(BaseModel):
         """Credentials for the fake platform."""
@@ -108,13 +109,26 @@ class _Storage:
         return self.record
 
 
-def _record(bot_id: str = "bot-1", enabled: bool = True) -> ChannelRecord:
+class _UnsupportedChannel(_FakeChannel):
+    """A registered adapter that does not opt in to scheduled tools."""
+
+    channel_type = "unsupported"
+    supports_scheduled_tools = False
+
+
+def _record(
+    bot_id: str = "bot-1",
+    enabled: bool = True,
+    *,
+    channel_type: str = "fake",
+    user_id: str = "owner-1",
+) -> ChannelRecord:
     """Build a minimal enabled channel record for the fake platform."""
     now = datetime.now().isoformat()
     return ChannelRecord(
         id="chan-1",
-        channel_type="fake",
-        user_id="owner-1",
+        channel_type=channel_type,
+        user_id=user_id,
         enabled=enabled,
         credentials={"bot_id": bot_id},
         routing=RoutingConfig(
@@ -218,6 +232,66 @@ class ChannelClientsTest(IsolatedAsyncioTestCase):
             type_registry=ChannelTypeRegistry([]),
         )
         self.assertIsNone(await clients.get("chan-1"))
+
+    async def test_scheduled_client_accepts_owned_disabled_channel(
+        self,
+    ) -> None:
+        """Scheduled tools need REST only, not an inbound connection."""
+        clients = self._clients(_Storage(_record(enabled=False)))
+
+        channel = await clients.get_scheduled("chan-1", "owner-1")
+
+        self.assertIsInstance(channel, _FakeChannel)
+        self.assertFalse(channel.listened)
+
+    async def test_scheduled_client_revalidates_owner_and_capability(
+        self,
+    ) -> None:
+        """Stale or forged schedule references fail closed."""
+        storage = _Storage(_record(enabled=False, user_id="another-user"))
+        clients = self._clients(storage)
+        self.assertIsNone(await clients.get_scheduled("chan-1", "owner-1"))
+
+        storage.record = _record(
+            enabled=False,
+            channel_type="unsupported",
+        )
+        clients = ChannelClients(
+            storage=storage,
+            message_bus=InMemoryMessageBus(),
+            type_registry=ChannelTypeRegistry(
+                [_FakeChannel, _UnsupportedChannel],
+            ),
+        )
+        self.assertIsNone(await clients.get_scheduled("chan-1", "owner-1"))
+
+    async def test_scheduled_client_final_check_rejects_rotation(
+        self,
+    ) -> None:
+        """A client borrowed before a record update is no longer current."""
+        storage = _Storage(_record(enabled=False))
+        clients = self._clients(storage)
+        channel = await clients.get_scheduled("chan-1", "owner-1")
+        self.assertIsNotNone(channel)
+        self.assertTrue(
+            await clients.is_scheduled_current(
+                "chan-1",
+                "owner-1",
+                channel,
+            ),
+        )
+
+        rotated = _record(enabled=False, bot_id="bot-2")
+        rotated.updated_at = "2099-01-01T00:00:00"
+        storage.record = rotated
+
+        self.assertFalse(
+            await clients.is_scheduled_current(
+                "chan-1",
+                "owner-1",
+                channel,
+            ),
+        )
 
 
 class ChannelDeliveryTest(IsolatedAsyncioTestCase):

--- a/tests/channel_gateway_test.py
+++ b/tests/channel_gateway_test.py
@@ -53,6 +53,13 @@ from agentscope.event import (
 )
 from agentscope.message import DataBlock, TextBlock
 from agentscope.message._block import Base64Source, URLSource
+from agentscope.permission import (
+    PermissionBehavior,
+    PermissionContext,
+    PermissionEngine,
+    PermissionMode,
+    PermissionRule,
+)
 from agentscope.types import ReplyFinishedReason
 
 _RID = "reply-1"
@@ -656,3 +663,84 @@ class DecisionRoutingTest(IsolatedAsyncioTestCase):
         # The routing guess was tried first, then the parked session.
         self.assertNotEqual(storage.asked[0], "the-parked-session")
         self.assertIn("the-parked-session", storage.asked)
+
+
+class FeishuScheduledToolsTest(IsolatedAsyncioTestCase):
+    """Scheduled Feishu tools use a narrow, explicit authorisation set."""
+
+    async def test_schedule_whitelist_and_permission_are_isolated(
+        self,
+    ) -> None:
+        """Only discovery/text-send tools are scheduled; normal sends ASK."""
+        from agentscope.app.channel._feishu._channel import FeishuChannel
+
+        class _Workspace:
+            def get_backend(self) -> Any:
+                return None
+
+        channel = FeishuChannel(
+            "c",
+            FeishuChannel.Credentials(app_id="a", app_secret="s"),
+            FeishuChannel.Config(),
+        )
+        normal = {
+            tool.name: tool for tool in await channel.list_tools(_Workspace())
+        }
+        scheduled = {
+            tool.name: tool
+            for tool in await channel.list_scheduled_tools(_Workspace())
+        }
+
+        self.assertEqual(
+            set(scheduled),
+            {"ListChats", "ListChatMembers", "SendMessage"},
+        )
+        context = PermissionContext(mode=PermissionMode.DONT_ASK)
+        self.assertEqual(
+            (
+                await normal["SendMessage"].check_permissions({}, context)
+            ).behavior,
+            PermissionBehavior.ASK,
+        )
+        self.assertEqual(
+            (
+                await PermissionEngine(context).check_permission(
+                    normal["SendMessage"],
+                    {},
+                )
+            ).behavior,
+            PermissionBehavior.DENY,
+        )
+        self.assertEqual(
+            (
+                await scheduled["SendMessage"].check_permissions({}, context)
+            ).behavior,
+            PermissionBehavior.ALLOW,
+        )
+        self.assertEqual(
+            (
+                await PermissionEngine(context).check_permission(
+                    scheduled["SendMessage"],
+                    {},
+                )
+            ).behavior,
+            PermissionBehavior.ALLOW,
+        )
+
+        for behavior in (PermissionBehavior.DENY, PermissionBehavior.ASK):
+            engine = PermissionEngine(
+                PermissionContext(mode=PermissionMode.DONT_ASK),
+            )
+            engine.add_rule(
+                PermissionRule(
+                    tool_name="SendMessage",
+                    rule_content=None,
+                    behavior=behavior,
+                    source="test",
+                ),
+            )
+            decision = await engine.check_permission(
+                scheduled["SendMessage"],
+                {},
+            )
+            self.assertEqual(decision.behavior, PermissionBehavior.DENY)

--- a/tests/schedule_router_test.py
+++ b/tests/schedule_router_test.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*-
-"""Tests for schedule validation before persistence and registration."""
+"""Tests for schedule validation and optional channel association."""
 from datetime import datetime
-from unittest import IsolatedAsyncioTestCase
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import AsyncMock, MagicMock
 
-from fastapi import HTTPException
+from fastapi import HTTPException, status
 
 from agentscope.app._manager import SchedulerManager
 from agentscope.app._manager._scheduler._tools._schedule_create import (
     ScheduleCreate,
 )
+from agentscope.app._router._channel import _to_response
 from agentscope.app._router._schedule import create_schedule, update_schedule
 from agentscope.app._router._schema._schedule import (
     CreateScheduleRequest,
@@ -16,8 +19,12 @@ from agentscope.app._router._schema._schedule import (
 )
 from agentscope.app.storage import (
     ChatModelConfig,
+    ChannelBinding,
+    ChannelRecord,
+    RoutingConfig,
     ScheduleData,
     ScheduleRecord,
+    SessionSettings,
 )
 from agentscope.permission import PermissionMode
 
@@ -310,3 +317,383 @@ class ScheduleValidationTest(IsolatedAsyncioTestCase):
             )
 
         self.assertEqual(storage.upserted, [])
+
+
+def _chat_model_config() -> ChatModelConfig:
+    """Return the minimal model configuration used by schedule tests."""
+    return ChatModelConfig(
+        type="test_credential",
+        credential_id="credential-1",
+        model="test-model",
+        parameters={},
+    )
+
+
+def _schedule_record(
+    *,
+    channel_id: str | None = "channel-1",
+) -> ScheduleRecord:
+    """Return a persisted schedule owned by ``owner``."""
+    return ScheduleRecord(
+        id="schedule-1",
+        user_id="owner",
+        agent_id="agent-1",
+        data=ScheduleData(
+            name="daily summary",
+            description="existing description",
+            cron_expression="0 9 * * *",
+            started_at=datetime(2025, 1, 1),
+            chat_model_config=_chat_model_config(),
+            channel_id=channel_id,
+        ),
+    )
+
+
+class ScheduleRouterChannelTest(IsolatedAsyncioTestCase):
+    """Channel association is persisted and ownership-checked."""
+
+    def setUp(self) -> None:
+        """Build lightweight async dependencies for direct router calls."""
+        self.storage = AsyncMock()
+        self.access = AsyncMock()
+        self.scheduler = AsyncMock()
+        self.scheduler.validate_schedule = MagicMock()
+        self.registry = MagicMock()
+        self.registry.get.return_value = SimpleNamespace(
+            supports_scheduled_tools=True,
+        )
+
+    def test_legacy_schedule_data_defaults_channel_to_none(self) -> None:
+        """Stored schedules written before the field was added still load."""
+        data = ScheduleData(
+            name="legacy",
+            cron_expression="0 9 * * *",
+            chat_model_config=_chat_model_config(),
+        )
+
+        self.assertIsNone(data.channel_id)
+
+    async def test_create_persists_owned_channel(self) -> None:
+        """Creating a schedule accepts a channel owned by the caller."""
+        self.storage.get_channel.return_value = SimpleNamespace(
+            user_id="owner",
+            channel_type="feishu",
+        )
+        body = CreateScheduleRequest(
+            name="daily summary",
+            cron_expression="0 9 * * *",
+            agent_id="agent-1",
+            chat_model_config=_chat_model_config(),
+            channel_id="channel-1",
+        )
+
+        await create_schedule(
+            body,
+            user_id="owner",
+            storage=self.storage,
+            registry=self.registry,
+            access=self.access,
+            scheduler=self.scheduler,
+        )
+
+        self.storage.get_channel.assert_awaited_once_with("channel-1")
+        record = self.storage.upsert_schedule.await_args.args[1]
+        self.assertEqual(record.data.channel_id, "channel-1")
+        self.scheduler.validate_schedule.assert_called_once_with(record)
+        self.scheduler.notify_changed.assert_awaited_once_with(record.id)
+
+    async def test_create_without_channel_skips_channel_storage(self) -> None:
+        """The optional field preserves storage-backend compatibility."""
+        body = CreateScheduleRequest(
+            name="daily summary",
+            cron_expression="0 9 * * *",
+            agent_id="agent-1",
+            chat_model_config=_chat_model_config(),
+        )
+
+        await create_schedule(
+            body,
+            user_id="owner",
+            storage=self.storage,
+            registry=self.registry,
+            access=self.access,
+            scheduler=self.scheduler,
+        )
+
+        self.storage.get_channel.assert_not_awaited()
+        record = self.storage.upsert_schedule.await_args.args[1]
+        self.assertIsNone(record.data.channel_id)
+        self.scheduler.validate_schedule.assert_called_once_with(record)
+        self.scheduler.notify_changed.assert_awaited_once_with(record.id)
+
+    async def test_create_rejects_missing_channel(self) -> None:
+        """A nonexistent channel cannot be attached to a new schedule."""
+        self.storage.get_channel.return_value = None
+        body = CreateScheduleRequest(
+            name="daily summary",
+            cron_expression="0 9 * * *",
+            agent_id="agent-1",
+            chat_model_config=_chat_model_config(),
+            channel_id="missing",
+        )
+
+        with self.assertRaises(HTTPException) as ctx:
+            await create_schedule(
+                body,
+                user_id="owner",
+                storage=self.storage,
+                registry=self.registry,
+                access=self.access,
+                scheduler=self.scheduler,
+            )
+
+        self.assertEqual(ctx.exception.status_code, status.HTTP_404_NOT_FOUND)
+        self.storage.upsert_schedule.assert_not_awaited()
+        self.scheduler.notify_changed.assert_not_awaited()
+
+    async def test_create_rejects_channel_owned_by_another_user(self) -> None:
+        """A caller cannot attach another user's channel."""
+        self.storage.get_channel.return_value = SimpleNamespace(
+            user_id="another-user",
+            channel_type="feishu",
+        )
+        body = CreateScheduleRequest(
+            name="daily summary",
+            cron_expression="0 9 * * *",
+            agent_id="agent-1",
+            chat_model_config=_chat_model_config(),
+            channel_id="channel-1",
+        )
+
+        with self.assertRaises(HTTPException) as ctx:
+            await create_schedule(
+                body,
+                user_id="owner",
+                storage=self.storage,
+                registry=self.registry,
+                access=self.access,
+                scheduler=self.scheduler,
+            )
+
+        self.assertEqual(ctx.exception.status_code, status.HTTP_403_FORBIDDEN)
+        self.storage.upsert_schedule.assert_not_awaited()
+
+    async def test_create_rejects_channel_without_scheduled_tools(
+        self,
+    ) -> None:
+        """A registered adapter must explicitly opt in to scheduled tools."""
+        self.storage.get_channel.return_value = SimpleNamespace(
+            user_id="owner",
+            channel_type="discord",
+        )
+        self.registry.get.return_value = SimpleNamespace(
+            supports_scheduled_tools=False,
+        )
+        body = CreateScheduleRequest(
+            name="daily summary",
+            cron_expression="0 9 * * *",
+            agent_id="agent-1",
+            chat_model_config=_chat_model_config(),
+            channel_id="channel-1",
+        )
+
+        with self.assertRaises(HTTPException) as ctx:
+            await create_schedule(
+                body,
+                user_id="owner",
+                storage=self.storage,
+                registry=self.registry,
+                access=self.access,
+                scheduler=self.scheduler,
+            )
+
+        self.assertEqual(
+            ctx.exception.status_code,
+            status.HTTP_400_BAD_REQUEST,
+        )
+        self.storage.upsert_schedule.assert_not_awaited()
+
+    async def test_create_rejects_unregistered_channel_type(self) -> None:
+        """A stale channel type cannot be attached through the API."""
+        self.storage.get_channel.return_value = SimpleNamespace(
+            user_id="owner",
+            channel_type="removed-adapter",
+        )
+        self.registry.get.return_value = None
+        body = CreateScheduleRequest(
+            name="daily summary",
+            cron_expression="0 9 * * *",
+            agent_id="agent-1",
+            chat_model_config=_chat_model_config(),
+            channel_id="channel-1",
+        )
+
+        with self.assertRaises(HTTPException) as ctx:
+            await create_schedule(
+                body,
+                user_id="owner",
+                storage=self.storage,
+                registry=self.registry,
+                access=self.access,
+                scheduler=self.scheduler,
+            )
+
+        self.assertEqual(
+            ctx.exception.status_code,
+            status.HTTP_400_BAD_REQUEST,
+        )
+        self.storage.upsert_schedule.assert_not_awaited()
+
+    async def test_update_omitted_channel_keeps_existing_value(self) -> None:
+        """An omitted channel field leaves the association unchanged."""
+        self.storage.get_schedule.return_value = _schedule_record()
+
+        updated = await update_schedule(
+            "schedule-1",
+            UpdateScheduleRequest(description="new description"),
+            user_id="owner",
+            storage=self.storage,
+            registry=self.registry,
+            scheduler=self.scheduler,
+        )
+
+        self.assertEqual(updated.data.channel_id, "channel-1")
+        self.assertEqual(updated.data.description, "new description")
+        self.storage.get_channel.assert_not_awaited()
+
+    async def test_update_explicit_null_clears_only_channel(self) -> None:
+        """Explicit null clears channel; other null fields stay ignored."""
+        self.storage.get_schedule.return_value = _schedule_record()
+
+        updated = await update_schedule(
+            "schedule-1",
+            UpdateScheduleRequest(channel_id=None, description=None),
+            user_id="owner",
+            storage=self.storage,
+            registry=self.registry,
+            scheduler=self.scheduler,
+        )
+
+        self.assertIsNone(updated.data.channel_id)
+        self.assertEqual(updated.data.description, "existing description")
+        self.storage.get_channel.assert_not_awaited()
+
+    async def test_update_validates_replacement_channel(self) -> None:
+        """Replacing a channel checks ownership before persisting."""
+        self.storage.get_schedule.return_value = _schedule_record()
+        self.storage.get_channel.return_value = SimpleNamespace(
+            user_id="another-user",
+            channel_type="feishu",
+        )
+
+        with self.assertRaises(HTTPException) as ctx:
+            await update_schedule(
+                "schedule-1",
+                UpdateScheduleRequest(channel_id="channel-2"),
+                user_id="owner",
+                storage=self.storage,
+                registry=self.registry,
+                scheduler=self.scheduler,
+            )
+
+        self.assertEqual(ctx.exception.status_code, status.HTTP_403_FORBIDDEN)
+        self.storage.upsert_schedule.assert_not_awaited()
+        self.scheduler.notify_changed.assert_not_awaited()
+
+    async def test_update_persists_owned_replacement_channel(self) -> None:
+        """An owned replacement channel is stored and notifies the scheduler
+        owner."""
+        self.storage.get_schedule.return_value = _schedule_record(
+            channel_id=None,
+        )
+        self.storage.get_channel.return_value = SimpleNamespace(
+            user_id="owner",
+            channel_type="feishu",
+        )
+
+        updated = await update_schedule(
+            "schedule-1",
+            UpdateScheduleRequest(channel_id="channel-2"),
+            user_id="owner",
+            storage=self.storage,
+            registry=self.registry,
+            scheduler=self.scheduler,
+        )
+
+        self.assertEqual(updated.data.channel_id, "channel-2")
+        self.storage.get_channel.assert_awaited_once_with("channel-2")
+        self.storage.upsert_schedule.assert_awaited_once()
+        self.scheduler.validate_schedule.assert_called_once_with(updated)
+        self.scheduler.notify_changed.assert_awaited_once_with("schedule-1")
+
+    async def test_update_rejects_channel_without_scheduled_tools(
+        self,
+    ) -> None:
+        """An unsupported replacement cannot alter or notify a task."""
+        self.storage.get_schedule.return_value = _schedule_record()
+        self.storage.get_channel.return_value = SimpleNamespace(
+            user_id="owner",
+            channel_type="discord",
+        )
+        self.registry.get.return_value = SimpleNamespace(
+            supports_scheduled_tools=False,
+        )
+
+        with self.assertRaises(HTTPException) as ctx:
+            await update_schedule(
+                "schedule-1",
+                UpdateScheduleRequest(channel_id="channel-2"),
+                user_id="owner",
+                storage=self.storage,
+                registry=self.registry,
+                scheduler=self.scheduler,
+            )
+
+        self.assertEqual(
+            ctx.exception.status_code,
+            status.HTTP_400_BAD_REQUEST,
+        )
+        self.storage.upsert_schedule.assert_not_awaited()
+        self.scheduler.notify_changed.assert_not_awaited()
+
+
+class ChannelResponseCapabilityTest(TestCase):
+    """Channel list responses expose scheduled-tool support to the UI."""
+
+    @staticmethod
+    def _record(channel_type: str) -> ChannelRecord:
+        """Build a minimal persisted channel record."""
+        return ChannelRecord(
+            id=f"{channel_type}-channel",
+            channel_type=channel_type,
+            name=channel_type,
+            user_id="owner",
+            enabled=False,
+            credentials={},
+            platform_config={},
+            routing=RoutingConfig(
+                bindings=[ChannelBinding(agent_id="agent-1")],
+            ),
+            session=SessionSettings(chat_model_config={}),
+            created_at="2025-01-01T00:00:00",
+            updated_at="2025-01-01T00:00:00",
+        )
+
+    def test_response_derives_capability_from_registered_adapter(self) -> None:
+        """Supported disabled channels remain selectable; others do not."""
+        registry = MagicMock()
+        registry.extract_platform_bot_id.return_value = "bot-id"
+
+        registry.get.return_value = SimpleNamespace(
+            supports_scheduled_tools=True,
+        )
+        feishu = _to_response(self._record("feishu"), registry)
+
+        registry.get.return_value = SimpleNamespace(
+            supports_scheduled_tools=False,
+        )
+        discord = _to_response(self._record("discord"), registry)
+
+        self.assertTrue(feishu.supports_scheduled_tools)
+        self.assertFalse(feishu.enabled)
+        self.assertFalse(discord.supports_scheduled_tools)

--- a/tests/service_chat_run_context_test.py
+++ b/tests/service_chat_run_context_test.py
@@ -3,6 +3,7 @@
 """ChatService resolves team/channel context once and fans it out."""
 
 from types import SimpleNamespace
+from collections.abc import Callable
 from typing import AsyncGenerator
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch
@@ -14,8 +15,11 @@ from agentscope.app.storage import (
     AgentData,
     AgentRecord,
     ChatModelConfig,
+    ScheduleData,
+    ScheduleRecord,
     SessionConfig,
     SessionRecord,
+    ScheduleOrigin,
     TeamData,
     TeamRecord,
 )
@@ -28,12 +32,16 @@ class _Storage:
         self,
         sessions: dict[str, SessionRecord],
         agents: dict[str, AgentRecord],
-        team: TeamRecord,
+        team: TeamRecord | None,
+        schedules: dict[str, ScheduleRecord] | None = None,
     ) -> None:
         self.sessions = sessions
         self.agents = agents
         self.team = team
+        self.schedules = schedules or {}
         self.get_team_calls = 0
+        self.get_schedule_calls = 0
+        self.after_schedule_read: Callable[[int], None] | None = None
 
     async def get_session(
         self,
@@ -60,7 +68,21 @@ class _Storage:
         """Count every read — the run must need exactly one."""
         del user_id
         self.get_team_calls += 1
-        return self.team if team_id == self.team.id else None
+        return self.team if self.team and team_id == self.team.id else None
+
+    async def get_schedule(
+        self,
+        user_id: str,
+        schedule_id: str,
+    ) -> ScheduleRecord | None:
+        """Return the current schedule and count dynamic revalidation."""
+        del user_id
+        self.get_schedule_calls += 1
+        record = self.schedules.get(schedule_id)
+        result = record.model_copy(deep=True) if record else None
+        if self.after_schedule_read is not None:
+            self.after_schedule_read(self.get_schedule_calls)
+        return result
 
     async def update_session_state(self, *_: object, **__: object) -> None:
         """Accept the post-run state persistence."""
@@ -211,3 +233,238 @@ class TestRunContextResolution(IsolatedAsyncioTestCase):
                 "leader_names": ["Leader"],
             },
         )
+
+    async def test_schedule_resolves_current_channel_without_chat_binding(
+        self,
+    ) -> None:
+        """A scheduled run gets its whitelist but no conversation context."""
+        user_id = "user-1"
+        agent = AgentRecord(
+            id="agent-1",
+            user_id=user_id,
+            data=AgentData(
+                name="agent",
+                context_config=ContextConfig(),
+                react_config=ReActConfig(),
+            ),
+        )
+        model_config = ChatModelConfig(
+            type="test",
+            credential_id="cred-1",
+            model="m",
+            parameters={},
+        )
+        session = SessionRecord(
+            id="session-1",
+            user_id=user_id,
+            agent_id=agent.id,
+            origin=ScheduleOrigin(schedule_id="schedule-1"),
+            config=SessionConfig(
+                workspace_id="ws-1",
+                chat_model_config=model_config,
+            ),
+        )
+        schedule = ScheduleRecord(
+            id="schedule-1",
+            user_id=user_id,
+            agent_id=agent.id,
+            data=ScheduleData(
+                name="daily",
+                cron_expression="0 9 * * *",
+                chat_model_config=model_config,
+                channel_id="channel-1",
+            ),
+        )
+        storage = _Storage(
+            sessions={session.id: session},
+            agents={agent.id: agent},
+            team=None,
+            schedules={schedule.id: schedule},
+        )
+
+        class _Channel:
+            """Expose scheduled tools and reject conversation lookups."""
+
+            def __init__(self, channel_id: str) -> None:
+                self.channel_id = channel_id
+
+            async def list_scheduled_tools(self, workspace: object) -> list:
+                """Return one tool identifying this selected channel."""
+                del workspace
+                return [
+                    SimpleNamespace(name=f"ScheduledSend:{self.channel_id}"),
+                ]
+
+            async def chat_kind(self, chat_id: str) -> object:
+                """Prove scheduled sessions never request chat context."""
+                raise AssertionError(chat_id)
+
+        class _Clients:
+            """Record schedule-specific client resolution."""
+
+            def __init__(self) -> None:
+                self.requests: list[tuple[str, str]] = []
+                self.current = True
+
+            async def get_scheduled(
+                self,
+                channel_id: str,
+                owner_id: str,
+            ) -> _Channel:
+                """Return a client while recording channel and owner."""
+                self.requests.append((channel_id, owner_id))
+                return _Channel(channel_id)
+
+            async def is_scheduled_current(
+                self,
+                channel_id: str,
+                owner_id: str,
+                channel: _Channel,
+            ) -> bool:
+                """Return the test-controlled final record check."""
+                return (
+                    self.current
+                    and channel.channel_id == channel_id
+                    and owner_id == user_id
+                )
+
+        clients = _Clients()
+        toolkit_kwargs: dict = {}
+        prompts: list[str] = []
+
+        class _Agent:
+            """Capture the system prompt and finish without events."""
+
+            def __init__(
+                self,
+                *,
+                system_prompt: str,
+                state: object,
+                **_: object,
+            ) -> None:
+                prompts.append(system_prompt)
+                self.state = state
+
+            async def reply_stream(
+                self,
+                inputs: object,
+            ) -> AsyncGenerator[object, None]:
+                """Complete without emitting reply events."""
+                del inputs
+                if False:
+                    yield object()
+
+        async def _get_toolkit(**kwargs: object) -> object:
+            toolkit_kwargs.update(kwargs)
+            return object()
+
+        async def _get_model(*_: object, **__: object) -> object:
+            return object()
+
+        class _Access:
+            async def resolve_agent(self, *_: object) -> AgentRecord:
+                """Return the schedule's agent."""
+                return agent.model_copy(deep=True)
+
+        service = ChatService(
+            storage=storage,
+            workspace_manager=_WorkspaceManager(),
+            scheduler_manager=object(),
+            background_task_manager=object(),
+            message_bus=InMemoryMessageBus(),
+            resource_access_service=_Access(),
+            custom_agent_cls=_Agent,
+            channel_clients=clients,  # type: ignore[arg-type]
+        )
+        with (
+            patch(
+                "agentscope.app._service._chat.get_toolkit",
+                new=_get_toolkit,
+            ),
+            patch("agentscope.app._service._chat.get_model", new=_get_model),
+        ):
+            await service._run_impl(user_id, session.id, agent.id, None)
+
+        self.assertEqual(storage.get_schedule_calls, 2)
+        self.assertEqual(clients.requests, [("channel-1", user_id)])
+        self.assertEqual(
+            [tool.name for tool in toolkit_kwargs["channel_tools"]],
+            ["ScheduledSend:channel-1"],
+        )
+        self.assertNotIn("bound to a chat", prompts[0])
+        self.assertEqual(
+            session.origin.model_dump(),
+            {"type": "schedule", "schedule_id": "schedule-1"},
+        )
+
+        # Stateful schedule sessions must follow later schedule edits.
+        schedule.data.channel_id = "channel-2"
+        with (
+            patch(
+                "agentscope.app._service._chat.get_toolkit",
+                new=_get_toolkit,
+            ),
+            patch("agentscope.app._service._chat.get_model", new=_get_model),
+        ):
+            await service._run_impl(user_id, session.id, agent.id, None)
+
+        self.assertEqual(storage.get_schedule_calls, 4)
+        self.assertEqual(
+            clients.requests,
+            [("channel-1", user_id), ("channel-2", user_id)],
+        )
+        self.assertEqual(
+            [tool.name for tool in toolkit_kwargs["channel_tools"]],
+            ["ScheduledSend:channel-2"],
+        )
+
+        # A channel record/version change during assembly removes the tools.
+        clients.current = False
+        with (
+            patch(
+                "agentscope.app._service._chat.get_toolkit",
+                new=_get_toolkit,
+            ),
+            patch("agentscope.app._service._chat.get_model", new=_get_model),
+        ):
+            await service._run_impl(user_id, session.id, agent.id, None)
+
+        self.assertEqual(storage.get_schedule_calls, 6)
+        self.assertEqual(toolkit_kwargs["channel_tools"], [])
+        clients.current = True
+
+        # Deleting the schedule removes only its optional channel tools.
+        storage.schedules.clear()
+        with (
+            patch(
+                "agentscope.app._service._chat.get_toolkit",
+                new=_get_toolkit,
+            ),
+            patch("agentscope.app._service._chat.get_model", new=_get_model),
+        ):
+            await service._run_impl(user_id, session.id, agent.id, None)
+
+        self.assertEqual(storage.get_schedule_calls, 7)
+        self.assertEqual(toolkit_kwargs["channel_tools"], [])
+
+        # A concurrent edit between the two reads fails closed for this run.
+        schedule.data.channel_id = "channel-3"
+        storage.schedules[schedule.id] = schedule
+
+        def _change_after_first_read(read_count: int) -> None:
+            if read_count == 8:
+                schedule.data.channel_id = "channel-4"
+
+        storage.after_schedule_read = _change_after_first_read
+        with (
+            patch(
+                "agentscope.app._service._chat.get_toolkit",
+                new=_get_toolkit,
+            ),
+            patch("agentscope.app._service._chat.get_model", new=_get_model),
+        ):
+            await service._run_impl(user_id, session.id, agent.id, None)
+
+        self.assertEqual(storage.get_schedule_calls, 9)
+        self.assertEqual(clients.requests[-1], ("channel-3", user_id))
+        self.assertEqual(toolkit_kwargs["channel_tools"], [])

--- a/tests/service_scheduler_test.py
+++ b/tests/service_scheduler_test.py
@@ -85,6 +85,7 @@ def _make_record(
     enabled: bool = True,
     stateful: bool = False,
     description: str = "run nightly summary",
+    channel_id: str | None = None,
 ) -> ScheduleRecord:
     """Build a minimal :class:`ScheduleRecord` for the trigger test."""
     return ScheduleRecord(
@@ -104,6 +105,7 @@ def _make_record(
             ),
             stateful=stateful,
             permission_mode=PermissionMode.DONT_ASK,
+            channel_id=channel_id,
         ),
     )
 
@@ -138,7 +140,10 @@ class TestSchedulerFireDelivery(_SchedulerFireTestBase):
     async def test_fire_pushes_hint_and_wakeup(self) -> None:
         """A fire creates a session, pushes the wrapped HintBlock to its
         inbox, and enqueues one wakeup pointing at that session."""
-        record = _make_record(description="please summarise the news")
+        record = _make_record(
+            description="please summarise the news",
+            channel_id="channel-1",
+        )
         trigger = self.manager._build_trigger(record)
         await trigger()
 


### PR DESCRIPTION
## AgentScope Version

2.0.6

## Description

Closes #2250.

This PR implements option 1 from the issue: a scheduled session remains owned by Agent Service, while an explicitly selected channel contributes proactive tools. It does not bind the schedule to an existing platform conversation or automatically forward the agent reply to a chat.

### What changed

- Add an optional, nullable `channel_id` to schedule storage and create/update APIs. Existing schedule data remains valid without a migration, omission preserves the current value, and explicit `null` clears it.
- Validate that a selected channel exists, belongs to the schedule owner, and explicitly supports scheduled tools. Unsupported or unregistered channel types cannot be persisted through the API.
- Expose `supports_scheduled_tools` in channel responses and add a Web UI selector that only lists capable channels. Disabled capable channels remain selectable and are labelled as disabled.
- Resolve the current schedule-to-channel association whenever a scheduled run is assembled. Stateful sessions therefore follow later schedule updates and lose the optional tools when the schedule is disabled or deleted.
- Use the upstream `ChannelClients` architecture: scheduled runs borrow an unconnected REST-only client, including for a disabled selected channel, without starting or re-enabling its inbound listener. The dedicated channel worker and lifecycle dispatcher remain unchanged.
- Revalidate schedule enabled/owner/selection state and channel owner/type/capability/version/client identity around tool assembly. Missing, deleted, stale, unsupported, cross-owner, rotated, and transiently unavailable records fail closed for that run without crashing normal schedule execution.
- Keep schedule provenance as `SessionSource.SCHEDULE` with `source_schedule_id`; no synthetic `source_channel_id` or `source_chat_id` is written, so scheduled runs receive no conversation-bound prompt or automatic reply delivery.

### Permission and security boundary

Selecting a channel is an explicit, schedule-scoped authorization for the adapter's scheduled-tool whitelist. Feishu currently exposes only:

- `ListChats`
- `ListChatMembers`
- `SendMessage`

Normal Feishu tools keep their existing confirmation behavior. Under the default scheduled `dont_ask` mode, the schedule-specific `SendMessage` can run unattended, while explicit `DENY` or `ASK` rules still take precedence. `SendFile` and `SendImage` are intentionally excluded because they can read workspace content and send it externally.

### Verification

- `MEM0_DIR=/private/tmp/agentscope-pr-2299-mem0 PYTHONPATH=src .venv/bin/python -m pytest tests -q`: 2015 passed, 125 skipped, 377 subtests passed
- Focused channel-client/worker, delivery, chat, schedule, router, toolkit, race, and permission tests: 80 passed
- `pre-commit run --all-files`: all hooks passed, including mypy, black, flake8, pylint, and Pyroma
- Frontend `npm run lint`: 0 errors (21 existing warnings in unrelated files)
- Frontend `npm run build`: passed
- `git diff --check`: passed

No live Feishu or DingTalk credentials were used; platform REST readiness, permission, ownership, version, update/delete race, and worker/client separation are covered with local tests.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated in the documentation repository (N/A for this repository-only integration; API descriptions and English/Chinese UI copy are included here)
- [x] Code is ready for review
