### PR TITLE
fix(web_ui): keep an uploaded file visible while the worker indexes it

### DIFF
--- a/examples/web_ui/frontend/src/components/knowledge/KnowledgeDocumentsPanel.tsx
+++ b/examples/web_ui/frontend/src/components/knowledge/KnowledgeDocumentsPanel.tsx
@@ -29,10 +29,9 @@ interface KnowledgeDocumentsPanelProps {
 }
 
 /**
- * A row that the panel renders. Either a server-side document (the
- * canonical record after upload returns) or a still-uploading local
- * task. Uploads that have already produced a `documentId` are routed
- * through the server row so the panel never double-renders one.
+ * A row that the panel renders. Either a server-side document — with
+ * the upload task that produced it, while one is still around — or a
+ * task whose document the list has not caught up with yet.
  */
 type Row =
 	| { kind: 'server'; doc: KnowledgeDocumentView; localTask: UploadTask | null }
@@ -261,7 +260,7 @@ export function KnowledgeDocumentsPanel({ knowledgeBaseId }: KnowledgeDocumentsP
 	const [detailTarget, setDetailTarget] = useState<KnowledgeDocumentView | null>(null);
 
 	const { enqueue, cancel, dismiss, tasksForKb, clearFinishedForKb } = useUploadContext();
-	const { documents, refetch } = useKnowledgeDocuments(knowledgeBaseId);
+	const { documents, loading, refetch } = useKnowledgeDocuments(knowledgeBaseId);
 	const tasks = tasksForKb(knowledgeBaseId);
 	const { statuses } = useDocumentStatusPolling({
 		knowledgeBaseId,
@@ -304,26 +303,29 @@ export function KnowledgeDocumentsPanel({ knowledgeBaseId }: KnowledgeDocumentsP
 		void refetch();
 	}, [terminalIdsKey, refetch]);
 
-	// Merge tasks + documents into a single ordered row list.
+	// Merge tasks + documents into a single ordered row list, uploads
+	// first — they're the rows the user just acted on.
+	//
+	// Every task keeps its row for its whole life: it renders from
+	// local state until the server list catches up, then hands over to
+	// the document record. Rendering a task only once its document is
+	// listed would make a freshly uploaded file disappear between the
+	// upload response and the next list refresh — which only happens
+	// when indexing finishes.
 	const rows: Row[] = useMemo(() => {
-		const tasksByDocId = new Map<string, UploadTask>();
-		const tasksWithoutDoc: UploadTask[] = [];
-		for (const task of tasks) {
-			if (task.documentId) tasksByDocId.set(task.documentId, task);
-			else tasksWithoutDoc.push(task);
-		}
-		const docRows: Row[] = documents.map((doc) => ({
+		const unclaimed = new Map(documents.map((doc) => [doc.id, doc]));
+		const taskRows: Row[] = tasks.map((task) => {
+			const doc = task.documentId ? unclaimed.get(task.documentId) : undefined;
+			if (!doc) return { kind: 'local', task };
+			unclaimed.delete(doc.id);
+			return { kind: 'server', doc, localTask: task };
+		});
+		const documentRows: Row[] = [...unclaimed.values()].map((doc) => ({
 			kind: 'server',
 			doc,
-			localTask: tasksByDocId.get(doc.id) ?? null,
+			localTask: null,
 		}));
-		const localRows: Row[] = tasksWithoutDoc.map((task) => ({
-			kind: 'local',
-			task,
-		}));
-		// Local-only rows go first (they're either uploading or queued
-		// — both are user-visible "I just hit upload" states).
-		return [...localRows, ...docRows];
+		return [...taskRows, ...documentRows];
 	}, [documents, tasks]);
 
 	const onUploadClick = useCallback(() => {
@@ -443,7 +445,13 @@ export function KnowledgeDocumentsPanel({ knowledgeBaseId }: KnowledgeDocumentsP
 					dragOver ? 'border-primary bg-primary/5' : 'border-border bg-transparent',
 				)}
 			>
-				{rows.length === 0 ? (
+				{rows.length === 0 && loading ? (
+					// First load — an empty state here would claim the
+					// knowledge base has no documents before we know.
+					<div className="flex justify-center py-10">
+						<Loader2 className="text-muted-foreground size-4 animate-spin" />
+					</div>
+				) : rows.length === 0 ? (
 					<Empty className="border-none py-6">
 						<EmptyHeader>
 							<EmptyMedia variant="icon">
@@ -468,10 +476,13 @@ export function KnowledgeDocumentsPanel({ knowledgeBaseId }: KnowledgeDocumentsP
 					<div className="flex flex-col gap-y-2 p-2">
 						{rows.map((row) => (
 							<RowView
+								// Keyed by document id once one exists so the
+								// local → server handover reuses the same node
+								// instead of remounting the row.
 								key={
 									row.kind === 'server'
-										? `srv-${row.doc.id}`
-										: `tsk-${row.task.taskId}`
+										? row.doc.id
+										: (row.task.documentId ?? row.task.taskId)
 								}
 								row={row}
 								onCancel={cancel}

--- a/examples/web_ui/frontend/src/hooks/useKnowledgeDocuments.ts
+++ b/examples/web_ui/frontend/src/hooks/useKnowledgeDocuments.ts
@@ -7,14 +7,17 @@ import type { KnowledgeDocumentView } from '@/api';
  * Owns the document list for a single knowledge base.
  *
  * Re-fetches on mount, when `knowledgeBaseId` changes, and via the
- * caller-driven `refetch`. The upload page should call `refetch` after
- * a successful upload (so the new `pending` row appears) and again
- * whenever a polling tick lifts a row to a terminal state (so
- * `chunk_count` reflects the worker's final commit).
+ * caller-driven `refetch`. In-flight uploads render from the upload
+ * provider until their record shows up here, so the only refetch the
+ * panel owes is the one after a polling tick lifts a row to a terminal
+ * state — that is what makes `chunk_count` reflect the worker's final
+ * commit.
  */
 export function useKnowledgeDocuments(knowledgeBaseId: string | null) {
 	const [documents, setDocuments] = useState<KnowledgeDocumentView[]>([]);
-	const [loading, setLoading] = useState(false);
+	// Starts true when there is something to fetch, so the first render
+	// already says "loading" instead of "no documents".
+	const [loading, setLoading] = useState(knowledgeBaseId !== null);
 	const [error, setError] = useState<Error | null>(null);
 	// Discards stale responses if the user switches KBs mid-flight.
 	const requestSeq = useRef(0);
@@ -22,6 +25,7 @@ export function useKnowledgeDocuments(knowledgeBaseId: string | null) {
 	const refetch = useCallback(async () => {
 		if (!knowledgeBaseId) {
 			setDocuments([]);
+			setLoading(false);
 			return;
 		}
 		const seq = ++requestSeq.current;


### PR DESCRIPTION
An uploaded file disappears from the documents panel while the worker
indexes it.

The panel built its rows from the server list, and an upload task only
rendered on its own while it had no document id yet:

```ts
if (task.documentId) tasksByDocId.set(task.documentId, task);  // only reachable via a listed document
else tasksWithoutDoc.push(task);
```

So the moment the upload endpoint returned a document id the row stopped
being rendered — and the list is refetched only when a polling tick lifts
a document to a terminal state. The file vanished from the panel for the
whole `parse → chunk → index` run and reappeared once it was `ready`,
which is exactly the window the phase progress bar exists for. From the
user's side: pick a file, the list stays empty for a while, then the file
pops in already finished.

Rows are now built from the tasks instead: every task keeps its row for
its whole life and hands over to the document record once the list
catches up. Rows are keyed by document id when one exists, so the
handover reuses the same node instead of remounting. No extra requests —
the status poller already drives the phases through the upload provider.

The panel also stopped flashing "no documents yet" over a list that is
still loading; it shows a spinner until the first response lands.

Frontend only — no API, service or storage changes.

## Verification

`tsc -b`, `eslint` (0 warnings in the changed files) and `vite build`
all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
