### PR TITLE
fix(toolkit): describe active tool groups in reset_tools

### DIFF
--- a/src/agentscope/tool/_builtin/_meta.py
+++ b/src/agentscope/tool/_builtin/_meta.py
@@ -44,6 +44,7 @@ class ResetTools(ToolBase):
     is_concurrency_safe: bool = True
     is_external_tool: bool = False
     is_state_injected: bool = True
+    activated_groups: list[str]
 
     def __init__(
         self,
@@ -55,6 +56,7 @@ class ResetTools(ToolBase):
         super().__init__(middlewares=middlewares)
         self.groups = groups
         self.response_template = response_template
+        self.activated_groups = []
 
     @property
     def input_schema(self) -> dict[str, Any]:  # type: ignore[override]
@@ -64,11 +66,18 @@ class ResetTools(ToolBase):
         for group in self.groups:
             if group.name == "basic":
                 continue
+            description = group.description
+            if group.name in self.activated_groups:
+                description += (
+                    "\n\nThis tool group is already active. Its tools are "
+                    "currently available. Do not activate it again unless "
+                    "you need to change the active tool-group set."
+                )
             fields[group.name] = (
                 bool,
                 Field(
                     default=False,
-                    description=group.description,
+                    description=description,
                 ),
             )
 

--- a/src/agentscope/tool/_toolkit.py
+++ b/src/agentscope/tool/_toolkit.py
@@ -215,6 +215,9 @@ class Toolkit:
         """
         function_schemas = []
 
+        # Keep the reset_tools schema aligned with the current runtime state.
+        self.builtin_meta_tool.tool.activated_groups = groups or []
+
         # Get all available tools
         tools_dict = await self._get_available_tools(groups)
         for tool in tools_dict.values():


### PR DESCRIPTION
Closes #2413

## Summary

- Synchronize the reset_tools schema with the currently active tool groups.
- Append an explicit prompt to descriptions of already active groups.
- Preserve the existing reset_tools boolean interface and final-state semantics.

## Testing

- Verified that active groups include the "already active" prompt.
- Verified that inactive groups keep their original descriptions.
- Ran the minimal reproduction successfully.