### PR TITLE
fix(context): allow trigger ratio of 0.9

### DIFF
--- a/src/agentscope/agent/_config.py
+++ b/src/agentscope/agent/_config.py
@@ -54,7 +54,7 @@ class ContextConfig(BaseModel):
     model_config = {"arbitrary_types_allowed": True}
     """Allow arbitrary types in the pydantic model."""
 
-    trigger_ratio: float = Field(default=0.8, gt=0, lt=0.9)
+    trigger_ratio: float = Field(default=0.8, gt=0, le=0.9)
     """When the token exceeds this ratio of the maximum context length, the
     context will be compressed. To reserve the context for context compression,
     the maximum ratio is 0.9."""


### PR DESCRIPTION
## AgentScope Version

2.0.6

## Description

Aligns `ContextConfig.trigger_ratio` validation with its documented maximum. A value of `0.9` now passes validation while values above `0.9` remain rejected, preserving at least 10% of the context window for the compression response.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review