### PR TITLE
fix(app): interrupt assembling chat run via local registry check (#2320)

### DIFF
--- a/src/agentscope/app/_lifespan.py
+++ b/src/agentscope/app/_lifespan.py
@@ -143,6 +143,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             scheduler_manager=scheduler,
             background_task_manager=bg_manager,
             message_bus=message_bus,
+            chat_run_registry=chat_run_registry,
             resource_access_service=resource_access_service,
             knowledge_base_manager=knowledge_base_manager,
             extra_agent_middlewares=app.state.extra_agent_middlewares,

--- a/src/agentscope/app/_service/_chat.py
+++ b/src/agentscope/app/_service/_chat.py
@@ -29,7 +29,11 @@ from ..message_bus import MessageBus, MessageBusKeys
 from ..rag.knowledge_base_manager import KnowledgeBaseManagerBase
 from ..channel import ChatKind
 from ..storage import StorageBase, AgentRecord, SessionRecord, SessionSource
-from .._manager import BackgroundTaskManager, SchedulerManager
+from .._manager import (
+    BackgroundTaskManager,
+    ChatRunRegistry,
+    SchedulerManager,
+)
 from ..workspace_manager import WorkspaceManagerBase
 from ..middleware import (
     InboxMiddleware,
@@ -101,6 +105,7 @@ class ChatService:
         custom_agent_cls: type[Agent] | None = None,
         extra_projectors: list[EventProjector] | None = None,
         channel_dispatcher: "ChannelLifecycleDispatcher | None" = None,
+        chat_run_registry: ChatRunRegistry | None = None,
     ) -> None:
         """Initialize chat service.
 
@@ -167,12 +172,20 @@ optional):
                 The node's channel dispatcher, forwarded to
                 :func:`get_toolkit` so a channel-originated session's
                 agent gets that channel's platform tools.
+            chat_run_registry (`ChatRunRegistry | None`, optional):
+                Per-process registry of in-flight chat-run asyncio
+                tasks. Consulted by :meth:`interrupt` to detect a run
+                that is live locally but has not yet acquired the
+                distributed session lock (during agent assembly).
+                ``None`` (tests / legacy callers) disables the registry
+                check, preserving the previous behaviour.
         """
         self._storage = storage
         self._workspace_manager = workspace_manager
         self._scheduler_manager = scheduler_manager
         self._background_task_manager = background_task_manager
         self._message_bus = message_bus
+        self._chat_run_registry = chat_run_registry
         self._access = resource_access_service
         self._knowledge_base_manager = knowledge_base_manager
         self._extra_agent_middlewares = extra_agent_middlewares
@@ -398,11 +411,27 @@ optional):
 
         Two paths, chosen by session liveness:
 
-        - **Running** (lock held): publish on the interrupt channel so
-          the local :class:`~agentscope.app._manager.CancelDispatcher`
-          cancels its chat-run task; the agent's ``CancelledError``
-          cleanup runs (fake tool results for pending calls, fallback
-          message, ``ReplyEndEvent(INTERRUPTED)``).
+        - **Running** (lock held, or a run is live in this process):
+          publish on the interrupt channel so the local
+          :class:`~agentscope.app._manager.CancelDispatcher` cancels
+          its chat-run task. Once the reply has started, the agent's
+          ``CancelledError`` cleanup runs (fake tool results for
+          pending calls, fallback message, ``ReplyEndEvent(INTERRUPTED)``).
+          The in-process registry check closes the agent-assembly
+          window — before :meth:`_run_impl` acquires the session lock
+          (step 7) — during which the run is already cancellable but
+          ``is_locked`` is not yet ``True``.
+        - **Assembly-window consequences** (same-process): the run is
+          cancelled before any reply exists, so nothing is persisted
+          and no ``ReplyStartEvent`` / ``ReplyEndEvent`` is emitted —
+          the input ``Msg`` is only persisted after assembly (inside
+          the step-7 lock), so it is dropped from the transcript.
+          Synthesising an ``INTERRUPTED`` terminal event for that case
+          is a follow-up (issue direction #2). The registry is
+          per-process: in multi-replica deployments an interrupt
+          landing on a non-hosting worker during assembly still falls
+          through to the resume path (a distributed run-alive marker
+          is the follow-up).
         - **Not running**: enqueue a ``resume`` trigger carrying a
           :class:`UserInterruptEvent`. If the session is parked on
           HITL, the agent short-circuits into the same cleanup path;
@@ -431,7 +460,7 @@ optional):
 
         if await self._message_bus.is_locked(
             MessageBusKeys.session_lock(session_id),
-        ):
+        ) or self._has_live_local_run(session_id):
             await self._message_bus.publish(
                 MessageBusKeys.session_interrupt_channel(),
                 {"session_id": session_id},
@@ -446,6 +475,38 @@ optional):
             kind=MessageBusKeys.WAKEUP_KIND_RESUME,
             inputs=UserInterruptEvent(reply_id=session.state.reply_id),
         )
+
+    def _has_live_local_run(self, session_id: str) -> bool:
+        """Whether a chat-run task for ``session_id`` is live in this
+        process.
+
+        The distributed session lock is acquired only after agent
+        assembly (step 7 of :meth:`_run_impl`); during assembly the run
+        is already live locally but ``is_locked`` still reports
+        ``False``. Consulting the per-process registry closes that
+        window so an interrupt lands on the cancel path instead of being
+        enqueued as a ``resume`` trigger the assembling run cannot
+        process.
+
+        Scope: the registry is per-process, so this only detects runs
+        hosted in *this* process. A run assembling on another worker is
+        invisible here; multi-replica deployments need a distributed
+        run-alive marker (issue follow-up).
+
+        Args:
+            session_id (`str`):
+                The session whose local run to look up.
+
+        Returns:
+            `bool`:
+                ``True`` when a non-finished chat-run task is
+                registered for the session; ``False`` when the service
+                was built without a registry or the task is finished.
+        """
+        if self._chat_run_registry is None:
+            return False
+        task = self._chat_run_registry.get(session_id)
+        return task is not None and not task.done()
 
     @staticmethod
     def _skip_parked_wakeup(

--- a/tests/service_interrupt_dispatch_test.py
+++ b/tests/service_interrupt_dispatch_test.py
@@ -1,0 +1,244 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=missing-class-docstring,missing-function-docstring
+"""Unit tests for :meth:`ChatService.interrupt` liveness dispatch.
+
+Regression test for the agent-assembly interrupt race (issue #2320): a
+chat run is spawned — and registered in ``ChatRunRegistry`` — *before*
+:meth:`ChatService._run_impl` acquires the distributed session lock, so
+``is_locked`` alone cannot tell "a reply is in flight here" during that
+window. The fix makes :meth:`ChatService.interrupt` also consult the
+per-process registry.
+
+Covers the four dispatch outcomes:
+
+- assembly window — live local task, lock not held → interrupt channel
+  (cancel path; previously misrouted to a resume trigger)
+- lock held (mid-reply / HITL-parked)             → interrupt channel
+  (cancel path; unchanged)
+- idle — no local task, lock not held             → resume trigger
+  (unchanged)
+- registry not wired (``None``), lock not held    → resume trigger
+  (legacy fallback preserved)
+"""
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from agentscope.app._manager import (
+    BackgroundTaskManager,
+    CancelDispatcher,
+    ChatRunRegistry,
+)
+from agentscope.app._service import ChatService
+from agentscope.app.message_bus import InMemoryMessageBus, MessageBusKeys
+
+
+class _FakeBus:
+    """Records ``publish`` calls and answers ``is_locked`` statically."""
+
+    def __init__(self, locked: bool) -> None:
+        self.locked = locked
+        self.published: list[tuple[str, dict]] = []
+        self.lock_checks: list[str] = []
+
+    async def is_locked(self, key: str) -> bool:
+        self.lock_checks.append(key)
+        return self.locked
+
+    async def publish(self, channel: str, payload: dict) -> None:
+        self.published.append((channel, payload))
+
+
+class _FakeStorage:
+    """Returns a session carrying ``state.reply_id``."""
+
+    def __init__(self) -> None:
+        self.session = SimpleNamespace(
+            state=SimpleNamespace(reply_id="reply-1"),
+        )
+
+    async def get_session(
+        self,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+    ):
+        del user_id, agent_id, session_id
+        return self.session
+
+
+def _make_service(bus: _FakeBus, registry: ChatRunRegistry | None) -> ChatService:
+    """Build a ChatService with only the deps ``interrupt`` touches wired.
+
+    All other dependencies are ``None``; ``interrupt`` reads only
+    ``_storage``, ``_message_bus`` and ``_chat_run_registry``.
+    """
+    return ChatService(
+        storage=_FakeStorage(),
+        workspace_manager=None,
+        scheduler_manager=None,
+        background_task_manager=None,
+        message_bus=bus,
+        resource_access_service=None,
+        chat_run_registry=registry,
+    )
+
+
+class InterruptLivenessDispatchTest(unittest.IsolatedAsyncioTestCase):
+    """Assert the cancel-vs-resume decision for each liveness state."""
+
+    async def test_assembly_window_live_task_cancels(self) -> None:
+        """A locally-live run with no lock yet must take the cancel path.
+
+        This is the regression the fix addresses: before, ``is_locked``
+        returned ``False`` during assembly and the interrupt was enqueued
+        as a ``resume`` trigger the assembling run could not process.
+        """
+        bus = _FakeBus(locked=False)
+        registry = ChatRunRegistry()
+        gate = asyncio.Event()
+        task = registry.spawn(gate.wait(), session_id="s")
+        service = _make_service(bus, registry)
+        try:
+            with patch(
+                "agentscope.app._service._chat.enqueue_run_trigger",
+                new=AsyncMock(),
+            ) as enqueue:
+                await service.interrupt("u", "s", "a")
+            self.assertEqual(
+                bus.published,
+                [
+                    (
+                        MessageBusKeys.session_interrupt_channel(),
+                        {"session_id": "s"},
+                    ),
+                ],
+            )
+            enqueue.assert_not_awaited()
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+    async def test_lock_held_cancels(self) -> None:
+        """A locked session (mid-reply / HITL-parked) still cancels."""
+        bus = _FakeBus(locked=True)
+        service = _make_service(bus, None)
+        with patch(
+            "agentscope.app._service._chat.enqueue_run_trigger",
+            new=AsyncMock(),
+        ) as enqueue:
+            await service.interrupt("u", "s", "a")
+        self.assertEqual(
+            bus.published,
+            [
+                (
+                    MessageBusKeys.session_interrupt_channel(),
+                    {"session_id": "s"},
+                ),
+            ],
+        )
+        enqueue.assert_not_awaited()
+
+    async def test_idle_empty_registry_resumes(self) -> None:
+        """Idle session, registry present but empty → resume trigger."""
+        bus = _FakeBus(locked=False)
+        registry = ChatRunRegistry()
+        service = _make_service(bus, registry)
+        with patch(
+            "agentscope.app._service._chat.enqueue_run_trigger",
+            new=AsyncMock(),
+        ) as enqueue:
+            await service.interrupt("u", "s", "a")
+        self.assertEqual(bus.published, [])
+        enqueue.assert_awaited_once()
+        self.assertEqual(
+            enqueue.await_args.kwargs["kind"],
+            MessageBusKeys.WAKEUP_KIND_RESUME,
+        )
+
+    async def test_no_registry_falls_back_to_resume(self) -> None:
+        """Unwired registry (``None``) must preserve the legacy behaviour.
+
+        Services built without a registry — tests, alternate wiring —
+        fall back to the lock-only check, so nothing regresses for
+        callers that have not opted into the registry.
+        """
+        bus = _FakeBus(locked=False)
+        service = _make_service(bus, None)
+        with patch(
+            "agentscope.app._service._chat.enqueue_run_trigger",
+            new=AsyncMock(),
+        ) as enqueue:
+            await service.interrupt("u", "s", "a")
+        self.assertEqual(bus.published, [])
+        enqueue.assert_awaited_once()
+        self.assertEqual(
+            enqueue.await_args.kwargs["kind"],
+            MessageBusKeys.WAKEUP_KIND_RESUME,
+        )
+        self.assertEqual(
+            enqueue.await_args.kwargs["inputs"].reply_id,
+            "reply-1",
+        )
+
+
+    async def test_assembly_interrupt_reaches_cancel_dispatcher(
+        self,
+    ) -> None:
+        """End-to-end: an assembly-window interrupt cancels the live task.
+
+        The dispatch tests above stop at the ``publish`` boundary. This
+        one wires the real pipeline — ``ChatService.interrupt`` →
+        ``CancelDispatcher`` → ``ChatRunRegistry`` lookup →
+        ``task.cancel()`` — against a task blocked *before* acquiring
+        any lock (the assembly window), and asserts the task is actually
+        cancelled. Guards the fix's premise ("the cancel machinery
+        already exists and works for the assembly task") rather than
+        asserting it.
+        """
+        bus = InMemoryMessageBus()
+        registry = ChatRunRegistry()
+        bg_manager = BackgroundTaskManager(message_bus=bus)
+
+        service = ChatService(
+            storage=_FakeStorage(),
+            workspace_manager=None,
+            scheduler_manager=None,
+            background_task_manager=None,
+            message_bus=bus,
+            resource_access_service=None,
+            chat_run_registry=registry,
+        )
+
+        cancelled: list[bool] = []
+        gate = asyncio.Event()
+
+        async def _assembling() -> None:
+            # Simulates a run mid-assembly: alive in the registry, no
+            # session lock held, parked on an await.
+            try:
+                await gate.wait()
+            except asyncio.CancelledError:
+                cancelled.append(True)
+                raise
+
+        task = registry.spawn(_assembling(), session_id="s")
+
+        async with bus:
+            async with CancelDispatcher(
+                message_bus=bus,
+                registry=registry,
+                bg_manager=bg_manager,
+            ):
+                await asyncio.sleep(0.05)  # let the dispatcher subscribe
+                await service.interrupt("u", "s", "a")
+                await asyncio.sleep(0.1)  # let the cancel propagate
+
+        self.assertTrue(task.done(), "assembly-phase task must be cancelled")
+        self.assertTrue(task.cancelled(), "task must end as cancelled")
+        self.assertEqual(cancelled, [True], "CancelledError must be delivered")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Fixes #2320. During the **assembly phase** of `ChatService._run_impl` (steps 1–6: workspace materialisation, TTS, middleware, KB, toolkit, model) — which on a session's **first message** can take seconds on a cold workspace — the distributed session lock is **not yet acquired** (step 7). `ChatService.interrupt` uses `message_bus.is_locked(session_lock)` as its **sole** "is a run active" judge, so an interrupt landing in this window takes the **resume-trigger** branch instead of the **cancel** branch:

- the run is never cancelled → it completes and the shielded `finally` persists the **full reply** → a "ghost/abandoned" assistant message the user never wanted;
- the `UserInterruptEvent` resume trigger only fires *after* the run finishes and releases the lock, by which time the session is idle and the trigger no-ops.

The cancel machinery is already in place: `CancelDispatcher._interrupt_session` looks the run up in `ChatRunRegistry` (the in-process asyncio task handle), and an assembly-phase `CancelledError` is a `BaseException` that neither `_run_impl`'s `except Exception` nor `run`'s `except Exception` swallows — so it bubbles out with `reply_msg` unbound and **nothing persisted**. The gap is purely **branch selection**.

## Scope of this PR (read this first)

**This PR fully fixes the assembly-window interrupt for single-process deployments** (embedded / one-worker mode, where the interrupt and the run share a process). It does **not** yet fix the same window in **multi-replica** deployments: `ChatRunRegistry` is per-process, so if the run is assembling on worker A and the interrupt lands on worker B, B sees `is_locked == False` *and* an empty local registry and still falls through to the resume-trigger branch — the ghost reply persists, unchanged. Closing that needs a distributed run-alive marker (set at spawn, before `acquire_lock`), which is a follow-up. The issue itself acknowledges this.

## Fix (targeted — the issue's recommended direction #1)

`ChatService.interrupt` now treats a run as active when **either** the distributed lock is held **or** a non-finished chat-run task is live in this process's `ChatRunRegistry`:

```python
if await self._message_bus.is_locked(
    MessageBusKeys.session_lock(session_id),
) or self._has_live_local_run(session_id):
    ...  # publish on session_interrupt_channel (cancel path)
```

`_has_live_local_run` is a small helper reading the already-injected per-process registry (no new state, no new dependency):

```python
if self._chat_run_registry is None:
    return False
task = self._chat_run_registry.get(session_id)
return task is not None and not task.done()
```

The registry is **injected via the constructor** (`ChatRunRegistry | None = None`) and wired at the single production construction site in `_lifespan.py`. `None` preserves the previous behaviour for test / alternate wiring — zero API break. (Note: this means a future construction site that forgets to wire the registry silently keeps the pre-fix behaviour; the `interrupt` docstring flags this.)

The assembly task is already registered at spawn (it occupies the 409 "busy" slot), so publishing on the interrupt channel reaches it immediately, and an in-assembly cancel persists nothing.

## Behaviour change in the fixed window (honest disclosure)

For the assembly window this PR *changes* what the user sees — it does not merely make the old path work:

- **Before**: the run completes → the user's input `Msg` **and** a full ghost assistant reply are both persisted.
- **After** (single-process): the run is cancelled before any reply exists → **nothing is persisted**, and no `ReplyStartEvent` / `ReplyEndEvent` is emitted. Because the input `Msg` is only persisted after assembly (inside the step-7 lock), **the user's message is dropped from the transcript** rather than answered-with-a-ghost.

Synthesising an `INTERRUPTED` terminal event (and persisting an empty assistant message) for assembly-phase cancels is the issue's **direction #2** and is left as a follow-up — direction #1 is its prerequisite. This trade-off (ghost reply → silent cancel, no terminal event) is exactly what the issue's direction #1 implies; we flag it rather than bury it.

## Tests

`tests/service_interrupt_dispatch_test.py` — 5 tests:

- **assembly window** (no lock + live local task) → cancel path (the regression; fails without the fix);
- **lock held** (mid-reply / HITL-parked) → cancel path (unchanged);
- **idle** (no lock + empty registry) → resume trigger (unchanged);
- **registry not wired** (`None`) → resume trigger (legacy fallback preserved);
- **end-to-end**: real `InMemoryMessageBus` + real `CancelDispatcher` + real registry — `ChatService.interrupt` on a task blocked *before* acquiring any lock, asserting the task is actually cancelled. Guards the fix's premise ("the cancel machinery already works for an assembly task") rather than asserting it.

Locally verified: the new file plus the existing `service_agent_interrupt_test.py`, `service_cancel_dispatcher_test.py`, `service_wakeup_dispatcher_test.py` and `service_chat_middleware_factory_test.py` all pass (31 tests, 0 failures).

## Impact on existing behaviour

The lock-held path, the resume-trigger path, and the `None`-registry fallback are byte-for-byte unchanged. The only production behaviour that changes is the single-process assembly window — the target of the fix. Multi-replica deployments are unchanged (and remain a follow-up).
