### PR TITLE
fix(gemini): exclude tool-execution tokens from output_tokens

### DIFF
--- a/src/agentscope/model/_gemini/_model.py
+++ b/src/agentscope/model/_gemini/_model.py
@@ -470,6 +470,15 @@ class GeminiChatModel(ChatModelBase):
         prompt_tokens = usage_metadata.prompt_token_count
         total_tokens = usage_metadata.total_token_count
         if prompt_tokens is not None and total_tokens is not None:
+            tool_use_tokens = (
+                getattr(
+                    usage_metadata,
+                    "tool_use_prompt_token_count",
+                    0,
+                )
+                or 0
+            )
+            input_tokens = prompt_tokens + tool_use_tokens
             candidates_tokens = getattr(
                 usage_metadata,
                 "candidates_token_count",
@@ -481,9 +490,9 @@ class GeminiChatModel(ChatModelBase):
                 )
             else:
                 # Fallback for SDK versions without the candidate count.
-                output_tokens = total_tokens - prompt_tokens
+                output_tokens = total_tokens - input_tokens
             return ChatUsage(
-                input_tokens=prompt_tokens,
+                input_tokens=input_tokens,
                 output_tokens=output_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
                 cache_input_tokens=getattr(

--- a/src/agentscope/model/_gemini/_model.py
+++ b/src/agentscope/model/_gemini/_model.py
@@ -470,9 +470,21 @@ class GeminiChatModel(ChatModelBase):
         prompt_tokens = usage_metadata.prompt_token_count
         total_tokens = usage_metadata.total_token_count
         if prompt_tokens is not None and total_tokens is not None:
+            candidates_tokens = getattr(
+                usage_metadata,
+                "candidates_token_count",
+                None,
+            )
+            if candidates_tokens is not None:
+                output_tokens = candidates_tokens + (
+                    getattr(usage_metadata, "thoughts_token_count", 0) or 0
+                )
+            else:
+                # Fallback for SDK versions without the candidate count.
+                output_tokens = total_tokens - prompt_tokens
             return ChatUsage(
                 input_tokens=prompt_tokens,
-                output_tokens=total_tokens - prompt_tokens,
+                output_tokens=output_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
                 cache_input_tokens=getattr(
                     usage_metadata,

--- a/tests/model_gemini_test.py
+++ b/tests/model_gemini_test.py
@@ -6,6 +6,7 @@ Tests cover both non-streaming and streaming modes.
 Gemini uses google.genai client with async iterator streaming.
 """
 import json
+from types import SimpleNamespace
 from typing import Any
 import unittest
 from unittest import IsolatedAsyncioTestCase
@@ -68,9 +69,14 @@ def _mock_completion(
     resp.candidates = [MagicMock()]
     resp.candidates[0].content = MagicMock()
     resp.candidates[0].content.parts = parts
-    resp.usage_metadata = MagicMock()
-    resp.usage_metadata.prompt_token_count = 10
-    resp.usage_metadata.candidates_token_count = 5
+    resp.usage_metadata = SimpleNamespace(
+        prompt_token_count=10,
+        candidates_token_count=5,
+        tool_use_prompt_token_count=0,
+        thoughts_token_count=0,
+        total_token_count=15,
+        cached_content_token_count=0,
+    )
     return resp
 
 
@@ -84,9 +90,14 @@ def _make_stream_chunk(
     chunk.candidates = [MagicMock()]
     chunk.candidates[0].content = MagicMock()
     chunk.candidates[0].content.parts = parts
-    chunk.usage_metadata = MagicMock()
-    chunk.usage_metadata.prompt_token_count = 10
-    chunk.usage_metadata.candidates_token_count = 5
+    chunk.usage_metadata = SimpleNamespace(
+        prompt_token_count=10,
+        candidates_token_count=5,
+        tool_use_prompt_token_count=0,
+        thoughts_token_count=0,
+        total_token_count=15,
+        cached_content_token_count=0,
+    )
     return chunk
 
 
@@ -243,6 +254,32 @@ class TestGeminiNonStream(IsolatedAsyncioTestCase):
             ),
         )
 
+    async def test_usage_excludes_tool_use_tokens(self) -> None:
+        """Usage counts only model-generated tokens, not tool-use tokens."""
+        parts = [_make_part(text="hello")]
+        resp = _mock_completion(parts)
+        # Mirror the SDK's documented invariant: total = prompt +
+        # candidates + tool_use_prompt + thoughts.
+        resp.usage_metadata = SimpleNamespace(
+            prompt_token_count=500,
+            candidates_token_count=120,
+            tool_use_prompt_token_count=300,
+            thoughts_token_count=0,
+            total_token_count=920,
+            cached_content_token_count=50,
+        )
+        self.mock_client.aio.models.generate_content = AsyncMock(
+            return_value=resp,
+        )
+
+        result = await self.model([])
+
+        self.assertEqual(result.usage.input_tokens, 500)
+        # Not total - prompt (420), which wrongly includes the 300
+        # tool-execution tokens.
+        self.assertEqual(result.usage.output_tokens, 120)
+        self.assertEqual(result.usage.cache_input_tokens, 50)
+
 
 # ---------------------------------------------------------------------------
 # Streaming tests
@@ -308,6 +345,29 @@ class TestGeminiStream(IsolatedAsyncioTestCase):
                 ),
             ],
         )
+
+    async def test_stream_usage_excludes_tool_use_tokens(self) -> None:
+        """Streaming usage counts only model-generated tokens."""
+        chunk = _make_stream_chunk([_make_part(text="hello")])
+        chunk.usage_metadata = SimpleNamespace(
+            prompt_token_count=500,
+            candidates_token_count=120,
+            tool_use_prompt_token_count=300,
+            thoughts_token_count=0,
+            total_token_count=920,
+            cached_content_token_count=50,
+        )
+        self.mock_client.aio.models.generate_content_stream = AsyncMock(
+            return_value=_MockAsyncStream([chunk]),
+        )
+
+        gen = await self.model([])
+        responses = [r async for r in gen]
+
+        # The delta and the accumulated final response both carry the
+        # usage of the last chunk.
+        self.assertEqual(responses[0].usage.output_tokens, 120)
+        self.assertEqual(responses[-1].usage.output_tokens, 120)
 
     async def test_stream_thinking_and_text(self) -> None:
         """Stream thinking + text yields deltas then accumulated final."""

--- a/tests/model_gemini_test.py
+++ b/tests/model_gemini_test.py
@@ -274,13 +274,18 @@ class TestGeminiNonStream(IsolatedAsyncioTestCase):
 
         result = await self.model([])
 
-        self.assertEqual(result.usage.input_tokens, 800)
-        self.assertEqual(result.usage.output_tokens, 130)
         self.assertEqual(
-            result.usage.input_tokens + result.usage.output_tokens,
-            930,
+            dict(result.usage),
+            {
+                "input_tokens": 800,
+                "output_tokens": 130,
+                "time": result.usage.time,
+                "cache_creation_input_tokens": 0,
+                "cache_input_tokens": 50,
+                "type": "chat",
+                "metadata": None,
+            },
         )
-        self.assertEqual(result.usage.cache_input_tokens, 50)
 
     async def test_usage_fallback_excludes_tool_use_tokens(self) -> None:
         """Usage fallback excludes tool-use tokens from output."""
@@ -298,8 +303,18 @@ class TestGeminiNonStream(IsolatedAsyncioTestCase):
 
         result = await self.model([])
 
-        self.assertEqual(result.usage.input_tokens, 800)
-        self.assertEqual(result.usage.output_tokens, 10)
+        self.assertEqual(
+            dict(result.usage),
+            {
+                "input_tokens": 800,
+                "output_tokens": 10,
+                "time": result.usage.time,
+                "cache_creation_input_tokens": 0,
+                "cache_input_tokens": 0,
+                "type": "chat",
+                "metadata": None,
+            },
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -387,10 +402,19 @@ class TestGeminiStream(IsolatedAsyncioTestCase):
 
         # The delta and the accumulated final response both carry the
         # usage of the last chunk.
-        self.assertEqual(responses[0].usage.input_tokens, 800)
-        self.assertEqual(responses[0].usage.output_tokens, 130)
-        self.assertEqual(responses[-1].usage.input_tokens, 800)
-        self.assertEqual(responses[-1].usage.output_tokens, 130)
+        self.assertEqual(
+            dict(responses[0].usage),
+            {
+                "input_tokens": 800,
+                "output_tokens": 130,
+                "time": responses[0].usage.time,
+                "cache_creation_input_tokens": 0,
+                "cache_input_tokens": 50,
+                "type": "chat",
+                "metadata": None,
+            },
+        )
+        self.assertEqual(responses[-1].usage, responses[0].usage)
 
     async def test_stream_thinking_and_text(self) -> None:
         """Stream thinking + text yields deltas then accumulated final."""

--- a/tests/model_gemini_test.py
+++ b/tests/model_gemini_test.py
@@ -254,8 +254,8 @@ class TestGeminiNonStream(IsolatedAsyncioTestCase):
             ),
         )
 
-    async def test_usage_excludes_tool_use_tokens(self) -> None:
-        """Usage counts only model-generated tokens, not tool-use tokens."""
+    async def test_usage_classifies_tool_use_tokens_as_input(self) -> None:
+        """Usage classifies tool-use tokens as input, not output."""
         parts = [_make_part(text="hello")]
         resp = _mock_completion(parts)
         # Mirror the SDK's documented invariant: total = prompt +
@@ -264,8 +264,8 @@ class TestGeminiNonStream(IsolatedAsyncioTestCase):
             prompt_token_count=500,
             candidates_token_count=120,
             tool_use_prompt_token_count=300,
-            thoughts_token_count=0,
-            total_token_count=920,
+            thoughts_token_count=10,
+            total_token_count=930,
             cached_content_token_count=50,
         )
         self.mock_client.aio.models.generate_content = AsyncMock(
@@ -274,11 +274,32 @@ class TestGeminiNonStream(IsolatedAsyncioTestCase):
 
         result = await self.model([])
 
-        self.assertEqual(result.usage.input_tokens, 500)
-        # Not total - prompt (420), which wrongly includes the 300
-        # tool-execution tokens.
-        self.assertEqual(result.usage.output_tokens, 120)
+        self.assertEqual(result.usage.input_tokens, 800)
+        self.assertEqual(result.usage.output_tokens, 130)
+        self.assertEqual(
+            result.usage.input_tokens + result.usage.output_tokens,
+            930,
+        )
         self.assertEqual(result.usage.cache_input_tokens, 50)
+
+    async def test_usage_fallback_excludes_tool_use_tokens(self) -> None:
+        """Usage fallback excludes tool-use tokens from output."""
+        resp = _mock_completion([_make_part(text="hello")])
+        resp.usage_metadata = SimpleNamespace(
+            prompt_token_count=500,
+            tool_use_prompt_token_count=300,
+            thoughts_token_count=10,
+            total_token_count=810,
+            cached_content_token_count=0,
+        )
+        self.mock_client.aio.models.generate_content = AsyncMock(
+            return_value=resp,
+        )
+
+        result = await self.model([])
+
+        self.assertEqual(result.usage.input_tokens, 800)
+        self.assertEqual(result.usage.output_tokens, 10)
 
 
 # ---------------------------------------------------------------------------
@@ -346,15 +367,15 @@ class TestGeminiStream(IsolatedAsyncioTestCase):
             ],
         )
 
-    async def test_stream_usage_excludes_tool_use_tokens(self) -> None:
-        """Streaming usage counts only model-generated tokens."""
+    async def test_stream_usage_classifies_tool_use_tokens(self) -> None:
+        """Streaming usage classifies tool-use tokens as input."""
         chunk = _make_stream_chunk([_make_part(text="hello")])
         chunk.usage_metadata = SimpleNamespace(
             prompt_token_count=500,
             candidates_token_count=120,
             tool_use_prompt_token_count=300,
-            thoughts_token_count=0,
-            total_token_count=920,
+            thoughts_token_count=10,
+            total_token_count=930,
             cached_content_token_count=50,
         )
         self.mock_client.aio.models.generate_content_stream = AsyncMock(
@@ -366,8 +387,10 @@ class TestGeminiStream(IsolatedAsyncioTestCase):
 
         # The delta and the accumulated final response both carry the
         # usage of the last chunk.
-        self.assertEqual(responses[0].usage.output_tokens, 120)
-        self.assertEqual(responses[-1].usage.output_tokens, 120)
+        self.assertEqual(responses[0].usage.input_tokens, 800)
+        self.assertEqual(responses[0].usage.output_tokens, 130)
+        self.assertEqual(responses[-1].usage.input_tokens, 800)
+        self.assertEqual(responses[-1].usage.output_tokens, 130)
 
     async def test_stream_thinking_and_text(self) -> None:
         """Stream thinking + text yields deltas then accumulated final."""


### PR DESCRIPTION
## AgentScope Version

2.0.6

## Description

Gemini reports prompt, candidate, server-side tool-use, and thinking tokens separately in `usage_metadata`. `GeminiChatModel` previously derived `output_tokens` as `total_token_count - prompt_token_count`, which incorrectly classified `tool_use_prompt_token_count` as model output. These tokens come from server-side tool results (for example, Google Search grounding or code execution) that are fed back to the model as input.

This caused incorrect input/output usage reporting and distorted weighted cost or budget accounting such as `ReplyBudgetControlMiddleware`.

Fixes #2405

**Changes:**

- Classify tool-use prompt tokens as input: `input_tokens = prompt_token_count + tool_use_prompt_token_count`
- Count only model-generated candidate and thinking tokens as output: `output_tokens = candidates_token_count + thoughts_token_count`
- When `candidates_token_count` is unavailable, fall back to `total_token_count - input_tokens`, so tool-use tokens are still excluded from output
- Add regression coverage for non-streaming, streaming, thinking-token, and missing-candidate-count paths in `tests/model_gemini_test.py`

For example, given `prompt=500`, `candidates=120`, `tool_use=300`, `thoughts=10`, and `total=930`, the model now reports:

```text
input_tokens = 800
output_tokens = 130
```

The two values preserve the API-reported total while correctly classifying tool-use results as input rather than output.

**How to test:**

```bash
pytest tests/model_gemini_test.py
```

## Checklist

- [x] An issue has been created for this PR (#2405)
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation has been updated (N/A — no doc changes needed)
- [x] Code is ready for review
