### PR TITLE
docs(tool): fix typo in toolkit group validation comment

### DIFF
--- a/src/agentscope/tool/_builtin/_meta.py
+++ b/src/agentscope/tool/_builtin/_meta.py
@@ -99,7 +99,7 @@ class ResetTools(ToolBase):
                 "Error: ResetTools requires state to be provided.",
             )
 
-        # First verify the existance of the given group names
+        # First verify the existence of the given group names
         unexist_groups: list[str] = []
         cur_groups: list[str] = [
             _.name for _ in self.groups if _.name != "basic"


### PR DESCRIPTION
## AgentScope Version

2.0.6

## Description

Fix the spelling of `existance` to `existence` in the toolkit group validation comment.

This is a comment-only change and does not affect runtime behavior.

Fixes #2354

## Validation

- `pre-commit run --files src/agentscope/tool/_builtin/_meta.py`
- `git diff --check`

All checks passed.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation is not affected
- [x] Code is ready for review
