### PR TITLE
fix(model): propagate max-token termination reasons

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -792,8 +792,24 @@ class Agent:
         self,
         finished_reason: FinishedReason,
         metadata: dict[str, Any],
+        model_response_start: int,
     ) -> tuple[list[AgentEvent], ReplyEndEvent | None, Msg | None]:
-        """Build the reply outcome for a terminal model response."""
+        """Build the reply outcome for a terminal model response.
+
+        Args:
+            finished_reason (`FinishedReason`):
+                The normalized model termination reason.
+            metadata (`dict[str, Any]`):
+                Metadata propagated from the model response.
+            model_response_start (`int`):
+                The index where the current model response begins in the
+                accumulated reply context.
+
+        Returns:
+            `tuple[list[AgentEvent], ReplyEndEvent | None, Msg | None]`:
+                Synthetic terminal events, the reply-end event, and the
+                terminal message when one is required.
+        """
         if finished_reason == FinishedReason.COMPLETED:
             return [], None, None
 
@@ -815,7 +831,7 @@ class Agent:
                 id=self.state.reply_id,
                 name=self.name,
                 content=(
-                    deepcopy(last_ctx.content)
+                    deepcopy(last_ctx.content[model_response_start:])
                     if last_ctx is not None
                     else _MAX_TOKENS_HINT
                 ),
@@ -994,6 +1010,15 @@ class Agent:
                         async for evt in self._inject_runtime_state():
                             yield evt
 
+                        last_ctx_before_reasoning = self._get_last_msg()
+                        model_response_start = (
+                            len(last_ctx_before_reasoning.content)
+                            if last_ctx_before_reasoning is not None
+                            and last_ctx_before_reasoning.id
+                            == self.state.reply_id
+                            else 0
+                        )
+
                         # Perform reasoning
                         model_finished_reason = FinishedReason.COMPLETED
                         model_finished_metadata: dict[str, Any] = {}
@@ -1023,6 +1048,7 @@ class Agent:
                         ) = await self._handle_model_termination(
                             model_finished_reason,
                             model_finished_metadata,
+                            model_response_start,
                         )
                         for termination_event in termination_events:
                             yield termination_event

--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -107,6 +107,15 @@ if TYPE_CHECKING:
 else:
     MiddlewareBase = Any
 
+_MAX_TOKENS_HINT = (
+    "The model response was truncated because it reached the maximum output "
+    "token limit. Increase max_tokens or ask the model to continue."
+)
+_MAX_TOKENS_TOOL_RESULT = (
+    "<system-reminder>The model reached its maximum output token limit before "
+    "the tool call completed. The tool was not executed.</system-reminder>"
+)
+
 
 class Agent:
     """The agent class."""
@@ -693,12 +702,21 @@ class Agent:
 
     async def _close_unfinished_tool_calls(
         self,
+        message: str | None = None,
+        result_state: ToolResultState = ToolResultState.INTERRUPTED,
     ) -> AsyncGenerator[
         ToolResultStartEvent | ToolResultTextDeltaEvent | ToolResultEndEvent,
         None,
     ]:
-        """Close the unfinished tool calls on interruption, so the next
-        input will be handled normally."""
+        """Close unfinished tool calls with a synthetic terminal result.
+
+        Args:
+            message (`str | None`, defaults to `None`):
+                The synthetic tool result message. Defaults to the user
+                interruption message.
+            result_state (`ToolResultState`, defaults to `INTERRUPTED`):
+                The terminal state assigned to the synthetic tool result.
+        """
         if not self.state.context:
             return
 
@@ -715,7 +733,7 @@ class Agent:
             elif isinstance(block, ToolResultBlock):
                 awaiting_tool_calls.pop(block.id, None)
 
-        interruption_message = (
+        message = message or (
             "<system-reminder>The tool call has been interrupted by "
             "the user.</system-reminder>"
         )
@@ -740,21 +758,70 @@ class Agent:
             yield ToolResultTextDeltaEvent(
                 reply_id=self.state.reply_id,
                 tool_call_id=last_msg.content[index].id,
-                delta=interruption_message,
+                delta=message,
             )
             yield ToolResultEndEvent(
                 reply_id=self.state.reply_id,
                 tool_call_id=last_msg.content[index].id,
-                state=ToolResultState.INTERRUPTED,
+                state=result_state,
             )
             last_msg.content.append(
                 ToolResultBlock(
                     id=last_msg.content[index].id,
                     name=last_msg.content[index].name,
-                    output=interruption_message,
-                    state=ToolResultState.INTERRUPTED,
+                    output=message,
+                    state=result_state,
                 ),
             )
+
+    async def _handle_model_termination(
+        self,
+        finished_reason: FinishedReason,
+        metadata: dict[str, Any],
+    ) -> tuple[list[AgentEvent], ReplyEndEvent | None, Msg | None]:
+        """Build the reply outcome for a terminal model response."""
+        if finished_reason == FinishedReason.COMPLETED:
+            return [], None, None
+
+        terminal_events: list[AgentEvent] = []
+        terminal_msg: Msg | None = None
+        reply_reason = ReplyFinishedReason(finished_reason.value)
+
+        if finished_reason == FinishedReason.MAX_TOKENS:
+            terminal_events = [
+                evt
+                async for evt in self._close_unfinished_tool_calls(
+                    message=_MAX_TOKENS_TOOL_RESULT,
+                    result_state=ToolResultState.ERROR,
+                )
+            ]
+
+            last_ctx = self._get_last_msg()
+            terminal_msg = AssistantMsg(
+                id=self.state.reply_id,
+                name=self.name,
+                content=(
+                    deepcopy(last_ctx.content)
+                    if last_ctx is not None
+                    else _MAX_TOKENS_HINT
+                ),
+                usage=(
+                    deepcopy(last_ctx.usage) if last_ctx is not None else None
+                ),
+                metadata=metadata,
+                finished_reason=ReplyFinishedReason.MAX_TOKENS,
+            )
+
+        return (
+            terminal_events,
+            ReplyEndEvent(
+                session_id=self.state.session_id,
+                reply_id=self.state.reply_id,
+                finished_reason=reply_reason,
+                metadata=metadata,
+            ),
+            terminal_msg,
+        )
 
     async def _reply_impl(
         self,
@@ -769,6 +836,7 @@ class Agent:
         """Core reply logic."""
 
         end_event: ReplyEndEvent | None = None
+        terminal_msg: Msg | None = None
         try:
             # Dispatch the unified inputs by type into the legacy local
             # variables
@@ -887,7 +955,8 @@ class Agent:
                             yield evt
 
                         # Perform reasoning
-                        interrupted = False
+                        model_finished_reason = FinishedReason.COMPLETED
+                        model_finished_metadata: dict[str, Any] = {}
                         async for evt in self._reasoning(
                             tool_choice=tool_choice,
                         ):
@@ -898,21 +967,26 @@ class Agent:
                                 continue
 
                             if isinstance(evt, ModelCallEndEvent):
-                                interrupted = (
-                                    evt.finished_reason
-                                    == FinishedReason.INTERRUPTED
+                                model_finished_reason = FinishedReason(
+                                    evt.finished_reason,
+                                )
+                                model_finished_metadata = deepcopy(
+                                    evt.metadata,
                                 )
 
                             yield evt
 
-                        if interrupted:
-                            end_event = ReplyEndEvent(
-                                session_id=self.state.session_id,
-                                reply_id=self.state.reply_id,
-                                finished_reason=(
-                                    ReplyFinishedReason.INTERRUPTED
-                                ),
-                            )
+                        (
+                            termination_events,
+                            end_event,
+                            terminal_msg,
+                        ) = await self._handle_model_termination(
+                            model_finished_reason,
+                            model_finished_metadata,
+                        )
+                        for termination_event in termination_events:
+                            yield termination_event
+                        if end_event is not None:
                             return
 
                     case Acting(tool_calls=tool_calls):
@@ -1002,14 +1076,13 @@ class Agent:
 
                 yield end_event
 
-                if interrupted_end:
-                    # The fallback msg goes last: Msg terminates the stream
-                    yield AssistantMsg(
-                        id=self.state.reply_id,
-                        name=self.name,
-                        content=self.react_config.interruption_message,
-                        finished_reason=ReplyFinishedReason.INTERRUPTED,
-                    )
+                # The fallback msg goes last: Msg terminates the stream.
+                yield terminal_msg or AssistantMsg(
+                    id=self.state.reply_id,
+                    name=self.name,
+                    content=self.react_config.interruption_message,
+                    finished_reason=ReplyFinishedReason.INTERRUPTED,
+                )
 
     async def _inject_runtime_state(
         self,
@@ -1421,12 +1494,27 @@ class Agent:
             if completed_response.usage
             else 0,
             finished_reason=completed_response.finished_reason,
+            metadata=deepcopy(completed_response.metadata),
         )
 
         self._save_to_context(
             list(completed_response.content),
             completed_response.usage,
         )
+
+        if completed_response.finished_reason == FinishedReason.MAX_TOKENS:
+            hint = HintBlock(
+                source="system",
+                hint=_MAX_TOKENS_HINT,
+            )
+            self.state.append_context(self.name, [hint])
+            yield HintBlockEvent(
+                reply_id=self.state.reply_id,
+                block_id=hint.id,
+                source=hint.source,
+                hint=hint.hint,
+            )
+            return
 
         # A thinking-only response is an intermediate reasoning step rather
         # than a user-visible final answer. Keep the ReAct loop running so the

--- a/src/agentscope/console/_renderer.py
+++ b/src/agentscope/console/_renderer.py
@@ -422,4 +422,12 @@ class ConsoleRenderer:
             self.console.print(
                 Text("⚠ Reply interrupted by the user.", style="yellow"),
             )
+        elif event.finished_reason == ReplyFinishedReason.MAX_TOKENS:
+            self.console.print(
+                Text(
+                    "⚠ Reply truncated because the model reached its "
+                    "maximum output token limit.",
+                    style="yellow",
+                ),
+            )
         self._debug_line(f"reply end · {event.finished_reason}")

--- a/src/agentscope/event/_event.py
+++ b/src/agentscope/event/_event.py
@@ -107,6 +107,7 @@ class ReplyEndReason(StrEnum):
     COMPLETED = "completed"
     INTERRUPTED = "interrupted"
     EXCEED_MAX_ITERS = "exceed_max_iters"
+    MAX_TOKENS = "max_tokens"
 
 
 class ReplyEndEvent(EventBase):

--- a/src/agentscope/message/_base.py
+++ b/src/agentscope/message/_base.py
@@ -101,7 +101,7 @@ class Msg(BaseModel):
     finished_at: str | None = Field(default=None)
     """The finished time of the message"""
     finished_reason: ReplyFinishedReason | None = Field(default=None)
-    """Terminal reason of this reply (error / interrupted /
+    """Terminal reason of this reply (error / interrupted / max_tokens /
     exceed_max_iters). ``None`` until a ``REPLY_END`` event is applied."""
     structured_output: dict | None = Field(default=None)
     """The structured output of the reply. Populated only when a structured

--- a/src/agentscope/model/_anthropic/_model.py
+++ b/src/agentscope/model/_anthropic/_model.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse, StructuredResponse
 from .._model_usage import ChatUsage
+from .._utils import _parse_provider_finished_reason
 from ..._utils._common import _generate_id
 from ...credential import AnthropicCredential
 from ...formatter import FormatterBase, AnthropicChatFormatter
@@ -293,6 +294,10 @@ class AnthropicChatModel(ChatModelBase):
                 the extracted content blocks and usage.
         """
         content_blocks: List[ThinkingBlock | TextBlock | ToolCallBlock] = []
+        finished_reason, reason_metadata = _parse_provider_finished_reason(
+            getattr(response, "stop_reason", None),
+            {"max_tokens"},
+        )
 
         if hasattr(response, "content") and response.content:
             for content_block in response.content:
@@ -374,6 +379,8 @@ class AnthropicChatModel(ChatModelBase):
             "content": content_blocks,
             "is_last": True,
             "usage": usage,
+            "finished_reason": finished_reason,
+            "metadata": reason_metadata,
         }
         response_id = getattr(response, "id", None)
         if response_id:
@@ -502,7 +509,21 @@ class AnthropicChatModel(ChatModelBase):
                 if event.usage and usage:
                     usage.output_tokens = event.usage.output_tokens
 
-            if delta_res.content:
+                (
+                    finished_reason,
+                    reason_metadata,
+                ) = _parse_provider_finished_reason(
+                    getattr(event.delta, "stop_reason", None),
+                    {"max_tokens"},
+                )
+                delta_res.finished_reason = finished_reason
+                delta_res.metadata.update(reason_metadata)
+
+            if (
+                delta_res.content
+                or delta_res.metadata
+                or (event.type == "message_delta" and usage)
+            ):
                 delta_res.usage = usage
                 yield delta_res
 

--- a/src/agentscope/model/_dashscope/_model.py
+++ b/src/agentscope/model/_dashscope/_model.py
@@ -13,6 +13,7 @@ from ..._utils._common import _generate_id
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse, StructuredResponse
 from .._model_usage import ChatUsage
+from .._utils import _parse_provider_finished_reason
 from ...credential import DashScopeCredential
 from ...formatter import FormatterBase, DashScopeChatFormatter
 from ...message import (
@@ -330,6 +331,15 @@ class DashScopeChatModel(ChatModelBase):
                     continue
 
                 choice = chunk.choices[0]
+                (
+                    finished_reason,
+                    reason_metadata,
+                ) = _parse_provider_finished_reason(
+                    getattr(choice, "finish_reason", None),
+                    {"length"},
+                )
+                delta_res.finished_reason = finished_reason
+                delta_res.metadata.update(reason_metadata)
                 delta = choice.delta
 
                 # Thinking
@@ -395,7 +405,7 @@ class DashScopeChatModel(ChatModelBase):
                             media_type="audio/wav",
                         )
 
-                if delta_res.content or usage:
+                if delta_res.content or usage or reason_metadata:
                     delta_res.usage = usage
                     yield delta_res
 
@@ -418,9 +428,17 @@ class DashScopeChatModel(ChatModelBase):
                 A single ``ChatResponse`` with ``is_last=True``.
         """
         content_blocks: List[TextBlock | ToolCallBlock | ThinkingBlock] = []
+        finished_reason, reason_metadata = _parse_provider_finished_reason(
+            None,
+            {"length"},
+        )
 
         if response.choices:
             choice = response.choices[0]
+            finished_reason, reason_metadata = _parse_provider_finished_reason(
+                getattr(choice, "finish_reason", None),
+                {"length"},
+            )
             reasoning = getattr(choice.message, "reasoning_content", None)
             if isinstance(reasoning, str) and reasoning:
                 content_blocks.append(ThinkingBlock(thinking=reasoning))
@@ -456,6 +474,8 @@ class DashScopeChatModel(ChatModelBase):
             "content": content_blocks,
             "is_last": True,
             "usage": usage,
+            "finished_reason": finished_reason,
+            "metadata": reason_metadata,
         }
         response_id = getattr(response, "id", None)
         if response_id:

--- a/src/agentscope/model/_deepseek/_model.py
+++ b/src/agentscope/model/_deepseek/_model.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse, StructuredResponse
 from .._model_usage import ChatUsage
+from .._utils import _parse_provider_finished_reason
 from ..._utils._common import _generate_id
 from ...credential import DeepSeekCredential
 from ...formatter import FormatterBase, DeepSeekChatFormatter
@@ -284,6 +285,15 @@ class DeepSeekChatModel(ChatModelBase):
                     continue
 
                 choice = chunk.choices[0]
+                (
+                    finished_reason,
+                    reason_metadata,
+                ) = _parse_provider_finished_reason(
+                    getattr(choice, "finish_reason", None),
+                    {"length"},
+                )
+                delta_res.finished_reason = finished_reason
+                delta_res.metadata.update(reason_metadata)
                 delta = choice.delta
 
                 # Thinking block
@@ -323,7 +333,7 @@ class DeepSeekChatModel(ChatModelBase):
                         input=delta_args or "",
                     )
 
-                if delta_res.content or usage:
+                if delta_res.content or usage or reason_metadata:
                     delta_res.usage = usage
                     yield delta_res
 
@@ -345,9 +355,17 @@ class DeepSeekChatModel(ChatModelBase):
                 A single ``ChatResponse`` with ``is_last=True``.
         """
         content_blocks: List[TextBlock | ToolCallBlock | ThinkingBlock] = []
+        finished_reason, reason_metadata = _parse_provider_finished_reason(
+            None,
+            {"length"},
+        )
 
         if response.choices:
             choice = response.choices[0]
+            finished_reason, reason_metadata = _parse_provider_finished_reason(
+                getattr(choice, "finish_reason", None),
+                {"length"},
+            )
             reasoning = getattr(choice.message, "reasoning_content", None)
             if isinstance(reasoning, str) and reasoning:
                 content_blocks.append(ThinkingBlock(thinking=reasoning))
@@ -382,6 +400,8 @@ class DeepSeekChatModel(ChatModelBase):
             "content": content_blocks,
             "is_last": True,
             "usage": usage,
+            "finished_reason": finished_reason,
+            "metadata": reason_metadata,
         }
         response_id = getattr(response, "id", None)
         if response_id:

--- a/src/agentscope/model/_gemini/_model.py
+++ b/src/agentscope/model/_gemini/_model.py
@@ -11,6 +11,7 @@ from ..._utils._common import _generate_id, _flatten_json_schema
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse
 from .._model_usage import ChatUsage
+from .._utils import _parse_provider_finished_reason
 from ...credential import GeminiCredential
 from ...formatter import FormatterBase, GeminiChatFormatter
 from ...message import Msg, ThinkingBlock, ToolCallBlock, TextBlock
@@ -344,12 +345,16 @@ class GeminiChatModel(ChatModelBase):
             response_id = getattr(chunk, "response_id", None) or response_id
             delta_res.id = response_id
 
-            if (
-                chunk.candidates
-                and chunk.candidates[0].content
-                and chunk.candidates[0].content.parts
-            ):
-                for part in chunk.candidates[0].content.parts:
+            candidate = chunk.candidates[0] if chunk.candidates else None
+            finished_reason, reason_metadata = _parse_provider_finished_reason(
+                getattr(candidate, "finish_reason", None),
+                {"max_tokens"},
+            )
+            delta_res.finished_reason = finished_reason
+            delta_res.metadata.update(reason_metadata)
+
+            if candidate and candidate.content and candidate.content.parts:
+                for part in candidate.content.parts:
                     if part.text:
                         # Thinking
                         if part.thought:
@@ -385,7 +390,7 @@ class GeminiChatModel(ChatModelBase):
 
             usage = self._extract_usage(chunk.usage_metadata, start_datetime)
 
-            if delta_res.content or usage:
+            if delta_res.content or usage or reason_metadata:
                 delta_res.usage = usage
                 yield delta_res
 
@@ -407,13 +412,14 @@ class GeminiChatModel(ChatModelBase):
                 A single ``ChatResponse`` with ``is_last=True``.
         """
         content_blocks: List[TextBlock | ToolCallBlock | ThinkingBlock] = []
+        candidate = response.candidates[0] if response.candidates else None
+        finished_reason, reason_metadata = _parse_provider_finished_reason(
+            getattr(candidate, "finish_reason", None),
+            {"max_tokens"},
+        )
 
-        if (
-            response.candidates
-            and response.candidates[0].content
-            and response.candidates[0].content.parts
-        ):
-            for part in response.candidates[0].content.parts:
+        if candidate and candidate.content and candidate.content.parts:
+            for part in candidate.content.parts:
                 if part.text:
                     if part.thought:
                         content_blocks.append(
@@ -445,6 +451,8 @@ class GeminiChatModel(ChatModelBase):
             content=content_blocks,
             is_last=True,
             usage=usage,
+            finished_reason=finished_reason,
+            metadata=reason_metadata,
         )
 
     def _extract_usage(

--- a/src/agentscope/model/_model_response.py
+++ b/src/agentscope/model/_model_response.py
@@ -28,6 +28,9 @@ class FinishedReason(StrEnum):
     COMPLETED = "completed"
     """The model response is completed."""
 
+    MAX_TOKENS = "max_tokens"
+    """The model stopped because it reached its output token limit."""
+
 
 @dataclass
 class ChatResponse(DictMixin):
@@ -314,6 +317,12 @@ class ChatResponse(DictMixin):
         # Override the chat usage
         if chat_response.usage:
             self.usage = chat_response.usage
+
+        if chat_response.finished_reason != FinishedReason.COMPLETED:
+            self.finished_reason = chat_response.finished_reason
+
+        if chat_response.metadata:
+            self.metadata.update(chat_response.metadata)
 
         return self
 

--- a/src/agentscope/model/_moonshot/_model.py
+++ b/src/agentscope/model/_moonshot/_model.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse, StructuredResponse
 from .._model_usage import ChatUsage
+from .._utils import _parse_provider_finished_reason
 from ..._utils._common import _generate_id
 from ...credential import MoonshotCredential
 from ...formatter import FormatterBase, MoonshotChatFormatter
@@ -292,6 +293,15 @@ class MoonshotChatModel(ChatModelBase):
                     continue
 
                 choice = chunk.choices[0]
+                (
+                    finished_reason,
+                    reason_metadata,
+                ) = _parse_provider_finished_reason(
+                    getattr(choice, "finish_reason", None),
+                    {"length"},
+                )
+                delta_res.finished_reason = finished_reason
+                delta_res.metadata.update(reason_metadata)
                 delta = choice.delta
 
                 # Thinking
@@ -331,7 +341,7 @@ class MoonshotChatModel(ChatModelBase):
                         input=delta_args or "",
                     )
 
-                if delta_res.content or usage:
+                if delta_res.content or usage or reason_metadata:
                     delta_res.usage = usage
                     yield delta_res
 
@@ -353,9 +363,17 @@ class MoonshotChatModel(ChatModelBase):
                 A single ``ChatResponse`` with ``is_last=True``.
         """
         content_blocks: List[ThinkingBlock | TextBlock | ToolCallBlock] = []
+        finished_reason, reason_metadata = _parse_provider_finished_reason(
+            None,
+            {"length"},
+        )
 
         if response.choices:
             choice = response.choices[0]
+            finished_reason, reason_metadata = _parse_provider_finished_reason(
+                getattr(choice, "finish_reason", None),
+                {"length"},
+            )
             reasoning = getattr(choice.message, "reasoning_content", None)
             if reasoning:
                 content_blocks.append(ThinkingBlock(thinking=reasoning))
@@ -386,6 +404,8 @@ class MoonshotChatModel(ChatModelBase):
             "content": content_blocks,
             "is_last": True,
             "usage": usage,
+            "finished_reason": finished_reason,
+            "metadata": reason_metadata,
         }
         response_id = getattr(response, "id", None)
         if response_id:

--- a/src/agentscope/model/_ollama/_model.py
+++ b/src/agentscope/model/_ollama/_model.py
@@ -10,6 +10,7 @@ from ..._utils._common import _generate_id
 from .._base import ChatModelBase
 from .._model_response import ChatResponse
 from .._model_usage import ChatUsage
+from .._utils import _parse_provider_finished_reason
 from ...credential import OllamaCredential
 from ...formatter import FormatterBase, OllamaChatFormatter
 from ...message import Msg, ThinkingBlock, ToolCallBlock, TextBlock
@@ -255,6 +256,12 @@ class OllamaChatModel(ChatModelBase):
                 is_last=False,
                 id=response_id,
             )
+            finished_reason, reason_metadata = _parse_provider_finished_reason(
+                getattr(chunk, "done_reason", None),
+                {"length"},
+            )
+            delta_res.finished_reason = finished_reason
+            delta_res.metadata.update(reason_metadata)
 
             msg = chunk.message
 
@@ -310,6 +317,10 @@ class OllamaChatModel(ChatModelBase):
                 A single ``ChatResponse`` with ``is_last=True``.
         """
         content_blocks: List[TextBlock | ToolCallBlock | ThinkingBlock] = []
+        finished_reason, reason_metadata = _parse_provider_finished_reason(
+            getattr(response, "done_reason", None),
+            {"length"},
+        )
 
         message_thinking = getattr(response.message, "thinking", None)
         if message_thinking:
@@ -345,4 +356,6 @@ class OllamaChatModel(ChatModelBase):
             content=content_blocks,
             is_last=True,
             usage=usage,
+            finished_reason=finished_reason,
+            metadata=reason_metadata,
         )

--- a/src/agentscope/model/_openai_chat/_model.py
+++ b/src/agentscope/model/_openai_chat/_model.py
@@ -13,6 +13,7 @@ from ..._utils._common import _generate_id, _flatten_json_schema
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse, StructuredResponse
 from .._model_usage import ChatUsage
+from .._utils import _parse_provider_finished_reason
 from ...credential import OpenAICredential
 from ...formatter import FormatterBase, OpenAIChatFormatter
 from ...message import (
@@ -362,6 +363,15 @@ class OpenAIChatModel(ChatModelBase):
                     continue
 
                 choice = chunk.choices[0]
+                (
+                    finished_reason,
+                    reason_metadata,
+                ) = _parse_provider_finished_reason(
+                    getattr(choice, "finish_reason", None),
+                    {"length"},
+                )
+                delta_res.finished_reason = finished_reason
+                delta_res.metadata.update(reason_metadata)
                 delta = choice.delta
 
                 # Thinking
@@ -443,7 +453,7 @@ class OpenAIChatModel(ChatModelBase):
                         input=delta_args or "",
                     )
 
-                if delta_res.content or usage:
+                if delta_res.content or usage or reason_metadata:
                     delta_res.usage = usage
                     yield delta_res
 
@@ -471,9 +481,17 @@ class OpenAIChatModel(ChatModelBase):
         content_blocks: List[
             TextBlock | ToolCallBlock | ThinkingBlock | DataBlock
         ] = []
+        finished_reason, reason_metadata = _parse_provider_finished_reason(
+            None,
+            {"length"},
+        )
 
         if response.choices:
             choice = response.choices[0]
+            finished_reason, reason_metadata = _parse_provider_finished_reason(
+                getattr(choice, "finish_reason", None),
+                {"length"},
+            )
             reasoning = getattr(choice.message, "reasoning_content", None)
             if not isinstance(reasoning, str):
                 reasoning = getattr(choice.message, "reasoning", None)
@@ -537,6 +555,8 @@ class OpenAIChatModel(ChatModelBase):
             "content": content_blocks,
             "is_last": True,
             "usage": usage,
+            "finished_reason": finished_reason,
+            "metadata": reason_metadata,
         }
         response_id = getattr(response, "id", None)
         if response_id:

--- a/src/agentscope/model/_openai_response/_model.py
+++ b/src/agentscope/model/_openai_response/_model.py
@@ -8,12 +8,14 @@ from pydantic import BaseModel, Field
 
 from ..._utils._common import _generate_id
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
-from .._model_response import ChatResponse
+from .._model_response import ChatResponse, FinishedReason
 from .._model_usage import ChatUsage
+from .._utils import _parse_provider_finished_reason
 from ...credential import OpenAICredential
 from ...formatter import FormatterBase, OpenAIResponseFormatter
 from ...message import Msg, ThinkingBlock, ToolCallBlock, TextBlock
 from ...tool import ToolChoice
+from ...types import JSONSerializableObject
 
 if TYPE_CHECKING:
     from openai.types.responses import Response
@@ -26,6 +28,22 @@ else:
 
 # kwargs accepted by Chat Completions but NOT by the Responses API.
 _RESPONSES_UNSUPPORTED_KWARGS = frozenset({"modalities", "audio"})
+
+
+def _parse_response_finished_reason(
+    response: Any,
+) -> tuple[FinishedReason, dict[str, JSONSerializableObject]]:
+    """Extract the terminal reason from an OpenAI Responses response."""
+    status = getattr(response, "status", None)
+    raw_reason = status
+    status_value = getattr(status, "value", status)
+    if str(status_value).casefold() == "incomplete":
+        details = getattr(response, "incomplete_details", None)
+        raw_reason = getattr(details, "reason", None) or status
+    return _parse_provider_finished_reason(
+        raw_reason,
+        {"max_output_tokens"},
+    )
 
 
 class OpenAIResponseModel(ChatModelBase):
@@ -310,8 +328,14 @@ class OpenAIResponseModel(ChatModelBase):
                         input=event.delta or "",
                     )
 
-            elif event_type == "response.completed":
+            elif event_type in ("response.completed", "response.incomplete"):
                 resp = event.response
+                (
+                    finished_reason,
+                    reason_metadata,
+                ) = _parse_response_finished_reason(resp)
+                delta_res.finished_reason = finished_reason
+                delta_res.metadata.update(reason_metadata)
                 if resp.usage:
                     u = resp.usage
                     details = getattr(u, "input_tokens_details", None)
@@ -344,7 +368,7 @@ class OpenAIResponseModel(ChatModelBase):
                                 reasoning_item_id=reasoning_item_id,
                             )
 
-            if delta_res.content or usage:
+            if delta_res.content or usage or delta_res.metadata:
                 delta_res.usage = usage
                 yield delta_res
 
@@ -366,6 +390,9 @@ class OpenAIResponseModel(ChatModelBase):
                 A single ``ChatResponse`` with ``is_last=True``.
         """
         content_blocks: List[TextBlock | ToolCallBlock | ThinkingBlock] = []
+        finished_reason, reason_metadata = _parse_response_finished_reason(
+            response,
+        )
 
         for item in response.output:
             item_type = getattr(item, "type", None)
@@ -425,6 +452,8 @@ class OpenAIResponseModel(ChatModelBase):
             "content": content_blocks,
             "is_last": True,
             "usage": usage,
+            "finished_reason": finished_reason,
+            "metadata": reason_metadata,
         }
         response_id = getattr(response, "id", None)
         if response_id:

--- a/src/agentscope/model/_utils.py
+++ b/src/agentscope/model/_utils.py
@@ -16,6 +16,50 @@ from ..message import (
     ToolCallBlock,
     URLSource,
 )
+from ..types import JSONSerializableObject
+
+_PROVIDER_FINISHED_REASON_KEY = "provider_finished_reason"
+
+
+def _parse_provider_finished_reason(
+    raw_reason: Any,
+    max_tokens_reasons: set[str],
+) -> tuple[FinishedReason, dict[str, JSONSerializableObject]]:
+    """Normalize a provider-specific model finish reason.
+
+    Only explicit provider signals are mapped to ``MAX_TOKENS``. Unknown
+    reasons retain the existing ``COMPLETED`` behavior, while their raw value
+    is preserved in metadata for diagnostics.
+
+    Args:
+        raw_reason (`Any`):
+            The provider-specific finish reason value or enum.
+        max_tokens_reasons (`set[str]`):
+            Case-insensitive provider values that mean the output token limit
+            was reached.
+
+    Returns:
+        `tuple[FinishedReason, dict[str, JSONSerializableObject]]`:
+            The normalized reason and metadata carrying the raw provider
+            value when one exists.
+    """
+    if raw_reason is None:
+        return FinishedReason.COMPLETED, {}
+
+    value = getattr(raw_reason, "value", None)
+    if not isinstance(value, (str, int)):
+        value = getattr(raw_reason, "name", None)
+    if not isinstance(value, (str, int)):
+        value = raw_reason
+
+    reason = str(value)
+    metadata: dict[str, JSONSerializableObject] = {
+        _PROVIDER_FINISHED_REASON_KEY: reason,
+    }
+    normalized_max_tokens_reasons = {_.casefold() for _ in max_tokens_reasons}
+    if reason.casefold() in normalized_max_tokens_reasons:
+        return FinishedReason.MAX_TOKENS, metadata
+    return FinishedReason.COMPLETED, metadata
 
 
 class _AccTextBlock(TextBlock):
@@ -75,6 +119,7 @@ class _AccToolCallBlock(ToolCallBlock):
     field holds the incremental JSON fragments until they are joined in
     ``build``."""
 
+    name: str
     input: list[str] = Field(  # type: ignore[assignment]
         default_factory=list,
     )
@@ -221,6 +266,9 @@ class _StreamAccumulator:
         self.finished_reason: FinishedReason = FinishedReason.COMPLETED
         """The finished reason to report in ``build``."""
 
+        self.metadata: dict[str, Any] = {}
+        """Metadata accumulated from streaming carrier chunks."""
+
     def append_chat_response(self, chat_response: ChatResponse) -> Self:
         """Collect one delta chunk in constant time per block.
 
@@ -263,6 +311,12 @@ class _StreamAccumulator:
         if chat_response.usage:
             self.usage = chat_response.usage
 
+        if chat_response.finished_reason != FinishedReason.COMPLETED:
+            self.finished_reason = chat_response.finished_reason
+
+        if chat_response.metadata:
+            self.metadata.update(chat_response.metadata)
+
         return self
 
     def build(self) -> ChatResponse:
@@ -276,5 +330,6 @@ class _StreamAccumulator:
             is_last=True,
             usage=self.usage,
             finished_reason=self.finished_reason,
+            metadata=self.metadata,
             **kwargs,
         )

--- a/src/agentscope/model/_xai/_model.py
+++ b/src/agentscope/model/_xai/_model.py
@@ -9,6 +9,7 @@ from ..._utils._common import _generate_id
 from .._base import ChatModelBase, _TOOL_CHOICE_LITERAL_MODES
 from .._model_response import ChatResponse
 from .._model_usage import ChatUsage
+from .._utils import _parse_provider_finished_reason
 from ...credential import XAICredential
 from ...formatter import XAIChatFormatter
 from ...message import (
@@ -390,7 +391,15 @@ class XAIChatModel(ChatModelBase):
                 ),
             )
 
-        if trailing.content or trailing.usage:
+        if last_response is not None:
+            finished_reason, reason_metadata = _parse_provider_finished_reason(
+                getattr(last_response, "finish_reason", None),
+                {"max_tokens"},
+            )
+            trailing.finished_reason = finished_reason
+            trailing.metadata.update(reason_metadata)
+
+        if trailing.content or trailing.usage or trailing.metadata:
             yield trailing
 
     def _parse_completion_response(
@@ -411,6 +420,10 @@ class XAIChatModel(ChatModelBase):
                 A single ``ChatResponse`` with ``is_last=True``.
         """
         content_blocks: List[TextBlock | ToolCallBlock | ThinkingBlock] = []
+        finished_reason, reason_metadata = _parse_provider_finished_reason(
+            getattr(response, "finish_reason", None),
+            {"max_tokens"},
+        )
 
         if response.reasoning_content:
             content_blocks.append(
@@ -446,6 +459,8 @@ class XAIChatModel(ChatModelBase):
             "content": content_blocks,
             "is_last": True,
             "usage": usage,
+            "finished_reason": finished_reason,
+            "metadata": reason_metadata,
         }
         response_id = getattr(response, "id", None)
         if response_id:

--- a/src/agentscope/types/_reply.py
+++ b/src/agentscope/types/_reply.py
@@ -14,6 +14,8 @@ class ReplyFinishedReason(StrEnum):
     INTERRUPTED = "interrupted"
     EXCEED_MAX_ITERS = "exceed_max_iters"
     ERROR = "error"
+    MAX_TOKENS = "max_tokens"
+    """The model stopped because it reached its output token limit."""
 
 
 class ErrorType(StrEnum):

--- a/tests/agent_basic_test.py
+++ b/tests/agent_basic_test.py
@@ -6,7 +6,7 @@ from unittest.async_case import IsolatedAsyncioTestCase
 from utils import AnyString, MockModel
 
 from agentscope.agent import Agent, ContextConfig, InjectionConfig, ReActConfig
-from agentscope.model import ChatResponse
+from agentscope.model import ChatResponse, FinishedReason
 from agentscope.tool import (
     ToolBase,
     Toolkit,
@@ -21,6 +21,7 @@ from agentscope.message import (
     TextBlock,
     ThinkingBlock,
     ToolCallBlock,
+    ToolResultState,
     UserMsg,
 )
 from agentscope.types import ReplyFinishedReason
@@ -700,6 +701,65 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
             tool_results[0].output[0].text,
             "Sequential result: x",
         )
+
+    async def test_max_tokens_returns_partial_response(self) -> None:
+        """A token-limited response is visible and explicitly terminal."""
+        self.model.set_responses(
+            [
+                ChatResponse(
+                    content=[TextBlock(text="partial answer")],
+                    is_last=True,
+                    finished_reason=FinishedReason.MAX_TOKENS,
+                    metadata={"provider_finished_reason": "length"},
+                ),
+            ],
+        )
+
+        msg = await self.agent.reply(UserMsg(name="user", content="Go"))
+
+        self.assertEqual(
+            msg.finished_reason,
+            ReplyFinishedReason.MAX_TOKENS,
+        )
+        self.assertEqual(msg.get_text_content(), "partial answer")
+        self.assertEqual(
+            msg.metadata,
+            {"provider_finished_reason": "length"},
+        )
+        self.assertEqual(len(msg.get_content_blocks("hint")), 1)
+        self.assertEqual(self.model.cnt, 1)
+
+    async def test_max_tokens_does_not_execute_partial_tool_call(self) -> None:
+        """A truncated tool call is closed with an error, not executed."""
+        self.agent.toolkit = Toolkit(tools=[MockSequentialTool()])
+        self.model.set_responses(
+            [
+                ChatResponse(
+                    content=[
+                        ToolCallBlock(
+                            id="tool_call_1",
+                            name="mock_sequential_tool",
+                            input='{"input": "x"',
+                        ),
+                    ],
+                    is_last=True,
+                    finished_reason=FinishedReason.MAX_TOKENS,
+                ),
+            ],
+        )
+
+        msg = await self.agent.reply(UserMsg(name="user", content="Go"))
+
+        self.assertEqual(
+            msg.finished_reason,
+            ReplyFinishedReason.MAX_TOKENS,
+        )
+        self.assertEqual(self.model.cnt, 1)
+        tool_calls = msg.get_content_blocks("tool_call")
+        tool_results = msg.get_content_blocks("tool_result")
+        self.assertEqual(tool_calls[0].state, "finished")
+        self.assertEqual(tool_results[0].state, ToolResultState.ERROR)
+        self.assertIn("was not executed", tool_results[0].output)
 
     async def test_thinking_only_response_continues_reasoning(self) -> None:
         """A thinking-only response should not end with an empty reply."""

--- a/tests/agent_basic_test.py
+++ b/tests/agent_basic_test.py
@@ -761,6 +761,90 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
         self.assertEqual(tool_results[0].state, ToolResultState.ERROR)
         self.assertIn("was not executed", tool_results[0].output)
 
+    async def test_max_tokens_returns_only_current_reasoning_round(
+        self,
+    ) -> None:
+        """A truncated reply excludes prior ReAct rounds."""
+        self.agent.toolkit = Toolkit(tools=[MockSequentialTool()])
+        self.model.set_responses(
+            [
+                ChatResponse(
+                    content=[
+                        ThinkingBlock(thinking="previous thinking"),
+                        ToolCallBlock(
+                            id="completed_tool_call",
+                            name="mock_sequential_tool",
+                            input='{"input": "first"}',
+                        ),
+                    ],
+                    is_last=True,
+                ),
+                ChatResponse(
+                    content=[
+                        ThinkingBlock(thinking="current thinking"),
+                        TextBlock(text="partial answer"),
+                        ToolCallBlock(
+                            id="truncated_tool_call",
+                            name="mock_sequential_tool",
+                            input='{"input": "second"',
+                        ),
+                    ],
+                    is_last=True,
+                    finished_reason=FinishedReason.MAX_TOKENS,
+                ),
+            ],
+        )
+
+        msg = await self.agent.reply(UserMsg(name="user", content="Go"))
+
+        self.assertEqual(msg.finished_reason, ReplyFinishedReason.MAX_TOKENS)
+        self.assertEqual(self.model.cnt, 2)
+        self.assertEqual(msg.get_text_content(), "partial answer")
+        self.assertEqual(
+            [block.thinking for block in msg.get_content_blocks("thinking")],
+            ["current thinking"],
+        )
+        self.assertEqual(
+            [block.id for block in msg.get_content_blocks("tool_call")],
+            ["truncated_tool_call"],
+        )
+        final_tool_results = msg.get_content_blocks("tool_result")
+        self.assertEqual(
+            [block.id for block in final_tool_results],
+            ["truncated_tool_call"],
+        )
+        self.assertEqual(final_tool_results[0].state, ToolResultState.ERROR)
+        self.assertEqual(len(msg.get_content_blocks("hint")), 1)
+
+        context_msg = self.agent.state.context[-1]
+        self.assertEqual(
+            [
+                block.thinking
+                for block in context_msg.get_content_blocks("thinking")
+            ],
+            ["previous thinking", "current thinking"],
+        )
+        self.assertEqual(
+            [
+                block.id
+                for block in context_msg.get_content_blocks("tool_call")
+            ],
+            ["completed_tool_call", "truncated_tool_call"],
+        )
+        context_tool_results = context_msg.get_content_blocks("tool_result")
+        self.assertEqual(
+            [block.id for block in context_tool_results],
+            ["completed_tool_call", "truncated_tool_call"],
+        )
+        self.assertEqual(
+            context_tool_results[0].output[0].text,
+            "Sequential result: first",
+        )
+        self.assertEqual(
+            context_tool_results[1].state,
+            ToolResultState.ERROR,
+        )
+
     async def test_thinking_only_response_continues_reasoning(self) -> None:
         """A thinking-only response should not end with an empty reply."""
         self.model.set_responses(

--- a/tests/console_renderer_test.py
+++ b/tests/console_renderer_test.py
@@ -307,3 +307,15 @@ class ConsoleRendererTest(TestCase):
             msg.finished_reason,
             ReplyFinishedReason.INTERRUPTED,
         )
+
+    def test_reply_end_max_tokens_always_warns(self) -> None:
+        """Token truncation is visible at the default verbosity."""
+        self.renderer.render(
+            ReplyEndEvent(
+                session_id="s",
+                reply_id=REPLY_ID,
+                finished_reason=ReplyFinishedReason.MAX_TOKENS,
+            ),
+        )
+
+        self.assertIn("maximum output token limit", self.output())

--- a/tests/event_to_message_test.py
+++ b/tests/event_to_message_test.py
@@ -1037,5 +1037,26 @@ class EventToMessageTest(IsolatedAsyncioTestCase):
             msg="Msg must not change when delta targets a missing block",
         )
 
+    async def test_reply_end_max_tokens_is_preserved(self) -> None:
+        """The additive max_tokens wire value round-trips into a Msg."""
+        msg = Msg(
+            id=_REPLY_ID,
+            name="assistant",
+            role="assistant",
+            content=[],
+        )
+        msg.append_event(
+            ReplyEndEvent(
+                reply_id=_REPLY_ID,
+                session_id=_SESSION_ID,
+                finished_reason=ReplyFinishedReason.MAX_TOKENS,
+            ),
+        )
+
+        self.assertEqual(
+            msg.finished_reason,
+            ReplyFinishedReason.MAX_TOKENS,
+        )
+
     async def asyncTearDown(self) -> None:
         """No teardown needed."""

--- a/tests/model_anthropic_test.py
+++ b/tests/model_anthropic_test.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, MagicMock
 from utils import AnyString
 
 from agentscope.message import TextBlock, ToolCallBlock, ThinkingBlock
-from agentscope.model import AnthropicChatModel
+from agentscope.model import AnthropicChatModel, FinishedReason
 from agentscope.credential import AnthropicCredential
 from agentscope.tool import ToolChoice
 
@@ -41,6 +41,7 @@ def _mock_completion(
     tool_calls: Any = None,
     thinking: Any = None,
     response_id: str = "msg-1",
+    stop_reason: str | None = None,
 ) -> MagicMock:
     """Build a mock non-streaming Anthropic Message response."""
     blocks = []
@@ -67,6 +68,7 @@ def _mock_completion(
     resp = MagicMock()
     resp.id = response_id
     resp.content = blocks
+    resp.stop_reason = stop_reason
     resp.usage = MagicMock()
     resp.usage.input_tokens = 10
     resp.usage.output_tokens = 5
@@ -926,3 +928,56 @@ class TestAnthropicFormatTools(unittest.TestCase):
         fmt_tools, fmt_choice = self.model._format_tools(_FT_TOOLS, None)
         self.assertEqual(fmt_tools, _FT_TOOLS_ANTHROPIC)
         self.assertIsNone(fmt_choice)
+
+
+class TestAnthropicFinishedReason(IsolatedAsyncioTestCase):
+    """Tests for Anthropic token-limit termination propagation."""
+
+    async def test_non_stream_and_stream_max_tokens(self) -> None:
+        """Both response modes map ``max_tokens`` explicitly."""
+        model = _make_model(stream=False)
+        model.client = MagicMock()
+        model.client.messages.create = AsyncMock(
+            return_value=_mock_completion(
+                text="partial",
+                stop_reason="max_tokens",
+            ),
+        )
+        response = await model([])
+        self.assertEqual(response.finished_reason, FinishedReason.MAX_TOKENS)
+
+        message = MagicMock(id="msg-1")
+        message.usage = MagicMock(
+            input_tokens=10,
+            output_tokens=0,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=0,
+        )
+        text_delta = MagicMock(type="text_delta", text="partial")
+        end_delta = MagicMock(stop_reason="max_tokens")
+        end_usage = MagicMock(output_tokens=5)
+        model = _make_model(stream=True)
+        model.client = MagicMock()
+        model.client.messages.create = AsyncMock(
+            return_value=_MockAsyncEventStream(
+                [
+                    _make_event("message_start", message=message),
+                    _make_event(
+                        "content_block_delta",
+                        index=0,
+                        delta=text_delta,
+                    ),
+                    _make_event(
+                        "message_delta",
+                        delta=end_delta,
+                        usage=end_usage,
+                    ),
+                ],
+            ),
+        )
+        stream = await model([])
+        responses = [item async for item in stream]
+        self.assertEqual(
+            responses[-1].finished_reason,
+            FinishedReason.MAX_TOKENS,
+        )

--- a/tests/model_base_test.py
+++ b/tests/model_base_test.py
@@ -35,6 +35,7 @@ def _expected(
     is_last: bool,
     finished_reason: FinishedReason = FinishedReason.COMPLETED,
     usage: dict | None = None,
+    metadata: dict | None = None,
 ) -> dict:
     """Build the expected serialized ``ChatResponse`` dict, with
     ``AnyString`` placeholders for auto-generated fields (id,
@@ -50,7 +51,7 @@ def _expected(
         "type": "chat_response",
         "usage": usage,
         "finished_reason": finished_reason,
-        "metadata": {},
+        "metadata": metadata or {},
     }
 
 
@@ -1064,6 +1065,37 @@ class ChatModelBaseCallTest(IsolatedAsyncioTestCase):
                     },
                 ),
             ],
+        )
+
+    async def test_stream_finished_reason_carrier_is_accumulated(self) -> None:
+        """A content-free terminal reason carrier reaches the final chunk."""
+        self.model.set_responses(
+            [
+                [
+                    ChatResponse(
+                        content=[TextBlock(text="partial", id="t1")],
+                        is_last=False,
+                    ),
+                    ChatResponse(
+                        content=[],
+                        is_last=False,
+                        finished_reason=FinishedReason.MAX_TOKENS,
+                        metadata={"provider_finished_reason": "length"},
+                    ),
+                ],
+            ],
+        )
+
+        stream = await self.model(messages=self.messages)
+        responses = [response async for response in stream]
+
+        self.assertEqual(
+            responses[-1].finished_reason,
+            FinishedReason.MAX_TOKENS,
+        )
+        self.assertEqual(
+            responses[-1].metadata,
+            {"provider_finished_reason": "length"},
         )
 
     async def asyncTearDown(self) -> None:

--- a/tests/model_dashscope_test.py
+++ b/tests/model_dashscope_test.py
@@ -20,7 +20,7 @@ from agentscope.message import (
     ThinkingBlock,
     DataBlock,
 )
-from agentscope.model import DashScopeChatModel
+from agentscope.model import DashScopeChatModel, FinishedReason
 from agentscope.credential import DashScopeCredential
 from agentscope.tool import ToolChoice
 
@@ -52,6 +52,7 @@ def _mock_completion(
     tool_calls: Any = None,
     reasoning: Any = None,
     response_id: str = "req-1",
+    finish_reason: str | None = None,
 ) -> MagicMock:
     """Build a mock non-streaming ChatCompletion response."""
     msg = MagicMock()
@@ -71,6 +72,7 @@ def _mock_completion(
 
     choice = MagicMock()
     choice.message = msg
+    choice.finish_reason = finish_reason
 
     resp = MagicMock()
     resp.id = response_id
@@ -90,6 +92,7 @@ def _make_stream_chunk(
     response_id: str = "req-1",
     usage: dict | None = None,
     has_choices: bool = True,
+    finish_reason: str | None = None,
 ) -> MagicMock:
     """Build a single mock streaming chunk."""
     chunk = MagicMock()
@@ -111,6 +114,7 @@ def _make_stream_chunk(
         delta.audio = delta_audio
         choice = MagicMock()
         choice.delta = delta
+        choice.finish_reason = finish_reason
         chunk.choices = [choice]
     else:
         chunk.choices = []
@@ -648,3 +652,37 @@ class TestDashScopeFormatTools(unittest.TestCase):
         fmt_tools, fmt_choice = self.model._format_tools(_FT_TOOLS, None)
         self.assertEqual(fmt_tools, _FT_TOOLS)
         self.assertIsNone(fmt_choice)
+
+
+class TestDashScopeFinishedReason(IsolatedAsyncioTestCase):
+    """Tests for DashScope token-limit termination propagation."""
+
+    async def test_non_stream_and_stream_max_tokens(self) -> None:
+        """Both response modes map ``length`` to max_tokens."""
+        model = _make_model(stream=False)
+        model.client = MagicMock()
+        model.client.chat.completions.create = AsyncMock(
+            return_value=_mock_completion(
+                text="partial",
+                finish_reason="length",
+            ),
+        )
+        response = await model([])
+        self.assertEqual(response.finished_reason, FinishedReason.MAX_TOKENS)
+
+        model = _make_model(stream=True)
+        model.client = MagicMock()
+        model.client.chat.completions.create = AsyncMock(
+            return_value=_MockAsyncStream(
+                [
+                    _make_stream_chunk(delta_text="partial"),
+                    _make_stream_chunk(finish_reason="length"),
+                ],
+            ),
+        )
+        stream = await model([])
+        responses = [item async for item in stream]
+        self.assertEqual(
+            responses[-1].finished_reason,
+            FinishedReason.MAX_TOKENS,
+        )

--- a/tests/model_deepseek_test.py
+++ b/tests/model_deepseek_test.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, MagicMock
 from utils import AnyString
 
 from agentscope.message import TextBlock, ToolCallBlock, ThinkingBlock
-from agentscope.model import DeepSeekChatModel
+from agentscope.model import DeepSeekChatModel, FinishedReason
 from agentscope.credential import DeepSeekCredential
 from agentscope.tool import ToolChoice
 
@@ -41,6 +41,7 @@ def _mock_completion(
     tool_calls: Any = None,
     reasoning: Any = None,
     response_id: str = "deepseek-1",
+    finish_reason: str | None = None,
 ) -> MagicMock:
     """Build a mock non-streaming ChatCompletion response."""
     msg = MagicMock()
@@ -60,6 +61,7 @@ def _mock_completion(
 
     choice = MagicMock()
     choice.message = msg
+    choice.finish_reason = finish_reason
 
     resp = MagicMock()
     resp.id = response_id
@@ -77,6 +79,7 @@ def _make_stream_chunk(
     response_id: str = "deepseek-1",
     usage: dict | None = None,
     has_choices: bool = True,
+    finish_reason: str | None = None,
 ) -> MagicMock:
     """Build a single mock streaming chunk."""
     chunk = MagicMock()
@@ -100,6 +103,7 @@ def _make_stream_chunk(
         delta.tool_calls = tool_calls
         choice = MagicMock()
         choice.delta = delta
+        choice.finish_reason = finish_reason
         chunk.choices = [choice]
     else:
         chunk.choices = []
@@ -729,3 +733,37 @@ class TestDeepSeekFormatTools(unittest.TestCase):
         fmt_tools, fmt_choice = self.model._format_tools(_FT_TOOLS, None)
         self.assertEqual(fmt_tools, _FT_TOOLS)
         self.assertIsNone(fmt_choice)
+
+
+class TestDeepSeekFinishedReason(IsolatedAsyncioTestCase):
+    """Tests for DeepSeek token-limit termination propagation."""
+
+    async def test_non_stream_and_stream_max_tokens(self) -> None:
+        """Both response modes map ``length`` to max_tokens."""
+        model = _make_model(stream=False)
+        model.client = MagicMock()
+        model.client.chat.completions.create = AsyncMock(
+            return_value=_mock_completion(
+                text="partial",
+                finish_reason="length",
+            ),
+        )
+        response = await model([])
+        self.assertEqual(response.finished_reason, FinishedReason.MAX_TOKENS)
+
+        model = _make_model(stream=True)
+        model.client = MagicMock()
+        model.client.chat.completions.create = AsyncMock(
+            return_value=_MockAsyncStream(
+                [
+                    _make_stream_chunk(delta_text="partial"),
+                    _make_stream_chunk(finish_reason="length"),
+                ],
+            ),
+        )
+        stream = await model([])
+        responses = [item async for item in stream]
+        self.assertEqual(
+            responses[-1].finished_reason,
+            FinishedReason.MAX_TOKENS,
+        )

--- a/tests/model_gemini_test.py
+++ b/tests/model_gemini_test.py
@@ -14,7 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 from utils import AnyString
 
 from agentscope.message import TextBlock, ToolCallBlock, ThinkingBlock
-from agentscope.model import GeminiChatModel
+from agentscope.model import FinishedReason, GeminiChatModel
 from agentscope.model._gemini._model import _sanitize_schema_for_gemini
 from agentscope._utils._common import _flatten_json_schema
 from agentscope.credential import GeminiCredential
@@ -61,11 +61,13 @@ def _make_part(
 def _mock_completion(
     parts: list,
     response_id: str = "resp-gem-1",
+    finish_reason: str | None = None,
 ) -> MagicMock:
     """Build a mock non-streaming Gemini response."""
     resp = MagicMock()
     resp.response_id = response_id
     resp.candidates = [MagicMock()]
+    resp.candidates[0].finish_reason = finish_reason
     resp.candidates[0].content = MagicMock()
     resp.candidates[0].content.parts = parts
     resp.usage_metadata = MagicMock()
@@ -77,11 +79,13 @@ def _mock_completion(
 def _make_stream_chunk(
     parts: list,
     response_id: str = "resp-gem-1",
+    finish_reason: str | None = None,
 ) -> MagicMock:
     """Build a single mock streaming chunk."""
     chunk = MagicMock()
     chunk.response_id = response_id
     chunk.candidates = [MagicMock()]
+    chunk.candidates[0].finish_reason = finish_reason
     chunk.candidates[0].content = MagicMock()
     chunk.candidates[0].content.parts = parts
     chunk.usage_metadata = MagicMock()
@@ -795,3 +799,40 @@ class TestGeminiSchemaUtils(unittest.TestCase):
         identity)."""
         schema = {"type": "object", "properties": {"x": {"type": "integer"}}}
         self.assertIs(_flatten_json_schema(schema), schema)
+
+
+class TestGeminiFinishedReason(IsolatedAsyncioTestCase):
+    """Tests for Gemini token-limit termination propagation."""
+
+    async def test_non_stream_and_stream_max_tokens(self) -> None:
+        """Both response modes map ``MAX_TOKENS`` explicitly."""
+        model = _make_model(stream=False)
+        model.client = MagicMock()
+        model.client.aio.models.generate_content = AsyncMock(
+            return_value=_mock_completion(
+                [_make_part(text="partial")],
+                finish_reason="MAX_TOKENS",
+            ),
+        )
+        response = await model([])
+        self.assertEqual(response.finished_reason, FinishedReason.MAX_TOKENS)
+
+        model = _make_model(stream=True)
+        model.client = MagicMock()
+        model.client.aio.models.generate_content_stream = AsyncMock(
+            return_value=_MockAsyncStream(
+                [
+                    _make_stream_chunk([_make_part(text="partial")]),
+                    _make_stream_chunk(
+                        [],
+                        finish_reason="MAX_TOKENS",
+                    ),
+                ],
+            ),
+        )
+        stream = await model([])
+        responses = [item async for item in stream]
+        self.assertEqual(
+            responses[-1].finished_reason,
+            FinishedReason.MAX_TOKENS,
+        )

--- a/tests/model_moonshot_test.py
+++ b/tests/model_moonshot_test.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 from utils import AnyString
 
 from agentscope.message import TextBlock, ToolCallBlock, ThinkingBlock
-from agentscope.model import MoonshotChatModel
+from agentscope.model import FinishedReason, MoonshotChatModel
 from agentscope.credential import MoonshotCredential
 from agentscope.tool import ToolChoice
 
@@ -38,6 +38,7 @@ def _mock_completion(
     tool_calls: Any = None,
     reasoning: Any = None,
     response_id: str = "kimi-1",
+    finish_reason: str | None = None,
 ) -> MagicMock:
     """Build a mock non-streaming ChatCompletion response."""
     msg = MagicMock()
@@ -57,6 +58,7 @@ def _mock_completion(
 
     choice = MagicMock()
     choice.message = msg
+    choice.finish_reason = finish_reason
 
     resp = MagicMock()
     resp.id = response_id
@@ -74,6 +76,7 @@ def _make_stream_chunk(
     response_id: str = "kimi-1",
     usage: dict | None = None,
     has_choices: bool = True,
+    finish_reason: str | None = None,
 ) -> MagicMock:
     """Build a single mock streaming chunk."""
     chunk = MagicMock()
@@ -94,6 +97,7 @@ def _make_stream_chunk(
         delta.tool_calls = tool_calls
         choice = MagicMock()
         choice.delta = delta
+        choice.finish_reason = finish_reason
         chunk.choices = [choice]
     else:
         chunk.choices = []
@@ -538,3 +542,37 @@ class TestMoonshotFormatTools(unittest.TestCase):
         fmt_tools, fmt_choice = self.model._format_tools(_FT_TOOLS, None)
         self.assertEqual(fmt_tools, _FT_TOOLS)
         self.assertIsNone(fmt_choice)
+
+
+class TestMoonshotFinishedReason(IsolatedAsyncioTestCase):
+    """Tests for Moonshot token-limit termination propagation."""
+
+    async def test_non_stream_and_stream_max_tokens(self) -> None:
+        """Both response modes map ``length`` to max_tokens."""
+        model = _make_model(stream=False)
+        model.client = MagicMock()
+        model.client.chat.completions.create = AsyncMock(
+            return_value=_mock_completion(
+                text="partial",
+                finish_reason="length",
+            ),
+        )
+        response = await model([])
+        self.assertEqual(response.finished_reason, FinishedReason.MAX_TOKENS)
+
+        model = _make_model(stream=True)
+        model.client = MagicMock()
+        model.client.chat.completions.create = AsyncMock(
+            return_value=_MockAsyncStream(
+                [
+                    _make_stream_chunk(delta_text="partial"),
+                    _make_stream_chunk(finish_reason="length"),
+                ],
+            ),
+        )
+        stream = await model([])
+        responses = [item async for item in stream]
+        self.assertEqual(
+            responses[-1].finished_reason,
+            FinishedReason.MAX_TOKENS,
+        )

--- a/tests/model_ollama_test.py
+++ b/tests/model_ollama_test.py
@@ -14,7 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 from utils import AnyString
 
 from agentscope.message import TextBlock, ToolCallBlock, ThinkingBlock
-from agentscope.model import OllamaChatModel
+from agentscope.model import FinishedReason, OllamaChatModel
 from agentscope.tool import ToolChoice
 
 A = AnyString()
@@ -37,6 +37,7 @@ def _mock_completion(
     content: str = "",
     thinking: str | None = None,
     tool_calls: list | None = None,
+    done_reason: str | None = None,
 ) -> MagicMock:
     """Build a mock non-streaming Ollama response."""
     msg = MagicMock()
@@ -59,6 +60,7 @@ def _mock_completion(
     resp.prompt_eval_count = 10
     resp.eval_count = 5
     resp.id = None
+    resp.done_reason = done_reason
     return resp
 
 
@@ -66,6 +68,7 @@ def _make_stream_chunk(
     content: str = "",
     thinking: str | None = None,
     tool_calls: list | None = None,
+    done_reason: str | None = None,
 ) -> MagicMock:
     """Build a single mock Ollama streaming chunk."""
     msg = MagicMock()
@@ -88,6 +91,7 @@ def _make_stream_chunk(
     chunk.prompt_eval_count = 10
     chunk.eval_count = 5
     chunk.id = None
+    chunk.done_reason = done_reason
     return chunk
 
 
@@ -399,3 +403,37 @@ class TestOllamaFormatTools(unittest.TestCase):
         self.assertEqual(len(fmt_tools), 1)
         self.assertEqual(fmt_tools[0]["function"]["name"], "get_weather")
         self.assertIsNone(fmt_choice)
+
+
+class TestOllamaFinishedReason(IsolatedAsyncioTestCase):
+    """Tests for Ollama token-limit termination propagation."""
+
+    async def test_non_stream_and_stream_max_tokens(self) -> None:
+        """Both response modes map ``length`` to max_tokens."""
+        model = _make_model(stream=False)
+        model.client = MagicMock()
+        model.client.chat = AsyncMock(
+            return_value=_mock_completion(
+                content="partial",
+                done_reason="length",
+            ),
+        )
+        response = await model([])
+        self.assertEqual(response.finished_reason, FinishedReason.MAX_TOKENS)
+
+        model = _make_model(stream=True)
+        model.client = MagicMock()
+        model.client.chat = AsyncMock(
+            return_value=_MockAsyncStream(
+                [
+                    _make_stream_chunk(content="partial"),
+                    _make_stream_chunk(done_reason="length"),
+                ],
+            ),
+        )
+        stream = await model([])
+        responses = [item async for item in stream]
+        self.assertEqual(
+            responses[-1].finished_reason,
+            FinishedReason.MAX_TOKENS,
+        )

--- a/tests/model_openai_chat_test.py
+++ b/tests/model_openai_chat_test.py
@@ -24,7 +24,7 @@ from agentscope.message import (
     DataBlock,
     Base64Source,
 )
-from agentscope.model import OpenAIChatModel
+from agentscope.model import FinishedReason, OpenAIChatModel
 from agentscope.credential import OpenAICredential
 from agentscope.tool import ToolChoice
 
@@ -51,6 +51,7 @@ def _mock_completion(
     reasoning: Any = None,
     response_id: str = "resp-1",
     audio: dict | None = None,
+    finish_reason: str | None = None,
 ) -> MagicMock:
     """Build a mock non-streaming ChatCompletion response."""
     msg = MagicMock()
@@ -72,6 +73,7 @@ def _mock_completion(
 
     choice = MagicMock()
     choice.message = msg
+    choice.finish_reason = finish_reason
 
     resp = MagicMock()
     resp.id = response_id
@@ -90,6 +92,7 @@ def _make_stream_chunk(
     usage: dict | None = None,
     has_choices: bool = True,
     delta_audio: dict | None = None,
+    finish_reason: str | None = None,
 ) -> MagicMock:
     """Build a single mock streaming chunk."""
     chunk = MagicMock()
@@ -112,6 +115,7 @@ def _make_stream_chunk(
         delta.tool_calls = tool_calls
         choice = MagicMock()
         choice.delta = delta
+        choice.finish_reason = finish_reason
         chunk.choices = [choice]
     else:
         chunk.choices = []
@@ -196,6 +200,23 @@ class TestOpenAIChatNonStream(IsolatedAsyncioTestCase):
             ),
         )
         self.assertEqual(result.id, "resp-1")
+
+    async def test_max_tokens_finished_reason(self) -> None:
+        """The OpenAI ``length`` reason is preserved as max_tokens."""
+        self.mock_client.chat.completions.create = AsyncMock(
+            return_value=_mock_completion(
+                text="partial",
+                finish_reason="length",
+            ),
+        )
+
+        result = await self.model([])
+
+        self.assertEqual(result.finished_reason, FinishedReason.MAX_TOKENS)
+        self.assertEqual(
+            result.metadata["provider_finished_reason"],
+            "length",
+        )
 
     async def test_default_thinking_enable_not_forwarded(
         self,
@@ -440,6 +461,28 @@ class TestOpenAIChatStream(IsolatedAsyncioTestCase):
             ],
         )
         self.assertEqual(responses[-1].id, "resp-1")
+
+    async def test_stream_max_tokens_carrier(self) -> None:
+        """A content-free ``length`` chunk marks the final response."""
+        chunks = [
+            _make_stream_chunk(delta_text="partial"),
+            _make_stream_chunk(finish_reason="length"),
+        ]
+        self.mock_client.chat.completions.create = AsyncMock(
+            return_value=_MockAsyncStream(chunks),
+        )
+
+        gen = await self.model([])
+        responses = [response async for response in gen]
+
+        self.assertEqual(
+            responses[-1].finished_reason,
+            FinishedReason.MAX_TOKENS,
+        )
+        self.assertEqual(
+            responses[-1].metadata["provider_finished_reason"],
+            "length",
+        )
 
     async def test_stream_thinking_and_text(
         self,

--- a/tests/model_openai_response_test.py
+++ b/tests/model_openai_response_test.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 from utils import AnyString
 
 from agentscope.message import TextBlock, ToolCallBlock, ThinkingBlock
-from agentscope.model import OpenAIResponseModel
+from agentscope.model import FinishedReason, OpenAIResponseModel
 from agentscope.credential import OpenAICredential
 from agentscope.tool import ToolChoice
 
@@ -40,6 +40,8 @@ def _mock_completion(
     reasoning_summary: Any = None,
     reasoning_id: str = "rs_test123",
     response_id: str = "resp-openai-1",
+    status: str = "completed",
+    incomplete_reason: str | None = None,
 ) -> MagicMock:
     """Build a mock non-streaming Responses API response."""
     output = []
@@ -84,6 +86,12 @@ def _mock_completion(
     resp = MagicMock()
     resp.id = response_id
     resp.output = output
+    resp.status = status
+    resp.incomplete_details = (
+        MagicMock(reason=incomplete_reason)
+        if incomplete_reason is not None
+        else None
+    )
     resp.usage = MagicMock()
     resp.usage.input_tokens = 10
     resp.usage.output_tokens = 5
@@ -744,3 +752,49 @@ class TestOpenAIResponseFormatTools(unittest.TestCase):
         fmt_tools, fmt_choice = self.model._format_tools(_FT_TOOLS, None)
         self.assertEqual(fmt_tools, _FT_TOOLS_RESPONSE)
         self.assertIsNone(fmt_choice)
+
+
+class TestOpenAIResponseFinishedReason(IsolatedAsyncioTestCase):
+    """Tests for Responses API token-limit termination propagation."""
+
+    async def test_non_stream_and_stream_max_tokens(self) -> None:
+        """Incomplete max_output_tokens responses map to max_tokens."""
+        model = _make_model(stream=False)
+        model.client = MagicMock()
+        model.client.responses.create = AsyncMock(
+            return_value=_mock_completion(
+                text="partial",
+                status="incomplete",
+                incomplete_reason="max_output_tokens",
+            ),
+        )
+        response = await model([])
+        self.assertEqual(response.finished_reason, FinishedReason.MAX_TOKENS)
+        self.assertEqual(
+            response.metadata["provider_finished_reason"],
+            "max_output_tokens",
+        )
+
+        incomplete = _mock_completion(
+            status="incomplete",
+            incomplete_reason="max_output_tokens",
+        )
+        model = _make_model(stream=True)
+        model.client = MagicMock()
+        model.client.responses.create = AsyncMock(
+            return_value=_MockAsyncEventStream(
+                [
+                    _make_event(
+                        "response.output_text.delta",
+                        delta="partial",
+                    ),
+                    _make_event("response.incomplete", response=incomplete),
+                ],
+            ),
+        )
+        stream = await model([])
+        responses = [item async for item in stream]
+        self.assertEqual(
+            responses[-1].finished_reason,
+            FinishedReason.MAX_TOKENS,
+        )

--- a/tests/model_response_test.py
+++ b/tests/model_response_test.py
@@ -472,5 +472,23 @@ class ChatResponseAppendTest(IsolatedAsyncioTestCase):
             ),
         )
 
+    async def test_append_chat_response_terminal_metadata(self) -> None:
+        """Terminal reason and metadata are copied from carrier deltas."""
+        acc = ChatResponse(content=[], is_last=True)
+        acc.append_chat_response(
+            ChatResponse(
+                content=[],
+                is_last=False,
+                finished_reason=FinishedReason.MAX_TOKENS,
+                metadata={"provider_finished_reason": "length"},
+            ),
+        )
+
+        self.assertEqual(acc.finished_reason, FinishedReason.MAX_TOKENS)
+        self.assertEqual(
+            acc.metadata,
+            {"provider_finished_reason": "length"},
+        )
+
     async def asyncTearDown(self) -> None:
         """The async teardown method."""

--- a/tests/model_xai_test.py
+++ b/tests/model_xai_test.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from utils import AnyString
 
 from agentscope.message import TextBlock, ToolCallBlock, ThinkingBlock
-from agentscope.model import XAIChatModel
+from agentscope.model import FinishedReason, XAIChatModel
 from agentscope.credential import XAICredential
 from agentscope.tool import ToolChoice
 
@@ -125,6 +125,7 @@ def _mock_completion(
     reasoning: str = "",
     tool_calls: list | None = None,
     response_id: str = "xai-resp-1",
+    finish_reason: str | None = None,
 ) -> MagicMock:
     """Build a mock xAI non-streaming response."""
     resp = MagicMock()
@@ -133,6 +134,7 @@ def _mock_completion(
     resp.reasoning_content = reasoning
     resp.tool_calls = None
     resp.usage = None
+    resp.finish_reason = finish_reason
 
     if tool_calls:
         tc_mocks = []
@@ -661,3 +663,52 @@ class TestXAIFormatTools(unittest.TestCase):
         self.assertEqual(len(fmt_tools), 1)
         self.assertEqual(fmt_tools[0].name, "get_weather")
         self.assertEqual(fmt_choice, "auto")
+
+
+class TestXAIFinishedReason(IsolatedAsyncioTestCase):
+    """Tests for xAI token-limit termination propagation."""
+
+    @patch("xai_sdk.AsyncClient")
+    async def test_non_stream_max_tokens(
+        self,
+        mock_client_cls: MagicMock,
+    ) -> None:
+        """Non-stream MAX_TOKENS is normalized."""
+        mock_chat = _MockChatStream(
+            sample_response=_mock_completion(
+                text="partial",
+                finish_reason="MAX_TOKENS",
+            ),
+        )
+        mock_client_cls.return_value.chat.create.return_value = mock_chat
+        mock_client_cls.return_value.close = AsyncMock()
+
+        response = await _make_model(stream=False)([])
+
+        self.assertEqual(response.finished_reason, FinishedReason.MAX_TOKENS)
+
+    @patch("xai_sdk.AsyncClient")
+    async def test_stream_max_tokens(
+        self,
+        mock_client_cls: MagicMock,
+    ) -> None:
+        """Stream MAX_TOKENS is carried into the final response."""
+        final_response = _mock_completion(
+            text="partial",
+            finish_reason="MAX_TOKENS",
+        )
+        stream_items = [
+            (final_response, _MockStreamChunk(content="partial")),
+        ]
+        mock_client_cls.return_value.chat.create.return_value = (
+            _MockChatStream(stream_items=stream_items)
+        )
+        mock_client_cls.return_value.close = AsyncMock()
+
+        stream = await _make_model(stream=True)([])
+        responses = [item async for item in stream]
+
+        self.assertEqual(
+            responses[-1].finished_reason,
+            FinishedReason.MAX_TOKENS,
+        )


### PR DESCRIPTION
## AgentScope Version

2.0.6

## Description

### Background

When an upstream model stops because it reaches its output token limit, AgentScope currently loses the provider’s termination reason and reports the response as `completed`.

This makes truncated responses indistinguishable from normally completed responses. In a ReAct loop, it may also allow another reasoning iteration or attempt to execute an incomplete tool call.

This is separate from the O(n²) streaming accumulation issue already addressed by #2158.

### Changes

- Added `MAX_TOKENS = "max_tokens"` to model-level and reply-level finished reasons.
- Normalized explicit token-limit signals from supported providers:
  - OpenAI Chat, DeepSeek, Moonshot, DashScope and Ollama
  - OpenAI Responses
  - Anthropic
  - Gemini
  - xAI
- Preserved the original provider finish reason in `metadata["provider_finished_reason"]`.
- Ensured streaming adapters emit a carrier chunk when the final provider frame contains only a finish reason or usage.
- Preserved the finished reason, usage and metadata during stream accumulation.
- Updated the ReAct loop to stop immediately after a max-token termination:
  - Keep partial text, thinking content and usage.
  - Do not start another reasoning iteration.
  - Do not execute truncated tool calls.
  - Close incomplete tool calls with a synthetic error result so tool calls and results remain paired in the context.
  - Emit a system hint explaining that the output token limit was reached.
  - Propagate `max_tokens` through `ModelCallEndEvent`, `ReplyEndEvent` and the final `AssistantMsg`.
- Added an always-visible console warning for token-limit truncation.
- Kept existing behavior unchanged for normal provider finish reasons such as `stop`, `end_turn`, `tool_calls` and `tool_use`.

Existing consumers do not need to migrate unless they exhaustively match finished-reason enum values. Such consumers should handle the new `max_tokens` wire value.

Fixes #2321

### How to test

- Run all static checks:

  `pre-commit run --all-files`

- Run the model, Agent, event and console tests covering this change.

Test results:

- `pre-commit run --all-files`: passed
- Relevant model, Agent, event and console tests: 217 passed
- Remaining non-environment-dependent test suite: 1753 passed, 133 skipped
- Local-service tests requiring unrestricted socket binding could not complete in the restricted test environment; the affected S3, MCP, Milvus and Bubblewrap tests do not overlap with the changed code paths.

Coverage added for:

- Streaming and non-streaming token-limit mapping across all affected model adapters.
- Provider finish-reason metadata and unchanged normal completion behavior.
- Finish-only streaming carrier frames, usage and metadata accumulation.
- Partial text preservation after truncation.
- Safe termination of truncated tool calls without executing the tool.
- Event-to-message conversion and console warning output.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [[CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation has been updated — inline API documentation was updated; no separate documentation PR is needed because this change introduces no new configuration or usage workflow
- [x] Code is ready for review