### PR TITLE
fix(model): fixing MoonshotChatModel streaming usage

### DIFF
--- a/src/agentscope/model/_moonshot/_model.py
+++ b/src/agentscope/model/_moonshot/_model.py
@@ -281,6 +281,14 @@ class MoonshotChatModel(ChatModelBase):
                     )
 
                 if not chunk.choices:
+                    # MoonShot emits a trailing usage-only chunk with no
+                    # choices; forward it as an empty-content delta so the
+                    # base class ``__call__`` can absorb ``usage`` into
+                    # ``acc_res``. The empty delta itself is filtered out
+                    # of the surfaced stream by ``_stream``.
+                    if usage is not None:
+                        delta_res.usage = usage
+                        yield delta_res
                     continue
 
                 choice = chunk.choices[0]


### PR DESCRIPTION
MoonShotChatModel not yield usage as deepseek or openai models do. This should be fixed by using the same method in deepseek varient, so usage track will be correct when using MoonshotChatModel.
### Background / Description

line in 283 src/agentscope/model/_moonshot/_model.py :
```
                if not chunk.choices:
                    continue
```
but in src/agentscope/model/_deepseek/_model.py line 275:
```
                if not chunk.choices:
                    # DeepSeek emits a trailing usage-only chunk with no
                    # choices; forward it as an empty-content delta so the
                    # base class ``__call__`` can absorb ``usage`` into
                    # ``acc_res``. The empty delta itself is filtered out
                    # of the surfaced stream by ``_stream``.
                    if usage is not None:
                        delta_res.usage = usage
                        yield delta_res
                    continue
```
which do not yield usage as the deepseek models do, which make tracking usage of moonshot model is not valid.
### Fix
add yield as the deepseek models do.