### PR TITLE
fix(tool): run sync tool functions in worker threads to avoid blocking the event loop

### DIFF
--- a/src/agentscope/tool/_adapters.py
+++ b/src/agentscope/tool/_adapters.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Adapters to convert functions and MCP tools to ToolProtocol."""
+import asyncio
 import inspect
 import json
 import re
@@ -118,8 +119,16 @@ class FunctionTool(ToolBase):
         """
         if inspect.iscoroutinefunction(self._func):
             result = await self._func(**kwargs)
-        else:
+        elif inspect.isasyncgenfunction(
+            self._func,
+        ) or inspect.isgeneratorfunction(self._func):
+            # Calling a generator function only creates the generator without
+            # running its body, so no need to offload to a thread here.
             result = self._func(**kwargs)
+        else:
+            # Run the sync function in a worker thread so its execution
+            # doesn't block the event loop.
+            result = await asyncio.to_thread(self._func, **kwargs)
 
         if isinstance(result, AsyncGenerator):
 
@@ -135,7 +144,17 @@ class FunctionTool(ToolBase):
         if isinstance(result, Generator):
 
             async def _stream() -> AsyncGenerator[ToolChunk, None]:
-                for chunk in result:
+                # Pull each chunk in a worker thread: the generator body runs
+                # between `next` calls and would otherwise block the loop.
+                sentinel = object()
+                while True:
+                    chunk = await asyncio.to_thread(
+                        next,  # type: ignore[arg-type]
+                        result,
+                        sentinel,
+                    )
+                    if chunk is sentinel:
+                        break
                     if isinstance(chunk, ToolChunk):
                         yield chunk
                     else:

--- a/src/agentscope/tool/_toolkit.py
+++ b/src/agentscope/tool/_toolkit.py
@@ -308,10 +308,17 @@ class Toolkit:
 
             if inspect.iscoroutinefunction(tool_func.__call__):
                 res = await tool_func(**kwargs)
-            else:
-                # When `tool_func.original_func` is Async generator function or
-                # Sync function
+            elif inspect.isasyncgenfunction(tool_func.__call__):
+                # Calling an async generator function only creates the
+                # generator without running its body
                 res = tool_func(**kwargs)
+            else:
+                # Run the sync `__call__` in a worker thread so it doesn't
+                # block the event loop
+                res = await asyncio.to_thread(
+                    tool_func,  # type: ignore[arg-type]
+                    **kwargs,
+                )
 
             if isinstance(res, ToolChunk):
                 yield res
@@ -325,7 +332,17 @@ class Toolkit:
 
             # If return a sync generator
             elif isinstance(res, Generator):
-                for chunk in res:
+                # Pull each chunk in a worker thread: the generator body runs
+                # between `next` calls and would otherwise block the loop
+                sentinel = object()
+                while True:
+                    chunk = await asyncio.to_thread(
+                        next,  # type: ignore[arg-type]
+                        res,
+                        sentinel,
+                    )
+                    if chunk is sentinel:
+                        break
                     yield chunk
                     tool_response.append_chunk(chunk)
 

--- a/tests/toolkit_test.py
+++ b/tests/toolkit_test.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=unused-argument
 """Toolkit test case."""
+import asyncio
 import base64
 import json
+import time
 from typing import Any, AsyncGenerator, Generator
 from unittest import TestCase
 from unittest.async_case import IsolatedAsyncioTestCase
@@ -1129,6 +1131,58 @@ class RegisterFunctionTest(IsolatedAsyncioTestCase):
             response.content[0].text,
             f"started{expected_dict_text}",
         )
+
+
+class SyncToolNonBlockingTest(IsolatedAsyncioTestCase):
+    """Sync tool functions must run in a worker thread so their execution
+    doesn't block the event loop."""
+
+    async def _ticks_while_calling(self, toolkit: Toolkit, name: str) -> int:
+        """Call the tool while a heartbeat task ticks on the event loop;
+        return the number of ticks observed during the call."""
+        ticks = 0
+
+        async def heartbeat() -> None:
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0.01)
+                ticks += 1
+
+        task = asyncio.create_task(heartbeat())
+        try:
+            tool_call = ToolCallBlock(id="test_id", name=name, input="{}")
+            async for _ in toolkit.call_tool(tool_call, AgentState()):
+                pass
+        finally:
+            task.cancel()
+        return ticks
+
+    async def test_sync_function_does_not_block_event_loop(self) -> None:
+        """A blocking sync function should not starve the event loop."""
+
+        def slow_tool() -> ToolChunk:
+            """A slow sync tool."""
+            time.sleep(0.2)
+            return ToolChunk(content=[TextBlock(text="done")])
+
+        toolkit = Toolkit(tools=[FunctionTool(slow_tool)])
+        ticks = await self._ticks_while_calling(toolkit, "slow_tool")
+        # If the sync function ran on the loop thread, the heartbeat would
+        # only tick after the tool finished (0-1 ticks)
+        self.assertGreaterEqual(ticks, 3)
+
+    async def test_sync_generator_does_not_block_event_loop(self) -> None:
+        """A blocking sync generator should not starve the event loop."""
+
+        def slow_stream() -> Generator[ToolChunk, None, None]:
+            """A slow sync streaming tool."""
+            for i in range(4):
+                time.sleep(0.05)
+                yield ToolChunk(content=[TextBlock(text=str(i))])
+
+        toolkit = Toolkit(tools=[FunctionTool(slow_stream)])
+        ticks = await self._ticks_while_calling(toolkit, "slow_stream")
+        self.assertGreaterEqual(ticks, 3)
 
 
 class ToolGroupTest(IsolatedAsyncioTestCase):


### PR DESCRIPTION
## AgentScope Version

2.0.6 (main)

## Description

Sync tool functions and sync generators are currently executed directly on the event loop thread, so a slow or CPU-bound sync tool blocks the whole loop — no other coroutine (other agents, streaming, heartbeats) can make progress until the tool returns.

This PR offloads sync execution to worker threads via `asyncio.to_thread`, without changing the tool-facing API or the chunk/response protocol:

- `FunctionTool.call`: run plain sync functions in a worker thread; for sync generators, pull each chunk via `to_thread(next, ...)` since the generator body runs between `next` calls. Calling an (a)sync generator function only creates the generator, so that stays inline.
- `Toolkit.call_tool`: same treatment for duck-typed tools whose `__call__` is sync, and for sync-generator results.

Async tools are untouched. Exceptions raised inside the thread still propagate to the existing error handling in `call_tool`, and cancellation still surfaces as `asyncio.CancelledError` at the await point.

**How to test:** `pytest tests/toolkit_test.py` — includes two new tests (`SyncToolNonBlockingTest`) that run a heartbeat task on the loop while a `time.sleep`-based sync tool / sync generator executes, asserting the loop keeps ticking. Also verified `pre-commit run --all-files` passes.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [x]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [x]  Code is ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)