### PR TITLE
feat(model): warn on unexpected thinking content

### DIFF
--- a/src/agentscope/model/_anthropic/_model.py
+++ b/src/agentscope/model/_anthropic/_model.py
@@ -176,6 +176,10 @@ class AnthropicChatModel(ChatModelBase):
             return self.parameters.thinking_mode
         return "enabled" if self.parameters.thinking_enable else None
 
+    def _is_thinking_disabled(self) -> bool:
+        """Whether the effective Anthropic thinking mode is disabled."""
+        return self._thinking_mode() in (None, "disabled")
+
     async def _call_api(
         self,
         model_name: str,

--- a/src/agentscope/model/_base.py
+++ b/src/agentscope/model/_base.py
@@ -96,6 +96,52 @@ class ChatModelBase:
         self.retry_delay = retry_delay
         self.context_size = context_size
 
+    def _is_thinking_disabled(self) -> bool:
+        """Whether thinking is explicitly disabled for this model.
+
+        Subclasses with provider-specific thinking controls can override this
+        method to report their effective configuration.
+
+        Returns:
+            `bool`:
+                Whether thinking is explicitly disabled.
+        """
+        return getattr(self.parameters, "thinking_enable", None) is False
+
+    def _warn_unexpected_thinking(
+        self,
+        response: ChatResponse,
+        warned: bool,
+    ) -> bool:
+        """Warn once if a disabled model returns thinking content.
+
+        Args:
+            response (`ChatResponse`):
+                The response to inspect.
+            warned (`bool`):
+                Whether this model call has already emitted the warning.
+
+        Returns:
+            `bool`:
+                Whether the warning has been emitted for this model call.
+        """
+        if warned or not self._is_thinking_disabled():
+            return warned
+
+        if any(
+            isinstance(block, ThinkingBlock) and bool(block.thinking)
+            for block in response.content
+        ):
+            logger.warning(
+                "Model %s returned thinking content while thinking is "
+                "disabled. The model provider may have ignored the request "
+                "parameter.",
+                self.model,
+            )
+            return True
+
+        return False
+
     @classmethod
     def _get_retryable_exceptions(cls) -> tuple[Type[Exception], ...]:
         """Return the exception types that should trigger a retry.
@@ -231,15 +277,23 @@ class ChatModelBase:
         # Consume the model calling result
         # =====================================================================
         if isinstance(res, ChatResponse):
+            self._warn_unexpected_thinking(res, warned=False)
             return res
 
         async def _stream() -> AsyncGenerator[ChatResponse, None]:
             """The wrapper around model calling."""
             # For backward compatibility
             yield_acc_res = True
+            unexpected_thinking_warned = False
             acc_res = _StreamAccumulator()
             try:
                 async for chunk in res:
+                    unexpected_thinking_warned = (
+                        self._warn_unexpected_thinking(
+                            chunk,
+                            unexpected_thinking_warned,
+                        )
+                    )
                     if not chunk.is_last:
                         acc_res.append_chat_response(chunk)
                         acc_res.id = chunk.id
@@ -581,6 +635,7 @@ class ChatModelBase:
         )
 
         completed_response: ChatResponse | None = None
+        unexpected_thinking_warned = False
         if self.stream:
             # ``_call_api`` yields raw incremental chunks whose ``is_last``
             # is always ``False``; subclasses rely on the ``__call__``
@@ -592,6 +647,10 @@ class ChatModelBase:
             acc_res = _StreamAccumulator()
 
             async for chunk in res:
+                unexpected_thinking_warned = self._warn_unexpected_thinking(
+                    chunk,
+                    unexpected_thinking_warned,
+                )
                 if chunk.is_last:
                     completed_response = chunk
                     break
@@ -602,6 +661,11 @@ class ChatModelBase:
                 completed_response = acc_res.build()
         else:
             completed_response = res
+            if completed_response is not None:
+                self._warn_unexpected_thinking(
+                    completed_response,
+                    unexpected_thinking_warned,
+                )
 
         if completed_response is None or not completed_response.content:
             raise RuntimeError(

--- a/tests/model_anthropic_test.py
+++ b/tests/model_anthropic_test.py
@@ -378,6 +378,26 @@ class TestAnthropicThinkingMode(IsolatedAsyncioTestCase):
 
         self.assertEqual(self._thinking(), {"type": "adaptive"})
 
+    def test_effective_mode_controls_common_thinking_guard(self) -> None:
+        """The common guard follows the effective Anthropic mode."""
+        cases = [
+            ({}, True),
+            ({"thinking_enable": True}, False),
+            ({"thinking_mode": "adaptive"}, False),
+            ({"thinking_mode": "enabled"}, False),
+            ({"thinking_mode": "disabled"}, True),
+            (
+                {"thinking_enable": False, "thinking_mode": "adaptive"},
+                False,
+            ),
+        ]
+        for params, expected in cases:
+            with self.subTest(params=params):
+                model = _make_model()
+                for key, val in params.items():
+                    setattr(model.parameters, key, val)
+                self.assertEqual(model._is_thinking_disabled(), expected)
+
     async def test_budget_mode_expands_max_tokens(self) -> None:
         """max_tokens must stay strictly above budget_tokens."""
         self.model.parameters.thinking_mode = "enabled"

--- a/tests/model_base_test.py
+++ b/tests/model_base_test.py
@@ -4,6 +4,9 @@ retry / accumulation / interrupt wrapper around ``_call_api``."""
 import asyncio
 import base64
 from unittest.async_case import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+from pydantic import BaseModel
 
 from utils import AnyString, MockModel
 
@@ -17,6 +20,12 @@ from agentscope.message import (
     UserMsg,
 )
 from agentscope.model import ChatResponse, ChatUsage, FinishedReason
+
+
+class _ThinkingParameters(BaseModel):
+    """Model parameters used to exercise the common thinking guard."""
+
+    thinking_enable: bool
 
 
 def _dump(chat_response: ChatResponse) -> dict:
@@ -103,6 +112,39 @@ class ChatModelBaseCallTest(IsolatedAsyncioTestCase):
             ),
         )
 
+    async def test_non_stream_warns_on_unexpected_thinking(self) -> None:
+        """Disabled thinking warns while preserving a non-stream response."""
+        self.model.parameters = _ThinkingParameters(thinking_enable=False)
+        response = ChatResponse(
+            content=[ThinkingBlock(thinking="unexpected", id="think-1")],
+            is_last=True,
+        )
+        self.model.set_responses([response])
+
+        with self.assertLogs("as", level="WARNING") as captured:
+            result = await self.model(messages=self.messages)
+
+        self.assertIs(result, response)
+        self.assertEqual(len(captured.output), 1)
+        self.assertIn("thinking is disabled", captured.output[0])
+
+    async def test_non_stream_does_not_warn_when_thinking_enabled(
+        self,
+    ) -> None:
+        """Expected thinking content does not produce a warning."""
+        self.model.parameters = _ThinkingParameters(thinking_enable=True)
+        response = ChatResponse(
+            content=[ThinkingBlock(thinking="expected", id="think-1")],
+            is_last=True,
+        )
+        self.model.set_responses([response])
+
+        with patch("agentscope.model._base.logger.warning") as mock_warning:
+            result = await self.model(messages=self.messages)
+
+        self.assertIs(result, response)
+        mock_warning.assert_not_called()
+
     # ------------------------------------------------------------------
     # 2) non-stream CancelledError raised from inside _call_api
     # ------------------------------------------------------------------
@@ -179,6 +221,31 @@ class ChatModelBaseCallTest(IsolatedAsyncioTestCase):
                 ),
             ],
         )
+
+    async def test_stream_warns_once_on_unexpected_thinking(self) -> None:
+        """Multiple unexpected thinking deltas produce one warning."""
+        self.model.parameters = _ThinkingParameters(thinking_enable=False)
+        deltas = [
+            ChatResponse(
+                content=[ThinkingBlock(thinking="un", id="think-1")],
+                is_last=False,
+            ),
+            ChatResponse(
+                content=[ThinkingBlock(thinking="expected", id="think-1")],
+                is_last=False,
+            ),
+        ]
+        self.model.set_responses([deltas])
+
+        with self.assertLogs("as", level="WARNING") as captured:
+            gen = await self.model(messages=self.messages)
+            responses = [response async for response in gen]
+
+        self.assertEqual(len(captured.output), 1)
+        self.assertIn("thinking is disabled", captured.output[0])
+        self.assertEqual(len(responses[-1].content), 1)
+        self.assertIsInstance(responses[-1].content[0], ThinkingBlock)
+        self.assertEqual(responses[-1].content[0].thinking, "unexpected")
 
     # ------------------------------------------------------------------
     # 4) stream CancelledError raised while consuming the generator


### PR DESCRIPTION
## AgentScope Version

2.0.6

## Description

Related feature discussion: https://github.com/agentscope-ai/agentscope/discussions/2272

When a chat model is configured with thinking disabled but its provider still returns non-empty thinking content, AgentScope now logs one warning per model call while preserving the returned `ThinkingBlock`.

- Applies the check in `ChatModelBase`, covering streaming and non-streaming responses for all current providers that expose `thinking_enable`.
- Keeps response content unchanged; no exception, retry, or content dropping.
- Uses Anthropic's effective `thinking_mode` so `adaptive` and `enabled` modes do not produce false warnings.
- Applies the same guard to the common structured-output fallback.

### Validation

- `pytest tests/model_*_test.py -q` — 185 passed, 12 subtests passed.
- Changed-files pre-commit — all hooks passed, including mypy, Black, Flake8, and Pylint.
- Full test suite — 1803 passed, 147 skipped; one unrelated MCP SSE schema test failed because the installed MCP dependency formats docstring indentation differently from the repository fixture.

No public API or documentation changes.

## Checklist

- [ ] An issue has been created for this PR (the feature proposal is tracked in Discussion #2272)
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation is not required (internal diagnostic behavior; no public API change)
- [x] Code is ready for review
