### PR TITLE
feat(agent): let a sub-agent template come with its own MCPs and skills

### DIFF
--- a/src/agentscope/app/_app.py
+++ b/src/agentscope/app/_app.py
@@ -234,7 +234,8 @@ def create_app(
             Reusable blueprints for sub-agent creation within teams.
             Each template defines a sub-agent *type* (e.g. ``"researcher"``,
             ``"coder"``) with pre-configured system prompt, context config,
-            ReAct config, permission context, and task context. When
+            ReAct config, permission context, task context, and the MCPs
+            and skills every worker of that type is equipped with. When
             registered, the ``AgentCreate`` tool exposes a
             ``subagent_type`` parameter so the leader agent can route to
             the appropriate template.  See

--- a/src/agentscope/app/_tool/_agent_create.py
+++ b/src/agentscope/app/_tool/_agent_create.py
@@ -13,6 +13,7 @@ from .._types import SubAgentTemplate
 from .._bus_ops import deliver_to_inbox
 from ..storage import AgentData, AgentRecord, SessionConfig, TeamMember
 from ..storage._utils import _ensure_team_members, _resolve_team_leader
+from ..._logging import logger
 from ...message import HintBlock, TextBlock, ToolResultState
 from ...permission import PermissionContext
 from ...state import AgentState
@@ -477,7 +478,58 @@ optional):
             ]
             await self._storage.upsert_team(self._user_id, team)
 
-            # 4. Deliver the initial task to the worker's inbox + wakeup.
+            # 4. Equip the worker with the template's MCPs and skills,
+            #    keyed on its own agent id so the leader and its
+            #    siblings are untouched. Installed one by one so a
+            #    single unusable entry — an unreachable skill, a name
+            #    the backend refuses — costs the worker that entry
+            #    rather than every tool it was meant to have.
+            if template.mcps or template.skills:
+                workspace = await self._workspace_manager.get_workspace(
+                    self._user_id,
+                    self._agent_id,
+                    self._session_id,
+                    leader_session.config.workspace_id,
+                )
+                for mcp in template.mcps:
+                    try:
+                        await workspace.add_mcp(
+                            mcp,
+                            agent_id=worker_agent.id,
+                            session_id=worker_session.id,
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to equip sub-agent %r with MCP %r: %s",
+                            name,
+                            mcp.name,
+                            e,
+                        )
+
+                for skill in template.skills:
+                    try:
+                        if isinstance(skill, str):
+                            await workspace.add_skill(
+                                skill,
+                                agent_id=worker_agent.id,
+                            )
+                        else:
+                            archive = await skill.open()
+                            await workspace.add_skill_archive(
+                                archive.stream,
+                                archive.format,
+                                skill.name,
+                                agent_id=worker_agent.id,
+                            )
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to equip sub-agent %r with skill %r: %s",
+                            name,
+                            skill if isinstance(skill, str) else skill.name,
+                            e,
+                        )
+
+            # 5. Deliver the initial task to the worker's inbox + wakeup.
             hint = HintBlock(
                 hint=(
                     f'<team-message from="{leader_name}">\n'

--- a/src/agentscope/app/_types.py
+++ b/src/agentscope/app/_types.py
@@ -3,12 +3,14 @@
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Protocol
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from ..agent import ContextConfig, ReActConfig
 from ..event import AgentEvent
+from ..mcp import MCPClient
 from ..middleware import MiddlewareBase
 from ..permission import PermissionContext
+from ..skill import SkillSourceBase
 from ..state import TaskContext
 from ..tool import ToolBase
 from ..workspace import WorkspaceBase
@@ -100,9 +102,11 @@ class SubAgentTemplate(BaseModel):
     per-instance identifier the leader assigns to each worker (used for
     ``TeamSay(to=name)``).
 
-    All fields are pure data (no callables), so the template is fully
-    serializable for future config-driven startup.
+    Fields are configuration rather than callables. :attr:`skills` may
+    hold loader objects, hence ``arbitrary_types_allowed``.
     """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     type: str = Field(
         description=(
@@ -191,5 +195,26 @@ class SubAgentTemplate(BaseModel):
         description=(
             "Pre-defined task context for the sub-agent, allowing "
             "the template to seed an initial workflow."
+        ),
+    )
+
+    mcps: list[MCPClient] = Field(
+        default_factory=list,
+        description=(
+            "MCPs equipped on every sub-agent created from this "
+            "template, declared into the worker's own agent/session "
+            "slot so siblings and the leader are unaffected."
+        ),
+    )
+
+    skills: list[str | SkillSourceBase] = Field(
+        default_factory=list,
+        description=(
+            "Skills equipped on every sub-agent created from this "
+            "template, installed into the worker's own partition. A "
+            "``str`` is a local directory copied as it is; a "
+            ":class:`~agentscope.skill.SkillSourceBase` is opened for "
+            "an archive, which is what a skill kept anywhere but the "
+            "local disk needs."
         ),
     )

--- a/src/agentscope/app/hub/_skill/_base.py
+++ b/src/agentscope/app/hub/_skill/_base.py
@@ -1,26 +1,10 @@
 # -*- coding: utf-8 -*-
 """The skill hub base class."""
 from abc import ABC, abstractmethod
-from typing import AsyncIterator, Literal, NamedTuple
 
 from ._card import SkillCard, SkillHubPage
 from .._base import HubBase
-
-
-class SkillArchive(NamedTuple):
-    """A skill archive as the hub serves it.
-
-    The format travels with the bytes so a hub can forward its upstream
-    response untouched — repacking to a fixed format would force every
-    hub to buffer the whole archive.
-
-    Attributes:
-        format: The archive format, as the installer must unpack it.
-        stream: The archive bytes, in order.
-    """
-
-    format: Literal["zip", "tar", "tar.gz"]
-    stream: AsyncIterator[bytes]
+from ....skill import SkillArchive
 
 
 class SkillHubBase(HubBase, ABC):

--- a/src/agentscope/skill/__init__.py
+++ b/src/agentscope/skill/__init__.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
 """The skill related classes and functions."""
 
+from ._archive import SkillArchive, SkillSourceBase
 from ._base import SkillLoaderBase, Skill
 from ._local_loader import LocalSkillLoader
 
 __all__ = [
     "Skill",
+    "SkillArchive",
     "SkillLoaderBase",
+    "SkillSourceBase",
     "LocalSkillLoader",
 ]

--- a/src/agentscope/skill/_archive.py
+++ b/src/agentscope/skill/_archive.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""Skill archives and the sources they are fetched from."""
+from abc import ABC, abstractmethod
+from typing import AsyncIterator, Literal, NamedTuple
+
+
+class SkillArchive(NamedTuple):
+    """A skill archive, already opened for reading.
+
+    The format travels with the bytes so a source can forward its
+    upstream response untouched — repacking to a fixed format would
+    force every source to buffer the whole archive.
+
+    Attributes:
+        format: The archive format, as the installer must unpack it.
+        stream: The archive bytes, in order.
+    """
+
+    format: Literal["zip", "tar", "tar.gz"]
+    stream: AsyncIterator[bytes]
+
+
+class SkillSourceBase(ABC):
+    """Where a skill archive comes from, before it is fetched.
+
+    :class:`SkillLoaderBase` enumerates skills that already exist as
+    directories, and hands out the path an agent reads them from. This
+    one has no directory yet — only a way to get the bytes, which the
+    workspace expands into the agent's partition.
+
+    :meth:`open` returns a fresh archive per call rather than the
+    source holding one: a stream is consumed once, while a source is
+    kept for a process's lifetime and installed into many workspaces.
+    """
+
+    def __init__(self, name: str) -> None:
+        """Bind the name the skill installs as.
+
+        Args:
+            name (`str`):
+                Directory name to install as, inside ``skills/``.
+        """
+        self.name = name
+
+    @abstractmethod
+    async def open(self) -> SkillArchive:
+        """Fetch the archive.
+
+        Returns:
+            `SkillArchive`:
+                The format plus the archive bytes.
+        """

--- a/tests/service_subagent_template_resources_test.py
+++ b/tests/service_subagent_template_resources_test.py
@@ -1,0 +1,356 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Tests for a :class:`SubAgentTemplate` equipping its workers with its
+own MCPs and skills.
+
+A worker shares the leader's ``workspace_id`` but has its own agent id,
+so the resources land in the worker's own MCP slot and skill partition.
+The tests below pin that isolation, the reclaim on delete, and that
+one unusable entry costs the worker only that entry.
+"""
+import io
+import os
+import tarfile
+import tempfile
+from contextlib import AsyncExitStack
+from typing import AsyncIterator
+from unittest import IsolatedAsyncioTestCase
+
+import fakeredis.aioredis
+
+from utils import AnyString, AnyValue
+
+from agentscope.agent import ContextConfig, ReActConfig
+from agentscope.app._service import SessionService
+from agentscope.app._tool import AgentCreate, TeamCreate
+from agentscope.app._types import SubAgentTemplate
+from agentscope.app.message_bus import RedisMessageBus
+from agentscope.app.storage import (
+    AgentData,
+    AgentRecord,
+    RedisStorage,
+    SessionConfig,
+)
+from agentscope.app.storage._model._team import TeamMember
+from agentscope.app.workspace_manager import LocalWorkspaceManager
+from agentscope.mcp import MCPClient
+from agentscope.skill import SkillArchive, SkillSourceBase
+from agentscope.tool import ToolChunk
+from agentscope.workspace import WorkspaceBase
+
+
+def _make_storage(fr: fakeredis.aioredis.FakeRedis) -> RedisStorage:
+    """Construct a :class:`RedisStorage` that talks to *fr*."""
+
+    class _S(RedisStorage):
+        async def __aenter__(self) -> "RedisStorage":  # type: ignore[override]
+            self._client = fr
+            return self
+
+        async def aclose(self) -> None:
+            self._client = None
+
+    return _S()
+
+
+def _make_bus(fr: fakeredis.aioredis.FakeRedis) -> RedisMessageBus:
+    """Construct a :class:`RedisMessageBus` that talks to *fr*."""
+
+    class _B(RedisMessageBus):
+        async def __aenter__(  # type: ignore[override]
+            self,
+        ) -> "RedisMessageBus":
+            self._client = fr
+            return self
+
+        async def aclose(self) -> None:
+            self._client = None
+
+    return _B()
+
+
+def _write_skill(root: str, dir_name: str, name: str) -> str:
+    """Write a minimal skill directory and return its path."""
+    path = os.path.join(root, dir_name)
+    os.makedirs(path)
+    with open(os.path.join(path, "SKILL.md"), "w", encoding="utf-8") as f:
+        f.write(f"---\nname: {name}\ndescription: a test skill\n---\nbody")
+    return path
+
+
+class _TarSkillSource(SkillSourceBase):
+    """A source serving one skill as a tar built in memory."""
+
+    async def open(self) -> SkillArchive:
+        """Return a fresh archive, as a reusable source must."""
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w") as tf:
+            body = (
+                f"---\nname: {self.name}\ndescription: a test skill"
+                f"\n---\nbody"
+            ).encode("utf-8")
+            info = tarfile.TarInfo(name=f"{self.name}/SKILL.md")
+            info.size = len(body)
+            tf.addfile(info, io.BytesIO(body))
+
+        async def _chunks() -> AsyncIterator[bytes]:
+            data = buf.getvalue()
+            for i in range(0, len(data), 11):
+                yield data[i : i + 11]
+
+        return SkillArchive("tar", _chunks())
+
+
+class _TemplateResourcesTestBase(IsolatedAsyncioTestCase):
+    """A leader that already owns a team, plus a real local workspace."""
+
+    user_id = "u"
+    chunk: ToolChunk
+    worker: TeamMember
+    workspace: WorkspaceBase
+
+    async def asyncSetUp(self) -> None:
+        # enterContext is the unittest equivalent of "with", which
+        # pylint does not recognize.
+        # pylint: disable=consider-using-with
+        self.skills_root = self.enterContext(tempfile.TemporaryDirectory())
+        basedir = self.enterContext(tempfile.TemporaryDirectory())
+
+        self.fr = fakeredis.aioredis.FakeRedis(decode_responses=True)
+        self._stack = AsyncExitStack()
+        self.storage = await self._stack.enter_async_context(
+            _make_storage(self.fr),
+        )
+        self.bus = await self._stack.enter_async_context(_make_bus(self.fr))
+        self.workspace_manager = LocalWorkspaceManager(basedir)
+        self.addAsyncCleanup(self.workspace_manager.close_all)
+
+        self.leader_agent = AgentRecord(
+            user_id=self.user_id,
+            source="user",
+            data=AgentData(
+                name="leader",
+                system_prompt="You are leader.",
+                context_config=ContextConfig(),
+                react_config=ReActConfig(),
+            ),
+        )
+        await self.storage.upsert_agent(self.user_id, self.leader_agent)
+        self.leader_session = await self.storage.upsert_session(
+            user_id=self.user_id,
+            agent_id=self.leader_agent.id,
+            config=SessionConfig(workspace_id="ws"),
+        )
+        await TeamCreate(
+            storage=self.storage,
+            message_bus=self.bus,
+            workspace_manager=self.workspace_manager,
+            user_id=self.user_id,
+            session_id=self.leader_session.id,
+            agent_id=self.leader_agent.id,
+        )(name="alpha", description="t-desc")
+
+    async def asyncTearDown(self) -> None:
+        await self._stack.aclose()
+        await self.fr.aclose()
+
+    async def _create_worker(self, template: SubAgentTemplate) -> None:
+        """Spawn one worker from *template* and record its identity."""
+        self.chunk = await AgentCreate(
+            storage=self.storage,
+            message_bus=self.bus,
+            workspace_manager=self.workspace_manager,
+            user_id=self.user_id,
+            session_id=self.leader_session.id,
+            agent_id=self.leader_agent.id,
+            sub_agent_templates={template.type: template},
+        )(
+            name="worker",
+            description="does research",
+            prompt="please look up X",
+            subagent_type=template.type,
+        )
+        session = await self.storage.get_session(
+            self.user_id,
+            self.leader_agent.id,
+            self.leader_session.id,
+        )
+        team = await self.storage.get_team(self.user_id, session.team_id)
+        self.worker = team.data.members[0]
+        self.workspace = await self.workspace_manager.get_workspace(
+            self.user_id,
+            self.leader_agent.id,
+            self.leader_session.id,
+            "ws",
+        )
+
+
+class TestSubAgentTemplateResources(_TemplateResourcesTestBase):
+    """A template's MCPs and skills reach its worker and nobody else."""
+
+    async def asyncSetUp(self) -> None:
+        await super().asyncSetUp()
+        await self._create_worker(
+            SubAgentTemplate(
+                type="researcher",
+                description="Looks things up.",
+                system_prompt_template="You are {member_name}.",
+                mcps=[
+                    MCPClient(
+                        name="tavily",
+                        is_stateful=False,
+                        mcp_config={
+                            "type": "http_mcp",
+                            "url": "https://example.invalid/mcp",
+                        },
+                    ),
+                ],
+                skills=[
+                    _write_skill(self.skills_root, "lit-review", "alpha"),
+                    _TarSkillSource("beta"),
+                ],
+            ),
+        )
+
+    async def test_the_worker_gets_the_template_mcps(self) -> None:
+        """The template's MCP is declared under the worker's own slot."""
+        mcps = await self.workspace.list_mcps(
+            agent_id=self.worker.agent_id,
+            session_id=self.worker.session_id,
+        )
+        self.assertListEqual(
+            [_.model_dump(mode="json") for _ in mcps],
+            [
+                {
+                    "name": "tavily",
+                    "is_stateful": False,
+                    "mcp_config": {
+                        "type": "http_mcp",
+                        "url": "https://example.invalid/mcp",
+                        "headers": None,
+                        "timeout": 30.0,
+                    },
+                    "enable_tools": None,
+                    "disable_tools": None,
+                    "execution_timeout": None,
+                },
+            ],
+        )
+
+    async def test_the_worker_gets_the_template_skills(self) -> None:
+        """A local directory and an archive source both land."""
+        skills = await self.workspace.list_skills(
+            agent_id=self.worker.agent_id,
+        )
+        self.assertListEqual(
+            sorted((vars(_) for _ in skills), key=lambda _: _["name"]),
+            [
+                {
+                    "name": "alpha",
+                    "description": "a test skill",
+                    "dir": AnyString(),
+                    "markdown": "body",
+                    "updated_at": AnyValue(),
+                },
+                {
+                    "name": "beta",
+                    "description": "a test skill",
+                    "dir": AnyString(),
+                    "markdown": "body",
+                    "updated_at": AnyValue(),
+                },
+            ],
+        )
+
+    async def test_the_leader_is_left_alone(self) -> None:
+        """The leader shares the workspace but not the worker's tools."""
+        self.assertListEqual(
+            [
+                await self.workspace.list_mcps(
+                    agent_id=self.leader_agent.id,
+                    session_id=self.leader_session.id,
+                ),
+                await self.workspace.list_skills(
+                    agent_id=self.leader_agent.id,
+                ),
+            ],
+            [[], []],
+        )
+
+    async def test_deleting_the_worker_reclaims_them(self) -> None:
+        """``delete_agent`` purges the worker's slot and partition."""
+        await SessionService(
+            self.storage,
+            self.bus,
+            self.workspace_manager,
+        ).delete_agent(self.user_id, self.worker.agent_id)
+
+        self.assertListEqual(
+            [
+                await self.workspace.list_mcps(
+                    agent_id=self.worker.agent_id,
+                    session_id=self.worker.session_id,
+                ),
+                await self.workspace.list_skills(
+                    agent_id=self.worker.agent_id,
+                ),
+            ],
+            [[], []],
+        )
+
+
+class TestSubAgentTemplateResourceFailures(_TemplateResourcesTestBase):
+    """One unusable entry must not sink the rest of the creation."""
+
+    async def test_an_unusable_skill_leaves_the_others_standing(
+        self,
+    ) -> None:
+        """A directory holding no ``SKILL.md`` is dropped on its own —
+        the worker keeps the rest and the tool still succeeds."""
+        empty = os.path.join(self.skills_root, "empty")
+        os.makedirs(empty)
+        await self._create_worker(
+            SubAgentTemplate(
+                type="researcher",
+                description="Looks things up.",
+                system_prompt_template="You are {member_name}.",
+                skills=[
+                    _write_skill(self.skills_root, "lit-review", "alpha"),
+                    empty,
+                ],
+            ),
+        )
+
+        skills = await self.workspace.list_skills(
+            agent_id=self.worker.agent_id,
+        )
+        self.assertListEqual(
+            [vars(_) for _ in skills],
+            [
+                {
+                    "name": "alpha",
+                    "description": "a test skill",
+                    "dir": AnyString(),
+                    "markdown": "body",
+                    "updated_at": AnyValue(),
+                },
+            ],
+        )
+        self.assertDictEqual(
+            self.chunk.model_dump(),
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": AnyString(),
+                        "id": AnyString(),
+                        "created_at": AnyString(),
+                        "finished_at": None,
+                    },
+                ],
+                "state": "running",
+                "is_last": True,
+                "metadata": {},
+                "id": AnyString(),
+            },
+        )


### PR DESCRIPTION
## Problem

A `SubAgentTemplate` can pin a worker's prompt, context, permissions and tasks — but not the tools it needs to act on them. A `"researcher"` type only works if someone has already installed a search MCP into the workspace by hand, which a developer registering the template at `create_app` cannot arrange: MCP and skill records are per-user, and the developer does not know a user's library ids at startup.

## What changed

`SubAgentTemplate` gains two fields, and `AgentCreate` installs them under the worker's own agent id right after its record and session land:

```python
create_app(
    ...,
    custom_subagent_templates=[
        SubAgentTemplate(
            type="researcher",
            description="Looks things up.",
            system_prompt_template="You are {member_name}.",
            mcps=[MCPClient(name="tavily", is_stateful=False, mcp_config={...})],
            skills=["./skills/literature-review", MySkillSource("note-taking")],
        ),
    ],
)
```

## Why it is this small

Nothing new is needed to isolate or reclaim these resources — the machinery already exists and this change only feeds it:

- **Isolation.** `get_toolkit` already reads per agent (`_service/_toolkit.py:241-247`): skills live in the `skills/<agent_id>` partition, MCP specs are keyed `(agent_id, session_id)`. A worker shares the leader's `workspace_id` (`_tool/_agent_create.py:441`) but not its agent id, so the leader and sibling workers are untouched.
- **Lifecycle.** `SessionService.delete_agent` already calls `purge_session` (`_service/_session.py:408`, closes live MCP instances and rewrites `.mcp`) and `purge_agent` (`:557`, deletes the skill partition). `TeamDelete` routes `role="created"` workers through the same path (`:461-469`). No new delete code — there is a test pinning that this actually holds.

## Skills: a path to copy, or a source to open

A skill is a directory of files — `SKILL.md` plus whatever scripts and resources it ships — and the `<dir>` an agent is handed in its system prompt has to be real. So a skill entry has to name **where the bytes come from**, which is what `SkillLoaderBase` does not do: it enumerates skills that already exist as directories and hands out the struct describing them.

`skills` therefore takes `str | SkillSourceBase`:

- a **`str`** is a local directory, copied by `workspace.add_skill` (`workspace/_base.py:1265-1308`);
- a **`SkillSourceBase`** is opened for a `SkillArchive`, streamed into the partition by `workspace.add_skill_archive` — the same install path `POST /workspace/skill/from-library` already uses.

`SkillArchive` moves down from `agentscope.app.hub` into `agentscope.skill` so the source abstraction can name it without depending on the app layer; `agentscope.app.hub` re-exports it, so `SkillHubBase.download` is untouched.

`open()` returns a *fresh* archive per call rather than the source holding one: a stream is consumed once, while a template is registered once at `create_app` and used for every worker it spawns.

No change to the blob store, which today is RAG-only and gated behind `knowledge_base_manager` — a blob-backed skill is a `SkillSourceBase` implementation, not a dependency change.

**Left out on purpose:** no `SkillSourceBase` implementation for skill hubs. `SkillHubBase.download` takes a `user_id`, which a process-level template does not have — resolving that (a `user_id` argument on `open()`, or a per-request source factory) is a design decision worth making separately rather than guessing at here.

## Per-entry install

Entries install one at a time, each failure logged and skipped. This is not defensive padding: a worker's partition is pre-seeded from `skills/.seed` by `_equip_partition`, and backends disagree on collisions — the base `add_skill` raises on a basename already present (`_base.py:1276-1281`) while `LocalWorkspace` dedups by content hash and suffixes the name instead. One unusable entry should cost the worker that entry, not every tool it was meant to have.

## Tests

New `tests/service_subagent_template_resources_test.py`, running `AgentCreate` against a real `LocalWorkspaceManager` plus fakeredis storage/bus:

- the worker's MCP slot and skill partition hold the template's resources — one skill from a local path, one from an archive source
- the leader, sharing the same workspace, holds neither
- after `delete_agent`, both are gone — this covers the existing purge path rather than assuming it
- a directory with no `SKILL.md` is dropped alone; the other installs and `AgentCreate` still succeeds

Full suite: **2018 passed, 144 skipped, 378 subtests passed**. `pre-commit run --all-files` clean.

Five `tests/test_e2e_api.py::TestPerAgentMCPAPI` cases fail in my local environment, unchanged by this PR: they mark `async def` with `@pytest.mark.asyncio`, and `pytest-asyncio` is neither installed nor declared in `.[dev]`, so pytest refuses to run them at all. CI's three `test` jobs pass, which confirms it is environment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fc4F2w1rQ3stemo6Fiic9S
