### PR TITLE
fix(formatter): include media type in DashScope audio data URLs

### DIFF
--- a/src/agentscope/formatter/_dashscope_formatter.py
+++ b/src/agentscope/formatter/_dashscope_formatter.py
@@ -186,7 +186,7 @@ class _DashScopeFormatterBase(FormatterBase, ABC):
             return {
                 "type": "input_audio",
                 "input_audio": {
-                    "data": f"data:;base64,{source.data}",
+                    "data": f"data:{source.media_type};base64,{source.data}",
                     "format": fmt,
                 },
             }
@@ -200,7 +200,7 @@ class _DashScopeFormatterBase(FormatterBase, ABC):
                 return {
                     "type": "input_audio",
                     "input_audio": {
-                        "data": f"data:;base64,{encoded}",
+                        "data": f"data:{source.media_type};base64,{encoded}",
                         "format": fmt,
                     },
                 }

--- a/tests/formatter_dashscope_test.py
+++ b/tests/formatter_dashscope_test.py
@@ -400,7 +400,7 @@ class TestDashScopeFormatter(IsolatedAsyncioTestCase):
                         {
                             "type": "input_audio",
                             "input_audio": {
-                                "data": "data:;base64,UklGRg==",
+                                "data": "data:audio/wav;base64,UklGRg==",
                                 "format": "wav",
                             },
                         },
@@ -437,7 +437,7 @@ class TestDashScopeFormatter(IsolatedAsyncioTestCase):
                         {
                             "type": "input_audio",
                             "input_audio": {
-                                "data": "data:;base64,SUQz",
+                                "data": "data:audio/mpeg;base64,SUQz",
                                 "format": "mp3",
                             },
                         },
@@ -478,7 +478,7 @@ class TestDashScopeFormatter(IsolatedAsyncioTestCase):
                         {
                             "type": "input_audio",
                             "input_audio": {
-                                "data": "data:;base64,UklGRg==",
+                                "data": "data:audio/wav;base64,UklGRg==",
                                 "format": "wav",
                             },
                         },


### PR DESCRIPTION
## Summary

`DashScopeChatFormatter` builds base64 audio data URLs as `data:;base64,<data>`, which omits the media type. Image and video sources already include it (`data:<media_type>;base64,...`), so audio is the only inconsistent case. DashScope's compatible API expects the media type in data URLs for audio payloads.

This fixes both the `Base64Source` and the local `file://` URL paths.

## Tests

- Updated the three existing assertions in `tests/formatter_dashscope_test.py` to expect the media type in the data URL.
- `python -m pytest tests/formatter_dashscope_test.py -q` → 15 passed
- `black --check`, `flake8`, `mypy` (per pre-commit config) pass on changed files.

## Notes

- No breaking changes.

> This PR was prepared with the help of an AI coding assistant; the change is small and fully explained above.