### PR TITLE
fix(tool): distinguish inactive tool groups from missing tools in check_tool_available

### DIFF
--- a/src/agentscope/tool/_toolkit.py
+++ b/src/agentscope/tool/_toolkit.py
@@ -571,18 +571,26 @@ class Toolkit:
         """
         tools = await self._get_available_tools(activated_groups)
         if tool_name not in tools:
+            # The dict above is already filtered to the basic + activated
+            # groups, so a tool from an inactive group is missing from it.
+            # Look the name up across all registered groups to distinguish
+            # "inactive" from "doesn't exist" - the same fallback call_tool
+            # performs - so the agent gets the activation hint instead of a
+            # misleading not-found error.
+            all_tools = await self._get_available_tools(
+                [_.name for _ in self.tool_groups],
+            )
+            if tool_name in all_tools:
+                raise ToolGroupInactiveError(
+                    f"ToolGroupInactiveError: The tool '{tool_name}' in "
+                    f"group '{all_tools[tool_name].group}' is currently "
+                    f"inactive. You should first activate the group by "
+                    f"calling the "
+                    f"'{self.builtin_meta_tool.tool.name}' tool.",
+                )
             raise ToolNotFoundError(
                 f"ToolNotFoundError: The tool named '{tool_name}' doesn't "
                 f"exist.",
-            )
-
-        group_name = tools[tool_name].group
-        if group_name != "basic" and group_name not in activated_groups:
-            raise ToolGroupInactiveError(
-                f"ToolGroupInactiveError: The tool '{tool_name}' in group "
-                f"'{group_name}' is currently inactive. "
-                f"You should first activate the group by calling the "
-                f"'{self.builtin_meta_tool.tool.name}' tool.",
             )
 
         return tools[tool_name].tool

--- a/tests/toolkit_test.py
+++ b/tests/toolkit_test.py
@@ -30,6 +30,10 @@ from agentscope.permission import (
     PermissionDecision,
     PermissionBehavior,
 )
+from agentscope.exception import (
+    ToolNotFoundError,
+    ToolGroupInactiveError,
+)
 
 
 class Tool1(ToolBase):
@@ -1387,6 +1391,40 @@ The tool instructions are a collection of suggestions, rules and notifications a
         )
 
         self.assertEqual(await toolkit.get_tool_schemas(), [])
+
+    async def test_check_tool_available_distinguishes_inactive_group(
+        self,
+    ) -> None:
+        """A tool in an inactive group raises ToolGroupInactiveError with
+        the activation hint (matching call_tool), while an unregistered
+        name still raises ToolNotFoundError."""
+        toolkit = Toolkit(
+            tool_groups=[
+                ToolGroup(
+                    name="group_1",
+                    description="Group 1",
+                    tools=[Tool1()],
+                ),
+            ],
+        )
+
+        # Inactive group -> the agent-facing check names the group and
+        # the meta tool, instead of claiming the tool doesn't exist.
+        with self.assertRaises(ToolGroupInactiveError) as ctx:
+            await toolkit.check_tool_available("tool_1", [])
+        self.assertIn("group_1", str(ctx.exception))
+        self.assertIn(
+            toolkit.builtin_meta_tool.tool.name,
+            str(ctx.exception),
+        )
+
+        # Activated group -> resolves normally.
+        tool = await toolkit.check_tool_available("tool_1", ["group_1"])
+        self.assertEqual(tool.name, "tool_1")
+
+        # Unregistered name -> still not found.
+        with self.assertRaises(ToolNotFoundError):
+            await toolkit.check_tool_available("no_such_tool", [])
 
 
 class RemoveTitleFieldTest(TestCase):


### PR DESCRIPTION
## Description

`Toolkit` has two lookup paths that disagree about a tool registered in an **inactive** tool group:

- `Toolkit.call_tool` distinguishes correctly: after missing the activated groups it falls back to the union of **all** registered groups and yields `ToolGroupInactiveError` with the "activate the group by calling 'reset_tools'" hint.
- `Toolkit.check_tool_available` — the path the agent actually takes (`Agent._execute_tool_call`, step 1) — builds its dict from `_get_available_tools(activated_groups)`, i.e. already filtered to basic + activated groups. A tool in an inactive group is missing from that dict, so it raises `ToolNotFoundError: The tool named '...' doesn't exist.` before the group question is ever asked. The `ToolGroupInactiveError` branch below the lookup is unreachable.

Since the agent calls `check_tool_available` first, the model never sees the corrective hint — it gets "doesn't exist" for a tool that exists. This matters most for smaller models that call a grouped tool directly instead of activating the group first: with the hint they recover (activate + retry), with "doesn't exist" they retry the same call until a stall guard kills the run. We hit exactly this in production: the same scheduled job succeeded on a model that called `reset_tools` first and died (3x "doesn't exist", early stop) on a smaller model that didn't.

Minimal repro on 2.0.6:

```python
tk = Toolkit(tool_groups=[ToolGroup(name="g", description="...", tools=[FunctionTool(web_search)])])
await tk.check_tool_available("web_search", activated_groups=[])
# ToolNotFoundError: The tool named 'web_search' doesn't exist.
# call_tool for the same state yields:
# ToolGroupInactiveError: ... You should first activate the group by calling the 'reset_tools' tool.
```

## Change

Mirror `call_tool`'s fallback inside `check_tool_available`: on a miss, look the name up across all registered groups; if found, raise `ToolGroupInactiveError` (existing exception, existing message shape); otherwise raise `ToolNotFoundError` as before. The previously unreachable inactive-group branch after the lookup is removed. `call_tool` behaviour is unchanged.

## Tests

Added `ToolGroupTest.test_check_tool_available_distinguishes_inactive_group`:
- tool in an inactive group -> `ToolGroupInactiveError` naming the group and the meta tool,
- same tool with the group activated -> resolves normally,
- unregistered name -> still `ToolNotFoundError`.

`pytest tests/toolkit_test.py tests/toolkit_skill_test.py tests/toolkit_task_test.py`: 44 passed. `pre-commit run` on the changed files: all hooks pass.

## Disclosure

This fix was developed with substantial AI assistance (Anthropic Claude): the AI diagnosed the issue in our production system, wrote the patch and the test under human direction, and a human reviewed the change before submission.

## Checklist

- [x] Code follows the project style (pre-commit passes)
- [x] Tests added and passing
- [x] No behaviour change outside the described fix