### PR TITLE
feat(tool): support custom input_schema in FunctionTool

### DIFF
--- a/src/agentscope/tool/_adapters.py
+++ b/src/agentscope/tool/_adapters.py
@@ -9,6 +9,7 @@ from typing import Callable, Any, AsyncGenerator, Generator
 
 from mcp import ClientSession
 import mcp
+from pydantic import BaseModel
 
 from ._types import Function
 from ._base import ToolBase, ToolMiddlewareBase
@@ -17,7 +18,11 @@ from ..permission import (
     PermissionDecision,
 )
 from ._response import ToolChunk
-from ._utils import _extract_func_description, _extract_input_schema
+from ._utils import (
+    _extract_func_description,
+    _extract_input_schema,
+    _remove_title_field,
+)
 from .._logging import logger
 from ..message import (
     TextBlock,
@@ -51,7 +56,7 @@ class FunctionTool(ToolBase):
         func: Function,
         name: str | None = None,
         description: str | None = None,
-        input_schema: dict | None = None,
+        input_schema: dict | type[BaseModel] | None = None,
         is_concurrency_safe: bool = True,
         is_read_only: bool = False,
         is_state_injected: bool = False,
@@ -66,9 +71,11 @@ class FunctionTool(ToolBase):
                 Custom tool name. If None, uses the function name.
             description (`str | None`, optional):
                 Custom tool description. If None, extracts from docstring.
-            input_schema (`dict | None`, optional):
-                Custom JSON schema for the tool input. If None, generates
-                the schema from the function's type annotations and
+            input_schema (`dict | type[BaseModel] | None`, optional):
+                Custom input schema for the tool, either a JSON schema
+                dict or a pydantic ``BaseModel`` subclass (converted via
+                its ``model_json_schema()``). If None, generates the
+                schema from the function's type annotations and
                 docstring, where constraints (e.g. enums, value ranges)
                 can be expressed with ``typing.Literal`` and
                 ``typing.Annotated`` with ``pydantic.Field``.
@@ -86,6 +93,13 @@ class FunctionTool(ToolBase):
         self.description = description or _extract_func_description(
             func.__doc__ or "",
         )
+        if isinstance(input_schema, type) and issubclass(
+            input_schema,
+            BaseModel,
+        ):
+            input_schema = _remove_title_field(
+                input_schema.model_json_schema(),
+            )
         self.input_schema = input_schema or _extract_input_schema(func)
         self.is_concurrency_safe = is_concurrency_safe
         self.is_read_only = is_read_only

--- a/src/agentscope/tool/_adapters.py
+++ b/src/agentscope/tool/_adapters.py
@@ -51,6 +51,7 @@ class FunctionTool(ToolBase):
         func: Function,
         name: str | None = None,
         description: str | None = None,
+        input_schema: dict | None = None,
         is_concurrency_safe: bool = True,
         is_read_only: bool = False,
         is_state_injected: bool = False,
@@ -65,6 +66,12 @@ class FunctionTool(ToolBase):
                 Custom tool name. If None, uses the function name.
             description (`str | None`, optional):
                 Custom tool description. If None, extracts from docstring.
+            input_schema (`dict | None`, optional):
+                Custom JSON schema for the tool input. If None, generates
+                the schema from the function's type annotations and
+                docstring, where constraints (e.g. enums, value ranges)
+                can be expressed with ``typing.Literal`` and
+                ``typing.Annotated`` with ``pydantic.Field``.
             is_concurrency_safe (`bool`, optional):
                 Whether this tool is safe to call concurrently.
             is_read_only (`bool`, optional):
@@ -79,7 +86,7 @@ class FunctionTool(ToolBase):
         self.description = description or _extract_func_description(
             func.__doc__ or "",
         )
-        self.input_schema = _extract_input_schema(func)
+        self.input_schema = input_schema or _extract_input_schema(func)
         self.is_concurrency_safe = is_concurrency_safe
         self.is_read_only = is_read_only
         self.is_state_injected = is_state_injected

--- a/tests/toolkit_test.py
+++ b/tests/toolkit_test.py
@@ -3,11 +3,12 @@
 """Toolkit test case."""
 import base64
 import json
-from typing import Any, AsyncGenerator, Generator
+from typing import Any, AsyncGenerator, Generator, Literal
 from unittest import TestCase
 from unittest.async_case import IsolatedAsyncioTestCase
 
 
+from pydantic import BaseModel, Field
 from utils import AnyString
 
 from agentscope.mcp import HttpMCPConfig, MCPClient
@@ -1180,6 +1181,70 @@ class RegisterFunctionTest(IsolatedAsyncioTestCase):
                                     "type": "string",
                                     "description": "The mode to use",
                                     "enum": ["fast", "slow"],
+                                },
+                            },
+                            "required": ["mode"],
+                        },
+                    },
+                },
+            ],
+        )
+
+    async def test_base_model_input_schema(self) -> None:
+        """Test passing a pydantic BaseModel class as the input schema."""
+
+        class SetModeInput(BaseModel):
+            """The input model of the set_mode tool."""
+
+            mode: Literal["fast", "slow"] = Field(
+                description="The mode to use",
+            )
+            level: int = Field(
+                default=5,
+                ge=1,
+                le=10,
+                description="The level to use",
+            )
+
+        def set_mode(mode: str, level: int = 5) -> str:
+            """Set the working mode."""
+            return f"Mode set to {mode} at level {level}"
+
+        toolkit = Toolkit(
+            tools=[
+                FunctionTool(
+                    set_mode,
+                    input_schema=SetModeInput,
+                ),
+            ],
+        )
+
+        schemas = await toolkit.get_tool_schemas()
+        self.assertListEqual(
+            schemas,
+            [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "set_mode",
+                        "description": "Set the working mode.",
+                        "parameters": {
+                            "type": "object",
+                            "description": (
+                                "The input model of the set_mode tool."
+                            ),
+                            "properties": {
+                                "mode": {
+                                    "type": "string",
+                                    "description": "The mode to use",
+                                    "enum": ["fast", "slow"],
+                                },
+                                "level": {
+                                    "type": "integer",
+                                    "description": "The level to use",
+                                    "default": 5,
+                                    "minimum": 1,
+                                    "maximum": 10,
                                 },
                             },
                             "required": ["mode"],

--- a/tests/toolkit_test.py
+++ b/tests/toolkit_test.py
@@ -1134,6 +1134,61 @@ class RegisterFunctionTest(IsolatedAsyncioTestCase):
             f"started{expected_dict_text}",
         )
 
+    async def test_custom_input_schema(self) -> None:
+        """Test overriding the auto-extracted schema with a custom one."""
+
+        def set_mode(mode: str) -> str:
+            """Set the working mode.
+
+            Args:
+                mode: The mode to use
+            """
+            return f"Mode set to {mode}"
+
+        toolkit = Toolkit(
+            tools=[
+                FunctionTool(
+                    set_mode,
+                    input_schema={
+                        "type": "object",
+                        "properties": {
+                            "mode": {
+                                "type": "string",
+                                "description": "The mode to use",
+                                "enum": ["fast", "slow"],
+                            },
+                        },
+                        "required": ["mode"],
+                    },
+                ),
+            ],
+        )
+
+        schemas = await toolkit.get_tool_schemas()
+        self.assertListEqual(
+            schemas,
+            [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "set_mode",
+                        "description": "Set the working mode.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "mode": {
+                                    "type": "string",
+                                    "description": "The mode to use",
+                                    "enum": ["fast", "slow"],
+                                },
+                            },
+                            "required": ["mode"],
+                        },
+                    },
+                },
+            ],
+        )
+
 
 class ToolGroupTest(IsolatedAsyncioTestCase):
     """The tool group test case."""


### PR DESCRIPTION
## AgentScope Version

2.0.6 (main branch)

## Description

Previously `FunctionTool` always generated its input schema via `_extract_input_schema(func)` from the function's type annotations and docstring. While constraints such as enums and value ranges can already be expressed with `typing.Literal` / `typing.Annotated` + `pydantic.Field`, there was no way to pass a pre-built input schema directly — unlike `name` and `description`, which are both overridable.

This PR adds an optional `input_schema` parameter to `FunctionTool.__init__`, accepting either form:

- **A JSON schema dict**: fully takes over the tool's input schema. Useful when the schema comes from external tool definitions (e.g. migrated from other frameworks), or when the wrapped function's signature cannot carry annotations (dynamically generated functions, `**kwargs` dispatchers, third-party functions).
- **A pydantic `BaseModel` subclass**: converted via its `model_json_schema()`, with auto-generated `title` fields stripped, consistent with the annotation-extraction path.
- When `None` (default), the schema is generated from the function's type annotations and docstring as before — fully backward compatible.

This also aligns `FunctionTool` with `MCPTool`, which already accepts the external `inputSchema` as-is.

**How to test**: `pytest tests/toolkit_test.py` — new tests `RegisterFunctionTest::test_custom_input_schema` and `RegisterFunctionTest::test_base_model_input_schema` cover the dict and BaseModel override paths; existing tests cover the default extraction path.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [x]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [x]  Code is ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
