### PR TITLE
feat(workspace): expose OpenSandbox proxy and volumes

### DIFF
--- a/src/agentscope/app/workspace_manager/_opensandbox_workspace_manager.py
+++ b/src/agentscope/app/workspace_manager/_opensandbox_workspace_manager.py
@@ -27,9 +27,11 @@ Differences from the Docker manager:
   ``sandbox.pause()`` is a remote round-trip per sandbox.
 """
 
+from __future__ import annotations
+
 import asyncio
 import time
-from typing import Any, Literal, Self
+from typing import TYPE_CHECKING, Any, Literal, Self
 
 from ..._logging import logger
 from ...mcp import MCPClient
@@ -42,6 +44,9 @@ from ...workspace._opensandbox._constants import (
 from ...workspace import OpenSandboxWorkspace
 
 from ._base import IsolationPolicy, WorkspaceManagerBase
+
+if TYPE_CHECKING:
+    from opensandbox.models.sandboxes import Volume
 
 DEFAULT_SWEEP_INTERVAL = 300.0
 
@@ -73,6 +78,8 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
         extra_pip: list[str] | None = None,
         default_mcps: list[MCPClient] | None = None,
         skill_paths: list[str] | None = None,
+        use_server_proxy: bool = False,
+        volumes: list[Volume] | None = None,
         ttl: float = 3600.0,
         sweep_interval: float = DEFAULT_SWEEP_INTERVAL,
     ) -> None:
@@ -126,6 +133,10 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
                 reattach, the sandbox's persisted ``.mcp`` file wins.
             skill_paths (`list[str] | None`, optional):
                 Skill directories seeded into brand-new workspaces.
+            use_server_proxy (`bool`, defaults to `False`):
+                Route sandbox traffic through the OpenSandbox API server.
+            volumes (`list[Volume] | None`, optional):
+                Volume declarations forwarded to each new sandbox.
             ttl (`float`, defaults to `3600.0`):
                 Seconds before an idle cached workspace is evicted and
                 its sandbox paused.
@@ -148,6 +159,8 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
         self._extra_pip = list(extra_pip or [])
         self._default_mcps = list(default_mcps or [])
         self._skill_paths = list(skill_paths or [])
+        self._use_server_proxy = use_server_proxy
+        self._volumes = list(volumes or [])
         self._ttl = ttl
         self._sweep_interval = sweep_interval
         super().__init__(isolation=isolation)
@@ -192,6 +205,8 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
             extra_pip=self._extra_pip,
             default_mcps=self._default_mcps,
             skill_paths=self._skill_paths,
+            use_server_proxy=self._use_server_proxy,
+            volumes=self._volumes,
         )
         await ws.initialize()
         return ws

--- a/src/agentscope/workspace/_opensandbox/_opensandbox_workspace.py
+++ b/src/agentscope/workspace/_opensandbox/_opensandbox_workspace.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from opensandbox.models.sandboxes import (
         NetworkPolicy,
         SandboxInfo,
+        Volume,
     )
 
 
@@ -66,6 +67,8 @@ class OpenSandboxWorkspace(SandboxedWorkspaceBase):
         instructions: str = DEFAULT_WORKSPACE_INSTRUCTIONS,
         default_mcps: list[MCPClient] | None = None,
         skill_paths: list[str] | None = None,
+        use_server_proxy: bool = False,
+        volumes: list[Volume] | None = None,
     ) -> None:
         """Construct an :class:`OpenSandboxWorkspace`.
 
@@ -114,6 +117,12 @@ class OpenSandboxWorkspace(SandboxedWorkspaceBase):
                 ``.mcp`` exists.
             skill_paths (`list[str] | None`, optional):
                 Local skill dirs seeded into ``skills/`` on first init.
+            use_server_proxy (`bool`, defaults to `False`):
+                Route sandbox traffic through the OpenSandbox API server
+                instead of connecting to sandbox dynamic ports directly.
+            volumes (`list[Volume] | None`, optional):
+                Volume declarations passed to ``Sandbox.create`` for
+                persistent workspace storage.
         """
         super().__init__(
             workspace_id=workspace_id,
@@ -135,6 +144,8 @@ class OpenSandboxWorkspace(SandboxedWorkspaceBase):
         self.network_policy = network_policy
         self.extra_pip = list(extra_pip or [])
         self.instructions = instructions
+        self.use_server_proxy = use_server_proxy
+        self.volumes = list(volumes or [])
 
         self._sandbox: Sandbox | None = None
         self._backend: OpenSandboxBackend | None = None
@@ -202,7 +213,10 @@ class OpenSandboxWorkspace(SandboxedWorkspaceBase):
         """Build OpenSandbox connection config on demand."""
         from opensandbox.config.connection import ConnectionConfig
 
-        kwargs: dict = {"protocol": self.protocol}
+        kwargs: dict = {
+            "protocol": self.protocol,
+            "use_server_proxy": self.use_server_proxy,
+        }
         if self.api_key:
             kwargs["api_key"] = self.api_key
         if self.domain:
@@ -270,6 +284,8 @@ class OpenSandboxWorkspace(SandboxedWorkspaceBase):
             kwargs["entrypoint"] = self.entrypoint
         if self.network_policy is not None:
             kwargs["network_policy"] = self.network_policy
+        if self.volumes:
+            kwargs["volumes"] = self.volumes
         return await Sandbox.create(**kwargs)
 
     async def _attach_existing_sandbox(self, info: SandboxInfo) -> Sandbox:

--- a/tests/workspace_opensandbox_test.py
+++ b/tests/workspace_opensandbox_test.py
@@ -1,14 +1,19 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access
 """Test cases for OpenSandboxWorkspace.
 
-The whole module is skipped when the ``OPENSANDBOX_DOMAIN`` environment
-variable is not set, because every test requires a live OpenSandbox
-service.
+Configuration tests use SDK doubles and run without OpenSandbox. Lifecycle
+tests require a live service and are skipped when ``OPENSANDBOX_DOMAIN`` is
+not set.
 """
 import os
+import sys
+import types
 import unittest
 from unittest.async_case import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from agentscope.app.workspace_manager import OpenSandboxWorkspaceManager
 from agentscope.mcp import MCPClient, StdioMCPConfig
 from agentscope.workspace import OpenSandboxWorkspace
 
@@ -18,6 +23,91 @@ from agentscope.workspace import OpenSandboxWorkspace
 _DOMAIN = os.getenv("OPENSANDBOX_DOMAIN", "")
 _API_KEY = os.getenv("OPENSANDBOX_API_KEY", "")
 _SKIP_REASON = "OPENSANDBOX_DOMAIN environment variable is not set"
+
+
+class TestOpenSandboxWorkspaceConfig(IsolatedAsyncioTestCase):
+    """Test SDK option forwarding without a live OpenSandbox service."""
+
+    @staticmethod
+    def _fake_sdk(create: AsyncMock) -> dict[str, types.ModuleType]:
+        """Build minimal OpenSandbox modules for config and create calls."""
+
+        class ConnectionConfig:
+            """Capture SDK connection arguments."""
+
+            def __init__(self, **kwargs: object) -> None:
+                self.kwargs = kwargs
+
+        opensandbox = types.ModuleType("opensandbox")
+        opensandbox.Sandbox = types.SimpleNamespace(create=create)
+        config = types.ModuleType("opensandbox.config")
+        connection = types.ModuleType("opensandbox.config.connection")
+        connection.ConnectionConfig = ConnectionConfig
+        return {
+            "opensandbox": opensandbox,
+            "opensandbox.config": config,
+            "opensandbox.config.connection": connection,
+        }
+
+    async def test_connection_proxy_and_volumes_are_forwarded(self) -> None:
+        """Workspace options reach the corresponding SDK calls."""
+        create = AsyncMock(return_value=MagicMock(id="sandbox-id"))
+        volumes = [{"name": "workspace-data"}]
+
+        with patch.dict(sys.modules, self._fake_sdk(create)):
+            workspace = OpenSandboxWorkspace(
+                use_server_proxy=True,
+                volumes=volumes,
+            )
+            connection_config = workspace._connection_config()
+            await workspace._create_sandbox()
+
+        self.assertTrue(connection_config.kwargs["use_server_proxy"])
+        self.assertEqual(create.await_args.kwargs["volumes"], volumes)
+
+    async def test_default_options_preserve_create_behavior(self) -> None:
+        """Defaults disable the proxy and omit empty volume arguments."""
+        create = AsyncMock(return_value=MagicMock(id="sandbox-id"))
+
+        with patch.dict(sys.modules, self._fake_sdk(create)):
+            workspace = OpenSandboxWorkspace()
+            connection_config = workspace._connection_config()
+            await workspace._create_sandbox()
+
+        self.assertFalse(connection_config.kwargs["use_server_proxy"])
+        self.assertNotIn("volumes", create.await_args.kwargs)
+
+    async def test_manager_forwards_proxy_and_volumes(self) -> None:
+        """Manager-created workspaces receive both SDK options."""
+        captured: dict[str, object] = {}
+
+        class FakeWorkspace:
+            """Capture manager workspace arguments."""
+
+            def __init__(self, **kwargs: object) -> None:
+                captured.update(kwargs)
+
+            async def initialize(self) -> None:
+                """Stand in for workspace startup."""
+
+        volumes = [{"name": "workspace-data"}]
+        manager = OpenSandboxWorkspaceManager(
+            use_server_proxy=True,
+            volumes=volumes,
+        )
+        with patch(
+            "agentscope.app.workspace_manager."
+            "_opensandbox_workspace_manager.OpenSandboxWorkspace",
+            FakeWorkspace,
+        ):
+            await manager._build_and_start(
+                workspace_id="workspace-id",
+                user_id="user-id",
+                agent_id="agent-id",
+            )
+
+        self.assertTrue(captured["use_server_proxy"])
+        self.assertEqual(captured["volumes"], volumes)
 
 
 # ── lifecycle tests ────────────────────────────────────────────────


### PR DESCRIPTION
## AgentScope Version

2.0.6 (current `main` at `da00849f`)

## Description

Closes #2194.

OpenSandbox already supports routing sandbox traffic through the API server and attaching persistent volumes, but the AgentScope workspace abstraction did not expose those SDK options. This change adds the missing, backward-compatible constructor parameters to both `OpenSandboxWorkspace` and `OpenSandboxWorkspaceManager`.

### Changes

- add `use_server_proxy: bool = False` and forward it to `ConnectionConfig`;
- add `volumes: list[Volume] | None = None` and forward non-empty values to `Sandbox.create()`;
- forward both options through `OpenSandboxWorkspaceManager`;
- keep OpenSandbox types behind `TYPE_CHECKING` so the optional dependency remains lazy;
- add offline SDK-double tests for enabled options, default behavior, and manager forwarding;
- update the public constructor docstrings.

This is a fresh implementation on current `main`. Credit to @RerankerGuo for the earlier work in #2198, which was closed unmerged and whose head branch is no longer available.

### Validation

- `pytest tests/workspace_opensandbox_test.py tests/backend_opensandbox_test.py -q`: 3 passed, 12 skipped (live-service tests skipped without `OPENSANDBOX_DOMAIN`)
- `pre-commit run --all-files`: passed
- `pytest tests -q`: 2000 passed, 125 skipped, 377 subtests passed

No breaking changes, new dependencies, or lifecycle/cache behavior changes are included.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the contributing guide
- [x] Docstrings are in Google style
- [x] Related documentation has been updated (constructor docstrings)
- [x] Code is ready for review