### PR TITLE
fix(formatter): stabilize unsupported media temp files

### DIFF
--- a/src/agentscope/formatter/_formatter_base.py
+++ b/src/agentscope/formatter/_formatter_base.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
 """The formatter module."""
+import atexit
 import base64
 import mimetypes
+import os
+import shutil
 import tempfile
 from abc import abstractmethod
 from fnmatch import fnmatch
 from typing import Any, List, AsyncGenerator
 
+import shortuuid
 from pydantic import BaseModel, Field
 
 from ..message import (
@@ -15,6 +19,30 @@ from ..message import (
     TextBlock,
     URLSource,
 )
+
+_UNSUPPORTED_MEDIA_TEMP_DIR: str | None = None
+
+
+def _get_unsupported_media_temp_dir() -> str:
+    """Return the process-owned directory for unsupported media files."""
+    global _UNSUPPORTED_MEDIA_TEMP_DIR
+    if _UNSUPPORTED_MEDIA_TEMP_DIR is None:
+        temp_dir = tempfile.mkdtemp(prefix="agentscope-unsupported-media-")
+        os.chmod(temp_dir, 0o700)
+        _UNSUPPORTED_MEDIA_TEMP_DIR = temp_dir
+    return _UNSUPPORTED_MEDIA_TEMP_DIR
+
+
+def _cleanup_unsupported_media_temp_files() -> None:
+    """Remove unsupported media files owned by the current process."""
+    global _UNSUPPORTED_MEDIA_TEMP_DIR
+    temp_dir = _UNSUPPORTED_MEDIA_TEMP_DIR
+    _UNSUPPORTED_MEDIA_TEMP_DIR = None
+    if temp_dir is not None:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+atexit.register(_cleanup_unsupported_media_temp_files)
 
 
 class FormatterBase(BaseModel):
@@ -70,8 +98,9 @@ class FormatterBase(BaseModel):
         """Convert an unsupported data block into its textual fallback.
 
         URL sources remain accessible through their URL. Base64 sources are
-        persisted to a temporary file so the model can still reference the
-        result when the target API cannot carry that media type directly.
+        persisted to a stable path in a process-owned temporary directory so
+        the model can still reference the result when the target API cannot
+        carry that media type directly.
 
         Args:
             block (`DataBlock`):
@@ -90,17 +119,37 @@ class FormatterBase(BaseModel):
                 f"</system-reminder>"
             )
 
-        extension = mimetypes.guess_extension(block.source.media_type)
-        with tempfile.NamedTemporaryFile(
-            suffix=extension,
-            delete=False,
-        ) as temp_file:
+        extension = mimetypes.guess_extension(block.source.media_type) or ""
+        stable_name = shortuuid.uuid(name=block.source.data)
+        temp_dir = _get_unsupported_media_temp_dir()
+        stable_path = os.path.join(
+            temp_dir,
+            f"as-unsup-{stable_name}{extension}",
+        )
+        if not os.path.exists(stable_path):
             decoded_data = base64.b64decode(block.source.data)
-            temp_file.write(decoded_data)
-            return (
-                f"<system-reminder>A(n) {main_type} file is returned and "
-                f"saved locally at: {temp_file.name}.</system-reminder>"
-            )
+            staging_path = ""
+            try:
+                with tempfile.NamedTemporaryFile(
+                    suffix=extension,
+                    dir=temp_dir,
+                    prefix="staging-",
+                    delete=False,
+                ) as temp_file:
+                    staging_path = temp_file.name
+                    temp_file.write(decoded_data)
+                os.replace(staging_path, stable_path)
+            except OSError:
+                if staging_path:
+                    try:
+                        os.remove(staging_path)
+                    except OSError:
+                        pass
+                raise
+        return (
+            f"<system-reminder>A(n) {main_type} file is returned and "
+            f"saved locally at: {stable_path}.</system-reminder>"
+        )
 
     def convert_tool_result_to_string(
         self,

--- a/tests/formatter_base_test.py
+++ b/tests/formatter_base_test.py
@@ -1,0 +1,242 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Test cases for :class:`FormatterBase`."""
+
+import base64
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import ExitStack
+from unittest.mock import patch
+
+import agentscope.formatter._formatter_base as formatter_base
+from agentscope.formatter._formatter_base import (
+    FormatterBase,
+    _cleanup_unsupported_media_temp_files,
+)
+from agentscope.message import Base64Source, DataBlock
+
+
+class _TextOnlyFormatter(FormatterBase):
+    """Formatter that sends every media block through the fallback path."""
+
+    async def format(
+        self,
+        *args: object,
+        **kwargs: object,
+    ) -> list[dict]:
+        """Implement the abstract formatter interface for unit tests."""
+        return []
+
+
+class FormatterBaseUnsupportedMediaTest(unittest.TestCase):
+    """Unsupported-media Base64 storage regressions for issue #2173."""
+
+    def setUp(self) -> None:
+        """Create a text-only formatter and base64 fixtures."""
+        _cleanup_unsupported_media_temp_files()
+        self._formatter = _TextOnlyFormatter(input_types=["text/plain"])
+        self._video_bytes = b"fake video payload"
+        self._video_b64 = base64.b64encode(self._video_bytes).decode("ascii")
+        self._binary_bytes = b"another binary payload"
+        self._binary_b64 = base64.b64encode(self._binary_bytes).decode("ascii")
+
+    def tearDown(self) -> None:
+        """Remove process-owned fallback files between tests."""
+        _cleanup_unsupported_media_temp_files()
+
+    @staticmethod
+    def _blocks(data: str, media_type: str) -> list[DataBlock]:
+        """Build one unsupported-media block."""
+        return [
+            DataBlock(
+                source=Base64Source(
+                    data=data,
+                    media_type=media_type,
+                ),
+            ),
+        ]
+
+    @staticmethod
+    def _saved_path(text: str) -> str:
+        """Extract the saved file path from a formatter reminder."""
+        prefix = "saved locally at: "
+        start = text.index(prefix) + len(prefix)
+        return text[start : text.index(".</system-reminder>", start)]
+
+    def test_same_base64_yields_deterministic_path(self) -> None:
+        """Identical Base64 input must produce identical output and path."""
+        blocks = self._blocks(self._video_b64, "video/mp4")
+
+        first, _ = self._formatter.convert_tool_result_to_string(blocks)
+        second, _ = self._formatter.convert_tool_result_to_string(blocks)
+
+        self.assertEqual(first, second)
+        self.assertEqual(self._saved_path(first), self._saved_path(second))
+
+    def test_written_file_contains_decoded_bytes(self) -> None:
+        """The fallback file must contain the decoded payload."""
+        blocks = self._blocks(self._binary_b64, "application/x-binary")
+
+        text, _ = self._formatter.convert_tool_result_to_string(blocks)
+
+        with open(self._saved_path(text), "rb") as file:
+            self.assertEqual(file.read(), self._binary_bytes)
+
+    def test_distinct_contents_yield_distinct_paths(self) -> None:
+        """Different payloads must use different stable paths."""
+        first, _ = self._formatter.convert_tool_result_to_string(
+            self._blocks(self._video_b64, "video/mp4"),
+        )
+        second, _ = self._formatter.convert_tool_result_to_string(
+            self._blocks(self._binary_b64, "video/mp4"),
+        )
+
+        self.assertNotEqual(
+            self._saved_path(first),
+            self._saved_path(second),
+        )
+
+    def test_cache_directory_is_private_and_cleaned(self) -> None:
+        """The cache must be process-private and removable by cleanup."""
+        text, _ = self._formatter.convert_tool_result_to_string(
+            self._blocks(self._video_b64, "video/mp4"),
+        )
+        path = self._saved_path(text)
+        temp_dir = os.path.dirname(path)
+
+        if os.name != "nt":
+            self.assertEqual(
+                stat.S_IMODE(os.stat(temp_dir).st_mode),
+                0o700,
+            )
+            self.assertEqual(
+                stat.S_IMODE(os.stat(path).st_mode),
+                0o600,
+            )
+
+        _cleanup_unsupported_media_temp_files()
+        self.assertFalse(os.path.exists(temp_dir))
+
+    def test_repeated_calls_leave_one_payload_file(self) -> None:
+        """Repeated formatting must reuse one fallback file."""
+        blocks = self._blocks(self._video_b64, "video/mp4")
+        text = ""
+        for _ in range(5):
+            text, _ = self._formatter.convert_tool_result_to_string(blocks)
+
+        temp_dir = os.path.dirname(self._saved_path(text))
+        self.assertEqual(len(os.listdir(temp_dir)), 1)
+
+    def test_cache_hit_skips_redundant_base64_decode(self) -> None:
+        """A cache hit must not decode the payload again."""
+        blocks = self._blocks(self._video_b64, "video/mp4")
+        first, _ = self._formatter.convert_tool_result_to_string(blocks)
+
+        with patch.object(
+            formatter_base.base64,
+            "b64decode",
+            side_effect=AssertionError("unexpected decode"),
+        ):
+            second, _ = self._formatter.convert_tool_result_to_string(blocks)
+
+        self.assertEqual(first, second)
+
+    def test_replace_failure_is_propagated_without_invalid_path(self) -> None:
+        """A failed atomic write must not return a missing target path."""
+        blocks = self._blocks(self._video_b64, "video/mp4")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with (
+                patch(
+                    "agentscope.formatter._formatter_base."
+                    "_get_unsupported_media_temp_dir",
+                    return_value=temp_dir,
+                ),
+                patch.object(
+                    formatter_base.os,
+                    "replace",
+                    side_effect=OSError("replace failed"),
+                ),
+            ):
+                with self.assertRaisesRegex(OSError, "replace failed"):
+                    self._formatter.convert_tool_result_to_string(blocks)
+
+            self.assertEqual(os.listdir(temp_dir), [])
+
+    def test_worker_exit_does_not_remove_another_worker_file(self) -> None:
+        """Each process must clean only its own unsupported-media cache."""
+        script = """
+import base64
+import sys
+
+from agentscope.formatter._formatter_base import FormatterBase
+from agentscope.message import Base64Source, DataBlock
+
+
+class TextOnlyFormatter(FormatterBase):
+    async def format(self, *args, **kwargs):
+        return []
+
+
+payload = base64.b64encode(b"shared payload").decode("ascii")
+text, _ = TextOnlyFormatter().convert_tool_result_to_string(
+    [
+        DataBlock(
+            source=Base64Source(
+                data=payload,
+                media_type="video/mp4",
+            ),
+        ),
+    ],
+)
+path = text.split("saved locally at: ", 1)[1].split(
+    ".</system-reminder>",
+    1,
+)[0]
+print(path, flush=True)
+sys.stdin.readline()
+"""
+        with ExitStack() as stack:
+            workers = [
+                stack.enter_context(
+                    subprocess.Popen(
+                        [sys.executable, "-c", script],
+                        stdin=subprocess.PIPE,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        text=True,
+                    ),
+                )
+                for _ in range(2)
+            ]
+            paths: list[str] = []
+            try:
+                for worker in workers:
+                    self.assertIsNotNone(worker.stdout)
+                    paths.append(worker.stdout.readline().strip())
+
+                self.assertNotEqual(
+                    os.path.dirname(paths[0]),
+                    os.path.dirname(paths[1]),
+                )
+                self.assertTrue(all(os.path.isfile(path) for path in paths))
+
+                self.assertIsNotNone(workers[0].stdin)
+                workers[0].stdin.close()
+                self.assertEqual(workers[0].wait(timeout=20), 0)
+                self.assertFalse(os.path.exists(paths[0]))
+                self.assertTrue(os.path.isfile(paths[1]))
+            finally:
+                for worker in workers:
+                    if worker.poll() is None:
+                        self.assertIsNotNone(worker.stdin)
+                        worker.stdin.close()
+                        worker.wait(timeout=20)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/formatter_openai_response_tool_result_test.py
+++ b/tests/formatter_openai_response_tool_result_test.py
@@ -2,7 +2,6 @@
 """Native tool-result tests for the OpenAI Responses formatter."""
 import re
 import tempfile
-from functools import partial
 from pathlib import Path
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch
@@ -148,13 +147,12 @@ class TestOpenAIResponseToolResultFormatter(IsolatedAsyncioTestCase):
     async def test_unsupported_base64_audio_fallback(self) -> None:
         """Unsupported Base64 audio is persisted and returned as text."""
         fmt = OpenAIResponseFormatter()
-        named_temp_file = tempfile.NamedTemporaryFile
 
         with tempfile.TemporaryDirectory() as temp_dir:
             with patch(
-                "agentscope.formatter._formatter_base.tempfile."
-                "NamedTemporaryFile",
-                side_effect=partial(named_temp_file, dir=temp_dir),
+                "agentscope.formatter._formatter_base."
+                "_get_unsupported_media_temp_dir",
+                return_value=temp_dir,
             ):
                 res = await fmt.format(
                     [


### PR DESCRIPTION
## AgentScope Version

2.0.7.post1 (current `main` at `10eaaac2`)

## Description

Closes #2173.

`FormatterBase.convert_tool_result_to_string` writes unsupported-media `Base64Source` payloads to `NamedTemporaryFile(delete=False)` on every formatting pass. Reformatting unchanged message history therefore changes the path shown to the model, defeats stable prompt prefixes, and leaves one undeleted file per pass.

The original issue example uses `application/pdf`, which is now a supported OpenAI input type. The same underlying fallback bug remains reproducible on current `main` with a genuinely unsupported type such as `video/mp4`.

### Changes

- lazily create a process-owned fallback directory with private `0700` permissions;
- derive a stable filename from the Base64 representation and media extension;
- reuse an existing stable file before decoding or writing again;
- write through a secure `0600` staging file and atomically replace the target;
- remove failed staging writes and propagate the original `OSError`;
- clean up only the process-owned directory at normal interpreter exit;
- add focused base formatter regressions for deterministic paths, decoded content, distinct payloads, private permissions, cache hits, write failure, cleanup, and multi-process isolation.

This is a fresh implementation on current `main`. Credit to @AmirF194 for #2174 and @RerankerGuo for #2195. The implementation carries forward the security and process-isolation boundaries identified during the maintainer review of those earlier attempts.

### Validation

- original bug reproduction: two formats of one unchanged unsupported `video/mp4` block produced two distinct paths and files
- latest-`main` compatibility check before restoring the required import: 9 failed, 1 passed with `NameError: shortuuid is not defined`
- `pytest tests/formatter_base_test.py tests/formatter_openai_response_tool_result_test.py -q`: 10 passed
- all formatter test modules: 122 passed, 4 subtests passed
- `pre-commit run --all-files`: passed
- `pytest tests -q`: 2158 passed, 127 skipped, 384 subtests passed
- post-test temp-directory check: no `agentscope-unsupported-media-*` directories remained

No public API changes, new dependencies, or supported-media promotion changes are included.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the contributing guide
- [x] Docstrings are in Google style
- [x] Related documentation is not required because this is an internal resource-management fix with no public API change
- [x] Code is ready for review
