### PR TITLE
fix(toolkit): mark active groups in reset_tools schema

### DIFF
--- a/src/agentscope/tool/_toolkit.py
+++ b/src/agentscope/tool/_toolkit.py
@@ -63,6 +63,12 @@ Skills are a collection of instructions, scripts, and resources to extend your c
 """  # noqa: E501
 
 
+_ALREADY_ACTIVE_TOOL_GROUP_HINT = (
+    "Already active. Its tools are currently available; do not activate it "
+    "again unless you need to change the active group set."
+)
+
+
 class Toolkit:
     """Toolkit is the core module to register, manage and delete tool
     functions, MCP clients, Agent skills in AgentScope.
@@ -218,7 +224,19 @@ class Toolkit:
         # Get all available tools
         tools_dict = await self._get_available_tools(groups)
         for tool in tools_dict.values():
-            function_schemas.append(tool.get_tool_schema())
+            tool_schema = tool.get_tool_schema()
+            if tool is self.builtin_meta_tool:
+                properties = tool_schema["function"]["parameters"][
+                    "properties"
+                ]
+                for group_name in set(groups or []):
+                    if group_name in properties:
+                        properties[group_name]["description"] = (
+                            f"{properties[group_name]['description']}\n\n"
+                            f"{_ALREADY_ACTIVE_TOOL_GROUP_HINT}"
+                        )
+
+            function_schemas.append(tool_schema)
 
         return function_schemas
 

--- a/tests/toolkit_test.py
+++ b/tests/toolkit_test.py
@@ -1490,6 +1490,51 @@ The tool instructions are a collection of suggestions, rules and notifications a
             },
         )
 
+    async def test_meta_tool_schema_marks_active_groups(self) -> None:
+        """The reset schema should identify already active groups."""
+        toolkit = Toolkit(
+            tool_groups=[
+                ToolGroup(
+                    name="group_1",
+                    description="Group 1",
+                ),
+                ToolGroup(
+                    name="group_2",
+                    description="Group 2",
+                    tools=[Tool1(), Tool2()],
+                ),
+            ],
+        )
+
+        state = AgentState()
+        state.tool_context.activated_groups = ["group_2"]
+        schemas = await toolkit.get_tool_schemas(
+            state.tool_context.activated_groups,
+        )
+
+        self.assertListEqual(
+            [schema["function"]["name"] for schema in schemas],
+            ["reset_tools", "tool_1", "tool_2"],
+        )
+        properties = schemas[0]["function"]["parameters"]["properties"]
+        self.assertEqual(properties["group_1"]["description"], "Group 1")
+        self.assertEqual(
+            properties["group_2"]["description"],
+            "Group 2\n\nAlready active. Its tools are currently available; "
+            "do not activate it again unless you need to change the active "
+            "group set.",
+        )
+        self.assertFalse(properties["group_1"]["default"])
+        self.assertFalse(properties["group_2"]["default"])
+
+        schemas = await toolkit.get_tool_schemas(["group_1"])
+        properties = schemas[0]["function"]["parameters"]["properties"]
+        self.assertIn(
+            "Already active.",
+            properties["group_1"]["description"],
+        )
+        self.assertEqual(properties["group_2"]["description"], "Group 2")
+
     async def test_broken_mcp_is_skipped_not_fatal(self) -> None:
         """One unreachable MCP must not take the whole reply down with
         it: an expired token or a server that is simply down would


### PR DESCRIPTION
Fixes #2413

## AgentScope Version

2.0.7

## Description

When a tool group was already active, its concrete tools were available to
the model, but `reset_tools` presented the same group description as it did
for inactive groups. That made a redundant activation look useful.

This change annotates already-active groups in the model-visible
`reset_tools` schema. The annotation is applied to the per-request schema
copy, so active state does not leak between agents or requests. The existing
boolean interface, defaults, and final-state behavior remain unchanged.

The regression coverage verifies that active tools remain visible, only the
active group's description is annotated, boolean defaults remain unchanged,
and later active-state changes produce a fresh schema.

## Verification

- Focused before/after schema regression: the base revision reproduced the
  missing active-state annotation; the patched revision passed.
- Focused repository regression test: passed in an isolated local harness.
- Python syntax, test discovery, line length, and whitespace checks: passed.
- `python3 -m pytest tests/toolkit_test.py -k meta_tool_schema_marks_active_groups -q`
  could not start because `pytest` is not installed in the local task
  environment. The project's normal CI installs the development dependencies
  and will run this collected test and the full suite.
- `pre-commit run --files src/agentscope/tool/_toolkit.py tests/toolkit_test.py`
  could not start because `pre-commit` is not installed in the local task
  environment. The repository's pre-commit workflow will run the configured
  checks.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation has been updated (not applicable: no public API
  or user-facing documentation changes)
- [x] Code is ready for review
