### PR TITLE
fix(tool): resolve PEP 563 lazy annotations when extracting tool schemas

### DIFF
--- a/src/agentscope/tool/_utils.py
+++ b/src/agentscope/tool/_utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """The tool module utils."""
 import inspect
+import typing
 from typing import Any, Dict, Callable
 
 from docstring_parser import parse
@@ -65,6 +66,15 @@ def _extract_func_description(docstring: str) -> str:
     return "\n".join(descriptions)
 
 
+def _build_param_field(description: str | None, default: Any) -> Any:
+    """Build the pydantic ``Field`` for a parameter, omitting an absent
+    description so it doesn't override metadata carried by
+    ``Annotated[..., Field(...)]`` annotations."""
+    if description is None:
+        return Field(default=default)
+    return Field(description=description, default=default)
+
+
 def _extract_input_schema(
     tool_func: Callable,
     include_var_positional: bool = False,
@@ -88,12 +98,24 @@ def _extract_input_schema(
     docstring = parse(tool_func.__doc__ or "")
     params_docstring = {_.arg_name: _.description for _ in docstring.params}
 
+    # Under PEP 563 (`from __future__ import annotations`) the annotations
+    # in the signature are raw strings, which pydantic cannot resolve
+    # outside the function's own module. Resolve them here instead.
+    try:
+        type_hints = typing.get_type_hints(tool_func, include_extras=True)
+    except Exception:
+        # e.g. `functools.partial` objects, or annotations referencing
+        # TYPE_CHECKING-only names; fall back to the raw annotations
+        type_hints = {}
+
     # Create a dynamic model with the function signature
     fields = {}
     for name, param in inspect.signature(tool_func).parameters.items():
         # Skip the `self` and `cls` parameters
         if name in ["self", "cls"]:
             continue
+
+        annotation = type_hints.get(name, param.annotation)
 
         # Handle `**kwargs`
         if param.kind == inspect.Parameter.VAR_KEYWORD:
@@ -102,9 +124,9 @@ def _extract_input_schema(
 
             fields[name] = (
                 Dict[str, Any]
-                if param.annotation == inspect.Parameter.empty
-                else Dict[str, param.annotation],  # type: ignore
-                Field(
+                if annotation == inspect.Parameter.empty
+                else Dict[str, annotation],  # type: ignore
+                _build_param_field(
                     description=params_docstring.get(
                         f"**{name}",
                         params_docstring.get(name, None),
@@ -121,9 +143,9 @@ def _extract_input_schema(
 
             fields[name] = (
                 list[Any]
-                if param.annotation == inspect.Parameter.empty
-                else list[param.annotation],  # type: ignore
-                Field(
+                if annotation == inspect.Parameter.empty
+                else list[annotation],  # type: ignore
+                _build_param_field(
                     description=params_docstring.get(
                         f"*{name}",
                         params_docstring.get(name, None),
@@ -136,10 +158,8 @@ def _extract_input_schema(
 
         else:
             fields[name] = (
-                Any
-                if param.annotation == inspect.Parameter.empty
-                else param.annotation,
-                Field(
+                Any if annotation == inspect.Parameter.empty else annotation,
+                _build_param_field(
                     description=params_docstring.get(name, None),
                     default=...
                     if param.default is param.empty

--- a/tests/tool_lazy_annotations_test.py
+++ b/tests/tool_lazy_annotations_test.py
@@ -74,27 +74,72 @@ class LazyAnnotationsTest(TestCase):
             kwargs_tool,
             include_var_keyword=True,
         )
-        self.assertEqual(
-            schema["properties"]["kwargs"]["additionalProperties"],
-            {"type": "string", "description": "Extras"},
+        self.assertDictEqual(
+            schema,
+            {
+                "type": "object",
+                "properties": {
+                    "kwargs": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "description": "Extras",
+                        },
+                        "default": {},
+                    },
+                },
+            },
         )
 
     def test_pydantic_model_parameter(self) -> None:
         """Custom model types must be resolved from the defining module."""
         schema = _extract_input_schema(model_tool)
-        self.assertIn("Location", schema.get("$defs", {}))
-        self.assertEqual(
-            schema["properties"]["location"]["$ref"],
-            "#/$defs/Location",
+        self.assertDictEqual(
+            schema,
+            {
+                "type": "object",
+                "$defs": {
+                    "Location": {
+                        "type": "object",
+                        "description": (
+                            "A location model used as a parameter type."
+                        ),
+                        "properties": {
+                            "city": {
+                                "type": "string",
+                                "description": "The city name",
+                            },
+                        },
+                        "required": ["city"],
+                    },
+                },
+                "properties": {
+                    "location": {
+                        "$ref": "#/$defs/Location",
+                        "description": "Where to report the weather for.",
+                    },
+                },
+                "required": ["location"],
+            },
         )
 
     def test_function_tool_registration(self) -> None:
         """FunctionTool must expose the resolved schema end to end."""
         tool = FunctionTool(annotated_tool)
-        self.assertEqual(
-            tool.input_schema["properties"]["query"],
+        self.assertDictEqual(
+            tool.input_schema,
             {
-                "type": "string",
-                "description": "The search query",
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "The search query",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 5,
+                    },
+                },
+                "required": ["query"],
             },
         )

--- a/tests/tool_lazy_annotations_test.py
+++ b/tests/tool_lazy_annotations_test.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+"""Test schema extraction under PEP 563 lazy annotations.
+
+The ``from __future__ import annotations`` import below is the point of
+this test module: it turns all annotations into strings, which must be
+resolved back to real types before being handed to pydantic.
+"""
+from __future__ import annotations
+
+from typing import Annotated
+from unittest import TestCase
+
+from pydantic import BaseModel, Field
+
+from agentscope.tool import FunctionTool
+from agentscope.tool._utils import _extract_input_schema
+
+
+class Location(BaseModel):
+    """A location model used as a parameter type."""
+
+    city: str = Field(description="The city name")
+
+
+def annotated_tool(
+    query: Annotated[str, Field(description="The search query")],
+    limit: int = 5,
+) -> str:
+    """Search for something."""
+    return query
+
+
+def kwargs_tool(**kwargs: Annotated[str, Field(description="Extras")]) -> None:
+    """A tool receiving keyword arguments only."""
+
+
+def model_tool(location: Location) -> str:
+    """Report the weather.
+
+    Args:
+        location: Where to report the weather for.
+    """
+    return location.city
+
+
+class LazyAnnotationsTest(TestCase):
+    """Schema extraction must work with stringized annotations."""
+
+    def test_annotated_field_parameter(self) -> None:
+        """`Annotated[str, Field(...)]` params must be resolved."""
+        schema = _extract_input_schema(annotated_tool)
+        self.assertDictEqual(
+            schema,
+            {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "The search query",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 5,
+                    },
+                },
+                "required": ["query"],
+            },
+        )
+
+    def test_annotated_var_keyword(self) -> None:
+        """`**kwargs` annotations must be resolved as well."""
+        schema = _extract_input_schema(
+            kwargs_tool,
+            include_var_keyword=True,
+        )
+        self.assertEqual(
+            schema["properties"]["kwargs"]["additionalProperties"],
+            {"type": "string", "description": "Extras"},
+        )
+
+    def test_pydantic_model_parameter(self) -> None:
+        """Custom model types must be resolved from the defining module."""
+        schema = _extract_input_schema(model_tool)
+        self.assertIn("Location", schema.get("$defs", {}))
+        self.assertEqual(
+            schema["properties"]["location"]["$ref"],
+            "#/$defs/Location",
+        )
+
+    def test_function_tool_registration(self) -> None:
+        """FunctionTool must expose the resolved schema end to end."""
+        tool = FunctionTool(annotated_tool)
+        self.assertEqual(
+            tool.input_schema["properties"]["query"],
+            {
+                "type": "string",
+                "description": "The search query",
+            },
+        )

--- a/tests/tool_lazy_annotations_test.py
+++ b/tests/tool_lazy_annotations_test.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=unused-argument
 """Test schema extraction under PEP 563 lazy annotations.
 
 The ``from __future__ import annotations`` import below is the point of


### PR DESCRIPTION
## AgentScope Version

2.0.6 (main, 77524b8f6)

## Description

### Background

When a tool function is defined in a module that uses `from __future__ import annotations` (PEP 563 lazy annotations), `inspect.signature` returns the parameter annotations as **raw strings** instead of type objects. `_extract_input_schema` feeds them directly into `pydantic.create_model`, which tries to resolve the resulting forward references outside the function's own module and fails:

```python
# a user module with `from __future__ import annotations`
def my_tool(x: Annotated[str, Field(description="the x")]) -> str:
    """Do something."""
    return x

FunctionTool(my_tool)
# pydantic.errors.PydanticUserError: `_StructuredOutputDynamicClass` is not
# fully defined; you should define `Annotated`, then call `model_rebuild()`.
```

Simple builtin annotations (e.g. `x: str`) happen to resolve, so the bug only surfaces with `Annotated[...]`, custom classes, etc. — anything that needs the defining module's namespace. Tool authors cannot be required to avoid (or use) the future import, so the framework must handle both.

### Changes

1. **`_extract_input_schema` now resolves annotations with `typing.get_type_hints(tool_func, include_extras=True)`** before building the pydantic model, so string annotations are evaluated in the function's own module namespace. `include_extras=True` keeps the `Annotated[..., Field(...)]` metadata. For modules without the future import this is a no-op (the hints are already real types). Falls back to the raw annotations when `get_type_hints` is unavailable (e.g. `functools.partial` objects), preserving current behavior.

2. **Fix a related pre-existing bug**: the description carried by `Annotated[str, Field(description=...)]` was silently dropped even *without* lazy annotations, because the schema builder always passed `Field(description=None)` when the docstring had no entry for the parameter, and the explicit `None` overrode the `Annotated` metadata during pydantic's `FieldInfo` merge. The `Field` is now built without a description when the docstring provides none, so `Annotated` metadata survives. A docstring description still takes precedence when present.

### How to test

```bash
pytest tests/tool_lazy_annotations_test.py
```

The new test module itself uses `from __future__ import annotations` and covers: `Annotated[str, Field(description=...)]` parameters, `**kwargs` annotations, custom pydantic-model parameter types, and end-to-end `FunctionTool` registration. Existing toolkit / tool tests all pass.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [x]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [x]  Code is ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
