### PR TITLE
fix(model): time out stalled model streams

### DIFF
--- a/src/agentscope/exception/__init__.py
+++ b/src/agentscope/exception/__init__.py
@@ -5,7 +5,11 @@ from ._base import (
     AgentOrientedException,
     DeveloperOrientedException,
 )
-from ._model import StructuredOutputError
+from ._model import (
+    ModelFirstChunkTimeoutError,
+    ModelStreamIdleTimeoutError,
+    StructuredOutputError,
+)
 from ._tool import (
     ToolInterruptedError,
     ToolNotFoundError,
@@ -16,6 +20,8 @@ from ._tool import (
 __all__ = [
     "AgentOrientedException",
     "DeveloperOrientedException",
+    "ModelFirstChunkTimeoutError",
+    "ModelStreamIdleTimeoutError",
     "StructuredOutputError",
     "ToolInterruptedError",
     "ToolNotFoundError",

--- a/src/agentscope/exception/_model.py
+++ b/src/agentscope/exception/_model.py
@@ -7,3 +7,29 @@ class StructuredOutputError(DeveloperOrientedException):
     """Raised when the model fails to produce a valid structured output,
     e.g. it does not call the structured-output tool, returns an empty
     response, or the returned arguments fail JSON/schema validation."""
+
+
+class ModelFirstChunkTimeoutError(TimeoutError):
+    """Raised when a streaming model does not produce initial content."""
+
+    def __init__(self, model: str, timeout: float) -> None:
+        """Initialize the exception."""
+        self.model = model
+        self.timeout = timeout
+        super().__init__(
+            f"Model '{model}' produced no initial stream content within "
+            f"{timeout:g} seconds.",
+        )
+
+
+class ModelStreamIdleTimeoutError(TimeoutError):
+    """Raised when a model stream stops producing meaningful content."""
+
+    def __init__(self, model: str, timeout: float) -> None:
+        """Initialize the exception."""
+        self.model = model
+        self.timeout = timeout
+        super().__init__(
+            f"Model '{model}' stream produced no content for "
+            f"{timeout:g} seconds.",
+        )

--- a/src/agentscope/model/_anthropic/_model.py
+++ b/src/agentscope/model/_anthropic/_model.py
@@ -106,6 +106,8 @@ class AnthropicChatModel(ChatModelBase):
         context_size: int = 200000,
         formatter: FormatterBase | None = None,
         client_kwargs: dict[str, Any] | None = None,
+        stream_first_chunk_timeout: float | None = 120.0,
+        stream_idle_timeout: float | None = 30.0,
     ) -> None:
         """Initialize the Anthropic chat model.
 
@@ -134,6 +136,11 @@ class AnthropicChatModel(ChatModelBase):
                 Extra keyword arguments forwarded to
                 ``anthropic.AsyncAnthropic`` (e.g. ``timeout``,
                 ``default_headers``, ``http_client``, ``auth_token``).
+            stream_first_chunk_timeout (`float | None`, defaults to `120.0`):
+                Maximum seconds from call start to initial meaningful stream
+                content. Delay before first iteration counts toward it.
+            stream_idle_timeout (`float | None`, defaults to `30.0`):
+                Maximum seconds between meaningful chunks and stream end.
         """
         super().__init__(
             credential=credential,
@@ -143,6 +150,8 @@ class AnthropicChatModel(ChatModelBase):
             max_retries=max_retries,
             retry_delay=retry_delay,
             context_size=context_size,
+            stream_first_chunk_timeout=stream_first_chunk_timeout,
+            stream_idle_timeout=stream_idle_timeout,
         )
         self.formatter = formatter or AnthropicChatFormatter()
         self.client_kwargs = client_kwargs or {}

--- a/src/agentscope/model/_base.py
+++ b/src/agentscope/model/_base.py
@@ -6,7 +6,7 @@ import json
 from abc import abstractmethod
 from copy import deepcopy
 from pathlib import Path
-from typing import Type, Any, AsyncGenerator
+from typing import Type, Any, AsyncGenerator, Awaitable
 
 import jsonschema
 from pydantic import BaseModel, ValidationError as PydanticValidationError
@@ -17,7 +17,12 @@ from ._utils import _StreamAccumulator
 from .._logging import logger
 from .._utils._common import _json_loads_with_repair
 from ..credential import CredentialBase
-from ..exception import StructuredOutputError, ToolJSONDecodeError
+from ..exception import (
+    ModelFirstChunkTimeoutError,
+    ModelStreamIdleTimeoutError,
+    StructuredOutputError,
+    ToolJSONDecodeError,
+)
 from ..message import (
     Msg,
     TextBlock,
@@ -59,6 +64,16 @@ class ChatModelBase:
     context_size: int
     """The model context size that will be used in the context compression."""
 
+    stream_first_chunk_timeout: float | None
+    """Maximum seconds to wait for initial meaningful stream content.
+
+    The deadline starts when the model call begins, so a caller delay before
+    consuming the returned stream counts toward this budget.
+    """
+
+    stream_idle_timeout: float | None
+    """Maximum seconds between meaningful chunks and stream completion."""
+
     def __init__(
         self,
         credential: CredentialBase,
@@ -68,6 +83,8 @@ class ChatModelBase:
         max_retries: int = 3,
         retry_delay: float = 1.0,
         context_size: int = 32768,
+        stream_first_chunk_timeout: float | None = 120.0,
+        stream_idle_timeout: float | None = 30.0,
     ) -> None:
         """Initialize the chat model base.
 
@@ -88,7 +105,24 @@ class ChatModelBase:
                 Seconds to sleep between retry attempts.
             context_size (`int`, defaults to `32768`):
                 The model context size used for context compression.
+            stream_first_chunk_timeout (`float | None`, defaults to `120.0`):
+                Maximum seconds from starting a streaming model call until
+                the first meaningful content chunk. A caller delay before
+                first iteration counts toward this budget. ``None`` disables
+                it.
+            stream_idle_timeout (`float | None`, defaults to `30.0`):
+                Maximum seconds between meaningful content chunks after the
+                first one. Empty chunks do not reset the deadline, and stream
+                completion must occur within the same window. ``None``
+                disables it.
         """
+        for name, value in (
+            ("stream_first_chunk_timeout", stream_first_chunk_timeout),
+            ("stream_idle_timeout", stream_idle_timeout),
+        ):
+            if value is not None and value <= 0:
+                raise ValueError(f"{name} must be greater than 0 or None.")
+
         self.credential = credential
         self.model = model
         self.parameters = parameters
@@ -96,6 +130,88 @@ class ChatModelBase:
         self.max_retries = max_retries
         self.retry_delay = retry_delay
         self.context_size = context_size
+        self.stream_first_chunk_timeout = stream_first_chunk_timeout
+        self.stream_idle_timeout = stream_idle_timeout
+
+    def _new_first_chunk_deadline(self) -> float | None:
+        """Create an absolute deadline for the current public model call."""
+        if not self.stream or self.stream_first_chunk_timeout is None:
+            return None
+        return (
+            asyncio.get_running_loop().time() + self.stream_first_chunk_timeout
+        )
+
+    async def _await_with_stream_deadline(
+        self,
+        awaitable: Awaitable[Any],
+        deadline: float | None,
+        first_chunk: bool,
+    ) -> Any:
+        """Await an operation under an absolute stream deadline."""
+        if deadline is None:
+            return await awaitable
+
+        timeout = asyncio.timeout_at(deadline)
+        try:
+            async with timeout:
+                return await awaitable
+        except TimeoutError as error:
+            if not timeout.expired():
+                raise
+            if first_chunk:
+                assert self.stream_first_chunk_timeout is not None
+                raise ModelFirstChunkTimeoutError(
+                    self.model,
+                    self.stream_first_chunk_timeout,
+                ) from error
+            assert self.stream_idle_timeout is not None
+            raise ModelStreamIdleTimeoutError(
+                self.model,
+                self.stream_idle_timeout,
+            ) from error
+
+    async def _iterate_stream_with_timeouts(
+        self,
+        stream: AsyncGenerator[ChatResponse, None],
+        first_chunk_deadline: float | None,
+    ) -> AsyncGenerator[ChatResponse, None]:
+        """Iterate a stream while enforcing progress-based deadlines.
+
+        After the first meaningful chunk, the stream must either make
+        meaningful progress or finish within each idle window.
+        """
+        iterator = aiter(stream)
+        received_content = False
+        deadline = first_chunk_deadline
+        try:
+            while True:
+                try:
+                    chunk = await self._await_with_stream_deadline(
+                        anext(iterator),
+                        deadline,
+                        first_chunk=not received_content,
+                    )
+                except StopAsyncIteration:
+                    break
+
+                made_progress = bool(chunk.content)
+                if made_progress:
+                    received_content = True
+                yield chunk
+
+                # Start the idle window only when the consumer asks for the
+                # next item. Time spent processing the current chunk is
+                # downstream backpressure, not upstream stream idleness.
+                if made_progress:
+                    if self.stream_idle_timeout is None:
+                        deadline = None
+                    else:
+                        deadline = (
+                            asyncio.get_running_loop().time()
+                            + self.stream_idle_timeout
+                        )
+        finally:
+            await iterator.aclose()
 
     @classmethod
     def _get_retryable_exceptions(cls) -> tuple[Type[Exception], ...]:
@@ -205,15 +321,20 @@ class ChatModelBase:
 
         retryable = self._get_retryable_exceptions()
         last_error: Exception | None = None
+        first_chunk_deadline = self._new_first_chunk_deadline()
         for attempt in range(self.max_retries + 1):
             # The accumulated chat response
             try:
-                res = await self._call_api(
-                    self.model,
-                    messages=messages,
-                    tools=tools,
-                    tool_choice=tool_choice,
-                    **kwargs,
+                res = await self._await_with_stream_deadline(
+                    self._call_api(
+                        self.model,
+                        messages=messages,
+                        tools=tools,
+                        tool_choice=tool_choice,
+                        **kwargs,
+                    ),
+                    first_chunk_deadline,
+                    first_chunk=True,
                 )
                 break
             except asyncio.CancelledError:
@@ -236,7 +357,11 @@ class ChatModelBase:
                         str(e),
                         self.retry_delay,
                     )
-                    await asyncio.sleep(self.retry_delay)
+                    await self._await_with_stream_deadline(
+                        asyncio.sleep(self.retry_delay),
+                        first_chunk_deadline,
+                        first_chunk=True,
+                    )
                 else:
                     logger.warning(
                         "All %d attempt(s) failed for model %s.",
@@ -258,12 +383,19 @@ class ChatModelBase:
             return res
 
         async def _stream() -> AsyncGenerator[ChatResponse, None]:
-            """The wrapper around model calling."""
+            """Wrap model streaming and accumulate its incremental chunks.
+
+            Stream timeouts propagate after any emitted deltas and do not
+            produce a synthetic final accumulated response.
+            """
             # For backward compatibility
             yield_acc_res = True
             acc_res = _StreamAccumulator()
             try:
-                async for chunk in res:
+                async for chunk in self._iterate_stream_with_timeouts(
+                    res,
+                    first_chunk_deadline,
+                ):
                     if not chunk.is_last:
                         acc_res.append_chat_response(chunk)
                         acc_res.id = chunk.id
@@ -479,6 +611,9 @@ class ChatModelBase:
         An explicit ``tool_choice`` in ``kwargs`` bypasses the strategy
         ladder and is forwarded unchanged.
 
+        For streaming models, all strategies, attempts, and retry backoffs
+        share one absolute first-chunk deadline for this public call.
+
         Args:
             messages (`list[Msg]`):
                 The context for LLM to generate the structured output.
@@ -522,6 +657,7 @@ class ChatModelBase:
         )
         first_error: Exception | None = None
         last_error: Exception | None = None
+        first_chunk_deadline = self._new_first_chunk_deadline()
         for name, extra_kwargs, tool_choice in strategies:
             # Overlay disable-thinking kwargs; a nested `extra_body` is
             # merged rather than overwritten so caller keys survive.
@@ -537,6 +673,7 @@ class ChatModelBase:
                         messages=messages,
                         structured_model=structured_model,
                         tool_choice=tool_choice,
+                        _first_chunk_deadline=first_chunk_deadline,
                         **merged,
                     )
                     if name not in ("forced", "explicit"):
@@ -567,7 +704,11 @@ class ChatModelBase:
                                 e,
                                 self.retry_delay,
                             )
-                            await asyncio.sleep(self.retry_delay)
+                            await self._await_with_stream_deadline(
+                                asyncio.sleep(self.retry_delay),
+                                first_chunk_deadline,
+                                first_chunk=True,
+                            )
                             continue
                         raise  # retries exhausted -> give up
                     if not isinstance(e, fallback):
@@ -598,6 +739,7 @@ class ChatModelBase:
         messages: list[Msg],
         structured_model: Type[BaseModel] | dict,
         tool_choice: ToolChoice | None = None,
+        _first_chunk_deadline: float | None = None,
         **kwargs: Any,
     ) -> StructuredResponse:
         """Run a single structured-output attempt via a forced tool call.
@@ -620,6 +762,8 @@ class ChatModelBase:
                 required output structure.
             tool_choice (`ToolChoice | None`, defaults to `None`):
                 The tool_choice forwarded to ``_call_api``, used as-is.
+            _first_chunk_deadline (`float | None`, defaults to `None`):
+                Absolute deadline shared by all attempts in the public call.
             **kwargs (`Any`):
                 Additional keyword arguments forwarded to ``_call_api``.
         """
@@ -647,23 +791,27 @@ class ChatModelBase:
                 UserMsg(name="user", content=[TextBlock(text=instruction)]),
             )
 
-        res = await self._call_api(
-            model_name=model_name,
-            messages=copied_messages,
-            tools=[
-                {
-                    "type": "function",
-                    "function": {
-                        "name": func_name,
-                        "description": "Call this function to generate "
-                        "structured output required by "
-                        "the user.",
-                        "parameters": input_schema,
+        res = await self._await_with_stream_deadline(
+            self._call_api(
+                model_name=model_name,
+                messages=copied_messages,
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": func_name,
+                            "description": "Call this function to generate "
+                            "structured output required by "
+                            "the user.",
+                            "parameters": input_schema,
+                        },
                     },
-                },
-            ],
-            tool_choice=tool_choice,
-            **kwargs,
+                ],
+                tool_choice=tool_choice,
+                **kwargs,
+            ),
+            _first_chunk_deadline,
+            first_chunk=True,
         )
 
         completed_response: ChatResponse | None = None
@@ -677,7 +825,10 @@ class ChatModelBase:
             # end without ever producing an ``is_last=True`` chunk.
             acc_res = _StreamAccumulator()
 
-            async for chunk in res:
+            async for chunk in self._iterate_stream_with_timeouts(
+                res,
+                _first_chunk_deadline,
+            ):
                 if chunk.is_last:
                     completed_response = chunk
                     break

--- a/src/agentscope/model/_dashscope/_model.py
+++ b/src/agentscope/model/_dashscope/_model.py
@@ -122,6 +122,8 @@ class DashScopeChatModel(ChatModelBase):
         context_size: int = 131072,
         formatter: FormatterBase | None = None,
         client_kwargs: dict[str, Any] | None = None,
+        stream_first_chunk_timeout: float | None = 120.0,
+        stream_idle_timeout: float | None = 30.0,
     ) -> None:
         """Initialize the DashScope chat model.
 
@@ -149,6 +151,11 @@ class DashScopeChatModel(ChatModelBase):
             client_kwargs (`dict[str, Any] | None`, defaults to `None`):
                 Extra keyword arguments forwarded to ``openai.AsyncClient``
                 (e.g. ``timeout``, ``default_headers``, ``http_client``).
+            stream_first_chunk_timeout (`float | None`, defaults to `120.0`):
+                Maximum seconds from call start to initial meaningful stream
+                content. Delay before first iteration counts toward it.
+            stream_idle_timeout (`float | None`, defaults to `30.0`):
+                Maximum seconds between meaningful chunks and stream end.
         """
         super().__init__(
             credential=credential,
@@ -158,6 +165,8 @@ class DashScopeChatModel(ChatModelBase):
             max_retries=max_retries,
             retry_delay=retry_delay,
             context_size=context_size,
+            stream_first_chunk_timeout=stream_first_chunk_timeout,
+            stream_idle_timeout=stream_idle_timeout,
         )
         self.formatter = formatter or DashScopeChatFormatter()
         self.client_kwargs = client_kwargs or {}

--- a/src/agentscope/model/_deepseek/_model.py
+++ b/src/agentscope/model/_deepseek/_model.py
@@ -87,6 +87,8 @@ class DeepSeekChatModel(ChatModelBase):
         context_size: int = 65536,
         formatter: FormatterBase | None = None,
         client_kwargs: dict[str, Any] | None = None,
+        stream_first_chunk_timeout: float | None = 120.0,
+        stream_idle_timeout: float | None = 30.0,
     ) -> None:
         """Initialize the DeepSeek chat model.
 
@@ -114,6 +116,11 @@ class DeepSeekChatModel(ChatModelBase):
             client_kwargs (`dict[str, Any] | None`, defaults to `None`):
                 Extra keyword arguments forwarded to ``openai.AsyncClient``
                 (e.g. ``timeout``, ``default_headers``, ``http_client``).
+            stream_first_chunk_timeout (`float | None`, defaults to `120.0`):
+                Maximum seconds from call start to initial meaningful stream
+                content. Delay before first iteration counts toward it.
+            stream_idle_timeout (`float | None`, defaults to `30.0`):
+                Maximum seconds between meaningful chunks and stream end.
         """
         super().__init__(
             credential=credential,
@@ -123,6 +130,8 @@ class DeepSeekChatModel(ChatModelBase):
             max_retries=max_retries,
             retry_delay=retry_delay,
             context_size=context_size,
+            stream_first_chunk_timeout=stream_first_chunk_timeout,
+            stream_idle_timeout=stream_idle_timeout,
         )
         self.formatter = formatter or DeepSeekChatFormatter()
         self.client_kwargs = client_kwargs or {}

--- a/src/agentscope/model/_gemini/_model.py
+++ b/src/agentscope/model/_gemini/_model.py
@@ -169,6 +169,8 @@ class GeminiChatModel(ChatModelBase):
         context_size: int = 1048576,
         formatter: FormatterBase | None = None,
         client_kwargs: dict[str, Any] | None = None,
+        stream_first_chunk_timeout: float | None = 120.0,
+        stream_idle_timeout: float | None = 30.0,
     ) -> None:
         """Initialize the Gemini chat model.
 
@@ -197,6 +199,11 @@ class GeminiChatModel(ChatModelBase):
                 Extra keyword arguments forwarded to ``google.genai.Client``
                 (e.g. ``vertexai``, ``project``, ``location``,
                 ``credentials``, ``http_options``).
+            stream_first_chunk_timeout (`float | None`, defaults to `120.0`):
+                Maximum seconds from call start to initial meaningful stream
+                content. Delay before first iteration counts toward it.
+            stream_idle_timeout (`float | None`, defaults to `30.0`):
+                Maximum seconds between meaningful chunks and stream end.
         """
         super().__init__(
             credential=credential,
@@ -206,6 +213,8 @@ class GeminiChatModel(ChatModelBase):
             max_retries=max_retries,
             retry_delay=retry_delay,
             context_size=context_size,
+            stream_first_chunk_timeout=stream_first_chunk_timeout,
+            stream_idle_timeout=stream_idle_timeout,
         )
         self.formatter = formatter or GeminiChatFormatter()
         self.client_kwargs = client_kwargs or {}

--- a/src/agentscope/model/_moonshot/_model.py
+++ b/src/agentscope/model/_moonshot/_model.py
@@ -86,6 +86,8 @@ class MoonshotChatModel(ChatModelBase):
         context_size: int = 131072,
         formatter: FormatterBase | None = None,
         client_kwargs: dict[str, Any] | None = None,
+        stream_first_chunk_timeout: float | None = 120.0,
+        stream_idle_timeout: float | None = 30.0,
     ) -> None:
         """Initialize the Moonshot AI chat model.
 
@@ -113,6 +115,11 @@ class MoonshotChatModel(ChatModelBase):
             client_kwargs (`dict[str, Any] | None`, defaults to `None`):
                 Extra keyword arguments forwarded to ``openai.AsyncClient``
                 (e.g. ``timeout``, ``default_headers``, ``http_client``).
+            stream_first_chunk_timeout (`float | None`, defaults to `120.0`):
+                Maximum seconds from call start to initial meaningful stream
+                content. Delay before first iteration counts toward it.
+            stream_idle_timeout (`float | None`, defaults to `30.0`):
+                Maximum seconds between meaningful chunks and stream end.
         """
         super().__init__(
             credential=credential,
@@ -122,6 +129,8 @@ class MoonshotChatModel(ChatModelBase):
             max_retries=max_retries,
             retry_delay=retry_delay,
             context_size=context_size,
+            stream_first_chunk_timeout=stream_first_chunk_timeout,
+            stream_idle_timeout=stream_idle_timeout,
         )
         self.formatter = formatter or MoonshotChatFormatter()
         self.client_kwargs = client_kwargs or {}

--- a/src/agentscope/model/_ollama/_model.py
+++ b/src/agentscope/model/_ollama/_model.py
@@ -64,6 +64,8 @@ class OllamaChatModel(ChatModelBase):
         context_size: int = 32768,
         formatter: FormatterBase | None = None,
         client_kwargs: dict[str, Any] | None = None,
+        stream_first_chunk_timeout: float | None = 120.0,
+        stream_idle_timeout: float | None = 30.0,
     ) -> None:
         """Initialize the Ollama chat model.
 
@@ -93,6 +95,11 @@ class OllamaChatModel(ChatModelBase):
                 Extra keyword arguments forwarded to ``ollama.AsyncClient``
                 and onward to the underlying ``httpx.AsyncClient``
                 (e.g. ``timeout``, ``headers``, ``verify``).
+            stream_first_chunk_timeout (`float | None`, defaults to `120.0`):
+                Maximum seconds from call start to initial meaningful stream
+                content. Delay before first iteration counts toward it.
+            stream_idle_timeout (`float | None`, defaults to `30.0`):
+                Maximum seconds between meaningful chunks and stream end.
         """
         resolved_credential = credential or OllamaCredential()
 
@@ -104,6 +111,8 @@ class OllamaChatModel(ChatModelBase):
             max_retries=max_retries,
             retry_delay=retry_delay,
             context_size=context_size,
+            stream_first_chunk_timeout=stream_first_chunk_timeout,
+            stream_idle_timeout=stream_idle_timeout,
         )
 
         self.formatter = formatter or OllamaChatFormatter()

--- a/src/agentscope/model/_openai_chat/_model.py
+++ b/src/agentscope/model/_openai_chat/_model.py
@@ -120,6 +120,8 @@ class OpenAIChatModel(ChatModelBase):
         formatter: FormatterBase | None = None,
         client_kwargs: dict[str, Any] | None = None,
         extra_body: dict[str, Any] | None = None,
+        stream_first_chunk_timeout: float | None = 120.0,
+        stream_idle_timeout: float | None = 30.0,
     ) -> None:
         """Initialize the OpenAI chat model.
 
@@ -150,6 +152,11 @@ class OpenAIChatModel(ChatModelBase):
             extra_body (`dict[str, Any] | None`, defaults to `None`):
                 Additional request body fields forwarded to
                 OpenAI-compatible APIs.
+            stream_first_chunk_timeout (`float | None`, defaults to `120.0`):
+                Maximum seconds from call start to initial meaningful stream
+                content. Delay before first iteration counts toward it.
+            stream_idle_timeout (`float | None`, defaults to `30.0`):
+                Maximum seconds between meaningful chunks and stream end.
         """
         super().__init__(
             credential=credential,
@@ -159,6 +166,8 @@ class OpenAIChatModel(ChatModelBase):
             max_retries=max_retries,
             retry_delay=retry_delay,
             context_size=context_size,
+            stream_first_chunk_timeout=stream_first_chunk_timeout,
+            stream_idle_timeout=stream_idle_timeout,
         )
         self.formatter = formatter or OpenAIChatFormatter()
         self.client_kwargs = client_kwargs or {}

--- a/src/agentscope/model/_openai_response/_model.py
+++ b/src/agentscope/model/_openai_response/_model.py
@@ -92,6 +92,8 @@ class OpenAIResponseModel(ChatModelBase):
         context_size: int = 200000,
         formatter: FormatterBase | None = None,
         client_kwargs: dict[str, Any] | None = None,
+        stream_first_chunk_timeout: float | None = 120.0,
+        stream_idle_timeout: float | None = 30.0,
     ) -> None:
         """Initialize the OpenAI Responses API chat model.
 
@@ -119,6 +121,11 @@ class OpenAIResponseModel(ChatModelBase):
             client_kwargs (`dict[str, Any] | None`, defaults to `None`):
                 Extra keyword arguments forwarded to ``openai.AsyncClient``
                 (e.g. ``timeout``, ``default_headers``, ``http_client``).
+            stream_first_chunk_timeout (`float | None`, defaults to `120.0`):
+                Maximum seconds from call start to initial meaningful stream
+                content. Delay before first iteration counts toward it.
+            stream_idle_timeout (`float | None`, defaults to `30.0`):
+                Maximum seconds between meaningful chunks and stream end.
         """
         super().__init__(
             credential=credential,
@@ -128,6 +135,8 @@ class OpenAIResponseModel(ChatModelBase):
             max_retries=max_retries,
             retry_delay=retry_delay,
             context_size=context_size,
+            stream_first_chunk_timeout=stream_first_chunk_timeout,
+            stream_idle_timeout=stream_idle_timeout,
         )
         self.formatter = formatter or OpenAIResponseFormatter()
         self.client_kwargs = client_kwargs or {}

--- a/src/agentscope/model/_xai/_model.py
+++ b/src/agentscope/model/_xai/_model.py
@@ -101,6 +101,8 @@ class XAIChatModel(ChatModelBase):
         context_size: int = 131072,
         formatter: XAIChatFormatter | None = None,
         client_kwargs: dict[str, Any] | None = None,
+        stream_first_chunk_timeout: float | None = 120.0,
+        stream_idle_timeout: float | None = 30.0,
     ) -> None:
         """Initialize the xAI chat model.
 
@@ -131,6 +133,11 @@ class XAIChatModel(ChatModelBase):
                 that overlap with credential-derived arguments (such as
                 ``api_key`` or ``api_host``) take precedence over the
                 credential values.
+            stream_first_chunk_timeout (`float | None`, defaults to `120.0`):
+                Maximum seconds from call start to initial meaningful stream
+                content. Delay before first iteration counts toward it.
+            stream_idle_timeout (`float | None`, defaults to `30.0`):
+                Maximum seconds between meaningful chunks and stream end.
         """
         super().__init__(
             credential=credential,
@@ -140,6 +147,8 @@ class XAIChatModel(ChatModelBase):
             max_retries=max_retries,
             retry_delay=retry_delay,
             context_size=context_size,
+            stream_first_chunk_timeout=stream_first_chunk_timeout,
+            stream_idle_timeout=stream_idle_timeout,
         )
         self.formatter = formatter or XAIChatFormatter()
         self.client_kwargs = client_kwargs or {}

--- a/tests/model_base_test.py
+++ b/tests/model_base_test.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access
 """Unit tests for :class:`agentscope.model.ChatModelBase.__call__` — the
 retry / accumulation / interrupt wrapper around ``_call_api``."""
 import asyncio
 import base64
-from typing import Any
+from typing import Any, AsyncGenerator
 from unittest.async_case import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
 
 from utils import AnyString, MockModel
 
@@ -18,17 +20,26 @@ from agentscope.message import (
     UserMsg,
 )
 from agentscope.model import (
+    ChatModelBase,
     ChatResponse,
     ChatUsage,
     FinishedReason,
     StructuredResponse,
 )
-from agentscope.exception import StructuredOutputError
+from agentscope.exception import (
+    ModelFirstChunkTimeoutError,
+    ModelStreamIdleTimeoutError,
+    StructuredOutputError,
+)
 from agentscope.tool import ToolChoice
 
 
 class _BadRequestError(Exception):
     """A provider "bad request" error used to exercise strategy fallback."""
+
+
+class _TransientError(Exception):
+    """A transient provider error used to exercise retry behavior."""
 
 
 class StructuredOutputStrategyMockModel(MockModel):
@@ -44,6 +55,7 @@ class StructuredOutputStrategyMockModel(MockModel):
         self.responses = list(responses or [])
         self.reject_forced = reject_forced
         self.structured_calls: list[tuple[str | None, dict[str, Any]]] = []
+        self.structured_deadlines: list[float | None] = []
 
     def _get_disable_thinking_kwargs(self) -> dict:
         """Expose a provider-specific thinking toggle."""
@@ -56,18 +68,25 @@ class StructuredOutputStrategyMockModel(MockModel):
         """Declare the provider error that permits a strategy fallback."""
         return (_BadRequestError,)
 
+    @classmethod
+    def _get_retryable_exceptions(cls) -> tuple[type[Exception], ...]:
+        """Declare the transient provider error used by retry tests."""
+        return (_TransientError,)
+
     async def _call_api_with_structured_output(
         self,
         model_name: str,
         messages: list,
         structured_model: Any,
         tool_choice: ToolChoice | None = None,
+        _first_chunk_deadline: float | None = None,
         **kwargs: Any,
     ) -> StructuredResponse:
         """Return or raise the configured result for one strategy."""
         del model_name, messages, structured_model
         mode = tool_choice.mode if tool_choice is not None else None
         self.structured_calls.append((mode, kwargs))
+        self.structured_deadlines.append(_first_chunk_deadline)
         await asyncio.sleep(0)
 
         if self.reject_forced and mode == "generate_structured_output":
@@ -1165,6 +1184,61 @@ class StructuredOutputStrategyTest(IsolatedAsyncioTestCase):
             ],
         )
 
+    async def test_strategies_and_retries_share_deadline(self) -> None:
+        """All attempts in one public call use one absolute deadline."""
+        model = StructuredOutputStrategyMockModel(
+            responses=[
+                _TransientError("retry"),
+                _BadRequestError("fallback"),
+                StructuredResponse(content={}),
+            ],
+        )
+        model.max_retries = 1
+        model.retry_delay = 0.0
+
+        await model.generate_structured_output(self.messages, self.schema)
+
+        deadline = model.structured_deadlines[0]
+        self.assertIsNotNone(deadline)
+        self.assertEqual(
+            (model.structured_calls, model.structured_deadlines),
+            (
+                [
+                    ("generate_structured_output", {}),
+                    ("generate_structured_output", {}),
+                    ("auto", {}),
+                ],
+                [deadline, deadline, deadline],
+            ),
+        )
+
+    async def test_retry_sleep_uses_shared_deadline(self) -> None:
+        """Retry backoff cannot exceed the public first-chunk budget."""
+        model = StructuredOutputStrategyMockModel(
+            responses=[_TransientError("retry")],
+        )
+        model.max_retries = 1
+        model.retry_delay = 0.1
+        model.stream_first_chunk_timeout = 0.02
+
+        with self.assertRaises(ModelFirstChunkTimeoutError) as raised:
+            await model.generate_structured_output(self.messages, self.schema)
+
+        self.assertEqual(
+            (
+                raised.exception.model,
+                raised.exception.timeout,
+                model.structured_calls,
+                len(model.structured_deadlines),
+            ),
+            (
+                "mock-model",
+                0.02,
+                [("generate_structured_output", {})],
+                1,
+            ),
+        )
+
     async def test_success_does_not_permanently_promote_strategy(self) -> None:
         """Every call starts from the strongest immutable strategy."""
         model = StructuredOutputStrategyMockModel(
@@ -1284,3 +1358,316 @@ class StructuredOutputStrategyTest(IsolatedAsyncioTestCase):
                 ("auto", {}),
             ],
         )
+
+
+class ChatModelStreamTimeoutTest(IsolatedAsyncioTestCase):
+    """Tests for progress-based model stream timeouts."""
+
+    @staticmethod
+    def _chunk(text: str) -> ChatResponse:
+        """Build a streaming text chunk."""
+        return ChatResponse(
+            content=[TextBlock(text=text, id="text-1")],
+            is_last=False,
+        )
+
+    async def test_first_chunk_timeout_covers_api_call(self) -> None:
+        """The first deadline starts before ``_call_api``."""
+        model = MockModel(stream_first_chunk_timeout=0.02)
+
+        async def stalled_call(*args: Any, **kwargs: Any) -> Any:
+            del args, kwargs
+            await asyncio.Event().wait()
+
+        model._call_api = AsyncMock(side_effect=stalled_call)
+
+        with self.assertRaises(ModelFirstChunkTimeoutError) as raised:
+            await model([])
+
+        self.assertEqual(
+            (
+                raised.exception.model,
+                raised.exception.timeout,
+                str(raised.exception),
+                model._call_api.call_count,
+            ),
+            (
+                "mock-model",
+                0.02,
+                "Model 'mock-model' produced no initial stream content "
+                "within 0.02 seconds.",
+                1,
+            ),
+        )
+
+    async def test_idle_timeout_closes_stream(self) -> None:
+        """A stalled stream closes after its first content chunk."""
+        closed = asyncio.Event()
+
+        async def stalled_stream() -> AsyncGenerator[ChatResponse, None]:
+            try:
+                yield self._chunk("first")
+                await asyncio.Event().wait()
+            finally:
+                closed.set()
+
+        model = MockModel(
+            stream_first_chunk_timeout=1.0,
+            stream_idle_timeout=0.02,
+        )
+        model._call_api = AsyncMock(return_value=stalled_stream())
+
+        stream = await model([])
+        first = await anext(stream)
+        with self.assertRaises(ModelStreamIdleTimeoutError) as raised:
+            await anext(stream)
+
+        self.assertEqual(
+            (
+                _dump(first),
+                raised.exception.model,
+                raised.exception.timeout,
+                str(raised.exception),
+                closed.is_set(),
+            ),
+            (
+                _expected(
+                    content=[
+                        {
+                            "type": "text",
+                            "id": AnyString(),
+                            "text": "first",
+                        },
+                    ],
+                    is_last=False,
+                ),
+                "mock-model",
+                0.02,
+                "Model 'mock-model' stream produced no content for "
+                "0.02 seconds.",
+                True,
+            ),
+        )
+
+    async def test_empty_chunks_do_not_reset_idle_deadline(self) -> None:
+        """Carrier chunks cannot keep a stalled model alive."""
+        closed = asyncio.Event()
+
+        async def carrier_stream() -> AsyncGenerator[ChatResponse, None]:
+            try:
+                yield self._chunk("first")
+                while True:
+                    await asyncio.sleep(0.005)
+                    yield ChatResponse(content=[], is_last=False)
+            finally:
+                closed.set()
+
+        model = MockModel(
+            stream_first_chunk_timeout=1.0,
+            stream_idle_timeout=0.03,
+        )
+        model._call_api = AsyncMock(return_value=carrier_stream())
+
+        stream = await model([])
+        first = await anext(stream)
+        with self.assertRaises(ModelStreamIdleTimeoutError):
+            await anext(stream)
+
+        self.assertEqual(
+            (_dump(first), closed.is_set()),
+            (
+                _expected(
+                    content=[
+                        {
+                            "type": "text",
+                            "id": AnyString(),
+                            "text": "first",
+                        },
+                    ],
+                    is_last=False,
+                ),
+                True,
+            ),
+        )
+
+    async def test_content_resets_idle_deadline(self) -> None:
+        """Each meaningful chunk receives a fresh idle deadline."""
+
+        async def progressing_stream() -> AsyncGenerator[ChatResponse, None]:
+            yield self._chunk("first")
+            await asyncio.sleep(0.05)
+            yield self._chunk(" second")
+            await asyncio.sleep(0.05)
+
+        model = MockModel(
+            stream_first_chunk_timeout=1.0,
+            stream_idle_timeout=0.15,
+        )
+        model._call_api = AsyncMock(return_value=progressing_stream())
+
+        stream = await model([])
+        responses = [response async for response in stream]
+
+        self.assertEqual(
+            [_dump(response) for response in responses],
+            [
+                _expected(
+                    content=[
+                        {
+                            "type": "text",
+                            "id": AnyString(),
+                            "text": "first",
+                        },
+                    ],
+                    is_last=False,
+                ),
+                _expected(
+                    content=[
+                        {
+                            "type": "text",
+                            "id": AnyString(),
+                            "text": " second",
+                        },
+                    ],
+                    is_last=False,
+                ),
+                _expected(
+                    content=[
+                        {
+                            "type": "text",
+                            "id": AnyString(),
+                            "text": "first second",
+                        },
+                    ],
+                    is_last=True,
+                ),
+            ],
+        )
+
+    async def test_none_disables_idle_timeout(self) -> None:
+        """An explicit ``None`` permits an arbitrary inter-chunk delay."""
+
+        async def delayed_stream() -> AsyncGenerator[ChatResponse, None]:
+            yield self._chunk("first")
+            await asyncio.sleep(0.03)
+            yield self._chunk(" second")
+
+        model = MockModel(
+            stream_first_chunk_timeout=1.0,
+            stream_idle_timeout=None,
+        )
+        model._call_api = AsyncMock(return_value=delayed_stream())
+
+        stream = await model([])
+        responses = [response async for response in stream]
+
+        self.assertEqual(
+            [block.text for block in responses[-1].content],
+            ["first second"],
+        )
+
+    async def test_slow_consumer_is_not_stream_idleness(self) -> None:
+        """Downstream chunk processing does not consume the idle budget."""
+
+        async def ready_stream() -> AsyncGenerator[ChatResponse, None]:
+            yield self._chunk("first")
+            yield self._chunk(" second")
+
+        model = MockModel(
+            stream_first_chunk_timeout=1.0,
+            stream_idle_timeout=0.05,
+        )
+        model._call_api = AsyncMock(return_value=ready_stream())
+
+        stream = await model([])
+        first = await anext(stream)
+        await asyncio.sleep(0.15)
+        second = await anext(stream)
+
+        self.assertEqual(
+            [_dump(first), _dump(second)],
+            [
+                _expected(
+                    content=[
+                        {
+                            "type": "text",
+                            "id": AnyString(),
+                            "text": "first",
+                        },
+                    ],
+                    is_last=False,
+                ),
+                _expected(
+                    content=[
+                        {
+                            "type": "text",
+                            "id": AnyString(),
+                            "text": " second",
+                        },
+                    ],
+                    is_last=False,
+                ),
+            ],
+        )
+        await stream.aclose()
+
+    async def test_non_stream_call_ignores_stream_timeouts(self) -> None:
+        """Stream deadlines do not affect non-stream model calls."""
+        expected = ChatResponse(
+            content=[TextBlock(text="complete")],
+            is_last=True,
+        )
+
+        async def delayed_call(*args: Any, **kwargs: Any) -> ChatResponse:
+            del args, kwargs
+            await asyncio.sleep(0.03)
+            return expected
+
+        model = MockModel(
+            stream=False,
+            stream_first_chunk_timeout=0.01,
+            stream_idle_timeout=0.01,
+        )
+        model._call_api = AsyncMock(side_effect=delayed_call)
+
+        response = await model([])
+
+        self.assertIs(response, expected)
+
+    def test_timeout_values_must_be_positive_or_none(self) -> None:
+        """Invalid timeout values fail during model construction."""
+        for name in (
+            "stream_first_chunk_timeout",
+            "stream_idle_timeout",
+        ):
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    f"{name} must be greater than 0 or None.",
+                ):
+                    MockModel(**{name: 0.0})
+
+    async def test_structured_output_uses_first_chunk_timeout(self) -> None:
+        """Structured-output streams share the first-content deadline."""
+        model = MockModel(stream_first_chunk_timeout=0.02)
+
+        async def stalled_call(*args: Any, **kwargs: Any) -> Any:
+            del args, kwargs
+            await asyncio.Event().wait()
+
+        model._call_api = AsyncMock(side_effect=stalled_call)
+
+        with self.assertRaises(ModelFirstChunkTimeoutError):
+            await ChatModelBase._call_api_with_structured_output(
+                model,
+                model_name=model.model,
+                messages=[UserMsg(name="user", content="test")],
+                structured_model={
+                    "type": "object",
+                    "properties": {"answer": {"type": "string"}},
+                    "required": ["answer"],
+                },
+                _first_chunk_deadline=model._new_first_chunk_deadline(),
+            )
+
+        self.assertEqual(model._call_api.call_count, 1)

--- a/tests/service_classify_error_test.py
+++ b/tests/service_classify_error_test.py
@@ -18,7 +18,11 @@ from agentscope.app._service._errors import (
     _classify_type,
     _GENERIC_MESSAGE,
 )
-from agentscope.exception import DeveloperOrientedException
+from agentscope.exception import (
+    DeveloperOrientedException,
+    ModelFirstChunkTimeoutError,
+    ModelStreamIdleTimeoutError,
+)
 from agentscope.types import ErrorType
 
 
@@ -99,6 +103,27 @@ class ClassifyErrorTest(unittest.TestCase):
         self.assertEqual(
             _classify_type(ConnectionError()),
             ErrorType.CONNECTION,
+        )
+
+    def test_model_stream_timeouts_are_connection_errors(self) -> None:
+        """Progress timeouts surface as connection failures in the UI."""
+        errors = (
+            ModelFirstChunkTimeoutError("model", 120.0),
+            ModelStreamIdleTimeoutError("model", 30.0),
+        )
+
+        self.assertEqual(
+            [_classify_error(error).model_dump() for error in errors],
+            [
+                {
+                    "type": ErrorType.CONNECTION,
+                    "message": _GENERIC_MESSAGE[ErrorType.CONNECTION],
+                },
+                {
+                    "type": ErrorType.CONNECTION,
+                    "message": _GENERIC_MESSAGE[ErrorType.CONNECTION],
+                },
+            ],
         )
 
     def test_cause_chain_is_walked(self) -> None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -62,6 +62,8 @@ class MockModel(ChatModelBase):
         mock_chat_responses: list | None = None,
         mock_structured_response: Any = None,
         formatter: FormatterBase | None = None,
+        stream_first_chunk_timeout: float | None = 120.0,
+        stream_idle_timeout: float | None = 30.0,
     ) -> None:
         """Initialize the mock model."""
         super().__init__(
@@ -70,6 +72,8 @@ class MockModel(ChatModelBase):
             stream=stream,
             parameters=MockModel.Parameters(),
             context_size=context_size,
+            stream_first_chunk_timeout=stream_first_chunk_timeout,
+            stream_idle_timeout=stream_idle_timeout,
         )
         # Mirror real models, which each expose a formatter; the agent reads
         # ``formatter.supported_input_media_types`` on every incoming message.


### PR DESCRIPTION
## AgentScope Version

2.0.6

## Description

Add configurable first-chunk and idle timeouts across all chat model providers to prevent streaming calls from hanging indefinitely. The deadlines also cover retries and structured-output strategies, with dedicated timeout errors and comprehensive tests.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review