### PR TITLE
fix(tracing): include input messages in chat spans

### DIFF
--- a/src/agentscope/middleware/_tracing/_extractor.py
+++ b/src/agentscope/middleware/_tracing/_extractor.py
@@ -177,16 +177,18 @@ def _get_llm_request_attributes(
         instance (`ChatModelBase`):
             The chat model instance making the request.
         kwargs (`Dict[str, Any]`):
-            Keyword arguments including generation parameters such as
-            temperature, top_p, top_k, max_tokens, presence_penalty,
-            frequency_penalty, stop_sequences, seed, tools, and tool_choice.
+            Keyword arguments including input messages, tools, tool choice,
+            and generation parameters such as temperature, top_p, top_k,
+            max_tokens, presence_penalty, frequency_penalty, stop sequences,
+            and seed.
 
     Returns:
         `Dict[str, Any]`:
             OpenTelemetry GenAI attributes with mixed-type values (``str``,
             ``int``, ``float``, or ``list``), including operation name,
-            provider name, model name, generation parameters (e.g.
-            temperature, max_tokens, stop_sequences), and tool definitions.
+            provider name, model name, input messages, generation parameters
+            (e.g. temperature, max_tokens, stop sequences), and tool
+            definitions.
     """
 
     attributes = {
@@ -220,6 +222,14 @@ def _get_llm_request_attributes(
     )
     if tool_definitions:
         attributes[SpanAttributes.GEN_AI_TOOL_DEFINITIONS] = tool_definitions
+
+    messages = kwargs.get("messages")
+    if isinstance(messages, (Msg, list)):
+        input_messages = _get_agent_messages(messages)
+        if input_messages:
+            attributes[
+                SpanAttributes.GEN_AI_INPUT_MESSAGES
+            ] = _serialize_to_str(input_messages)
 
     return {k: v for k, v in attributes.items() if v is not None}
 

--- a/tests/tracing_test.py
+++ b/tests/tracing_test.py
@@ -14,7 +14,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
 
 from utils import MockModel
 
-from agentscope.agent import Agent
+from agentscope.agent import Agent, InjectionConfig
 from agentscope.event import (
     ConfirmResult,
     ExternalExecutionResultEvent,
@@ -360,6 +360,54 @@ class TracingTest(IsolatedAsyncioTestCase):
             span_attrs.get("gen_ai.operation.name"),
             "chat",
             "chat span gen_ai.operation.name should equal chat",
+        )
+
+    async def test_chat_span_has_input_messages(self) -> None:
+        """Chat spans carry messages observed at the tracing middleware
+        boundary."""
+        self.agent.injection_config = InjectionConfig(
+            inject_runtime_state=False,
+        )
+        self.model.set_responses(
+            [_make_text_response("Input captured.")],
+        )
+        user_text = "Which messages reached the tracing boundary?"
+        await self.agent.reply(UserMsg(name="user", content=user_text))
+
+        chat_spans = self._spans_by_name("chat")
+        self.assertEqual(len(chat_spans), 1, "Expected exactly one chat span")
+        span_attrs = dict(chat_spans[0].attributes or {})
+        input_raw = span_attrs.get("gen_ai.input.messages")
+        assert isinstance(
+            input_raw,
+            str,
+        ), "chat span gen_ai.input.messages should be a string"
+        self.assertEqual(
+            json.loads(input_raw),
+            [
+                {
+                    "role": "system",
+                    "parts": [
+                        {
+                            "type": "text",
+                            "content": "You are a test assistant.",
+                        },
+                    ],
+                    "name": "system",
+                    "finish_reason": "stop",
+                },
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "type": "text",
+                            "content": user_text,
+                        },
+                    ],
+                    "name": "user",
+                    "finish_reason": "stop",
+                },
+            ],
         )
 
     async def test_chat_span_has_output_messages(self) -> None:


### PR DESCRIPTION
## AgentScope Version

[The version of AgentScope you are working on, e.g. `import agentscope; print(agentscope.__version__)`]

## Description

Fix OpenTelemetry chat spans missing `gen_ai.input.messages`.

`TracingMiddleware.on_model_call` already passes model-call messages to `_get_llm_request_attributes`, but the extractor previously recorded only generation parameters and tool definitions. As a result, tracing backends could display tool definitions without the corresponding chat messages.

This change:

- serializes messages observed at the tracing middleware boundary into `gen_ai.input.messages`;
- reuses the existing AgentScope-to-OpenTelemetry message conversion;
- preserves `gen_ai.tool.definitions` as a separate attribute;
- adds a regression test that verifies the complete system/user message structure and ordering.

Fixes #2224

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review