### PR TITLE
fix(model): use conservative fallback token estimate

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -5,6 +5,7 @@ import collections
 import inspect
 import re
 import warnings
+from contextlib import contextmanager
 
 from asyncio import Queue
 from copy import deepcopy
@@ -17,6 +18,7 @@ from typing import (
     List,
     TYPE_CHECKING,
     Type,
+    Iterator,
 )
 
 import jsonschema
@@ -336,12 +338,13 @@ class Agent:
                 A final reply message.
         """
         final_msg: Msg | None = None
-        async for evt_or_msg in self._reply(
-            inputs=inputs,
-            structured_schema=structured_schema,
-        ):
-            if isinstance(evt_or_msg, Msg):
-                final_msg = evt_or_msg
+        with self._model_calibration_scope():
+            async for evt_or_msg in self._reply(
+                inputs=inputs,
+                structured_schema=structured_schema,
+            ):
+                if isinstance(evt_or_msg, Msg):
+                    final_msg = evt_or_msg
         if final_msg is None:
             raise RuntimeError("Agent did not produce a final message.")
         return final_msg
@@ -432,7 +435,10 @@ class Agent:
 
         # Count the current tokens
         kwargs = await self._prepare_model_input()
-        estimated_tokens = await self.model.count_tokens(**kwargs)
+        estimated_tokens = await self._count_model_tokens(
+            kwargs["messages"],
+            kwargs.get("tools"),
+        )
 
         # Skip if no compression is needed
         threshold = cfg.trigger_ratio * self.model.context_size
@@ -534,7 +540,7 @@ class Agent:
             },
         ]
         context_overflow = False
-        estimated_compression_tokens = await self.model.count_tokens(
+        estimated_compression_tokens = await self._count_model_tokens(
             messages,
             compression_tool_schema,
         )
@@ -550,7 +556,7 @@ class Agent:
         # Compress the messages
         res = None
         try:
-            res = await self.model.generate_structured_output(
+            res = await self._generate_structured_output(
                 messages=messages,
                 structured_model=cfg.summary_schema,
             )
@@ -575,7 +581,7 @@ class Agent:
                         ]
                     )
                     estimated_compression_tokens = (
-                        await self.model.count_tokens(
+                        await self._count_model_tokens(
                             messages,
                             compression_tool_schema,
                         )
@@ -589,7 +595,7 @@ class Agent:
                         break
 
                 try:
-                    res = await self.model.generate_structured_output(
+                    res = await self._generate_structured_output(
                         messages=messages,
                         structured_model=cfg.summary_schema,
                     )
@@ -656,6 +662,7 @@ class Agent:
             # Update the context and summary
             self.state.summary = new_summary
             self.state.context = msgs_to_reserve
+            self._clear_model_usage_anchor()
 
             logger.info(
                 "[AGENT %s]: The context compression finished.",
@@ -1388,7 +1395,10 @@ class Agent:
         if self.state.cur_iter == 0:
             # Count the current tokens
             kwargs = await self._prepare_model_input()
-            input_tokens = await self.model.count_tokens(**kwargs)
+            input_tokens = await self._count_model_tokens(
+                kwargs["messages"],
+                kwargs.get("tools"),
+            )
 
             trigger_tokens = int(
                 self.context_config.trigger_ratio * self.model.context_size,
@@ -1704,7 +1714,9 @@ class Agent:
             # Given event, required but not match
             extra_ids = set(
                 _.tool_call.id for _ in event.confirm_results
-            ) - set(awaiting_confirmations)
+            ) - set(
+                awaiting_confirmations,
+            )
             if extra_ids:
                 raise ValueError(
                     f"Received UserConfirmResultEvent with tool call ids "
@@ -2708,7 +2720,7 @@ class Agent:
         msg_index = len(self.state.context) - 1
         while msg_index >= 0:
             # Count the tokens when msgs after msg_index are reserved
-            reserved_tokens = await self.model.count_tokens(
+            reserved_tokens = await self._count_model_tokens(
                 system_msg + self.state.context[msg_index:],
                 tools,
             )
@@ -2737,7 +2749,7 @@ class Agent:
             attempt_msg.content = boundary_msg_content[block_index:]
 
             try_reserved = system_msg + [attempt_msg] + msgs_to_reserve
-            reserved_tokens = await self.model.count_tokens(
+            reserved_tokens = await self._count_model_tokens(
                 try_reserved,
                 tools,
             )
@@ -2828,7 +2840,7 @@ class Agent:
                 A tuple of the tool result blocks to reserved in context and
                 to offload (if any).
         """
-        n_tokens = await self.model.count_tokens(
+        n_tokens = await self._count_model_tokens(
             [AssistantMsg(self.name, content=tool_result.output)],
             None,
         )
@@ -2850,7 +2862,7 @@ class Agent:
         boundary_index = 0
         for i in range(len(copied_tool_result.output) - 1, 0, -1):
             copied_tool_result.output = tool_result.output[:i]
-            cur_tokens = await self.model.count_tokens(
+            cur_tokens = await self._count_model_tokens(
                 [
                     AssistantMsg(
                         self.name,
@@ -2877,11 +2889,11 @@ class Agent:
         if isinstance(boundary_block, TextBlock):
             # Truncate it
             truncated_text = boundary_block.text
-            cur_tokens = await self.model.count_tokens(
+            cur_tokens = await self._count_model_tokens(
                 [AssistantMsg(self.name, content=reserved_blocks)],
                 None,
             )
-            cur_tokens_plus = await self.model.count_tokens(
+            cur_tokens_plus = await self._count_model_tokens(
                 [
                     AssistantMsg(
                         self.name,
@@ -2964,6 +2976,52 @@ class Agent:
     # ======================================================================
     # Agent internal utility methods
     # ======================================================================
+    @contextmanager
+    def _model_calibration_scope(
+        self,
+        model: ChatModelBase | None = None,
+    ) -> Iterator[None]:
+        """Bind model usage calibration to this agent's session."""
+        target = model or self.model
+        scope = getattr(target, "_token_calibration_scope", None)
+        if scope is None:
+            yield
+            return
+        with scope(self.state.session_id):
+            yield
+
+    def _clear_model_usage_anchor(self) -> None:
+        """Reset provider calibration after replacing the context."""
+        models = [self.model]
+        if self.model_config.fallback_model is not None:
+            models.append(self.model_config.fallback_model)
+        for model in models:
+            clear_anchor = getattr(model, "_clear_usage_anchor", None)
+            if clear_anchor is not None:
+                clear_anchor(self.state.session_id)
+
+    async def _count_model_tokens(
+        self,
+        messages: list[Msg],
+        tools: list[dict] | None,
+    ) -> int:
+        """Count tokens while preserving per-session calibration."""
+        with self._model_calibration_scope():
+            return await self.model.count_tokens(messages, tools)
+
+    async def _generate_structured_output(
+        self,
+        messages: list[Msg],
+        structured_model: Any,
+    ) -> Any:
+        """Generate structured output within this agent's session scope."""
+        with self._model_calibration_scope():
+            response = await self.model.generate_structured_output(
+                messages=messages,
+                structured_model=structured_model,
+            )
+            return response
+
     async def _get_system_prompt(self) -> str:
         """Get the system prompt of the agent."""
         prompt = [self._system_prompt]
@@ -3063,11 +3121,12 @@ class Agent:
                 try:
                     # Apply middleware to wrap the actual model() call
                     if not self._model_call_middlewares:
-                        return await model(
-                            messages=messages,
-                            tools=tools,
-                            tool_choice=tool_choice,
-                        )
+                        with self._model_calibration_scope(model):
+                            return await model(
+                                messages=messages,
+                                tools=tools,
+                                tool_choice=tool_choice,
+                            )
                     else:
                         # pylint: disable=cell-var-from-loop
                         async def execute_chain(
@@ -3111,7 +3170,8 @@ class Agent:
                                     next_handler=next_handler,
                                 )
 
-                        return await execute_chain()
+                        with self._model_calibration_scope(model):
+                            return await execute_chain()
                 except Exception as e:
                     last_exception = e
                     # Only log a "Retrying" message when there's actually a

--- a/src/agentscope/model/_base.py
+++ b/src/agentscope/model/_base.py
@@ -376,8 +376,9 @@ class ChatModelBase:
         Note a standard way to count the tokens is first formatting the input
         messages into the API required format, then use the tokenizer of the
         underlying API to count the tokens. The base implementation instead
-        counts one token per UTF-8 byte so that context-length guardrails do
-        not underestimate dense, structured, or non-ASCII text.
+        applies a conservative estimate to the UTF-8 input size so that
+        context-length guardrails do not underestimate dense, structured, or
+        non-ASCII text.
 
         Subclasses may override this method to provide a more accurate
         implementation tailored to their specific tokenizer.
@@ -451,9 +452,15 @@ class ChatModelBase:
 
         # Count the text tokens
         acc_text = "".join(acc_texts)
-        cnt += len(acc_text.encode("utf-8"))
+        cnt += self._estimate_text_tokens(acc_text)
 
         return cnt
+
+    def _estimate_text_tokens(self, text: str) -> int:
+        """Estimate text tokens without a model-specific tokenizer."""
+        byte_count = len(text.encode("utf-8"))
+        # Dense structured input can approach 0.8 tokens per UTF-8 byte.
+        return (byte_count * 4 + 4) // 5
 
     async def generate_structured_output(
         self,

--- a/src/agentscope/model/_base.py
+++ b/src/agentscope/model/_base.py
@@ -371,12 +371,13 @@ class ChatModelBase:
         messages: list[Msg],
         tools: list[dict] | None,
     ) -> int:
-        """A quick and unified method to estimate the token count of the
-        model input by dividing the total input size in bytes by 4.
+        """Conservatively estimate the token count of the model input.
 
         Note a standard way to count the tokens is first formatting the input
         messages into the API required format, then use the tokenizer of the
-        underlying API to count the tokens.
+        underlying API to count the tokens. The base implementation instead
+        counts one token per UTF-8 byte so that context-length guardrails do
+        not underestimate dense, structured, or non-ASCII text.
 
         Subclasses may override this method to provide a more accurate
         implementation tailored to their specific tokenizer.
@@ -450,7 +451,7 @@ class ChatModelBase:
 
         # Count the text tokens
         acc_text = "".join(acc_texts)
-        cnt += int(len(acc_text.encode("utf-8")) / 4 + 0.5)
+        cnt += len(acc_text.encode("utf-8"))
 
         return cnt
 

--- a/src/agentscope/model/_base.py
+++ b/src/agentscope/model/_base.py
@@ -3,6 +3,7 @@
 import asyncio
 import inspect
 import json
+import unicodedata
 from abc import abstractmethod
 from copy import deepcopy
 from pathlib import Path
@@ -32,6 +33,7 @@ from ..tool import ToolChoice
 
 _TOOL_CHOICE_LITERAL_MODES = {"auto", "none", "required"}
 _MULTIMODAL_DATA_BLOCK_TOKEN_ESTIMATE = 2000
+_STRUCTURED_TEXT_CHARS = frozenset("{}[]():,;=<>\"'")
 
 
 class ChatModelBase:
@@ -376,9 +378,10 @@ class ChatModelBase:
         Note a standard way to count the tokens is first formatting the input
         messages into the API required format, then use the tokenizer of the
         underlying API to count the tokens. The base implementation instead
-        applies a conservative estimate to the UTF-8 input size so that
-        context-length guardrails do not underestimate dense, structured, or
-        non-ASCII text.
+        applies a class-aware fallback: it preserves the ASCII bytes-per-token
+        baseline, adds local weight for dense numeric/structured text, and
+        uses East Asian width for non-ASCII characters so context-length
+        guardrails do not underestimate the input.
 
         Subclasses may override this method to provide a more accurate
         implementation tailored to their specific tokenizer.
@@ -457,10 +460,71 @@ class ChatModelBase:
         return cnt
 
     def _estimate_text_tokens(self, text: str) -> int:
-        """Estimate text tokens without a model-specific tokenizer."""
-        byte_count = len(text.encode("utf-8"))
-        # Dense structured input can approach 0.8 tokens per UTF-8 byte.
-        return (byte_count * 4 + 4) // 5
+        """Estimate text tokens without a model-specific tokenizer.
+
+        The fallback deliberately keeps ordinary ASCII prose at the existing
+        four-bytes-per-token estimate.  Numeric and structured ASCII is more
+        token-dense, so it uses a higher bound only when the text contains a
+        meaningful amount of digits or structural punctuation.  Non-ASCII
+        characters use East Asian width (two units for wide/full-width,
+        otherwise one) because UTF-8 byte length is not a useful proxy for
+        CJK, kana, or accented text.
+
+        This is a guardrail estimate, not a tokenizer replacement. Provider
+        models with an exact tokenizer should continue to override
+        :meth:`count_tokens`.
+        """
+        if not text:
+            return 0
+
+        ascii_bytes = 0
+        non_ascii_tokens = 0
+        structured_chars = 0
+        dense_numeric_chars = 0
+        numeric_run = 0
+        for char in text:
+            if ord(char) < 128:
+                ascii_bytes += 1
+                if char.isdigit():
+                    numeric_run += 1
+                else:
+                    if numeric_run >= 3:
+                        dense_numeric_chars += numeric_run
+                    numeric_run = 0
+                structured_chars += char in _STRUCTURED_TEXT_CHARS
+            else:
+                if numeric_run >= 3:
+                    dense_numeric_chars += numeric_run
+                numeric_run = 0
+                non_ascii_tokens += (
+                    2
+                    if unicodedata.east_asian_width(char) in {"W", "F"}
+                    else 1
+                )
+        if numeric_run >= 3:
+            dense_numeric_chars += numeric_run
+
+        # Preserve the previous behavior for natural ASCII prose. Wide/full-
+        # width characters receive two units, avoiding the UTF-8 undercount
+        # for CJK while narrow non-ASCII characters remain one unit.
+        ascii_tokens = (ascii_bytes + 2) // 4
+
+        # Add weight only to dense numeric runs. This keeps a date or a small
+        # number in otherwise natural prose local to that value.
+        weighted_units = ascii_bytes + dense_numeric_chars * 2
+
+        # JSON/SQL punctuation is often tokenized separately. Add weight to
+        # those punctuation characters only when they are genuinely common;
+        # ordinary English punctuation never changes the whole text's rate.
+        if structured_chars >= 8 and structured_chars * 20 >= max(
+            ascii_bytes,
+            1,
+        ):
+            weighted_units += structured_chars * 3
+
+        ascii_tokens = max(ascii_tokens, (weighted_units + 3) // 4)
+
+        return ascii_tokens + non_ascii_tokens
 
     async def generate_structured_output(
         self,

--- a/src/agentscope/model/_base.py
+++ b/src/agentscope/model/_base.py
@@ -3,7 +3,6 @@
 import asyncio
 import inspect
 import json
-import unicodedata
 from abc import abstractmethod
 from copy import deepcopy
 from pathlib import Path
@@ -33,7 +32,7 @@ from ..tool import ToolChoice
 
 _TOOL_CHOICE_LITERAL_MODES = {"auto", "none", "required"}
 _MULTIMODAL_DATA_BLOCK_TOKEN_ESTIMATE = 2000
-_STRUCTURED_TEXT_CHARS = frozenset("{}[]():,;=<>\"'")
+_STRUCTURED_TEXT_CHARS = frozenset("{}[]():,;=<>\"'._+-*/%")
 
 
 class ChatModelBase:
@@ -380,8 +379,8 @@ class ChatModelBase:
         underlying API to count the tokens. The base implementation instead
         applies a class-aware fallback: it preserves the ASCII bytes-per-token
         baseline, adds local weight for dense numeric/structured text, and
-        uses East Asian width for non-ASCII characters so context-length
-        guardrails do not underestimate the input.
+        counts non-ASCII characters separately so context-length guardrails
+        do not underestimate the input.
 
         Subclasses may override this method to provide a more accurate
         implementation tailored to their specific tokenizer.
@@ -465,10 +464,9 @@ class ChatModelBase:
         The fallback deliberately keeps ordinary ASCII prose at the existing
         four-bytes-per-token estimate.  Numeric and structured ASCII is more
         token-dense, so it uses a higher bound only when the text contains a
-        meaningful amount of digits or structural punctuation.  Non-ASCII
-        characters use East Asian width (two units for wide/full-width,
-        otherwise one) because UTF-8 byte length is not a useful proxy for
-        CJK, kana, or accented text.
+        meaningful amount of digits or structural punctuation. Non-ASCII
+        characters count as one token each because UTF-8 byte length is not a
+        useful proxy for CJK, kana, or accented text.
 
         This is a guardrail estimate, not a tokenizer replacement. Provider
         models with an exact tokenizer should continue to override
@@ -496,17 +494,13 @@ class ChatModelBase:
                 if numeric_run >= 3:
                     dense_numeric_chars += numeric_run
                 numeric_run = 0
-                non_ascii_tokens += (
-                    2
-                    if unicodedata.east_asian_width(char) in {"W", "F"}
-                    else 1
-                )
+                non_ascii_tokens += 1
         if numeric_run >= 3:
             dense_numeric_chars += numeric_run
 
-        # Preserve the previous behavior for natural ASCII prose. Wide/full-
-        # width characters receive two units, avoiding the UTF-8 undercount
-        # for CJK while narrow non-ASCII characters remain one unit.
+        # Preserve the previous behavior for natural ASCII prose. Non-ASCII
+        # characters receive one unit each, avoiding the bytes/4 undercount
+        # for CJK without applying the dense-ASCII rate to ordinary prose.
         ascii_tokens = (ascii_bytes + 2) // 4
 
         # Add weight only to dense numeric runs. This keeps a date or a small

--- a/src/agentscope/model/_base.py
+++ b/src/agentscope/model/_base.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 """The base class for the chat models."""
 import asyncio
+from collections import OrderedDict
 import inspect
 import json
 from abc import abstractmethod
+from contextlib import contextmanager
+from contextvars import ContextVar
 from copy import deepcopy
 from pathlib import Path
-from typing import Type, Any, AsyncGenerator
+from typing import Type, Any, AsyncGenerator, Iterator
 
 import jsonschema
 from pydantic import BaseModel, ValidationError as PydanticValidationError
@@ -33,6 +36,11 @@ from ..tool import ToolChoice
 _TOOL_CHOICE_LITERAL_MODES = {"auto", "none", "required"}
 _MULTIMODAL_DATA_BLOCK_TOKEN_ESTIMATE = 2000
 _STRUCTURED_TEXT_CHARS = frozenset("{}[]():,;=<>\"'._+-*/%")
+_MAX_TOKEN_CALIBRATION_SESSIONS = 128
+_TOKEN_CALIBRATION_SESSION: ContextVar[str | None] = ContextVar(
+    "agentscope_token_calibration_session",
+    default=None,
+)
 
 
 class ChatModelBase:
@@ -97,6 +105,66 @@ class ChatModelBase:
         self.max_retries = max_retries
         self.retry_delay = retry_delay
         self.context_size = context_size
+        self._usage_anchors: OrderedDict[str, tuple[int, int]] = OrderedDict()
+
+    @contextmanager
+    def _token_calibration_scope(
+        self,
+        session_id: str | None,
+    ) -> Iterator[None]:
+        """Scope usage calibration to one agent session.
+
+        A context variable keeps concurrent agents from sharing the active
+        session, while the per-model anchor table keeps the latest provider
+        usage isolated between sessions.
+        """
+        token = _TOKEN_CALIBRATION_SESSION.set(session_id)
+        try:
+            yield
+        finally:
+            _TOKEN_CALIBRATION_SESSION.reset(token)
+
+    def _record_usage_anchor(
+        self,
+        messages: list[Msg],
+        tools: list[dict] | None,
+        usage: Any,
+        session_id: str | None = None,
+    ) -> None:
+        """Remember successful provider input usage for this session.
+
+        Provider-specific ``count_tokens`` overrides remain authoritative and
+        therefore do not receive the fallback estimator's calibration.
+        """
+        session_id = (
+            session_id
+            if session_id is not None
+            else _TOKEN_CALIBRATION_SESSION.get()
+        )
+        if (
+            session_id is None
+            or usage is None
+            or type(self).count_tokens is not ChatModelBase.count_tokens
+        ):
+            return
+
+        self._usage_anchors.pop(session_id, None)
+        self._usage_anchors[session_id] = (
+            self._estimate_input_tokens(messages, tools),
+            int(usage.input_tokens),
+        )
+        while len(self._usage_anchors) > _MAX_TOKEN_CALIBRATION_SESSIONS:
+            self._usage_anchors.popitem(last=False)
+
+    def _clear_usage_anchor(self, session_id: str | None = None) -> None:
+        """Forget calibration after an agent context is compacted."""
+        key = (
+            session_id
+            if session_id is not None
+            else _TOKEN_CALIBRATION_SESSION.get()
+        )
+        if key is not None:
+            self._usage_anchors.pop(key, None)
 
     @classmethod
     def _get_retryable_exceptions(cls) -> tuple[Type[Exception], ...]:
@@ -256,13 +324,17 @@ class ChatModelBase:
         # Consume the model calling result
         # =====================================================================
         if isinstance(res, ChatResponse):
+            self._record_usage_anchor(messages, tools, res.usage)
             return res
+
+        calibration_session = _TOKEN_CALIBRATION_SESSION.get()
 
         async def _stream() -> AsyncGenerator[ChatResponse, None]:
             """The wrapper around model calling."""
             # For backward compatibility
             yield_acc_res = True
             acc_res = _StreamAccumulator()
+            final_usage: Any = None
             try:
                 async for chunk in res:
                     if not chunk.is_last:
@@ -280,13 +352,28 @@ class ChatModelBase:
                             continue
                     else:
                         yield_acc_res = False
+                        final_usage = chunk.usage or acc_res.usage
                     yield chunk
             except asyncio.CancelledError:
                 acc_res.finished_reason = FinishedReason.INTERRUPTED
                 yield_acc_res = True
 
-            if yield_acc_res:
-                yield acc_res.build()
+            completed_response = acc_res.build() if yield_acc_res else None
+            if completed_response is not None:
+                self._record_usage_anchor(
+                    messages,
+                    tools,
+                    completed_response.usage,
+                    session_id=calibration_session,
+                )
+                yield completed_response
+            elif not yield_acc_res:
+                self._record_usage_anchor(
+                    messages,
+                    tools,
+                    final_usage,
+                    session_id=calibration_session,
+                )
 
         return _stream()
 
@@ -395,6 +482,26 @@ class ChatModelBase:
             `int`:
                 The number of tokens in the model.
         """
+        estimated_tokens = self._estimate_input_tokens(messages, tools)
+        session_id = _TOKEN_CALIBRATION_SESSION.get()
+        anchor = (
+            self._usage_anchors.get(session_id)
+            if session_id is not None
+            else None
+        )
+        if anchor is None:
+            return estimated_tokens
+
+        anchor_estimate, usage_tokens = anchor
+        conservative_delta = max(0, estimated_tokens - anchor_estimate)
+        return max(estimated_tokens, usage_tokens + conservative_delta)
+
+    def _estimate_input_tokens(
+        self,
+        messages: list[Msg],
+        tools: list[dict] | None,
+    ) -> int:
+        """Estimate the input surface without applying usage calibration."""
         cnt = 0
 
         acc_texts = []
@@ -707,7 +814,9 @@ class ChatModelBase:
             # Insert a user message to the last
             copied_messages[-1].content = copied_messages[
                 -1
-            ].get_content_blocks() + [TextBlock(text=instruction)]
+            ].get_content_blocks() + [
+                TextBlock(text=instruction),
+            ]
         else:
             copied_messages.append(
                 UserMsg(name="user", content=[TextBlock(text=instruction)]),

--- a/tests/model_count_tokens_test.py
+++ b/tests/model_count_tokens_test.py
@@ -146,17 +146,17 @@ class ModelCountTokensTest(IsolatedAsyncioTestCase):
             (
                 "SELECT order_id, sum(amount * (1 - discount)) "
                 "FROM orders WHERE customer_id = 88392019482;",
-                28,
+                37,
             ),
-            ("上下文压缩不应因词数低估而跳过。", 32),
+            ("上下文压缩不应因词数低估而跳过。", 16),
             (
                 ("上下文压缩不应因词数低估而跳过。" * 3)[:44],
-                88,
+                44,
             ),
-            ('{"amount":10000.50,"customer_id":88392019482}', 26),
+            ('{"amount":10000.50,"customer_id":88392019482}', 28),
             (
                 'Review 中文 JSON: {"金额": 12345.67, "status": "ok"}',
-                31,
+                28,
             ),
         ]
 
@@ -187,6 +187,63 @@ class ModelCountTokensTest(IsolatedAsyncioTestCase):
             ),
             (len(cjk.encode("utf-8")) + 2) // 4,
         )
+
+    async def test_reported_payloads_bound_tokenizer_counts(self) -> None:
+        """The issue's exact payloads stay above their pure-text counts."""
+        english = (
+            "Please analyze the quarterly revenue trends, cost breakdown, "
+            "and operating profit margin across all departments for Q3 "
+            "2026."
+        )
+        chinese = (
+            "请分析2026年第三季度集团财务营收趋势、成本结构明细"
+            "以及各事业部的营业利润率情况。"
+        )
+        sql = (
+            "SELECT order_id, sum(amount * (1 - discount)) as net_total, "
+            "count(item_id) as total_items FROM orders WHERE amount > "
+            "10000.50 AND customer_id IN (88392019482, 88392019483, "
+            "88392019484)   AND create_time >= '2026-01-01 00:00:00' "
+            "AND status IN ('PAID', 'SETTLED', 'DELIVERED') GROUP BY "
+            "order_id HAVING net_total > 500000.00 ORDER BY net_total "
+            "DESC LIMIT 100;"
+        )
+        json_result = (
+            '{"status": "success", "code": 200, "data": ['
+            '{"order_id": 1001, "amount": 15200.5, "customer_id": '
+            '88392019482, "status": "PAID"}, {"order_id": 1002, '
+            '"amount": 83400.0, "customer_id": 88392019483, '
+            '"status": "SETTLED"}], "summary": {"total_count": 2, '
+            '"sum_amount": 98600.5}}'
+        )
+        mixed = "".join(
+            [
+                "请帮我查询 2026 年 Q3 大额订单及结算状态。",
+                "好的，我将调用数据库执行 SQL 查询：SELECT * FROM orders "
+                "WHERE amount > 50000;",
+                '返回结果如下：{"orders": [{"id": 1, "amount": '
+                '62000.0, "status": "SETTLED"}], "total": 1}',
+                "已获取到 1 笔大额订单，金额为 62,000.00 元，状态为已结算。"
+                "请问还需要进一步汇总分析吗？",
+            ],
+        )
+        payloads = [
+            (english, 26, 33),
+            (chinese, 24, 41),
+            (sql, 149, 149),
+            (json_result, 134, 151),
+            (mixed, 136, 143),
+        ]
+
+        for text, tokenizer_tokens, expected in payloads:
+            with self.subTest(text=text[:40]):
+                estimate = await self.model.count_tokens(
+                    [UserMsg(name="user", content=text)],
+                    None,
+                )
+                self.assertEqual(estimate, expected)
+                self.assertGreaterEqual(estimate, tokenizer_tokens)
+                self.assertLessEqual(estimate, tokenizer_tokens * 2)
 
     async def _run_compression_flow(
         self,
@@ -253,7 +310,7 @@ class ModelCountTokensTest(IsolatedAsyncioTestCase):
             (
                 "cjk",
                 ("上下文压缩不应因词数低估而跳过。" * 3)[:44],
-                70,
+                54,
             ),
             (
                 "json",

--- a/tests/model_count_tokens_test.py
+++ b/tests/model_count_tokens_test.py
@@ -1,16 +1,101 @@
 # -*- coding: utf-8 -*-
 """Tests for the fallback chat model token estimation."""
+from typing import Any
 from unittest.async_case import IsolatedAsyncioTestCase
 
 from utils import MockModel
 
+from agentscope.agent import Agent, ContextConfig, InjectionConfig
 from agentscope.message import (
     Base64Source,
     DataBlock,
+    Msg,
     TextBlock,
     URLSource,
     UserMsg,
 )
+from agentscope.model import ChatResponse, StructuredResponse
+from agentscope.state import AgentState
+from agentscope.tool import Toolkit
+
+
+class CompressionAwareMockModel(MockModel):
+    """Record provider calls while using the fallback token estimator."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize a non-streaming model with provider-call recording."""
+        super().__init__(
+            *args,
+            stream=False,
+            use_fallback_token_estimate=True,
+            **kwargs,
+        )
+        self.provider_messages: list[list[Msg]] = []
+        self.reject_dense_context: str | None = None
+
+    async def _call_api(
+        self,
+        model_name: str,
+        **kwargs: Any,
+    ) -> ChatResponse:
+        """Record the messages that reach the provider boundary."""
+        del model_name
+        messages = kwargs["messages"]
+        self.provider_messages.append(messages)
+        if self.reject_dense_context:
+            provider_text = "".join(
+                block.text
+                for msg in messages
+                for block in msg.get_content_blocks("text")
+            )
+            if self.reject_dense_context in provider_text:
+                raise RuntimeError("context_length_exceeded")
+        return ChatResponse(
+            content=[TextBlock(text="provider response")],
+            is_last=True,
+        )
+
+
+class LegacyCompressionAwareMockModel(CompressionAwareMockModel):
+    """Record provider calls with the pre-PR bytes/4 fallback."""
+
+    def _estimate_text_tokens(self, text: str) -> int:
+        """Use the legacy estimate for the regression comparison."""
+        return int(len(text.encode("utf-8")) / 4 + 0.5)
+
+
+class DropOldestMockModel(CompressionAwareMockModel):
+    """Fail the first oversized summary request containing the oldest item."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize structured-output call recording."""
+        super().__init__(*args, **kwargs)
+        self.structured_messages: list[list[Msg]] = []
+        self.oldest_marker = ""
+
+    async def _call_api_with_structured_output(
+        self,
+        model_name: str,
+        messages: list[Msg],
+        structured_model: Any,
+        **kwargs: Any,
+    ) -> StructuredResponse:
+        """Reject the first compression request that still has the oldest."""
+        self.structured_messages.append(messages)
+        text = "".join(
+            block.text
+            for msg in messages
+            for block in msg.get_content_blocks("text")
+        )
+        if self.oldest_marker and self.oldest_marker in text:
+            self.oldest_marker = ""
+            raise RuntimeError("context_length_exceeded")
+        return await super()._call_api_with_structured_output(
+            model_name,
+            messages,
+            structured_model,
+            **kwargs,
+        )
 
 
 class ModelCountTokensTest(IsolatedAsyncioTestCase):
@@ -41,28 +126,212 @@ class ModelCountTokensTest(IsolatedAsyncioTestCase):
             None,
         )
 
-        self.assertEqual(tokens, 2002)
+        self.assertEqual(tokens, 2001)
 
-    async def test_text_uses_conservative_utf8_byte_estimate(self) -> None:
-        """Dense ASCII and non-ASCII text are not underestimated."""
-        texts = [
+    async def test_natural_ascii_keeps_original_estimate(self) -> None:
+        """Natural English must not be inflated by the fallback bound."""
+        text = "This is ordinary English prose with natural punctuation."
+        tokens = await self.model.count_tokens(
+            [UserMsg(name="user", content=[TextBlock(text=text)])],
+            None,
+        )
+
+        self.assertEqual(tokens, 14)
+
+    async def test_dense_text_and_non_ascii_are_not_underestimated(
+        self,
+    ) -> None:
+        """Numeric, structured, and CJK text use denser fallback estimates."""
+        texts_and_expected = [
             (
                 "SELECT order_id, sum(amount * (1 - discount)) "
-                "FROM orders WHERE customer_id = 88392019482;"
+                "FROM orders WHERE customer_id = 88392019482;",
+                28,
             ),
-            "上下文压缩不应因词数低估而跳过。",
-            '{"amount":10000.50,"customer_id":88392019482}',
+            ("上下文压缩不应因词数低估而跳过。", 32),
+            (
+                ("上下文压缩不应因词数低估而跳过。" * 3)[:44],
+                88,
+            ),
+            ('{"amount":10000.50,"customer_id":88392019482}', 26),
+            (
+                'Review 中文 JSON: {"金额": 12345.67, "status": "ok"}',
+                31,
+            ),
         ]
 
-        for text in texts:
+        for text, expected in texts_and_expected:
             with self.subTest(text=text):
                 tokens = await self.model.count_tokens(
                     [UserMsg(name="user", content=[TextBlock(text=text)])],
                     None,
                 )
 
-                byte_count = len(text.encode("utf-8"))
-                self.assertEqual(tokens, (byte_count * 4 + 4) // 5)
+                baseline = (len(text.encode("utf-8")) + 2) // 4
+                self.assertEqual(tokens, expected)
+                self.assertGreaterEqual(tokens, baseline)
+
+        english = "This is ordinary English prose with natural punctuation."
+        cjk = texts_and_expected[1][0]
+        self.assertLess(
+            await self.model.count_tokens(
+                [UserMsg(name="user", content=[TextBlock(text=english)])],
+                None,
+            ),
+            len(english.encode("utf-8")),
+        )
+        self.assertGreater(
+            await self.model.count_tokens(
+                [UserMsg(name="user", content=[TextBlock(text=cjk)])],
+                None,
+            ),
+            (len(cjk.encode("utf-8")) + 2) // 4,
+        )
+
+    async def _run_compression_flow(
+        self,
+        model: CompressionAwareMockModel,
+        old_context: str,
+        context_size: int,
+        context: list[Msg] | None = None,
+        reserve_ratio: float = 0.1,
+    ) -> str:
+        """Run one reply and return the text sent to the provider."""
+        model.context_size = context_size
+        model.set_structured_response(
+            StructuredResponse(
+                content={
+                    "task_overview": "Keep the active task.",
+                    "current_state": "The old context was summarized.",
+                    "important_discoveries": "The context is token dense.",
+                    "next_steps": "Continue with the latest user input.",
+                    "context_to_preserve": "Preserve the user requirements.",
+                },
+            ),
+        )
+        agent = Agent(
+            name="Friday",
+            system_prompt="Be concise.",
+            model=model,
+            context_config=ContextConfig(
+                trigger_ratio=0.8,
+                reserve_ratio=reserve_ratio,
+            ),
+            toolkit=Toolkit(),
+            state=AgentState(
+                session_id="compression-regression",
+                context=context or [UserMsg(name="user", content=old_context)],
+            ),
+            injection_config=InjectionConfig(inject_runtime_state=False),
+        )
+
+        await agent.reply(UserMsg(name="user", content="Continue."))
+
+        self.assertEqual(len(model.provider_messages), 1)
+        return "".join(
+            block.text
+            for msg in model.provider_messages[0]
+            for block in msg.get_content_blocks("text")
+        )
+
+    async def test_compression_happens_before_provider_call(self) -> None:
+        """Each issue-shaped input is compressed before the provider call."""
+        scenarios = [
+            (
+                "sql",
+                "SELECT order_id, sum(amount * (1 - discount)) "
+                "as net_total FROM orders WHERE amount > 10000.50 "
+                "AND customer_id = 88392019482 GROUP BY order_id "
+                "HAVING net_total > 500000.00;",
+                68,
+            ),
+            (
+                "numeric",
+                "1234567890 9876543210 1122334455 9988776655",
+                40,
+            ),
+            (
+                "cjk",
+                ("上下文压缩不应因词数低估而跳过。" * 3)[:44],
+                70,
+            ),
+            (
+                "json",
+                '{"amount":10000.50,"customer_id":88392019482,'
+                '"status":"paid","items":[{"sku":"A-1024","qty":17}]}',
+                60,
+            ),
+            (
+                "mixed",
+                'Review 中文 JSON: {"金额": 12345.67, "status": "ok"}',
+                35,
+            ),
+        ]
+
+        for name, old_context, context_size in scenarios:
+            with self.subTest(name=name):
+                legacy_model = LegacyCompressionAwareMockModel()
+                legacy_model.reject_dense_context = old_context
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "context_length_exceeded",
+                ):
+                    await self._run_compression_flow(
+                        legacy_model,
+                        old_context,
+                        context_size,
+                    )
+
+                new_model = CompressionAwareMockModel()
+                new_model.reject_dense_context = old_context
+                provider_text = await self._run_compression_flow(
+                    new_model,
+                    old_context,
+                    context_size,
+                )
+                self.assertIn("The old context was summarized.", provider_text)
+                self.assertNotIn(old_context, provider_text)
+
+    async def test_drop_oldest_retries_real_overflow(self) -> None:
+        """A real overflow retry removes the oldest context before retrying."""
+        oldest_marker = "OLDEST_DROP_OLDEST_MARKER"
+        second_marker = "SECOND_DROP_OLDEST_MARKER"
+        oldest = oldest_marker + ('{"amount":10000.50},' * 100)
+        second = second_marker + ("9876543210," * 4)
+        recent = "recent context " * 20
+
+        model = DropOldestMockModel()
+        model.oldest_marker = oldest_marker
+        provider_text = await self._run_compression_flow(
+            model,
+            oldest,
+            context_size=1200,
+            context=[
+                UserMsg(name="user", content=oldest),
+                UserMsg(name="user", content=second),
+                UserMsg(name="user", content=recent),
+            ],
+            reserve_ratio=0.08,
+        )
+
+        self.assertEqual(len(model.structured_messages), 2)
+        first_text = "".join(
+            block.text
+            for msg in model.structured_messages[0]
+            for block in msg.get_content_blocks("text")
+        )
+        second_text = "".join(
+            block.text
+            for msg in model.structured_messages[1]
+            for block in msg.get_content_blocks("text")
+        )
+        self.assertIn(oldest_marker, first_text)
+        self.assertIn(second_marker, first_text)
+        self.assertNotIn(oldest_marker, second_text)
+        self.assertIn(second_marker, second_text)
+        self.assertNotIn(oldest_marker, provider_text)
+        self.assertNotIn(second_marker, provider_text)
+        self.assertNotIn(oldest, provider_text)
 
     async def test_base64_and_url_data_blocks_have_same_estimate(self) -> None:
         """The same data block should not differ by source representation."""

--- a/tests/model_count_tokens_test.py
+++ b/tests/model_count_tokens_test.py
@@ -18,7 +18,7 @@ class ModelCountTokensTest(IsolatedAsyncioTestCase):
 
     async def asyncSetUp(self) -> None:
         """Set up a mock model that uses ChatModelBase.count_tokens."""
-        self.model = MockModel()
+        self.model = MockModel(use_fallback_token_estimate=True)
 
     async def test_data_blocks_use_flat_multimodal_estimate(self) -> None:
         """Large base64 payloads are not counted as prompt text."""
@@ -61,7 +61,8 @@ class ModelCountTokensTest(IsolatedAsyncioTestCase):
                     None,
                 )
 
-                self.assertEqual(tokens, len(text.encode("utf-8")))
+                byte_count = len(text.encode("utf-8"))
+                self.assertEqual(tokens, (byte_count * 4 + 4) // 5)
 
     async def test_base64_and_url_data_blocks_have_same_estimate(self) -> None:
         """The same data block should not differ by source representation."""

--- a/tests/model_count_tokens_test.py
+++ b/tests/model_count_tokens_test.py
@@ -10,11 +10,12 @@ from agentscope.message import (
     Base64Source,
     DataBlock,
     Msg,
+    SystemMsg,
     TextBlock,
     URLSource,
     UserMsg,
 )
-from agentscope.model import ChatResponse, StructuredResponse
+from agentscope.model import ChatResponse, ChatUsage, StructuredResponse
 from agentscope.state import AgentState
 from agentscope.tool import Toolkit
 
@@ -64,6 +65,19 @@ class LegacyCompressionAwareMockModel(CompressionAwareMockModel):
         return int(len(text.encode("utf-8")) / 4 + 0.5)
 
 
+class ProviderCountMockModel(MockModel):
+    """Mock provider with an authoritative token counter."""
+
+    async def count_tokens(
+        self,
+        messages: list[Msg],
+        tools: list[dict] | None,
+    ) -> int:
+        """Return the provider's exact count independent of calibration."""
+        del messages, tools
+        return 7
+
+
 class DropOldestMockModel(CompressionAwareMockModel):
     """Fail the first oversized summary request containing the oldest item."""
 
@@ -104,6 +118,14 @@ class ModelCountTokensTest(IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:
         """Set up a mock model that uses ChatModelBase.count_tokens."""
         self.model = MockModel(use_fallback_token_estimate=True)
+
+    @staticmethod
+    def _calibration_scope(model: MockModel, session_id: str) -> Any:
+        """Enter the model's private session scope for direct tests."""
+        # pylint: disable=protected-access
+        return model._token_calibration_scope(
+            session_id,
+        )
 
     async def test_data_blocks_use_flat_multimodal_estimate(self) -> None:
         """Large base64 payloads are not counted as prompt text."""
@@ -195,10 +217,7 @@ class ModelCountTokensTest(IsolatedAsyncioTestCase):
             "and operating profit margin across all departments for Q3 "
             "2026."
         )
-        chinese = (
-            "请分析2026年第三季度集团财务营收趋势、成本结构明细"
-            "以及各事业部的营业利润率情况。"
-        )
+        chinese = "请分析2026年第三季度集团财务营收趋势、成本结构明细以及各事业部的营业利润率情况。"
         sql = (
             "SELECT order_id, sum(amount * (1 - discount)) as net_total, "
             "count(item_id) as total_items FROM orders WHERE amount > "
@@ -223,8 +242,7 @@ class ModelCountTokensTest(IsolatedAsyncioTestCase):
                 "WHERE amount > 50000;",
                 '返回结果如下：{"orders": [{"id": 1, "amount": '
                 '62000.0, "status": "SETTLED"}], "total": 1}',
-                "已获取到 1 笔大额订单，金额为 62,000.00 元，状态为已结算。"
-                "请问还需要进一步汇总分析吗？",
+                "已获取到 1 笔大额订单，金额为 62,000.00 元，状态为已结算。请问还需要进一步汇总分析吗？",
             ],
         )
         payloads = [
@@ -244,6 +262,202 @@ class ModelCountTokensTest(IsolatedAsyncioTestCase):
                 self.assertEqual(estimate, expected)
                 self.assertGreaterEqual(estimate, tokenizer_tokens)
                 self.assertLessEqual(estimate, tokenizer_tokens * 2)
+
+    async def test_provider_usage_anchors_are_session_local(self) -> None:
+        """Provider overhead calibrates later turns without cross-talk."""
+        messages = [UserMsg(name="user", content="short prompt")]
+        raw_estimate = await self.model.count_tokens(messages, None)
+        self.model.set_responses(
+            [
+                ChatResponse(
+                    content=[TextBlock(text="ok")],
+                    is_last=True,
+                    usage=ChatUsage(input_tokens=52, output_tokens=1, time=0),
+                ),
+            ],
+        )
+
+        with self._calibration_scope(self.model, "session-a"):
+            await self.model(messages=messages)
+            self.assertEqual(
+                await self.model.count_tokens(messages, None),
+                52,
+            )
+            expanded = [
+                UserMsg(name="user", content="short prompt plus new text"),
+            ]
+            expanded_estimate = await self.model.count_tokens(expanded, None)
+            with self._calibration_scope(self.model, "session-b"):
+                expanded_raw_estimate = await self.model.count_tokens(
+                    expanded,
+                    None,
+                )
+            self.assertGreaterEqual(
+                expanded_estimate,
+                52
+                + max(
+                    0,
+                    expanded_raw_estimate - raw_estimate,
+                ),
+            )
+
+        with self._calibration_scope(self.model, "session-b"):
+            self.assertEqual(
+                await self.model.count_tokens(messages, None),
+                raw_estimate,
+            )
+
+    async def test_streaming_final_usage_anchors_the_next_estimate(
+        self,
+    ) -> None:
+        """A usage-bearing final stream chunk calibrates later turns."""
+        model = MockModel(stream=True, use_fallback_token_estimate=True)
+        model.set_responses(
+            [
+                [
+                    ChatResponse(
+                        content=[TextBlock(text="part")],
+                        is_last=False,
+                    ),
+                    ChatResponse(
+                        content=[],
+                        is_last=True,
+                        usage=ChatUsage(
+                            input_tokens=52,
+                            output_tokens=1,
+                            time=0,
+                        ),
+                    ),
+                ],
+            ],
+        )
+        messages = [UserMsg(name="user", content="streamed prompt")]
+
+        with self._calibration_scope(model, "stream-session"):
+            response = await model(messages=messages)
+            chunks = [chunk async for chunk in response]
+            self.assertTrue(chunks[-1].is_last)
+            self.assertEqual(
+                await model.count_tokens(messages, None),
+                52,
+            )
+
+    async def test_provider_count_tokens_override_stays_authoritative(
+        self,
+    ) -> None:
+        """Provider counters are not replaced by fallback calibration."""
+        model = ProviderCountMockModel(stream=False)
+        model.set_responses(
+            [
+                ChatResponse(
+                    content=[TextBlock(text="ok")],
+                    is_last=True,
+                    usage=ChatUsage(
+                        input_tokens=1000,
+                        output_tokens=1,
+                        time=0,
+                    ),
+                ),
+            ],
+        )
+        messages = [UserMsg(name="user", content="exact prompt")]
+
+        with self._calibration_scope(model, "exact-session"):
+            await model(messages=messages)
+            self.assertEqual(await model.count_tokens(messages, None), 7)
+
+    async def test_usage_anchor_table_is_bounded(
+        self,
+    ) -> None:
+        """Short-lived sessions cannot grow the anchor table forever."""
+        for index in range(129):
+            # pylint: disable=protected-access
+            self.model._record_usage_anchor(
+                [UserMsg(name="user", content="prompt")],
+                None,
+                ChatUsage(input_tokens=index, output_tokens=1, time=0),
+                session_id=f"short-session-{index}",
+            )
+
+        self.assertLessEqual(
+            len(self.model._usage_anchors),  # pylint: disable=protected-access
+            128,
+        )
+
+    async def test_agent_reply_sets_the_calibration_session(self) -> None:
+        """The public reply path records usage under its Agent session."""
+        model = MockModel(stream=False, use_fallback_token_estimate=True)
+        model.set_responses(
+            [
+                ChatResponse(
+                    content=[TextBlock(text="ok")],
+                    is_last=True,
+                    usage=ChatUsage(input_tokens=52, output_tokens=1, time=0),
+                ),
+            ],
+        )
+        agent = Agent(
+            name="Friday",
+            system_prompt="Be concise.",
+            model=model,
+            state=AgentState(session_id="reply-session"),
+            toolkit=Toolkit(),
+            injection_config=InjectionConfig(inject_runtime_state=False),
+        )
+
+        await agent.reply(UserMsg(name="user", content="hello"))
+
+        with self._calibration_scope(model, "reply-session"):
+            self.assertEqual(
+                await model.count_tokens(
+                    [UserMsg(name="user", content="hello")],
+                    None,
+                ),
+                52,
+            )
+
+    async def test_usage_anchor_is_cleared_after_context_replacement(
+        self,
+    ) -> None:
+        """A compacted context must not retain the old large baseline."""
+        messages = [UserMsg(name="user", content="old context")]
+        raw_estimate = await self.model.count_tokens(messages, None)
+        self.model.context_size = 100
+        self.model.set_structured_response(
+            StructuredResponse(
+                content={
+                    "task_overview": "Keep the active task.",
+                    "current_state": "The old context was summarized.",
+                    "important_discoveries": "The context is token dense.",
+                    "next_steps": "Continue with the latest user input.",
+                    "context_to_preserve": "Preserve the user requirements.",
+                },
+            ),
+        )
+        anchor_messages = [
+            SystemMsg(name="system", content="Be concise."),
+            *messages,
+        ]
+        self.model._record_usage_anchor(  # pylint: disable=protected-access
+            anchor_messages,
+            [],
+            ChatUsage(input_tokens=1000, output_tokens=1, time=0),
+            session_id="compression-session",
+        )
+        agent = Agent(
+            name="Friday",
+            system_prompt="Be concise.",
+            model=self.model,
+            state=AgentState(session_id="compression-session"),
+            toolkit=Toolkit(),
+        )
+        agent.state.context = messages
+        await agent.compress_context()
+        with self._calibration_scope(self.model, "compression-session"):
+            self.assertEqual(
+                await self.model.count_tokens(messages, None),
+                raw_estimate,
+            )
 
     async def _run_compression_flow(
         self,
@@ -362,7 +576,7 @@ class ModelCountTokensTest(IsolatedAsyncioTestCase):
         provider_text = await self._run_compression_flow(
             model,
             oldest,
-            context_size=1200,
+            context_size=1300,
             context=[
                 UserMsg(name="user", content=oldest),
                 UserMsg(name="user", content=second),

--- a/tests/model_count_tokens_test.py
+++ b/tests/model_count_tokens_test.py
@@ -41,7 +41,27 @@ class ModelCountTokensTest(IsolatedAsyncioTestCase):
             None,
         )
 
-        self.assertEqual(tokens, 2001)
+        self.assertEqual(tokens, 2002)
+
+    async def test_text_uses_conservative_utf8_byte_estimate(self) -> None:
+        """Dense ASCII and non-ASCII text are not underestimated."""
+        texts = [
+            (
+                "SELECT order_id, sum(amount * (1 - discount)) "
+                "FROM orders WHERE customer_id = 88392019482;"
+            ),
+            "上下文压缩不应因词数低估而跳过。",
+            '{"amount":10000.50,"customer_id":88392019482}',
+        ]
+
+        for text in texts:
+            with self.subTest(text=text):
+                tokens = await self.model.count_tokens(
+                    [UserMsg(name="user", content=[TextBlock(text=text)])],
+                    None,
+                )
+
+                self.assertEqual(tokens, len(text.encode("utf-8")))
 
     async def test_base64_and_url_data_blocks_have_same_estimate(self) -> None:
         """The same data block should not differ by source representation."""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -62,6 +62,7 @@ class MockModel(ChatModelBase):
         mock_chat_responses: list | None = None,
         mock_structured_response: Any = None,
         formatter: FormatterBase | None = None,
+        use_fallback_token_estimate: bool = False,
     ) -> None:
         """Initialize the mock model."""
         super().__init__(
@@ -76,7 +77,14 @@ class MockModel(ChatModelBase):
         self.formatter = formatter or OpenAIChatFormatter()
         self.mock_chat_responses = mock_chat_responses or []
         self.mock_structured_response = mock_structured_response
+        self.use_fallback_token_estimate = use_fallback_token_estimate
         self.cnt = 0
+
+    def _estimate_text_tokens(self, text: str) -> int:
+        """Keep context-size fixtures independent of fallback tuning."""
+        if self.use_fallback_token_estimate:
+            return super()._estimate_text_tokens(text)
+        return int(len(text.encode("utf-8")) / 4 + 0.5)
 
     def set_responses(
         self,


### PR DESCRIPTION
Fixes #2385

## AgentScope Version

2.0.6

## Description

`ChatModelBase.count_tokens` previously estimated all text as one token per
four UTF-8 bytes. That fallback can undercount token-dense numeric and
structured input, wide non-ASCII text, and hidden provider template overhead,
allowing context compression to be skipped before the provider rejects the
request.

This change adds two conservative fallback layers while leaving exact
provider-specific counters authoritative:

- class-aware estimates preserve the existing behavior for ordinary ASCII
  prose, while assigning local weight to dense numbers, structured punctuation,
  wide/full-width characters, and decodable textual data blocks;
- after a successful model call, the fallback records the provider's real
  `usage.input_tokens` for that agent session and estimates later turns as the
  larger of the heuristic or the latest usage plus the incremental input
  surface.

Calibration is isolated per agent session, works for streaming and
non-streaming responses, is bounded for shared model instances, and is cleared
after context replacement so an old large context cannot force repeated early
compression. There are no public API, dependency, or serialized-data changes.

## Verification

- The exact five payloads supplied in #2385 are covered. Their fallback
  estimates are 33/41/149/151/143 tokens versus pure-tokenizer counts of
  26/24/149/134/136, so none undercount and none exceed 2x.
- Old-vs-new provider-boundary regressions cover SQL, numeric, CJK, JSON, and
  mixed content: the legacy estimate sends oversized input and receives
  `context_length_exceeded`; the new fallback compresses first.
- Provider-usage regressions cover fixed template overhead, multi-turn deltas,
  session isolation, streaming final usage, authoritative provider counters,
  bounded session retention, and clearing after context compression.
- A fallback-driven overflow regression covers compression-request failure,
  drop-oldest retry, and successful provider delivery without the evicted
  context.
- 97 focused tests plus 15 subtests passed locally; formatting, type, lint, and
  package checks pass.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the CONTRIBUTING.md
- [x] Docstrings are in Google style
- [x] Related documentation has been updated (not applicable; no public API or
  setup behavior changed)
- [x] Code is ready for review
