### PR TITLE
fix(event): validate tool result data source

### DIFF
--- a/src/agentscope/event/_event.py
+++ b/src/agentscope/event/_event.py
@@ -2,9 +2,9 @@
 """Event types for agent execution."""
 from datetime import datetime
 from enum import StrEnum
-from typing import Any, Dict, Literal, List, TypeAlias
+from typing import Any, Dict, Literal, List, Self, TypeAlias
 
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, Field, ConfigDict, model_validator
 from typing_extensions import deprecated
 
 from .._utils._common import _generate_id
@@ -375,6 +375,15 @@ class ToolResultDataDeltaEvent(EventBase):
     """Base64-encoded binary data, mutually exclusive with `url`."""
     url: str | None = None
     """URL pointing to the binary content, mutually exclusive with `data`."""
+
+    @model_validator(mode="after")
+    def validate_data_source(self) -> Self:
+        """Ensure exactly one data source is provided."""
+        if (self.data is None) == (self.url is None):
+            raise ValueError(
+                "Exactly one of `data` or `url` must be provided.",
+            )
+        return self
 
 
 class ToolResultEndEvent(EventBase):

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 """Event test"""
 from unittest.async_case import IsolatedAsyncioTestCase
+
+from pydantic import ValidationError
+
 from utils import AnyString
-from agentscope.event import ReplyStartEvent
+from agentscope.event import ReplyStartEvent, ToolResultDataDeltaEvent
 
 
 class EventTest(IsolatedAsyncioTestCase):
@@ -45,6 +48,45 @@ class EventTest(IsolatedAsyncioTestCase):
             "role": "assistant",
         }
         ReplyStartEvent.model_validate(data)
+
+    async def test_tool_result_data_delta_source_validation(self) -> None:
+        """Test exactly one data source is required."""
+        common = {
+            "reply_id": "test_reply",
+            "tool_call_id": "test_tool_call",
+            "media_type": "image/png",
+        }
+
+        data_event = ToolResultDataDeltaEvent(
+            **common,
+            data="iVBOR==",
+        )
+        self.assertEqual(data_event.data, "iVBOR==")
+        self.assertIsNone(data_event.url)
+
+        url_event = ToolResultDataDeltaEvent(
+            **common,
+            url="https://example.com/image.png",
+        )
+        self.assertIsNone(url_event.data)
+        self.assertEqual(url_event.url, "https://example.com/image.png")
+
+        for invalid_source in (
+            {},
+            {
+                "data": "iVBOR==",
+                "url": "https://example.com/image.png",
+            },
+        ):
+            with self.subTest(source=invalid_source):
+                with self.assertRaisesRegex(
+                    ValidationError,
+                    "Exactly one of",
+                ):
+                    ToolResultDataDeltaEvent(
+                        **common,
+                        **invalid_source,
+                    )
 
     async def asyncTearDown(self) -> None:
         """The async teardown method."""


### PR DESCRIPTION
## AgentScope Version

2.0.6, based on current `main` at `77524b8f`.

## Description

Closes #2363.

`ToolResultDataDeltaEvent` documents `data` and `url` as mutually exclusive, but both fields were optional and no cross-field invariant was enforced. Downstream message reconstruction assumes exactly one source: it prefers `data` and otherwise constructs a `URLSource`. This allowed missing sources to fail late and conflicting sources to silently discard the URL.

This PR:

- adds an after-model validator that requires exactly one of `data` or `url` using explicit `is None` checks;
- adds the four-combination regression matrix: data only, URL only, neither, and both;
- keeps the existing flat event wire format and valid Base64/URL conversion behavior unchanged.

No URL syntax or Base64-content validation is added, so the change remains scoped to the documented source-selection contract.

## Verification

- `.venv/bin/pytest tests/event_test.py tests/event_to_message_test.py -q`
  - `6 passed, 2 subtests passed`
- `PATH="$PWD/.venv/bin:/opt/homebrew/opt/node@24/bin:$PATH" .venv/bin/pre-commit run --all-files`
  - all hooks passed, including mypy, Black, flake8, pylint, and Pyroma
- `.venv/bin/pytest tests`
  - `1853 passed, 125 skipped, 223 warnings in 320.85s`
- direct runtime construction matrix
  - data-only and URL-only accepted
  - neither and both rejected at event construction
- live AgentScope model/tool probes through an explicitly configured OpenAI-compatible endpoint
  - OpenAI Responses `gpt-4.1-mini`: one tool call, Base64 PNG `ToolResultDataDeltaEvent`, success result, second model call, exact final verification token
  - Qwen `qwen3-max`: one text tool call/result, success, exact final verification token

### Verification boundaries

- The 125 skips are environment/platform-gated backend paths such as Apple Container, Bubblewrap, Daytona, Docker, E2B, OpenSandbox, PowerShell, and Kubernetes.
- The 223 warnings are existing deprecation warnings, including AgentScope compatibility APIs and DashScope Assistants deprecation; none originate from this validator.
- A `gpt-5.6-luna` probe hit an upstream regional rate limit.
- `qwen3-vl-flash` / `qwen3-vl-plus` could not verify multimodal Qwen results because the configured gateway returned an empty stream or upstream `url error`; therefore only Qwen text tool protocol is claimed.
- Remote PR CI is green; maintainer review is pending.

Related follow-up discussion: #2369 covers native multimodal `function_call_output.output` arrays for `OpenAIResponseFormatter`; it is intentionally separate from this validation fix.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation has been reviewed; no companion docs change is needed because the documented wire format and valid behavior stay unchanged
- [x] Code is ready for review