### PR TITLE
chore(version): bump version to 2.0.7 for release

### DIFF
--- a/src/agentscope/_version.py
+++ b/src/agentscope/_version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """The version of agentscope."""
 
-__version__ = "2.0.6"
+__version__ = "2.0.7"


### PR DESCRIPTION
Bump `agentscope` version from 2.0.6 to 2.0.7 for release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WCzX6BCDnMmytExPorcqr