### PR TITLE
fix(agent): discard swallowed final context

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -705,6 +705,19 @@ class Agent:
                 self._receive_reply_end = True
             yield item
 
+    def _restore_context_before_final(
+        self,
+        context_before_final: tuple[Msg | None, int, Usage | None],
+    ) -> None:
+        """Restore context written before a swallowed final answer."""
+        context_msg, content_length, usage = context_before_final
+        if context_msg is None:
+            if self._get_last_msg() is not None:
+                self.state.context.pop()
+        else:
+            context_msg.content = context_msg.content[:content_length]
+            context_msg.usage = usage
+
     async def _close_unfinished_tool_calls(
         self,
     ) -> AsyncGenerator[
@@ -874,6 +887,11 @@ class Agent:
             #  or no more tool calls to execute
             # =================================================================
             final_msg: Msg | None = None
+            context_before_final: tuple[Msg | None, int, Usage | None] = (
+                None,
+                0,
+                None,
+            )
             # Detects middlewares swallowing the ReplyEndEvent repeatedly
             # without any reasoning/acting in between (a busy loop)
             made_progress = True
@@ -910,6 +928,10 @@ class Agent:
                                 "the event again.",
                             )
                         made_progress = False
+                        if final_msg is not None:
+                            self._restore_context_before_final(
+                                context_before_final,
+                            )
                         final_msg = None
                         continue
 
@@ -925,6 +947,17 @@ class Agent:
                         # Inject runtime state if needed before reasoning
                         async for evt in self._inject_runtime_state():
                             yield evt
+
+                        context_msg = self._get_last_msg()
+                        context_before_final = (
+                            context_msg,
+                            len(context_msg.content)
+                            if context_msg is not None
+                            else 0,
+                            deepcopy(context_msg.usage)
+                            if context_msg is not None
+                            else None,
+                        )
 
                         # Perform reasoning
                         interrupted = False

--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -707,14 +707,17 @@ class Agent:
 
     def _restore_context_before_final(
         self,
-        context_before_final: tuple[Msg | None, int, Usage | None],
+        context_before_final: tuple[int, Msg | None, int, Usage | None],
     ) -> None:
         """Restore context written before a swallowed final answer."""
-        context_msg, content_length, usage = context_before_final
-        if context_msg is None:
-            if self._get_last_msg() is not None:
-                self.state.context.pop()
-        else:
+        (
+            context_length,
+            context_msg,
+            content_length,
+            usage,
+        ) = context_before_final
+        del self.state.context[context_length:]
+        if context_msg is not None:
             context_msg.content = context_msg.content[:content_length]
             context_msg.usage = usage
 
@@ -887,7 +890,8 @@ class Agent:
             #  or no more tool calls to execute
             # =================================================================
             final_msg: Msg | None = None
-            context_before_final: tuple[Msg | None, int, Usage | None] = (
+            context_before_final: tuple[int, Msg | None, int, Usage | None] = (
+                0,
                 None,
                 0,
                 None,
@@ -949,7 +953,13 @@ class Agent:
                             yield evt
 
                         context_msg = self._get_last_msg()
+                        if (
+                            context_msg is not None
+                            and context_msg.id != self.state.reply_id
+                        ):
+                            context_msg = None
                         context_before_final = (
+                            len(self.state.context),
                             context_msg,
                             len(context_msg.content)
                             if context_msg is not None

--- a/tests/middleware_test.py
+++ b/tests/middleware_test.py
@@ -232,6 +232,14 @@ class TestMiddleware(IsolatedAsyncioTestCase):
                 ],
             },
         )
+        self.assertListEqual(
+            [
+                block.text
+                for block in agent.state.context[-1].content
+                if isinstance(block, TextBlock)
+            ],
+            ["second answer"],
+        )
 
     async def test_on_reasoning_middleware_pre_yield(self) -> None:
         """Test on_reasoning middleware pre and yield positions."""

--- a/tests/middleware_test.py
+++ b/tests/middleware_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=abstract-method,protected-access
+# pylint: disable=abstract-method,protected-access,too-many-public-methods
 """Unit tests for middleware system."""
 from unittest.async_case import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, patch
@@ -231,6 +231,79 @@ class TestMiddleware(IsolatedAsyncioTestCase):
                     },
                 ],
             },
+        )
+        self.assertListEqual(
+            [
+                block.text
+                for block in agent.state.context[-1].content
+                if isinstance(block, TextBlock)
+            ],
+            ["second answer"],
+        )
+
+    async def test_on_reply_middleware_swallow_reply_end_with_previous_reply(
+        self,
+    ) -> None:
+        """Test swallowing a final reply keeps the previous reply unchanged."""
+
+        class SwallowOnceMiddleware(MiddlewareBase):
+            """Middleware swallowing the first ReplyEndEvent."""
+
+            def __init__(self) -> None:
+                self.swallowed = False
+
+            async def on_reply(
+                self,
+                agent: Agent,
+                input_kwargs: dict,
+                next_handler: Callable[[], AsyncGenerator],
+            ) -> AsyncGenerator:
+                """Swallow the first ReplyEndEvent, deliver the rest."""
+                async for item in next_handler():
+                    if isinstance(item, ReplyEndEvent) and not self.swallowed:
+                        self.swallowed = True
+                        continue
+                    yield item
+
+        self.mock_model.set_responses(
+            [
+                ChatResponse(
+                    content=[TextBlock(text="first answer")],
+                    is_last=True,
+                ),
+                ChatResponse(
+                    content=[TextBlock(text="second answer")],
+                    is_last=True,
+                ),
+            ],
+        )
+        agent = Agent(
+            name="test_agent",
+            system_prompt="test prompt",
+            model=self.mock_model,
+            toolkit=self.toolkit,
+            middlewares=[SwallowOnceMiddleware()],
+            injection_config=InjectionConfig(inject_runtime_state=False),
+        )
+        previous_msg = Msg(
+            id="previous-reply",
+            role="assistant",
+            name="test_agent",
+            content=[TextBlock(text="previous answer")],
+        )
+        agent.state.context.append(previous_msg)
+
+        async for _ in agent.reply_stream(None, yield_final_msg=True):
+            pass
+
+        self.assertIs(agent.state.context[0], previous_msg)
+        self.assertListEqual(
+            [
+                block.text
+                for block in previous_msg.content
+                if isinstance(block, TextBlock)
+            ],
+            ["previous answer"],
         )
         self.assertListEqual(
             [


### PR DESCRIPTION
## Summary

Fixes #2328.

When an `on_reply` middleware swallows a completed `ReplyEndEvent`, restore the context written by that candidate final-answer round before continuing. This keeps earlier completed reasoning and tool context in the same reply intact while preventing the discarded draft from being appended to the final assistant message.

## Scope

This change covers only the issue-reproduced plain-text final-answer path. Structured-output and HITL paths are intentionally unchanged.

## Validation

- `PYTHONPATH=tests .venv/bin/python -m unittest middleware_test.TestMiddleware.test_on_reply_middleware_swallow_reply_end`
- `pre-commit run --files src/agentscope/agent/_agent.py tests/middleware_test.py`
- `git diff --check`