### PR TITLE
fix(middleware): isolate static RAG inputs across concurrent replies

### DIFF
--- a/src/agentscope/middleware/_rag.py
+++ b/src/agentscope/middleware/_rag.py
@@ -31,6 +31,7 @@ service, to the knowledge-base manager) that constructs the
 """
 import asyncio
 import json
+from contextvars import ContextVar
 from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
@@ -588,8 +589,11 @@ class RAGMiddleware(MiddlewareBase):
         # consumed by ``on_reasoning`` so the auto-search can use the
         # original reply inputs (which are no longer in
         # ``agent.state.context`` by the time ``on_reasoning`` runs in
-        # a tool-call loop).  Cleared in ``on_reply``'s finally.
-        self._cached_inputs: list[TextBlock | DataBlock] | None = None
+        # a tool-call loop).  It must be task-local because middleware
+        # instances may be shared by concurrent agents.
+        self._cached_inputs: ContextVar[
+            list[TextBlock | DataBlock] | None
+        ] = ContextVar("rag_middleware_cached_inputs", default=None)
 
     # ------------------------------------------------------------------
     # Agentic mode — expose the search tool
@@ -655,12 +659,13 @@ class RAGMiddleware(MiddlewareBase):
         ):
             msgs = inputs
 
+        blocks: list[TextBlock | DataBlock] | None = None
         if msgs:
             # Deepcopy because we are about to mutate the first text block of
             # each message to prepend the speaker name — never touch the
             # caller's message objects.
             msgs = deepcopy(msgs)
-            blocks: list[TextBlock | DataBlock] = []
+            blocks = []
             for msg in msgs:
                 if not msg.content:
                     continue
@@ -671,13 +676,13 @@ class RAGMiddleware(MiddlewareBase):
                     blocks.append(TextBlock(text=speaker))
                 blocks.extend(msg.content)
 
-            self._cached_inputs = blocks
+        token = self._cached_inputs.set(blocks)
 
         try:
             async for evt in next_handler(**input_kwargs):
                 yield evt
         finally:
-            self._cached_inputs = None
+            self._cached_inputs.reset(token)
 
     async def on_reasoning(
         self,
@@ -715,15 +720,17 @@ class RAGMiddleware(MiddlewareBase):
         """
         hint: HintBlock | None = None
 
+        cached_inputs = self._cached_inputs.get()
+
         if (
             self._parameters.mode == "static"
             and agent.state.cur_iter == 0
-            and self._cached_inputs
+            and cached_inputs
         ):
             try:
                 results = await _search_across(
                     self._knowledge_bases,
-                    self._cached_inputs,
+                    cached_inputs,
                     top_k=self._parameters.top_k,
                     score_threshold=self._parameters.score_threshold,
                 )

--- a/tests/middleware_rag_concurrency_test.py
+++ b/tests/middleware_rag_concurrency_test.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""Concurrency regression tests for :class:`RAGMiddleware`."""
+import asyncio
+from types import SimpleNamespace
+from typing import Any, AsyncGenerator
+from unittest.async_case import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+from agentscope.message import Msg, TextBlock
+from agentscope.middleware import RAGMiddleware
+from agentscope.middleware import _rag as rag_module
+
+
+class RAGMiddlewareConcurrencyTest(IsolatedAsyncioTestCase):
+    """Verify static RAG inputs are isolated per concurrent reply."""
+
+    async def test_shared_middleware_keeps_queries_task_local(self) -> None:
+        """One reply's cleanup cannot overwrite another reply's query."""
+        middleware = RAGMiddleware(
+            knowledge_bases=[],
+            parameters=RAGMiddleware.Parameters(
+                mode="static",
+                emit_hint_event=False,
+            ),
+        )
+        entered_a = asyncio.Event()
+        entered_b = asyncio.Event()
+        resume_a = asyncio.Event()
+        resume_b = asyncio.Event()
+        searched_queries: list[list[str]] = []
+
+        async def fake_search_across(
+            knowledge_bases: list[Any],
+            queries: list[TextBlock],
+            top_k: int,
+            score_threshold: float | None,
+        ) -> list[Any]:
+            del knowledge_bases, top_k, score_threshold
+            searched_queries.append([block.text for block in queries])
+            return []
+
+        async def run_reply(
+            query: str,
+            entered: asyncio.Event,
+            resume: asyncio.Event,
+        ) -> None:
+            agent = SimpleNamespace(
+                name="assistant",
+                state=SimpleNamespace(cur_iter=0),
+            )
+
+            async def reasoning_next(**_kwargs: Any) -> AsyncGenerator:
+                yield "reasoning-evt"
+
+            async def reply_next(**_kwargs: Any) -> AsyncGenerator:
+                entered.set()
+                await resume.wait()
+                async for event in middleware.on_reasoning(
+                    agent=agent,
+                    input_kwargs={},
+                    next_handler=reasoning_next,
+                ):
+                    yield event
+
+            async for _ in middleware.on_reply(
+                agent=agent,
+                input_kwargs={
+                    "inputs": Msg(name="user", content=query, role="user"),
+                },
+                next_handler=reply_next,
+            ):
+                pass
+
+        with patch.object(
+            rag_module,
+            "_search_across",
+            side_effect=fake_search_across,
+        ):
+            task_a = asyncio.create_task(
+                run_reply("query-a", entered_a, resume_a),
+            )
+            await entered_a.wait()
+            task_b = asyncio.create_task(
+                run_reply("query-b", entered_b, resume_b),
+            )
+            await entered_b.wait()
+
+            # A resumes after B enters.  The original instance field would
+            # make A search query-b, then clear B's pending query on exit.
+            resume_a.set()
+            await task_a
+            resume_b.set()
+            await task_b
+
+        self.assertEqual(
+            searched_queries,
+            [["user: query-a"], ["user: query-b"]],
+        )


### PR DESCRIPTION
## Summary

Fixes #2331.

### Root cause

In static mode, `RAGMiddleware` stored reply inputs in one mutable instance attribute, `_cached_inputs`. A shared middleware instance therefore allowed an overlapping reply to overwrite another reply's retrieval query. When the first reply completed, its cleanup also cleared the second reply's pending query.

### Fix

`_cached_inputs` is now an instance-owned `ContextVar`. `on_reply` sets the reply-local value and retains the returned Token; its `finally` block calls `reset(token)`.

`ContextVar` values are isolated per asyncio task, so concurrent replies on the same middleware instance read their own retrieval inputs. Token reset is essential: it restores the prior value for nested calls and ensures exception or cancellation cleanup does not erase an outer reply's context. This preserves the existing API and serial behavior.

### Regression coverage

Added a deterministic concurrency regression test using `asyncio.Event` (no timing sleeps):

1. Reply A captures `query-a` and pauses.
2. Reply B captures `query-b` and pauses on the same middleware instance.
3. A resumes and must search `query-a`.
4. After A exits and cleans up, B resumes and must still search `query-b`.

The test asserts both exact embedding inputs, covering both cross-request contamination and cleanup interference.

### Verification

Run successfully:

- `python -m py_compile src\\agentscope\\middleware\\_rag.py tests\\middleware_rag_concurrency_test.py`
- `git diff --check`

Attempted but blocked by the local environment:

- `python -m pytest tests/middleware_rag_concurrency_test.py -q` — pytest was not installed.
- `python -m unittest tests/middleware_rag_concurrency_test.py -v` — failed before collection because `docstring_parser` was missing.
- Created an E-drive-only virtual environment and ran `pip install -e '.[dev]'`; installation made no progress and was stopped, so the targeted RAG suite, pre-commit, type checks, and full test suite could not be run in this environment.