### PR TITLE
fix(rag): isolate concurrent middleware inputs

### DIFF
--- a/src/agentscope/middleware/_rag.py
+++ b/src/agentscope/middleware/_rag.py
@@ -31,6 +31,7 @@ service, to the knowledge-base manager) that constructs the
 """
 import asyncio
 import json
+from contextvars import ContextVar
 from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
@@ -589,7 +590,9 @@ class RAGMiddleware(MiddlewareBase):
         # original reply inputs (which are no longer in
         # ``agent.state.context`` by the time ``on_reasoning`` runs in
         # a tool-call loop).  Cleared in ``on_reply``'s finally.
-        self._cached_inputs: list[TextBlock | DataBlock] | None = None
+        self._cached_inputs: ContextVar[
+            list[TextBlock | DataBlock] | None
+        ] = ContextVar("rag_middleware_cached_inputs", default=None)
 
     # ------------------------------------------------------------------
     # Agentic mode — expose the search tool
@@ -655,6 +658,7 @@ class RAGMiddleware(MiddlewareBase):
         ):
             msgs = inputs
 
+        cached_inputs: list[TextBlock | DataBlock] | None = None
         if msgs:
             # Deepcopy because we are about to mutate the first text block of
             # each message to prepend the speaker name — never touch the
@@ -671,13 +675,14 @@ class RAGMiddleware(MiddlewareBase):
                     blocks.append(TextBlock(text=speaker))
                 blocks.extend(msg.content)
 
-            self._cached_inputs = blocks
+            cached_inputs = blocks
 
+        token = self._cached_inputs.set(cached_inputs)
         try:
             async for evt in next_handler(**input_kwargs):
                 yield evt
         finally:
-            self._cached_inputs = None
+            self._cached_inputs.reset(token)
 
     async def on_reasoning(
         self,
@@ -714,16 +719,17 @@ class RAGMiddleware(MiddlewareBase):
                 from downstream.
         """
         hint: HintBlock | None = None
+        cached_inputs = self._cached_inputs.get()
 
         if (
             self._parameters.mode == "static"
             and agent.state.cur_iter == 0
-            and self._cached_inputs
+            and cached_inputs
         ):
             try:
                 results = await _search_across(
                     self._knowledge_bases,
-                    self._cached_inputs,
+                    cached_inputs,
                     top_k=self._parameters.top_k,
                     score_threshold=self._parameters.score_threshold,
                 )
@@ -763,3 +769,4 @@ class RAGMiddleware(MiddlewareBase):
                         continue
                     msg.content = [b for b in msg.content if b.id != hint.id]
                     break
+

--- a/tests/middleware_rag_test.py
+++ b/tests/middleware_rag_test.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """Unit tests for the :class:`RAGMiddleware` class."""
+import asyncio
+
 from contextlib import AsyncExitStack
 from types import SimpleNamespace
 from typing import Any, AsyncGenerator
@@ -380,6 +382,86 @@ class RAGMiddlewareTest(IsolatedAsyncioTestCase):
         self.assertEqual(self.embedding_model.calls, [])
         self.assertEqual(agent.state.context, [])
 
+    async def test_static_inputs_are_isolated_between_concurrent_agents(
+        self,
+    ) -> None:
+        """A shared middleware keeps each concurrent reply's query."""
+        middleware = self._middleware(
+            mode="static",
+            top_k=1,
+            emit_hint_event=False,
+        )
+        agent_a = _make_agent()
+        agent_a.state.session_id = "session-a"
+        agent_b = _make_agent()
+        agent_b.state.session_id = "session-b"
+
+        entered_a = asyncio.Event()
+        entered_b = asyncio.Event()
+        release_a = asyncio.Event()
+        release_b = asyncio.Event()
+
+        async def run_reply(
+            agent: Any,
+            query: str,
+            entered: asyncio.Event,
+            release: asyncio.Event,
+        ) -> None:
+            async def reasoning_next(**_kwargs: Any) -> AsyncGenerator:
+                yield "reasoning-evt"
+
+            async def reply_next(**_kwargs: Any) -> AsyncGenerator:
+                entered.set()
+                await release.wait()
+                async for event in middleware.on_reasoning(
+                    agent=agent,
+                    input_kwargs={"tool_choice": None},
+                    next_handler=reasoning_next,
+                ):
+                    yield event
+
+            await _drain(
+                middleware.on_reply(
+                    agent=agent,
+                    input_kwargs={
+                        "inputs": UserMsg(name="user", content=query),
+                    },
+                    next_handler=reply_next,
+                ),
+            )
+
+        task_a = asyncio.create_task(
+            run_reply(
+                agent_a,
+                "query-a",
+                entered_a,
+                release_a,
+            ),
+        )
+        await entered_a.wait()
+        task_b = asyncio.create_task(
+            run_reply(
+                agent_b,
+                "query-b",
+                entered_b,
+                release_b,
+            ),
+        )
+        await entered_b.wait()
+
+        release_a.set()
+        await task_a
+        release_b.set()
+        await task_b
+
+        self.assertEqual(
+            [
+                [block.text for block in call if isinstance(block, TextBlock)]
+                for call in self.embedding_model.calls
+            ],
+            [["user: query-a"], ["user: query-b"]],
+        )
+
     async def test_multimodal_query_extraction(self) -> None:
         """DataBlocks reach the embedding model when it declares
         ``supports_multimodal``."""
@@ -550,3 +632,4 @@ class RAGMiddlewareTest(IsolatedAsyncioTestCase):
             RAGMiddleware.Parameters(hint_template="{context} twice {context}")
         # Exactly one placeholder is fine.
         RAGMiddleware.Parameters(hint_template="wrapped: {context}.")
+


### PR DESCRIPTION
## AgentScope Version

2.0.6 (current `main` at `3a4e2ae`)

## Description

Fixes #2331.

`RAGMiddleware` static mode kept reply inputs in one instance field. When a middleware instance was shared across concurrent agents, the later reply overwrote that field: the first agent searched with the second agent's query, and the first reply's cleanup then caused the second agent to skip retrieval.

This change stores the reply-local input blocks in a `ContextVar` and restores the prior value with its token when the reply chain exits. This isolates concurrent asyncio tasks and preserves nested middleware calls without maintaining a mutable session registry.

The regression test deterministically barriers two replies before reasoning, resumes them in sequence, and verifies that both exact queries reach the embedding model.

### Validation

```bash
uv run pytest tests/middleware_rag_test.py tests/middleware_test.py -q
# 41 passed

uv run pre-commit run --files src/agentscope/middleware/_rag.py tests/middleware_rag_test.py
# all hooks passed
```

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation has been updated (not needed: no public API or documented behavior changes)
- [x] Code is ready for review