### PR TITLE
fix(memory): own minimal ReMe configuration

### DIFF
--- a/examples/long_term_memory/reme/README.md
+++ b/examples/long_term_memory/reme/README.md
@@ -16,12 +16,11 @@ is no add tool. The demo drives ReMe with AgentScope's own DashScope
 chat model (LLM-backed `auto_memory` write-back) and DashScope
 embedding model (vector search), both injected into the embedded app.
 
-ReMe's bundled `default` config searches with **BM25 (keyword) only** —
-its file store ships with the vector store disabled. A long-term
-*memory* demo wants **semantic** recall ("plot monthly sales" should
-find a "prefers matplotlib" card), so `reme_demo.py` injects an
-`embedding_model` — which turns ReMe's vector store on automatically;
-see below.
+AgentScope's minimal embedded ReMe config searches with **BM25 (keyword)
+only** by default. A long-term *memory* demo wants **semantic** recall
+("plot monthly sales" should find a "prefers matplotlib" card), so
+`reme_demo.py` injects an `embedding_model` — which turns the vector store
+on automatically; see below.
 
 ## Install
 
@@ -71,16 +70,13 @@ well-defined even when one middleware instance is shared across agents.
 
 | `chat_model` / `embedding_model` | Behavior |
 |:-:|---|
-| provided | Injected into ReMe's default LLM / embedding components at start; only a DashScope key is needed. An `embedding_model` also enables the vector store for semantic search. |
-| omitted | ReMe uses the LLM / embedding backend from its own config/credentials; search stays keyword-only. |
+| provided | Injected into the embedded app's default-named LLM / embedding components at start; only a DashScope key is needed. An `embedding_model` also enables the vector store for semantic search. |
+| omitted | AgentScope's minimal config supplies the LLM from ReMe's `LLM_*` environment variables and stays keyword-only without an `embedding_model`. |
 
-> **Why inject `embedding_model`?** ReMe starts its embedding
-> component eagerly at `start()` — even under the BM25-only default —
-> and builds it from credentials in its config. Injecting an
-> AgentScope `embedding_model` bypasses that credential path, so the
-> only key you need is a DashScope one. It is also what powers vector
-> search: providing it flips ReMe's file store from BM25-only to the
-> vector store automatically.
+> **Why inject `embedding_model`?** The minimal config omits embedding
+> components in BM25-only mode. Providing an AgentScope `embedding_model`
+> adds and wires those components before ReMe starts, and powers vector
+> search without requiring separate ReMe embedding credentials.
 
 ## How the middleware controls memory
 
@@ -174,11 +170,13 @@ down the embedded app (AgentScope doesn't manage middleware lifecycle).
 
 ## Configuration
 
-`config` selects a ReMe config (defaults to the bundled `"default"`,
-which is auto-memory + **BM25-only** search — its file store ships with
-`embedding_store: ""`). To enable **vector search**, provide an
-`embedding_model` (what the demo does) — the middleware then wires
-ReMe's file store to the default embedding store automatically:
+The middleware always builds an AgentScope-owned minimal ReMe config. It keeps
+the full memory lifecycle: conversation write-back, nightly/manual dream
+consolidation from daily cards into digest memory, and search across both daily
+and digest memory. Only the file/index jobs required by that lifecycle are
+registered; ReMe's resource ingestion, independent chat, daily-paper and
+operational jobs are not loaded. Search is **BM25-only** unless an
+`embedding_model` is provided:
 
 ```python
 ReMeMiddleware(
@@ -189,12 +187,8 @@ ReMeMiddleware(
 )
 ```
 
-ReMe's `as_llm` / `as_embedding` components are otherwise driven by
-environment variables (`LLM_API_KEY`, `EMBEDDING_API_KEY`, ...) from its
-own config; injecting AgentScope `chat_model` / `embedding_model`
-bypasses those. If you need a config the dedicated parameters don't
-expose, point `config` at your own ReMe config file. See ReMe's
-`default.yaml` for the full component set.
+The minimal config's `as_llm` component honors ReMe's `LLM_*` environment
+variables; injecting an AgentScope `chat_model` bypasses those.
 
 > **Note (indexing):** `auto_memory` write-back returns as soon as the
 > daily card is written to disk; the card only becomes searchable once

--- a/examples/long_term_memory/reme/reme_demo.py
+++ b/examples/long_term_memory/reme/reme_demo.py
@@ -255,7 +255,7 @@ async def main() -> None:
     embedding_model = DashScopeEmbeddingModel(
         credential=DashScopeCredential(api_key=api_key),
         model="text-embedding-v4",
-        dimensions=1024,  # matches ReMe's default embedding dimension
+        dimensions=1024,
     )
 
     # One middleware, shared across both sessions. ReMe is embedded
@@ -267,12 +267,11 @@ async def main() -> None:
     # never stored on the middleware — so sharing one instance across
     # agents/sessions is safe.
     #
-    # ReMe's bundled ``default`` config searches keyword-only (its file
-    # store ships with ``embedding_store: ""``). For a long-term *memory*
-    # demo we want semantic recall — "plot monthly sales" should find a
-    # "prefers matplotlib / dark mode" card even without shared keywords —
-    # so we pass an ``embedding_model``, which the middleware uses to turn
-    # ReMe's vector store on automatically when it builds the app.
+    # AgentScope's minimal embedded ReMe config searches keyword-only by
+    # default. For a long-term *memory* demo we want semantic recall — "plot
+    # monthly sales" should find a "prefers matplotlib / dark mode" card even
+    # without shared keywords — so we pass an ``embedding_model``, which the
+    # middleware uses to turn ReMe's vector store on when it builds the app.
     mw = ReMeMiddleware(
         workspace_dir=WORKSPACE_DIR,
         parameters=ReMeMiddleware.Parameters(

--- a/src/agentscope/middleware/_longterm_memory/_reme/_config.py
+++ b/src/agentscope/middleware/_longterm_memory/_reme/_config.py
@@ -360,7 +360,7 @@ def _memory_components(
     return components
 
 
-def build_reme_app_config(
+def _build_reme_app_config(
     *,
     workspace_dir: str,
     embedding_dimensions: int | None = None,
@@ -374,6 +374,3 @@ def build_reme_app_config(
         "jobs": _memory_jobs(),
         "components": _memory_components(embedding_dimensions),
     }
-
-
-__all__ = ["build_reme_app_config"]

--- a/src/agentscope/middleware/_longterm_memory/_reme/_config.py
+++ b/src/agentscope/middleware/_longterm_memory/_reme/_config.py
@@ -1,0 +1,379 @@
+# -*- coding: utf-8 -*-
+"""Minimal embedded ReMe configuration for AgentScope memory.
+
+ReMe's bundled ``default`` configuration describes a standalone memory
+application. It includes resource ingestion, chat, operational endpoints and
+other jobs that are unrelated to :class:`ReMeMiddleware`. The middleware needs
+the complete conversation-memory lifecycle: write-back, nightly dream
+consolidation, search, and the small set of jobs/components those paths depend
+on.
+
+Keep this configuration as a Python dictionary rather than resolving ReMe's
+``default.yaml`` so adding a new standalone ReMe feature cannot silently add
+background work to an AgentScope process.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+_MAX_FILE_BYTES = 10 * 1024 * 1024
+
+
+def _object_schema(
+    properties: dict[str, Any],
+    required: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    """Build the JSON schema used by a ReMe job."""
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+    }
+    if required:
+        schema["required"] = list(required)
+    return schema
+
+
+def _job(
+    step: str,
+    description: str,
+    properties: dict[str, Any],
+    required: tuple[str, ...] = (),
+    **step_options: Any,
+) -> dict[str, Any]:
+    """Build a single-step ReMe request job."""
+    return {
+        "backend": "base",
+        "description": description,
+        "parameters": _object_schema(properties, required),
+        "steps": [{"backend": step, **step_options}],
+    }
+
+
+def _dream_steps() -> list[dict[str, Any]]:
+    """Build ReMe's daily-to-digest memory consolidation pipeline."""
+    return [
+        {
+            "backend": "dream_extract_step",
+            "file_catalog": "dream",
+            "topic_session_id": "interests",
+            "scan_days": 2,
+            "max_units": 5,
+        },
+        {"backend": "dream_integrate_step"},
+        {
+            "backend": "dream_topics_step",
+            "topic_count": 3,
+            "topic_diversity_days": 7,
+        },
+        {
+            "backend": "dream_finish_step",
+            "file_catalog": "dream",
+        },
+    ]
+
+
+def _memory_jobs() -> dict[str, Any]:
+    """Return only the jobs required by AgentScope memory flows."""
+    string = {"type": "string"}
+    return {
+        # This is the only continuous filesystem watcher in the embedded app.
+        # It keeps both the daily cards from ``auto_memory`` and the digest
+        # nodes from dream searchable.
+        "index_update_loop": {
+            "backend": "background",
+            "max_file_bytes": _MAX_FILE_BYTES,
+            "watch_dirs": ["daily_dir", "digest_dir"],
+            "watch_suffixes": ["md"],
+            "steps": [
+                {
+                    "backend": "init_changes_step",
+                    "monitor_type": "file_store",
+                    "monitor_name": "default",
+                    "dispatch_steps": ["update_index_step"],
+                },
+                {
+                    "backend": "watch_changes_step",
+                    "dispatch_steps": [
+                        {
+                            "backend": "update_index_step",
+                            "persist": False,
+                        },
+                    ],
+                },
+            ],
+        },
+        "search": _job(
+            "search_step",
+            "Search conversation memory cards.",
+            {
+                "query": string,
+                "limit": {"type": "integer", "default": 5},
+                "min_score": {"type": "number", "default": 0.0},
+            },
+            ("query",),
+            vector_weight=0.7,
+            candidate_multiplier=3.0,
+            expand_links=False,
+        ),
+        "reindex": {
+            "backend": "base",
+            "description": "Rebuild the conversation-memory search index.",
+            "max_file_bytes": _MAX_FILE_BYTES,
+            "watch_dirs": ["daily_dir", "digest_dir"],
+            "watch_suffixes": ["md"],
+            "parameters": _object_schema({}),
+            "steps": [
+                {"backend": "clear_store_step"},
+                {
+                    "backend": "init_changes_step",
+                    "monitor_type": "file_store",
+                    "monitor_name": "default",
+                    "dispatch_steps": ["update_index_step"],
+                },
+            ],
+        },
+        "auto_memory": _job(
+            "auto_memory_step",
+            "Record conversation facts into a daily memory card.",
+            {
+                "messages": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                },
+                "session_id": {"type": "string", "default": ""},
+                "memory_hint": string,
+            },
+            ("messages",),
+        ),
+        # ``auto_memory`` writes daily cards; dream is the downstream memory
+        # consolidation phase that turns those cards into durable digest
+        # nodes. Keep both the nightly schedule and an explicit job for
+        # deterministic/manual execution.
+        "dream_cron": {
+            "backend": "cron",
+            "cron": "0 23 * * *",
+            "steps": _dream_steps(),
+        },
+        "auto_dream": {
+            "backend": "base",
+            "description": (
+                "Consolidate daily conversation memory into digest nodes "
+                "and interest topics."
+            ),
+            "parameters": _object_schema(
+                {
+                    "date": {"type": "string", "default": ""},
+                    "hint": {"type": "string", "default": ""},
+                    "scan_days": {"type": "integer", "default": 2},
+                    "max_units": {"type": "integer", "default": 5},
+                    "topic_count": {"type": "integer", "default": 3},
+                    "topic_diversity_days": {
+                        "type": "integer",
+                        "default": 7,
+                    },
+                },
+            ),
+            "steps": _dream_steps(),
+        },
+        "node_search": _job(
+            "node_search_step",
+            "Find related digest nodes during dream consolidation.",
+            {
+                "query": string,
+                "limit": {"type": "integer", "default": 20},
+            },
+            ("query",),
+            vector_weight=0.7,
+            candidate_multiplier=5.0,
+        ),
+        # ``auto_memory_step`` calls these jobs directly and exposes a subset
+        # of them as tools to its internal AgentScope extraction agent. Dream
+        # also uses read/write/edit/frontmatter jobs as restricted tools.
+        "daily_list": _job(
+            "daily_list_step",
+            "List memory cards under one day.",
+            {"date": {"type": "string", "default": ""}},
+        ),
+        "frontmatter_update": _job(
+            "frontmatter_update_step",
+            "Merge fields into a memory card's frontmatter.",
+            {"path": string, "metadata": {"type": "object"}},
+            ("path", "metadata"),
+        ),
+        "frontmatter_read": _job(
+            "frontmatter_read_step",
+            "Read a memory card's frontmatter.",
+            {"path": string},
+            ("path",),
+        ),
+        "move": _job(
+            "move_step",
+            "Rename a memory card.",
+            {
+                "src_path": string,
+                "dst_path": string,
+                "overwrite": {"type": "boolean", "default": False},
+                "retarget": {"type": "boolean", "default": True},
+            },
+            ("src_path", "dst_path"),
+        ),
+        "read": _job(
+            "read_step",
+            "Read a memory card.",
+            {
+                "path": string,
+                "start_line": {"type": "integer"},
+                "end_line": {"type": "integer"},
+            },
+            ("path",),
+            with_neighbors=False,
+        ),
+        "write": _job(
+            "write_step",
+            "Write a memory card with frontmatter.",
+            {
+                "path": string,
+                "name": string,
+                "description": string,
+                "content": string,
+                "metadata": {"type": "object"},
+            },
+            ("path", "name", "description", "content"),
+        ),
+        "daily_write": _job(
+            "daily_write_step",
+            "Create a daily conversation memory card.",
+            {
+                "name": string,
+                "description": string,
+                "session_id": string,
+                "content": string,
+                "date": {"type": "string", "default": ""},
+                "metadata": {"type": "object"},
+            },
+            ("name", "description", "session_id", "content"),
+        ),
+        "edit": _job(
+            "edit_step",
+            "Replace text in a memory card.",
+            {
+                "path": string,
+                "old": string,
+                "new": {"type": "string", "default": ""},
+            },
+            ("path", "old", "new"),
+        ),
+    }
+
+
+def _memory_components(
+    embedding_dimensions: int | None,
+) -> dict[str, Any]:
+    """Return components required by the minimal memory jobs."""
+    components: dict[str, Any] = {
+        "tokenizer": {"default": {"backend": "regex"}},
+        # The AgentScope model is injected before ReMe starts in the usual
+        # middleware path.  Environment-backed values preserve the existing
+        # no-injection escape hatch without loading ReMe's default config.
+        "as_llm": {
+            "default": {
+                "backend": os.getenv("LLM_BACKEND", "openai"),
+                "model": os.getenv("LLM_MODEL_NAME", "qwen3.7-plus"),
+                "stream": True,
+                "context_size": 200_000,
+                "max_retries": 3,
+                "credential": {
+                    "api_key": os.getenv("LLM_API_KEY", ""),
+                    "base_url": os.getenv("LLM_BASE_URL", ""),
+                },
+                "parameters": {
+                    "max_tokens": 65_536,
+                    "thinking_enable": False,
+                },
+            },
+        },
+        "agent_wrapper": {
+            "default": {
+                "backend": "agentscope",
+                "as_llm": "default",
+                "builtin_tools": False,
+                "permission_mode": "bypass",
+                "react_config": {"max_iters": 30},
+                "context_config": {
+                    "trigger_ratio": 0.8,
+                    "reserve_ratio": 0.1,
+                    "tool_result_limit": 50_000,
+                },
+                "model_config": {"max_retries": 1},
+            },
+        },
+        "file_graph": {"default": {"backend": "local"}},
+        "file_catalog": {"dream": {"backend": "local"}},
+        "file_chunker": {
+            "markdown": {
+                "backend": "markdown",
+                "supported_extensions": ["md"],
+            },
+        },
+        "keyword_index": {
+            "default": {"backend": "bm25", "tokenizer": "default"},
+        },
+        "file_store": {
+            "default": {
+                "backend": "local",
+                "store_name": "local",
+                "embedding_store": "",
+                "keyword_index": "default",
+                "file_graph": "default",
+            },
+        },
+    }
+
+    if embedding_dimensions is not None:
+        components.update(
+            {
+                "as_embedding": {
+                    "default": {
+                        "backend": "openai",
+                        "model": "agentscope-injected",
+                        "dimensions": embedding_dimensions,
+                        "credential": {"api_key": "", "base_url": ""},
+                        "parameters": {},
+                    },
+                },
+                "embedding_store": {
+                    "default": {
+                        "backend": "local",
+                        "as_embedding": "default",
+                        "enable_cache": True,
+                        "max_cache_size": 3_000,
+                        "max_input_length": 8_192,
+                        "max_batch_size": 10,
+                    },
+                },
+            },
+        )
+        components["file_store"]["default"]["embedding_store"] = "default"
+
+    return components
+
+
+def build_reme_app_config(
+    *,
+    workspace_dir: str,
+    embedding_dimensions: int | None = None,
+) -> dict[str, Any]:
+    """Return a fresh, self-contained ReMe config for AgentScope memory."""
+    return {
+        "workspace_dir": workspace_dir,
+        "enable_logo": False,
+        "log_to_console": False,
+        "service": {"backend": "http"},
+        "jobs": _memory_jobs(),
+        "components": _memory_components(embedding_dimensions),
+    }
+
+
+__all__ = ["build_reme_app_config"]

--- a/src/agentscope/middleware/_longterm_memory/_reme/_middleware.py
+++ b/src/agentscope/middleware/_longterm_memory/_reme/_middleware.py
@@ -6,6 +6,11 @@ toolkit built on AgentScope. This middleware **embeds the ReMe
 application in-process** (no separate service to run); a chat model for
 ReMe's LLM-backed jobs is configured once at construction.
 
+The embedded app uses an AgentScope-owned minimal configuration rather than
+ReMe's standalone ``default.yaml``. It keeps the complete conversation-memory
+lifecycle (write-back, dream consolidation and search) plus only the
+indexing/file jobs required by those paths.
+
 ReMe records memory by **listening to the conversation through the
 ``on_reply`` hook** — after every reply the new exchange is written back
 via ReMe's ``auto_memory`` job, in *all* modes. The agent never writes
@@ -43,6 +48,7 @@ from ...._logging import logger
 from ....embedding import EmbeddingModelBase
 from ....message import AssistantMsg, HintBlock, Msg
 from ....model import ChatModelBase
+from ._config import build_reme_app_config
 from ._tools import _build_memory_tools
 from ._utils import _extract_memory_texts, _extract_query_text
 
@@ -55,11 +61,8 @@ if TYPE_CHECKING:
 _SEARCH_JOB = "search"
 _AUTO_MEMORY_JOB = "auto_memory"
 
-# ReMe component coordinates for the default chat-model / embedding
-# backends. ReMe starts both eagerly at ``start()`` (the embedding
-# component is wired in even when the default file store searches
-# keyword-only), so an injected model bypasses ReMe building its own
-# from credentials — the same escape hatch for both components.
+# ReMe component coordinates for the AgentScope-owned chat-model / embedding
+# backends. An injected model bypasses ReMe building its own from credentials.
 _AS_LLM_COMPONENT = "as_llm"
 _AS_EMBEDDING_COMPONENT = "as_embedding"
 _AS_DEFAULT = "default"
@@ -89,11 +92,11 @@ class ReMeMiddleware(MiddlewareBase):
     ReMe is embedded **in-process** (no separate service): the middleware
     instantiates a :class:`reme.ReMe` application whose LLM-backed jobs use
     the ``chat_model`` configured at construction. The app is built and
-    owned by the middleware — pass ``workspace_dir`` / ``config`` (and
-    optionally a ``Parameters`` with ``chat_model`` / ``embedding_model``)
-    and it is created lazily on first use. When ``chat_model`` is omitted,
-    ReMe uses the LLM from its own config/credentials. Providing an
-    ``embedding_model`` enables ReMe's vector store; otherwise search stays
+    owned by the middleware — pass ``workspace_dir`` and optionally a
+    ``Parameters`` with ``chat_model`` / ``embedding_model``; it is created
+    lazily on first use. When ``chat_model`` is omitted, the AgentScope config
+    supplies the LLM from ReMe's ``LLM_*`` environment variables. Providing
+    an ``embedding_model`` enables the vector store; otherwise search stays
     keyword-only.
 
     The model is fixed at construction (never taken from an agent), so the
@@ -129,8 +132,7 @@ class ReMeMiddleware(MiddlewareBase):
         """User-tunable ReMe memory parameters.
 
         The agent service parses this schema to render a configuration
-        form. Structural wiring (``workspace_dir`` / ``config``) stays on
-        the constructor.
+        form. Structural wiring (``workspace_dir``) stays on the constructor.
         """
 
         model_config = {"arbitrary_types_allowed": True}
@@ -139,10 +141,10 @@ class ReMeMiddleware(MiddlewareBase):
             default=None,
             title="Chat Model",
             description=(
-                "AgentScope chat model injected into ReMe's default LLM "
-                "component, fixed for the lifetime of the embedded app. "
-                "When `None`, ReMe uses the LLM from its own "
-                "config/credentials. Needed for `auto_memory` write-back."
+                "AgentScope chat model injected into the embedded app's "
+                "default-named LLM component, fixed for the lifetime of "
+                "the app. When `None`, the AgentScope ReMe config supplies "
+                "the LLM. Needed for `auto_memory` write-back."
             ),
         )
 
@@ -150,13 +152,11 @@ class ReMeMiddleware(MiddlewareBase):
             default=None,
             title="Embedding Model",
             description=(
-                "AgentScope embedding model injected into ReMe's default "
-                "embedding component, fixed for the lifetime of the embedded "
-                "app. ReMe starts this component eagerly (it is wired into "
-                "the file store even when search is keyword-only), so "
-                "injecting a model bypasses ReMe building its own from "
-                "credentials. When `None`, ReMe uses the embedding backend "
-                "from its own config/credentials."
+                "AgentScope embedding model injected into the embedded "
+                "app's default-named embedding component, fixed for the "
+                "lifetime of the app. In the AgentScope minimal config, "
+                "`None` keeps search keyword-only; providing a model enables "
+                "vector search."
             ),
         )
 
@@ -185,7 +185,6 @@ class ReMeMiddleware(MiddlewareBase):
         self,
         *,
         workspace_dir: str = ".reme",
-        config: str = "default",
         parameters: Parameters | None = None,
     ) -> None:
         """Initialize the ReMe middleware.
@@ -200,9 +199,6 @@ class ReMeMiddleware(MiddlewareBase):
             workspace_dir (`str`, optional):
                 ReMe workspace (vault) directory for memory cards and
                 indexes. Defaults to ``".reme"``.
-            config (`str`, optional):
-                ReMe config name or path. Defaults to ``"default"``
-                (ReMe's bundled ``default.yaml``).
             parameters (`ReMeMiddleware.Parameters | None`, optional):
                 User-tunable parameters (``chat_model`` / ``embedding_model``
                 / ``mode`` / ``top_k``) whose schema the agent service
@@ -217,7 +213,6 @@ class ReMeMiddleware(MiddlewareBase):
         self._app: Any | None = None
         self._started = False
         self._workspace_dir = workspace_dir
-        self._config = config
         self._parameters = parameters or self.Parameters()
         # In-flight background retrieval per session (started in ``on_reply``,
         # consumed/injected in ``on_reasoning``, cleaned up in ``on_reply``'s
@@ -238,7 +233,6 @@ class ReMeMiddleware(MiddlewareBase):
         """
         try:
             from reme import ReMe
-            from reme.config import resolve_app_config
         except ImportError as e:  # pragma: no cover - import guard
             raise ImportError(
                 "ReMeMiddleware requires the `reme-ai` package. Install "
@@ -246,36 +240,30 @@ class ReMeMiddleware(MiddlewareBase):
                 "`pip install reme-ai`).",
             ) from e
 
-        app_kwargs: dict[str, Any] = {
-            "config": self._config,
-            "workspace_dir": self._workspace_dir,
-            "enable_logo": False,
-            "log_to_console": False,
-        }
-        # An embedding model turns on ReMe's vector store: the bundled
-        # ``default`` config ships it off (BM25 keyword search only), so we
-        # wire the file store to the default embedding store when — and
-        # only when — a model is available to build the vectors.
+        embedding_dimensions = None
         if self._parameters.embedding_model is not None:
-            app_kwargs["components"] = {
-                "file_store": {"default": {"embedding_store": "default"}},
-            }
-        app_config = resolve_app_config(**app_kwargs)
+            embedding_dimensions = self._parameters.embedding_model.dimensions
+        app_config = build_reme_app_config(
+            workspace_dir=self._workspace_dir,
+            embedding_dimensions=embedding_dimensions,
+        )
         return ReMe(**app_config)
 
     async def _ensure_started(self) -> None:
         """Build (if needed) and start the embedded app (idempotent).
 
         The configured ``chat_model`` / ``embedding_model`` are injected
-        into ReMe's default LLM and embedding components **before** the
+        into the embedded app's default-named components **before** the
         one-time ``start()`` (ReMe's ``BaseAsLLM._start`` /
         ``BaseAsEmbedding._start`` skip building a model from credentials
         when ``model`` is already set). Both are fixed at construction —
         never taken from an agent — so the embedded app (which has a
         single LLM and a single embedding component) has one well-defined
         model each regardless of how many agents share this middleware.
-        When either is ``None``, ReMe falls back to the backend configured
-        in its own config/credentials.
+        When ``chat_model`` is ``None``, the AgentScope config supplies its
+        LLM.
+        The AgentScope minimal config only creates an embedding component when
+        ``embedding_model`` is provided.
         """
         if self._app is None:
             self._app = self._build_app()

--- a/src/agentscope/middleware/_longterm_memory/_reme/_middleware.py
+++ b/src/agentscope/middleware/_longterm_memory/_reme/_middleware.py
@@ -48,7 +48,7 @@ from ...._logging import logger
 from ....embedding import EmbeddingModelBase
 from ....message import AssistantMsg, HintBlock, Msg
 from ....model import ChatModelBase
-from ._config import build_reme_app_config
+from ._config import _build_reme_app_config
 from ._tools import _build_memory_tools
 from ._utils import _extract_memory_texts, _extract_query_text
 
@@ -243,7 +243,7 @@ class ReMeMiddleware(MiddlewareBase):
         embedding_dimensions = None
         if self._parameters.embedding_model is not None:
             embedding_dimensions = self._parameters.embedding_model.dimensions
-        app_config = build_reme_app_config(
+        app_config = _build_reme_app_config(
             workspace_dir=self._workspace_dir,
             embedding_dimensions=embedding_dimensions,
         )

--- a/tests/reme_middleware_test.py
+++ b/tests/reme_middleware_test.py
@@ -87,6 +87,8 @@ class _FakeEmbedding(EmbeddingModelBase):
     the middleware only checks presence and passes it through to ReMe.
     """
 
+    dimensions = 1024
+
     def __init__(self) -> None:
         """Skip the heavy base init; nothing here is exercised."""
 
@@ -472,61 +474,92 @@ class TestConstructorValidation(IsolatedAsyncioTestCase):
         self.assertEqual(mw._session_id_of(_Agent()), "sess-xyz")
         self.assertIsNone(mw._session_id_of(object()))
 
-    def test_embedding_model_enables_vector_store(self) -> None:
-        """An ``embedding_model`` turns ReMe's vector store on at build."""
+    def test_config_is_agentscope_owned_and_minimal(self) -> None:
+        """Building the app uses only AgentScope's minimal ReMe config."""
         captured: dict = {}
-
-        def _fake_resolve(**kwargs: Any) -> dict:
-            captured.update(kwargs)
-            return {"_ok": True}
-
         fake_reme = types.ModuleType("reme")
-        fake_reme.ReMe = lambda **kw: ("app", kw)  # type: ignore[attr-defined]
-        fake_cfg = types.ModuleType("reme.config")
-        setattr(fake_cfg, "resolve_app_config", _fake_resolve)
+        fake_reme.ReMe = (  # type: ignore[attr-defined]
+            lambda **kw: captured.update(kw)
+        )
+
+        mw = ReMeMiddleware(workspace_dir="/real/ws")
+        with mock.patch.dict(sys.modules, {"reme": fake_reme}):
+            mw._build_app()
+
+        self.assertEqual(captured["workspace_dir"], "/real/ws")
+        self.assertFalse(captured["enable_logo"])
+        self.assertFalse(captured["log_to_console"])
+        self.assertEqual(
+            set(captured["jobs"]),
+            {
+                "index_update_loop",
+                "search",
+                "reindex",
+                "auto_memory",
+                "dream_cron",
+                "auto_dream",
+                "node_search",
+                "daily_list",
+                "frontmatter_update",
+                "frontmatter_read",
+                "move",
+                "read",
+                "write",
+                "daily_write",
+                "edit",
+            },
+        )
+        self.assertNotIn("resource_watch_loop", captured["jobs"])
+        self.assertNotIn("digest_watch_loop", captured["jobs"])
+        self.assertNotIn("daily_paper", captured["jobs"])
+        self.assertEqual(
+            captured["jobs"]["dream_cron"]["steps"],
+            captured["jobs"]["auto_dream"]["steps"],
+        )
+        self.assertEqual(
+            captured["jobs"]["index_update_loop"]["watch_dirs"],
+            ["daily_dir", "digest_dir"],
+        )
+        self.assertEqual(
+            captured["jobs"]["reindex"]["watch_dirs"],
+            ["daily_dir", "digest_dir"],
+        )
+        components = captured["components"]
+        self.assertEqual(set(components["file_catalog"]), {"dream"})
+        self.assertNotIn("as_embedding", components)
+        self.assertNotIn("embedding_store", components)
+        self.assertEqual(
+            components["file_store"]["default"]["embedding_store"],
+            "",
+        )
+
+    def test_embedding_model_enables_internal_vector_store(self) -> None:
+        """An embedding model extends the minimal config with vector search."""
+        captured: dict = {}
+        fake_reme = types.ModuleType("reme")
+        fake_reme.ReMe = (  # type: ignore[attr-defined]
+            lambda **kw: captured.update(kw)
+        )
 
         mw = ReMeMiddleware(
             workspace_dir="/real/ws",
-            config="mycfg",
             parameters=ReMeMiddleware.Parameters(
                 embedding_model=_FakeEmbedding(),
             ),
         )
-        with mock.patch.dict(
-            sys.modules,
-            {"reme": fake_reme, "reme.config": fake_cfg},
-        ):
+        with mock.patch.dict(sys.modules, {"reme": fake_reme}):
             mw._build_app()
 
+        components = captured["components"]
         self.assertEqual(
-            captured["components"],
-            {"file_store": {"default": {"embedding_store": "default"}}},
+            components["file_store"]["default"]["embedding_store"],
+            "default",
         )
-        self.assertEqual(captured["workspace_dir"], "/real/ws")
-        self.assertEqual(captured["config"], "mycfg")
-        self.assertFalse(captured["enable_logo"])
-
-    def test_no_embedding_model_keeps_keyword_only(self) -> None:
-        """Without an ``embedding_model`` the vector store stays off."""
-        captured: dict = {}
-
-        def _fake_resolve(**kwargs: Any) -> dict:
-            captured.update(kwargs)
-            return {"_ok": True}
-
-        fake_reme = types.ModuleType("reme")
-        fake_reme.ReMe = lambda **kw: ("app", kw)  # type: ignore[attr-defined]
-        fake_cfg = types.ModuleType("reme.config")
-        setattr(fake_cfg, "resolve_app_config", _fake_resolve)
-
-        mw = ReMeMiddleware(workspace_dir="/real/ws")
-        with mock.patch.dict(
-            sys.modules,
-            {"reme": fake_reme, "reme.config": fake_cfg},
-        ):
-            mw._build_app()
-
-        self.assertNotIn("components", captured)
+        self.assertEqual(
+            components["as_embedding"]["default"]["dimensions"],
+            1024,
+        )
+        self.assertIn("embedding_store", components)
 
 
 # ----------------------------------------------------------------------
@@ -918,7 +951,7 @@ class TestStaticControlMode(IsolatedAsyncioTestCase):
         """Without a chat_model the middleware injects nothing.
 
         The model is fixed at construction and never taken from the agent,
-        so ReMe falls back to the LLM in its own config/credentials.
+        so the AgentScope ReMe config supplies the environment-backed LLM.
         """
         fake = _FakeReMeApp()
         mw = _mw(


### PR DESCRIPTION
## AgentScope Version

2.0.6

## Description

Fixes #2357. Supersedes the narrower configuration patch in #2358.

`ReMeMiddleware` previously resolved ReMe's bundled `default.yaml`. That standalone configuration registers many jobs the middleware never uses, changes independently of AgentScope, and currently omits the embedding components that the middleware expects when an `embedding_model` is provided.

This PR makes the embedded ReMe configuration fully owned by AgentScope:

- add a self-contained minimal configuration for conversation write-back, daily/digest indexing and search, and the complete `auto_memory -> dream` lifecycle
- declare and wire `as_embedding` / `embedding_store` only when an embedding model is provided, using the model's actual dimensions
- remove the constructor `config` parameter so the middleware cannot silently fall back to ReMe's standalone defaults
- keep BM25-only search as the no-embedding default
- update the ReMe example, inline documentation, and configuration tests

### Breaking change

`ReMeMiddleware(config=...)` is removed. Construct the middleware with `workspace_dir` and `ReMeMiddleware.Parameters`; the embedded job/component graph is now maintained by AgentScope.

### Validation

- `pre-commit run --all-files` — passed
- `pytest tests/reme_middleware_test.py -q` — 34 passed
- real DashScope end-to-end demo with ReMe v0.4.1.7 — `auto_memory`, reindex, vector search, and cross-session recall passed
- `pytest tests -q` was also attempted; collection requires optional development dependencies absent from the ReMe test environment (`fakeredis`, `boto3`, and `mem0`), so CI remains the full-suite authority
- companion documentation PR: https://github.com/agentscope-ai/docs/pull/54

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  An issue has been created for this PR (#2357)
- [x]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated in [agentscope-ai/docs#54](https://github.com/agentscope-ai/docs/pull/54)
- [x]  Code is ready for review
