### PR TITLE
fix(tool): pick the shell by the backend OS instead of the host OS in Bash

### DIFF
--- a/src/agentscope/tool/_builtin/_backend.py
+++ b/src/agentscope/tool/_builtin/_backend.py
@@ -176,6 +176,15 @@ class BackendBase(ABC):
     #:     explicit ``cwd`` argument.
     _path_module: ModuleType = posixpath
 
+    #: The operating system family of the backend's **environment**,
+    #: following the :data:`os.name` convention (``"posix"`` or
+    #: ``"nt"``).  Like :attr:`_path_module`, this describes where the
+    #: commands actually run, not the host process, so tools can pick
+    #: the right shell (``/bin/sh`` vs ``cmd.exe``) when a Windows host
+    #: drives a Linux sandbox.  Defaults to ``"posix"``; subclasses
+    #: targeting Windows environments override it.
+    os_name: str = "posix"
+
     # ── path manipulation helpers (pure string ops) ────────────────
 
     def join_path(self, path: str, *paths: str) -> str:
@@ -747,6 +756,10 @@ class LocalBackend(BackendBase):
     # the base class default (``posixpath``), so path helpers behave
     # correctly when running on a Windows host.
     _path_module = os.path
+
+    # The local backend runs commands on the host, so its environment
+    # OS is the host OS.
+    os_name = os.name
 
     async def exec_shell(
         self,

--- a/src/agentscope/tool/_builtin/_bash.py
+++ b/src/agentscope/tool/_builtin/_bash.py
@@ -703,10 +703,10 @@ easier to review tool calls and give permission.
             # ``command`` is a full shell command line (it may contain
             # pipes, redirects, ``&&``, …), so wrap it in a shell — the
             # backend primitive runs the argv directly without one. Pick
-            # the platform's native shell so the Windows experience that
-            # ``main`` had (commands interpreted by ``cmd.exe``) is
-            # preserved; POSIX hosts use ``/bin/sh``.
-            if os.name == "nt":
+            # the native shell of the *backend's* environment (not the
+            # host's): ``cmd.exe`` on Windows, ``/bin/sh`` on POSIX, so
+            # a Windows host driving a Linux sandbox still works.
+            if self._backend.os_name == "nt":
                 shell_command = ["cmd", "/c", command]
             else:
                 shell_command = ["/bin/sh", "-c", command]

--- a/tests/builtin_bash_test.py
+++ b/tests/builtin_bash_test.py
@@ -15,6 +15,9 @@ from agentscope.permission import (
 )
 from agentscope.tool import Bash, ToolChunk
 from agentscope.tool._builtin._backend import (
+    BackendBase,
+    ExecResult,
+    LocalBackend,
     _subprocess_creation_kwargs,
 )
 
@@ -72,6 +75,49 @@ class BashCwdTest(IsolatedAsyncioTestCase):
             expected_argv,
         )
         self.assertEqual(chunks[0].state, "running")
+
+
+class _PosixSandboxBackend(BackendBase):
+    """A minimal non-local backend whose environment is POSIX."""
+
+    def __init__(self) -> None:
+        self.commands: list[list[str]] = []
+
+    async def exec_shell(
+        self,
+        command: list[str],
+        *,
+        cwd: str | None = None,
+        timeout: float | None = None,
+    ) -> ExecResult:
+        self.commands.append(command)
+        return ExecResult(0, b"ok\n", b"")
+
+    async def read_file(self, path: str) -> bytes:
+        raise NotImplementedError
+
+    async def write_file(self, path: str, data: bytes) -> None:
+        raise NotImplementedError
+
+
+class BashShellSelectionTest(IsolatedAsyncioTestCase):
+    """The shell wrapper must follow the backend OS, not the host OS."""
+
+    async def test_posix_backend_on_windows_host_uses_sh(self) -> None:
+        """A Linux sandbox driven from a Windows host still gets /bin/sh."""
+        backend = _PosixSandboxBackend()
+        with patch("agentscope.tool._builtin._backend.os.name", "nt"):
+            chunks = []
+            async for chunk in await Bash(backend=backend)(command="pwd"):
+                chunks.append(chunk)
+
+        self.assertEqual(backend.commands, [["/bin/sh", "-c", "pwd"]])
+        self.assertEqual(chunks[-1].content[0].text, "ok\n")
+
+    def test_local_backend_os_name_follows_host(self) -> None:
+        """LocalBackend reports the host OS; the base default is posix."""
+        self.assertEqual(LocalBackend().os_name, os.name)
+        self.assertEqual(_PosixSandboxBackend().os_name, "posix")
 
 
 @unittest.skipIf(


### PR DESCRIPTION
## Summary

Fixes #2340.

`Bash.call` decided between `cmd /c` and `/bin/sh -c` by the **host** `os.name`, so a Windows host driving a Linux sandbox backend (Docker / K8s / E2B / Daytona / OpenSandbox …) sent `["cmd", "/c", ...]` into the container and every command failed.

## Changes

- `BackendBase`: add an `os_name` primitive (`"posix"` / `"nt"`, same convention as `os.name`) describing the backend's **environment**, alongside the existing `_path_module`. Defaults to `"posix"`, which is correct for all sandbox backends; `LocalBackend` overrides it with the host `os.name`.
- `Bash`: choose the shell wrapper by `self._backend.os_name` instead of the host `os.name`.

## Tests

- `tests/builtin_bash_test.py`: new `BashShellSelectionTest` — a minimal POSIX sandbox backend driven with the host `os.name` patched to `"nt"` still receives `["/bin/sh", "-c", cmd]` (this test fails on `main`); `LocalBackend().os_name == os.name` and base default is `"posix"`.
- `pytest tests/builtin_bash_test.py`: 29 passed; `pre-commit run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)