### PR TITLE
docs: add inspect.software health badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
             alt="pypi"
         />
     </a>
+<a href="https://inspect.software/software/agentscope-ai/agentscope"><img src="https://raw.githubusercontent.com/inspect-software/badges/main/v1/a/agentscope-ai/agentscope.svg" alt="inspect.software score badge for agentscope-ai/agentscope" /></a>
     <a href="https://discord.gg/eYMpfnkG8h">
         <img
             src="https://img.shields.io/badge/Discord-Join%20Us-5865F2?logo=discord&logoColor=white"


### PR DESCRIPTION
This PR adds the [inspect.software](https://inspect.software) health badge to the README.

**Why this PR?**
Your project ranks in the upper rating bands of our open-source health index (which measures maintainability, responsiveness, and security). This badge makes that standing objectively visible to your users. Our index is a free public good, and scores cannot be bought.

**Technical details:**
- **No tracking:** Static SVG served via GitHub's CDN. No JavaScript, no third-party tracking.
- **No maintenance:** The badge updates automatically after every inspection.
- **Transparent:** Links directly to [your full report](https://inspect.software/software/agentscope-ai/agentscope), based on our open [methodology](https://inspect.software/methodology).

If you prefer to keep your README minimal, feel free to close this PR without replying. Your report will remain publicly available and up-to-date either way.
