### PR TITLE
fix(mcp): detect SSE transport by URL path so query strings work

### DIFF
--- a/src/agentscope/mcp/_mcp_client.py
+++ b/src/agentscope/mcp/_mcp_client.py
@@ -3,6 +3,7 @@
 import re
 from contextlib import AsyncExitStack, _AsyncGeneratorContextManager
 from typing import Any, TYPE_CHECKING
+from urllib.parse import urlsplit
 
 import httpx
 import mcp.types
@@ -192,8 +193,14 @@ class MCPClient(BaseModel):
         """Create an HTTP MCP client (SSE or streamable HTTP)."""
         config = self.mcp_config
 
-        # Determine transport from URL
-        if config.url.endswith("/sse") or config.url.endswith("/messages/"):
+        # Determine transport from the URL *path* only. Inspecting the full
+        # URL with endswith would misdetect SSE endpoints whose URL carries
+        # a query string (e.g. https://mcp.amap.com/sse?key=API_KEY): such
+        # URLs no longer end with '/sse' and would fall through to the
+        # streamable HTTP transport, which then fails to handshake against
+        # an SSE server with 'Session terminated'.
+        path = urlsplit(config.url).path
+        if path.endswith("/sse") or path.endswith("/messages/"):
             return sse_client(
                 url=config.url,
                 headers=config.headers,

--- a/tests/mcp_sse_client_test.py
+++ b/tests/mcp_sse_client_test.py
@@ -279,6 +279,36 @@ class SseMCPClientTest(IsolatedAsyncioTestCase):
         await stateful_client.close()
         self.assertFalse(stateful_client.is_connected)
 
+    async def test_stateless_client_with_query_string_in_url(self) -> None:
+        """An SSE URL carrying a query string must still be detected as SSE.
+
+        Regression test: ``_create_http_client`` used to detect the transport
+        with ``url.endswith('/sse')``, which fails for URLs that carry a query
+        string such as ``http://host:port/sse?key=API_KEY`` (a very common
+        shape for key-based SSE MCP servers, e.g. the Amap MCP at
+        https://mcp.amap.com/sse?key=API_KEY). Such URLs were misdetected as
+        streamable HTTP, and the client then failed to handshake against the
+        SSE server with ``McpError: Session terminated``.
+
+        After the fix, only the URL path is inspected, so the query string no
+        longer affects transport detection.
+        """
+        client = MCPClient(
+            name="test_sse_query_client",
+            is_stateful=False,
+            mcp_config=HttpMCPConfig(
+                type="http_mcp",
+                url=f"http://127.0.0.1:{self.port}/sse?key=API_KEY",
+            ),
+        )
+
+        mcp_tool_1 = await client.get_tool("tool_1")
+        res: ToolChunk = await mcp_tool_1(arg1="123", arg2=[1, 2, 3])
+        self.assertEqual(
+            res.content[0].text,
+            "arg1: 123, arg2: [1, 2, 3]",
+        )
+
 
 class SseSchemaDefsPreservationTest(IsolatedAsyncioTestCase):
     """End-to-end tests for $defs preservation in MCP tool schemas.


### PR DESCRIPTION
## Problem

SSE MCP servers whose URL carries a query string fail to connect.
`MCPClient.list_tools()` / `get_tool()` raise:

```
mcp.shared.exceptions.McpError: Session terminated
```

and when the client is registered in a `Toolkit`:

```
WARNING - Skipping MCP '<name>' in group 'basic': listing its tools failed with Session terminated
```

This is a very common shape for key-based SSE MCP servers — e.g. the official Amap (高德地图) MCP at `https://mcp.amap.com/sse?key=API_KEY`.

## Root cause

`_create_http_client` detects the transport with `url.endswith('/sse')`. An SSE URL with a query string ends with `?key=...`, not `/sse`, so the check is `False` and the client wrongly falls through to `streamable_http_client`, which cannot handshake against an SSE server.

## Fix

Inspect only the URL **path** via `urlsplit` (which strips the query and fragment) instead of the full URL. Behaviour is unchanged for existing URLs without a query/fragment.

```python
path = urlsplit(config.url).path
if path.endswith("/sse") or path.endswith("/messages/"):
    return sse_client(...)
```

## Test

Added `test_stateless_client_with_query_string_in_url` in `tests/mcp_sse_client_test.py`. It connects to the existing local FastMCP SSE server through `http://127.0.0.1:<port>/sse?key=API_KEY` — fails with `Session terminated` before the fix, passes after.

The transport-selection logic was also verified directly for:

- `.../sse`, `.../sse?key=...`, `.../sse#frag`, `.../mcp_server/sse?k=v`, `.../messages/?s=1` -> `sse`
- `.../mcp`, `.../mcp?session_id=abc` -> `streamable_http`

## Related issue

<!-- Please link the corresponding issue here, e.g. Closes #XXXX -->
