### PR TITLE
fix(reme): declare as_embedding/embedding_store components when vector store is enabled

### DIFF
--- a/src/agentscope/middleware/_longterm_memory/_reme/_middleware.py
+++ b/src/agentscope/middleware/_longterm_memory/_reme/_middleware.py
@@ -256,9 +256,24 @@ class ReMeMiddleware(MiddlewareBase):
         # ``default`` config ships it off (BM25 keyword search only), so we
         # wire the file store to the default embedding store when — and
         # only when — a model is available to build the vectors.
+        #
+        # ReMe's ``default.yaml`` leaves the ``as_embedding`` /
+        # ``embedding_store`` components *commented out* (embeddings are
+        # disabled by default since reme-ai 0.4.1.0), so merely referencing
+        # ``embedding_store: default`` from ``file_store`` is not enough —
+        # the two components must be declared here or they are never
+        # instantiated and ``update_component`` in ``_ensure_started``
+        # raises ``KeyError: Component 'default' not found in as_embedding``.
+        # The injected model is set on the component via ``update_component``
+        # before ``start()``, so the ``backend`` below only has to name a
+        # registered wrapper type; it is never used to build a model.
         if self._parameters.embedding_model is not None:
             app_kwargs["components"] = {
                 "file_store": {"default": {"embedding_store": "default"}},
+                "as_embedding": {"default": {"backend": "openai"}},
+                "embedding_store": {
+                    "default": {"backend": "local", "as_embedding": "default"},
+                },
             }
         app_config = resolve_app_config(**app_kwargs)
         return ReMe(**app_config)

--- a/tests/reme_middleware_test.py
+++ b/tests/reme_middleware_test.py
@@ -500,7 +500,13 @@ class TestConstructorValidation(IsolatedAsyncioTestCase):
 
         self.assertEqual(
             captured["components"],
-            {"file_store": {"default": {"embedding_store": "default"}}},
+            {
+                "file_store": {"default": {"embedding_store": "default"}},
+                "as_embedding": {"default": {"backend": "openai"}},
+                "embedding_store": {
+                    "default": {"backend": "local", "as_embedding": "default"},
+                },
+            },
         )
         self.assertEqual(captured["workspace_dir"], "/real/ws")
         self.assertEqual(captured["config"], "mycfg")


### PR DESCRIPTION
Fixes #2357 (also the underlying cause of #2356).

## Summary

`ReMeMiddleware` with an `embedding_model` crashes every ReMe job with `KeyError: Component 'default' not found in as_embedding`. Root cause: ReMe's bundled `default.yaml` has kept the `as_embedding` / `embedding_store` components **commented out** since reme-ai **0.4.1.0** (embeddings disabled by default), so merely referencing `embedding_store: default` from `file_store` never instantiates the components. `_ensure_started` then calls `app.update_component("as_embedding", "default", ...)`, which raises because the component group does not exist.

## Fix

In `_build_app`, when an `embedding_model` is provided, also declare the `as_embedding` and `embedding_store` components in the app config so ReMe instantiates them. The injected model is set via `update_component` before `start()`, so the `backend` values only name registered wrapper types and are never used to build a model.

## Verification

Minimal harness against real `reme-ai 0.4.1.7` (mock-based tests never exercise reme-ai, so they could not catch this):

- Before fix — search and write-back both raise:
  ```
  KeyError: "Component 'default' not found in as_embedding"
  ```
- After fix — both complete and `app.start()` succeeds.

Tests: `tests/reme_middleware_test.py` 34 passed; assertion for the components config updated to the new shape.