### PR TITLE
fix(app): support cross-owner agent invites

### DIFF
--- a/src/agentscope/app/_router/_session.py
+++ b/src/agentscope/app/_router/_session.py
@@ -58,6 +58,7 @@ from ..workspace_manager import WorkspaceManagerBase
 
 async def _build_team_detail(
     storage: StorageBase,
+    access: ResourceAccessService,
     user_id: str,
     team: TeamRecord,
 ) -> TeamDetailResponse:
@@ -68,6 +69,8 @@ async def _build_team_detail(
         storage (`StorageBase`):
             Application storage. Used to look up the leader session,
             each member agent, and each member's session.
+        access (`ResourceAccessService`):
+            Resolves roster agents against the viewer's current grants.
         user_id (`str`):
             The owner user id.
         team (`TeamRecord`):
@@ -90,8 +93,8 @@ async def _build_team_detail(
 
     members: list[TeamMemberView] = []
     for member in await _ensure_team_members(storage, user_id, team):
-        agent = await storage.get_agent(member.owner_id, member.agent_id)
-        if agent is None:
+        agent = await access.try_resolve_agent(user_id, member.agent_id)
+        if agent is None or agent.user_id != member.owner_id:
             continue
         # Use the member's team-scoped session id directly; an invited
         # agent has multiple sessions and only ``member.session_id``
@@ -242,6 +245,7 @@ async def list_sessions(
             if team_record is not None:
                 team_detail = await _build_team_detail(
                     storage,
+                    access,
                     user_id,
                     team_record,
                 )

--- a/src/agentscope/app/_service/_access.py
+++ b/src/agentscope/app/_service/_access.py
@@ -412,6 +412,22 @@ class ResourceAccessService:
         ``source == "user"`` agents since team workers are not
         shareable.
         """
+        record = await self.try_resolve_agent(viewer_id, agent_id)
+        if record is None:
+            raise self._not_found(ResourceKind.AGENT, agent_id)
+        return record
+
+    async def try_resolve_agent(
+        self,
+        viewer_id: str,
+        agent_id: str,
+    ) -> AgentRecord | None:
+        """Resolve an agent for runtime use, returning ``None`` when hidden.
+
+        This is the non-raising counterpart of :meth:`resolve_agent` for
+        stale references such as team rosters or toolkit snapshots. Owner
+        reads include team workers; cross-owner refs only resolve user agents.
+        """
         record = await self._storage.get_agent(viewer_id, agent_id)
         if record is not None:
             return record
@@ -425,7 +441,7 @@ class ResourceAccessService:
             )
             if record is not None and record.source != "team":
                 return record
-        raise self._not_found(ResourceKind.AGENT, agent_id)
+        return None
 
     async def resolve_knowledge_base(
         self,

--- a/src/agentscope/app/_service/_session.py
+++ b/src/agentscope/app/_service/_session.py
@@ -436,7 +436,8 @@ class SessionService:
           are fully removed.
         - ``role == "invited"``: the member is a pre-existing user-owned
           agent borrowed via ``AgentInvite``. Only the borrowed
-          team-scoped session is removed; the underlying
+          team-scoped session in the team owner's namespace is removed;
+          the underlying
           :class:`AgentRecord` and its other sessions survive.
 
         The leader's own session is **not** deleted — teams dissolve,
@@ -463,7 +464,7 @@ class SessionService:
                 await self.delete_agent(member.owner_id, member.agent_id)
             else:  # invited
                 await self.delete_session(
-                    member.owner_id,
+                    user_id,
                     member.agent_id,
                     member.session_id,
                 )

--- a/src/agentscope/app/_service/_toolkit.py
+++ b/src/agentscope/app/_service/_toolkit.py
@@ -216,6 +216,7 @@ time or interval"
                 AgentInvite(
                     **team_tool_kwargs,
                     invitable_pool=invitable_pool,
+                    resource_access_service=resource_access_service,
                 ),
             )
 

--- a/src/agentscope/app/_tool/_agent_invite.py
+++ b/src/agentscope/app/_tool/_agent_invite.py
@@ -34,6 +34,7 @@ from ..._utils._common import _generate_id
 
 if TYPE_CHECKING:
     from ..message_bus import MessageBus
+    from .._service._access import ResourceAccessService
     from ..storage import AgentRecord, StorageBase
     from ..workspace_manager import WorkspaceManagerBase
 
@@ -168,6 +169,7 @@ class AgentInvite(_TeamToolBase):
         session_id: str,
         agent_id: str,
         invitable_pool: list["AgentRecord"],
+        resource_access_service: "ResourceAccessService | None" = None,
     ) -> None:
         """Bind the base dependencies plus the invitable pool snapshot.
 
@@ -188,6 +190,10 @@ class AgentInvite(_TeamToolBase):
             invitable_pool (`list[AgentRecord]`):
                 Snapshot of currently-invitable agents. Must be
                 non-empty — the caller skips construction otherwise.
+            resource_access_service (`ResourceAccessService | None`):
+                Resolves the selected agent against the caller's current
+                access grants. ``None`` preserves direct construction for
+                owner-only integrations.
         """
         super().__init__(
             storage,
@@ -201,6 +207,7 @@ class AgentInvite(_TeamToolBase):
         self._pool_by_id: dict[str, "AgentRecord"] = {
             a.id: a for a in invitable_pool
         }
+        self._resource_access_service = resource_access_service
 
         # Build enum + a human-readable per-target rundown for the LLM.
         enum_values = [
@@ -266,12 +273,10 @@ class AgentInvite(_TeamToolBase):
 
             team = await self._require_leader_team("invite members")
 
-            # Re-fetch fresh — the snapshot could be stale if the user
-            # just toggled the invite off.
-            fresh = await self._storage.get_agent(
-                self._user_id,
-                invited.id,
-            )
+            # Re-fetch fresh — both the invite settings and a cross-owner
+            # access grant may have changed since the toolkit snapshot was
+            # assembled.
+            fresh = await self._resolve_fresh_agent(invited)
             if (
                 fresh is None
                 or not fresh.data.invite_config.invitable
@@ -401,7 +406,7 @@ class AgentInvite(_TeamToolBase):
             team.data.members = [
                 *existing_members,
                 TeamMember(
-                    owner_id=self._user_id,
+                    owner_id=invited.user_id,
                     agent_id=invited.id,
                     session_id=borrowed.id,
                     role="invited",
@@ -453,6 +458,30 @@ class AgentInvite(_TeamToolBase):
                 content=[TextBlock(text=f"AgentInvite failed: {e}")],
                 state=ToolResultState.ERROR,
             )
+
+    async def _resolve_fresh_agent(
+        self,
+        invited: "AgentRecord",
+    ) -> "AgentRecord | None":
+        """Resolve a snapshot entry without losing its owner namespace."""
+        if self._resource_access_service is None:
+            return await self._storage.get_agent(invited.user_id, invited.id)
+
+        # Keep the web-framework exception dependency local to the app-only
+        # access-service path. A revoked share is a normal stale-snapshot
+        # outcome for this tool, not an unhandled tool failure.
+        from fastapi import HTTPException
+
+        try:
+            fresh = await self._resource_access_service.resolve_agent(
+                self._user_id,
+                invited.id,
+            )
+            return fresh if fresh.user_id == invited.user_id else None
+        except HTTPException as exc:
+            if exc.status_code == 404:
+                return None
+            raise
 
 
 def _resolve_target(

--- a/src/agentscope/app/_tool/_agent_invite.py
+++ b/src/agentscope/app/_tool/_agent_invite.py
@@ -5,10 +5,11 @@ Unlike :class:`AgentCreate`, which spawns a brand-new worker
 (``source='team'``) from a :class:`SubAgentTemplate`, this tool
 **borrows** a pre-existing user-owned agent by minting a fresh
 team-scoped :class:`SessionRecord` on top of the *existing*
-:class:`AgentRecord`.  The borrowed agent keeps its system prompt,
-context/react configs, workspace, MCP, skills, and model choice; only
-a new session is created so it can hold a parallel conversation for
-the team.
+:class:`AgentRecord`. The borrowed agent keeps its definition, including
+its system prompt and context/react configs. An agent owned by the leader
+may reuse its existing session configuration; a cross-owner agent instead
+runs in a fresh leader-owned workspace with the leader's chat model and
+without the owner's MCPs, skills, cache, or session permissions.
 
 When the team is dissolved or the leader is deleted, only the borrowed
 session is cleaned up — the underlying :class:`AgentRecord` survives
@@ -189,7 +190,9 @@ class AgentInvite(_TeamToolBase):
                 The calling agent id.
             invitable_pool (`list[AgentRecord]`):
                 Snapshot of currently-invitable agents. Must be
-                non-empty — the caller skips construction otherwise.
+                non-empty — the caller skips construction otherwise. When
+                no access service is supplied, the constructor is responsible
+                for ensuring every snapshot entry is safe for the caller.
             resource_access_service (`ResourceAccessService | None`):
                 Resolves the selected agent against the caller's current
                 access grants. ``None`` preserves direct construction for
@@ -326,13 +329,12 @@ class AgentInvite(_TeamToolBase):
             # not block the invite.
             leader_name = leader.name if leader else leader_session.agent_id
 
-            # Prefer the invited agent's own primary session for
-            # workspace + chat-model reuse: it already has any MCP /
-            # skills / cache set up. Fall back to a freshly-generated
-            # workspace id + the leader's chat model when the agent has
-            # never been opened — the underlying workspace is created
-            # lazily by the workspace manager on first chat, so a bare
-            # id is enough.
+            # A leader-owned invite may reuse its primary session's workspace
+            # and model configuration. Cross-owner sessions are stored under
+            # the leader, so they intentionally never reuse the owner's
+            # session: they get a fresh workspace, the leader's chat model,
+            # and none of the owner's MCPs, skills, cache, or permissions.
+            # The workspace itself is created lazily on first chat.
             invited_sessions = await self._storage.list_sessions(
                 self._user_id,
                 invited.id,
@@ -463,25 +465,24 @@ class AgentInvite(_TeamToolBase):
         self,
         invited: "AgentRecord",
     ) -> "AgentRecord | None":
-        """Resolve a snapshot entry without losing its owner namespace."""
+        """Resolve a snapshot entry without losing its owner namespace.
+
+        Without an access service, the invitable pool is trusted to contain
+        only entries that the caller may use. Production toolkit assembly
+        supplies the service and therefore re-checks current grants here.
+        """
         if self._resource_access_service is None:
             return await self._storage.get_agent(invited.user_id, invited.id)
 
-        # Keep the web-framework exception dependency local to the app-only
-        # access-service path. A revoked share is a normal stale-snapshot
-        # outcome for this tool, not an unhandled tool failure.
-        from fastapi import HTTPException
-
-        try:
-            fresh = await self._resource_access_service.resolve_agent(
-                self._user_id,
-                invited.id,
-            )
-            return fresh if fresh.user_id == invited.user_id else None
-        except HTTPException as exc:
-            if exc.status_code == 404:
-                return None
-            raise
+        fresh = await self._resource_access_service.try_resolve_agent(
+            self._user_id,
+            invited.id,
+        )
+        return (
+            fresh
+            if fresh is not None and fresh.user_id == invited.user_id
+            else None
+        )
 
 
 def _resolve_target(

--- a/src/agentscope/app/_tool/_agent_invite.py
+++ b/src/agentscope/app/_tool/_agent_invite.py
@@ -6,10 +6,9 @@ Unlike :class:`AgentCreate`, which spawns a brand-new worker
 **borrows** a pre-existing user-owned agent by minting a fresh
 team-scoped :class:`SessionRecord` on top of the *existing*
 :class:`AgentRecord`. The borrowed agent keeps its definition, including
-its system prompt and context/react configs. An agent owned by the leader
-may reuse its existing session configuration; a cross-owner agent instead
-runs in a fresh leader-owned workspace with the leader's chat model and
-without the owner's MCPs, skills, cache, or session permissions.
+its system prompt and context/react configs. Workspace and model are taken
+from the *caller's* own session of that agent, so a cross-owner borrow
+never picks up the owner's MCPs, skills, cache, or session permissions.
 
 When the team is dissolved or the leader is deleted, only the borrowed
 session is cleaned up — the underlying :class:`AgentRecord` survives
@@ -277,9 +276,23 @@ class AgentInvite(_TeamToolBase):
             team = await self._require_leader_team("invite members")
 
             # Re-fetch fresh — both the invite settings and a cross-owner
-            # access grant may have changed since the toolkit snapshot was
-            # assembled.
-            fresh = await self._resolve_fresh_agent(invited)
+            # access grant may have changed since the toolkit snapshot
+            # was assembled. Without an access service the pool is
+            # trusted to hold only entries the caller may use.
+            access = self._resource_access_service
+            if access is None:
+                fresh = await self._storage.get_agent(
+                    invited.user_id,
+                    invited.id,
+                )
+            else:
+                fresh = await access.try_resolve_agent(
+                    self._user_id,
+                    invited.id,
+                )
+                # Same id under a different owner is a different agent.
+                if fresh is not None and fresh.user_id != invited.user_id:
+                    fresh = None
             if (
                 fresh is None
                 or not fresh.data.invite_config.invitable
@@ -329,12 +342,11 @@ class AgentInvite(_TeamToolBase):
             # not block the invite.
             leader_name = leader.name if leader else leader_session.agent_id
 
-            # A leader-owned invite may reuse its primary session's workspace
-            # and model configuration. Cross-owner sessions are stored under
-            # the leader, so they intentionally never reuse the owner's
-            # session: they get a fresh workspace, the leader's chat model,
-            # and none of the owner's MCPs, skills, cache, or permissions.
-            # The workspace itself is created lazily on first chat.
+            # Reuse the caller's own primary session of this agent for
+            # workspace + model, else a fresh workspace and the leader's
+            # model. The lookup is caller-scoped, so a cross-owner borrow
+            # never reuses the owner's session, MCPs, skills, or cache.
+            # The workspace is created lazily on first chat.
             invited_sessions = await self._storage.list_sessions(
                 self._user_id,
                 invited.id,
@@ -460,29 +472,6 @@ class AgentInvite(_TeamToolBase):
                 content=[TextBlock(text=f"AgentInvite failed: {e}")],
                 state=ToolResultState.ERROR,
             )
-
-    async def _resolve_fresh_agent(
-        self,
-        invited: "AgentRecord",
-    ) -> "AgentRecord | None":
-        """Resolve a snapshot entry without losing its owner namespace.
-
-        Without an access service, the invitable pool is trusted to contain
-        only entries that the caller may use. Production toolkit assembly
-        supplies the service and therefore re-checks current grants here.
-        """
-        if self._resource_access_service is None:
-            return await self._storage.get_agent(invited.user_id, invited.id)
-
-        fresh = await self._resource_access_service.try_resolve_agent(
-            self._user_id,
-            invited.id,
-        )
-        return (
-            fresh
-            if fresh is not None and fresh.user_id == invited.user_id
-            else None
-        )
 
 
 def _resolve_target(

--- a/src/agentscope/app/storage/_base.py
+++ b/src/agentscope/app/storage/_base.py
@@ -858,7 +858,8 @@ class StorageBase(ABC):
              is fully removed because it was spawned solely for this
              team.
            - ``role == "invited"`` — call :meth:`delete_session` for
-             the borrowed team-scoped session only. The invited
+             the borrowed team-scoped session under the team owner's
+             namespace only. The invited
              agent's :class:`AgentRecord` and any other sessions it
              owns survive the team's dissolution.
         2. Clear ``team_id`` on the leader session referenced by

--- a/src/agentscope/app/storage/_model/_team.py
+++ b/src/agentscope/app/storage/_model/_team.py
@@ -22,13 +22,9 @@ class TeamMember(BaseModel):
 
     owner_id: str = Field(
         description=(
-            "Owner of the member's agent. Always equals the team owner "
-            "in today's user-only invite pool, but is stored explicitly "
-            "so a future admin-share layer (agents borrowed across users) "
-            "can slot in without a schema migration. Distinct name from "
-            ":attr:`TeamRecord.user_id` on purpose — the surrounding "
-            "team already carries the team owner in context, so calling "
-            "this field ``user_id`` too would be ambiguous."
+            "Owner of the member's agent definition. For a cross-owner "
+            "invited member this differs from the team owner; its borrowed "
+            "session still belongs to :attr:`TeamRecord.user_id`."
         ),
     )
 
@@ -41,8 +37,8 @@ class TeamMember(BaseModel):
             "The team-scoped session id for this member. For ``created`` "
             "members this is the sole session (1:1 with the agent). For "
             "``invited`` members this is the freshly-minted session that "
-            "``AgentInvite`` created — the agent's other sessions are "
-            "unrelated to this team."
+            "``AgentInvite`` created in the team owner's namespace — the "
+            "agent owner's other sessions are unrelated to this team."
         ),
     )
 

--- a/src/agentscope/app/storage/_redis_storage.py
+++ b/src/agentscope/app/storage/_redis_storage.py
@@ -1698,7 +1698,8 @@ class RedisStorage(StorageBase):
              worker's session.
            - ``role == "invited"`` — the member is a pre-existing
              user-owned agent that was borrowed via ``AgentInvite``.
-             Only remove the team-scoped session via
+             Only remove the team-scoped session from the team owner's
+             namespace via
              :meth:`delete_session`; the underlying
              :class:`AgentRecord` and its other sessions must survive.
 
@@ -1745,7 +1746,7 @@ class RedisStorage(StorageBase):
                 await self.delete_agent(member.owner_id, member.agent_id)
             else:  # invited
                 await self.delete_session(
-                    member.owner_id,
+                    user_id,
                     member.agent_id,
                     member.session_id,
                 )

--- a/src/agentscope/app/storage/_sql/_storage.py
+++ b/src/agentscope/app/storage/_sql/_storage.py
@@ -633,7 +633,7 @@ class AsyncSQLAlchemyStorage(StorageBase):
             else:  # invited — only the borrowed session goes
                 await self._delete_session_impl(
                     sess,
-                    member.owner_id,
+                    user_id,
                     member.agent_id,
                     member.session_id,
                 )

--- a/tests/resource_access_policy_test.py
+++ b/tests/resource_access_policy_test.py
@@ -369,6 +369,14 @@ class ResourceAccessServiceTest(IsolatedAsyncioTestCase):
             },
         )
 
+    async def test_try_resolve_agent_returns_none_when_not_visible(
+        self,
+    ) -> None:
+        """Non-raising resolution should represent hidden agents as None."""
+        agent = await self.service.try_resolve_agent("other", "agent-1")
+
+        self.assertIsNone(agent)
+
     async def test_list_agents_skips_shared_team_agents(self) -> None:
         """Cross-owner team agents should not appear in shared lists."""
         views = await self.service.list_resource(

--- a/tests/service_team_tools_test.py
+++ b/tests/service_team_tools_test.py
@@ -31,13 +31,21 @@ from agentscope.app._tool import (
     TeamSay,
 )
 from agentscope.app._types import SubAgentTemplate
+from agentscope.app._service import ResourceAccessService
+from agentscope.app.access import (
+    ResourceAccessPolicyBase,
+    ResourceKind,
+    ResourceRef,
+)
 from agentscope.app.message_bus import RedisMessageBus
 from agentscope.app.storage import (
     AgentData,
     AgentRecord,
     RedisStorage,
     SessionConfig,
+    StorageBase,
 )
+from agentscope.message import ToolResultState
 from agentscope.permission import (
     AdditionalWorkingDirectory,
     PermissionBehavior,
@@ -98,6 +106,31 @@ def _make_agent_record(
             react_config=ReActConfig(),
         ),
     )
+
+
+class _SharedAgentPolicy(ResourceAccessPolicyBase):
+    """Mutable sharing policy used to exercise grant revocation."""
+
+    def __init__(self, owner_id: str, agent_id: str) -> None:
+        self.owner_id = owner_id
+        self.agent_id = agent_id
+        self.allowed = True
+
+    async def list_accessible(
+        self,
+        viewer_id: str,
+        kind: ResourceKind,
+        storage: StorageBase,
+    ) -> list[ResourceRef]:
+        if not self.allowed or kind != ResourceKind.AGENT:
+            return []
+        return [
+            ResourceRef(
+                kind=ResourceKind.AGENT,
+                owner_id=self.owner_id,
+                resource_id=self.agent_id,
+            ),
+        ]
 
 
 class _TeamToolsTestBase(IsolatedAsyncioTestCase):
@@ -1467,6 +1500,142 @@ class TestAgentInviteSuccess(_AgentInviteTestBase):
             max_count=10,
         )
         self.assertEqual(primary_inbox, [])
+
+
+class TestAgentInviteCrossOwner(_AgentInviteTestBase):
+    """A viewer can invite an agent exposed by the access policy."""
+
+    async def _make_shared_agent(
+        self,
+    ) -> tuple[AgentRecord, _SharedAgentPolicy, ResourceAccessService]:
+        """Store a shared agent and expose it through a mutable policy."""
+        from agentscope.app.storage._model._agent import InviteConfig
+
+        shared_owner = "platform-owner"
+        shared_agent = AgentRecord(
+            user_id=shared_owner,
+            source="user",
+            data=AgentData(
+                name="Shared Specialist",
+                system_prompt="I am a shared specialist.",
+                context_config=ContextConfig(),
+                react_config=ReActConfig(),
+                invite_config=InviteConfig(
+                    invitable=True,
+                    invite_description="Shared expert.",
+                ),
+            ),
+        )
+        await self.storage.upsert_agent(shared_owner, shared_agent)
+        await self.storage.upsert_session(
+            user_id=shared_owner,
+            agent_id=shared_agent.id,
+            config=SessionConfig(workspace_id="owner-private-workspace"),
+        )
+        policy = _SharedAgentPolicy(shared_owner, shared_agent.id)
+        access = ResourceAccessService(self.storage, policy)
+        return shared_agent, policy, access
+
+    async def test_invites_shared_agent(self) -> None:
+        """The borrowed session belongs to the viewer, while the team
+        roster preserves the shared agent definition's real owner."""
+        shared_agent, _policy, access = await self._make_shared_agent()
+        pool = await access.list_resource(self.user_id, ResourceKind.AGENT)
+
+        tool = AgentInvite(
+            storage=self.storage,
+            message_bus=self.bus,
+            workspace_manager=self.workspace_manager,
+            user_id=self.user_id,
+            session_id=self.leader_session.id,
+            agent_id=self.leader_agent.id,
+            invitable_pool=pool,
+            resource_access_service=access,
+        )
+
+        chunk = await tool(
+            target=f"Shared Specialist@{shared_agent.id[:8]}",
+            prompt="Please handle this.",
+        )
+
+        self.assertNotEqual(
+            chunk.state,
+            ToolResultState.ERROR,
+            chunk.content[0].text,
+        )
+
+        leader = await self.storage.get_session(
+            self.user_id,
+            self.leader_agent.id,
+            self.leader_session.id,
+        )
+        team = await self.storage.get_team(self.user_id, leader.team_id)
+        member = team.data.members[0]
+        self.assertEqual(member.owner_id, shared_agent.user_id)
+
+        borrowed = await self.storage.get_session(
+            self.user_id,
+            shared_agent.id,
+            member.session_id,
+        )
+        self.assertIsNotNone(borrowed)
+        self.assertNotEqual(
+            borrowed.config.workspace_id,
+            "owner-private-workspace",
+        )
+        self.assertIsNone(
+            await self.storage.get_session(
+                shared_agent.user_id,
+                shared_agent.id,
+                member.session_id,
+            ),
+        )
+
+        await TeamDelete(
+            storage=self.storage,
+            message_bus=self.bus,
+            workspace_manager=self.workspace_manager,
+            user_id=self.user_id,
+            session_id=self.leader_session.id,
+            agent_id=self.leader_agent.id,
+        )()
+        self.assertIsNone(
+            await self.storage.get_session(
+                self.user_id,
+                shared_agent.id,
+                member.session_id,
+            ),
+        )
+        self.assertIsNotNone(
+            await self.storage.get_agent(
+                shared_agent.user_id,
+                shared_agent.id,
+            ),
+        )
+
+    async def test_rejects_shared_agent_after_access_revoked(self) -> None:
+        """Invocation rechecks a share captured in the toolkit snapshot."""
+        shared_agent, policy, access = await self._make_shared_agent()
+        pool = await access.list_resource(self.user_id, ResourceKind.AGENT)
+        tool = AgentInvite(
+            storage=self.storage,
+            message_bus=self.bus,
+            workspace_manager=self.workspace_manager,
+            user_id=self.user_id,
+            session_id=self.leader_session.id,
+            agent_id=self.leader_agent.id,
+            invitable_pool=pool,
+            resource_access_service=access,
+        )
+        policy.allowed = False
+
+        chunk = await tool(
+            target=f"Shared Specialist@{shared_agent.id[:8]}",
+            prompt="Please handle this.",
+        )
+
+        self.assertEqual(chunk.state, ToolResultState.ERROR)
+        self.assertIn("no longer invitable", chunk.content[0].text)
 
 
 class TestAgentInviteRejections(_AgentInviteTestBase):

--- a/tests/service_team_tools_test.py
+++ b/tests/service_team_tools_test.py
@@ -31,6 +31,7 @@ from agentscope.app._tool import (
     TeamSay,
 )
 from agentscope.app._types import SubAgentTemplate
+from agentscope.app._router._session import _build_team_detail
 from agentscope.app._service import ResourceAccessService
 from agentscope.app.access import (
     ResourceAccessPolicyBase,
@@ -1636,6 +1637,42 @@ class TestAgentInviteCrossOwner(_AgentInviteTestBase):
 
         self.assertEqual(chunk.state, ToolResultState.ERROR)
         self.assertIn("no longer invitable", chunk.content[0].text)
+
+    async def test_revoked_agent_is_hidden_from_team_detail(self) -> None:
+        """A stale roster must not bypass a revoked cross-owner grant."""
+        shared_agent, policy, access = await self._make_shared_agent()
+        pool = await access.list_resource(self.user_id, ResourceKind.AGENT)
+        invite = AgentInvite(
+            storage=self.storage,
+            message_bus=self.bus,
+            workspace_manager=self.workspace_manager,
+            user_id=self.user_id,
+            session_id=self.leader_session.id,
+            agent_id=self.leader_agent.id,
+            invitable_pool=pool,
+            resource_access_service=access,
+        )
+        result = await invite(
+            target=f"Shared Specialist@{shared_agent.id[:8]}",
+            prompt="Please handle this.",
+        )
+        self.assertNotEqual(result.state, ToolResultState.ERROR)
+
+        leader = await self.storage.get_session(
+            self.user_id,
+            self.leader_agent.id,
+            self.leader_session.id,
+        )
+        team = await self.storage.get_team(self.user_id, leader.team_id)
+        policy.allowed = False
+
+        detail = await _build_team_detail(
+            self.storage,
+            access,
+            self.user_id,
+            team,
+        )
+        self.assertEqual(detail.members, [])
 
 
 class TestAgentInviteRejections(_AgentInviteTestBase):

--- a/tests/storage_redis_test.py
+++ b/tests/storage_redis_test.py
@@ -16,6 +16,7 @@ from agentscope.app.storage import (
     ScheduleData,
     SessionSource,
     TeamData,
+    TeamMember,
     TeamRecord,
 )
 from agentscope.app.storage import MCPRecord, SkillRecord
@@ -1133,6 +1134,55 @@ class TestTeamCascade(IsolatedAsyncioTestCase):
         )
         self.assertIsNotNone(leader)
         self.assertIsNone(leader.team_id)
+
+    async def test_delete_team_removes_cross_owner_borrowed_session(
+        self,
+    ) -> None:
+        """An invited definition owner differs from its session owner."""
+        definition_owner = "user-2"
+        invited = make_agent_record(definition_owner)
+        await self.storage.upsert_agent(definition_owner, invited)
+        owner_session = await self.storage.upsert_session(
+            definition_owner,
+            invited.id,
+            make_session_config("owner-private-workspace"),
+        )
+        borrowed = await self.storage.upsert_session(
+            self.user_id,
+            invited.id,
+            make_session_config("viewer-borrowed-workspace"),
+        )
+        self.team.data.members = [
+            TeamMember(
+                owner_id=definition_owner,
+                agent_id=invited.id,
+                session_id=borrowed.id,
+                role="invited",
+            ),
+        ]
+        self.team.data.member_ids = [invited.id]
+        await self.storage.upsert_team(self.user_id, self.team)
+
+        self.assertTrue(
+            await self.storage.delete_team(self.user_id, self.team.id),
+        )
+        self.assertIsNone(
+            await self.storage.get_session(
+                self.user_id,
+                invited.id,
+                borrowed.id,
+            ),
+        )
+        self.assertIsNotNone(
+            await self.storage.get_session(
+                definition_owner,
+                invited.id,
+                owner_session.id,
+            ),
+        )
+        self.assertIsNotNone(
+            await self.storage.get_agent(definition_owner, invited.id),
+        )
 
     async def test_delete_leader_session_dissolves_team(self) -> None:
         """Deleting a leader session auto-dissolves its team."""

--- a/tests/storage_sql_test.py
+++ b/tests/storage_sql_test.py
@@ -461,10 +461,11 @@ class AsyncSQLAlchemyStorageTest(IsolatedAsyncioTestCase):
         # another that will be "invited".
         created_agent = _agent_record("user-1", "created")
         created_agent.source = "team"
-        invited_agent = _agent_record("user-1", "invited")
+        invited_owner = "user-2"
+        invited_agent = _agent_record(invited_owner, "invited")
 
         await self.storage.upsert_agent("user-1", created_agent)
-        await self.storage.upsert_agent("user-1", invited_agent)
+        await self.storage.upsert_agent(invited_owner, invited_agent)
 
         # Sessions for both, plus the leader session.
         leader = await self.storage.upsert_session(
@@ -483,7 +484,7 @@ class AsyncSQLAlchemyStorageTest(IsolatedAsyncioTestCase):
             config=_session_config(),
         )
         surviving_session = await self.storage.upsert_session(
-            user_id="user-1",
+            user_id=invited_owner,
             agent_id=invited_agent.id,
             config=_session_config(),
         )
@@ -501,7 +502,7 @@ class AsyncSQLAlchemyStorageTest(IsolatedAsyncioTestCase):
                         role="created",
                     ),
                     TeamMember(
-                        owner_id="user-1",
+                        owner_id=invited_owner,
                         agent_id=invited_agent.id,
                         session_id=invited_session.id,
                         role="invited",
@@ -526,7 +527,7 @@ class AsyncSQLAlchemyStorageTest(IsolatedAsyncioTestCase):
         )
         # Invited member: agent survives, only the invited session is gone.
         self.assertIsNotNone(
-            await self.storage.get_agent("user-1", invited_agent.id),
+            await self.storage.get_agent(invited_owner, invited_agent.id),
         )
         self.assertIsNone(
             await self.storage.get_session(
@@ -537,7 +538,7 @@ class AsyncSQLAlchemyStorageTest(IsolatedAsyncioTestCase):
         )
         self.assertIsNotNone(
             await self.storage.get_session(
-                "user-1",
+                invited_owner,
                 invited_agent.id,
                 surviving_session.id,
             ),


### PR DESCRIPTION
## Summary

- re-resolve invite targets through `ResourceAccessService` so cross-owner access is checked again at invocation time
- preserve the shared agent definition owner while keeping the borrowed session in the team owner namespace
- clean up cross-owner borrowed sessions correctly in the service, Redis, and SQL storage paths
- add regression coverage for successful invitations, revoked access, workspace isolation, routing ownership, and team deletion

## Tests

- `pre-commit run --files <changed files>`
- `pytest tests/service_team_tools_test.py tests/storage_redis_test.py -q`
- `pytest tests/storage_sql_test.py -q`
- `pytest tests/service_toolkit_test.py tests/resource_access_policy_test.py -q`

Closes #2319