### PR TITLE
fix(web_ui): correct thinking/reply elapsed time across UTC offsets

### DIFF
--- a/examples/web_ui/frontend/src/components/chat/ASMessageBubble.tsx
+++ b/examples/web_ui/frontend/src/components/chat/ASMessageBubble.tsx
@@ -22,6 +22,7 @@ import {
 import * as mime from 'mime-types';
 import { useEffect, useRef, useState } from 'react';
 
+import { useElapsedSeconds } from '@/hooks/useElapsedSeconds';
 import { renderToolCall } from './tool-renderers';
 import { countDiffStats, DiffStats, getResultDiff } from './tool-renderers/_shared';
 import type { TFunction, ToolCallWithResult } from './tool-renderers/types';
@@ -375,8 +376,8 @@ interface MessageBubbleProps {
  * `[state-icon] [duration] [↑in ↓out]`:
  *   - State icon: spinning `Loader2` while running, static `CheckCircle`
  *     once finished.
- *   - Duration is `now - created_at` while running (ticking each second),
- *     `finished_at - created_at` once complete.
+ *   - Duration uses {@link useElapsedSeconds}: local anchor while running,
+ *     server timestamps once complete (avoids UTC-offset elapsed flashes).
  *   - Token counts only appear once `usage` is populated with non-zero
  *     values — typically after the message finishes.
  *
@@ -392,13 +393,12 @@ export function ASMessageBubble({ message }: MessageBubbleProps) {
 		!!message.usage &&
 		((message.usage.input_tokens ?? 0) > 0 || (message.usage.output_tokens ?? 0) > 0);
 
-	// Tick once per second while running so the elapsed time updates live.
-	const [now, setNow] = useState(() => Date.now());
-	useEffect(() => {
-		if (!isRunning) return;
-		const id = setInterval(() => setNow(Date.now()), 1000);
-		return () => clearInterval(id);
-	}, [isRunning]);
+	const elapsedSeconds = useElapsedSeconds(
+		message.created_at,
+		message.finished_at,
+		message.id,
+	);
+	const elapsedText = formatTime(elapsedSeconds);
 
 	// Audio data blocks are rendered in the footer;
 	// For role="user" messages, the data blocks are rendered as attachments in the
@@ -409,11 +409,6 @@ export function ASMessageBubble({ message }: MessageBubbleProps) {
 	);
 
 	const blocks = groupToolCalls(message.content);
-
-	const startMs = new Date(message.created_at).getTime();
-	const endMs = isRunning ? now : new Date(message.finished_at!).getTime();
-	const elapsedSeconds = Math.max(0, (endMs - startMs) / 1000);
-	const elapsedText = formatTime(elapsedSeconds);
 
 	return (
 		<Message align={isUser ? 'end' : 'start'} data-role={message.role}>
@@ -492,17 +487,7 @@ function ThinkingBlockView({ block }: { block: ThinkingBlock }) {
 	const { t } = useTranslation();
 	const isRunning = !block.finished_at;
 
-	// Tick once per second while running so the elapsed time updates live.
-	const [now, setNow] = useState(() => Date.now());
-	useEffect(() => {
-		if (!isRunning) return;
-		const id = setInterval(() => setNow(Date.now()), 1000);
-		return () => clearInterval(id);
-	}, [isRunning]);
-
-	const startMs = new Date(block.created_at).getTime();
-	const endMs = isRunning ? now : new Date(block.finished_at!).getTime();
-	const elapsedSeconds = Math.max(0, (endMs - startMs) / 1000);
+	const elapsedSeconds = useElapsedSeconds(block.created_at, block.finished_at, block.id);
 	const elapsedText = formatTime(elapsedSeconds);
 	return (
 		<Collapsible>

--- a/examples/web_ui/frontend/src/hooks/useElapsedSeconds.ts
+++ b/examples/web_ui/frontend/src/hooks/useElapsedSeconds.ts
@@ -1,0 +1,60 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Parse API / SSE ISO timestamps into epoch ms.
+ *
+ * AgentScope emits UTC ISO 8601 strings (``Z`` suffix). For backward
+ * compatibility, naive strings without a zone are treated as UTC.
+ */
+export function parseApiTimestamp(value?: string | null): number | null {
+	if (!value) return null;
+	const trimmed = value.trim();
+	if (!trimmed) return null;
+	if (/[zZ]$/.test(trimmed) || /[+-]\d{2}:\d{2}$/.test(trimmed)) {
+		const ms = Date.parse(trimmed);
+		return Number.isNaN(ms) ? null : ms;
+	}
+	const ms = Date.parse(`${trimmed}Z`);
+	return Number.isNaN(ms) ? null : ms;
+}
+
+/**
+ * Elapsed seconds for a block or message that may still be streaming.
+ *
+ * - **Finished**: ``finished_at - created_at`` (both from server).
+ * - **Running**: anchor to local mount time so we never mix server
+ *   ``created_at`` with ``Date.now()`` (avoids UTC-offset flashes like
+ *   "8h" while streaming in UTC+8 browsers).
+ */
+export function useElapsedSeconds(
+	createdAt: string | undefined,
+	finishedAt: string | null | undefined,
+	resetKey?: string,
+): number {
+	const isRunning = !finishedAt;
+	const [now, setNow] = useState(() => Date.now());
+	const runningStartRef = useRef<number | null>(null);
+
+	useEffect(() => {
+		runningStartRef.current = null;
+	}, [resetKey]);
+
+	useEffect(() => {
+		if (!isRunning) return;
+		const id = setInterval(() => setNow(Date.now()), 1000);
+		return () => clearInterval(id);
+	}, [isRunning]);
+
+	if (!isRunning) {
+		const startMs = parseApiTimestamp(createdAt);
+		const endMs = parseApiTimestamp(finishedAt);
+		if (startMs != null && endMs != null) {
+			return Math.max(0, (endMs - startMs) / 1000);
+		}
+	}
+
+	if (runningStartRef.current === null) {
+		runningStartRef.current = Date.now();
+	}
+	return Math.max(0, (now - runningStartRef.current) / 1000);
+}

--- a/src/agentscope/_utils/_common.py
+++ b/src/agentscope/_utils/_common.py
@@ -9,7 +9,7 @@ import json
 import os
 import types
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Callable
 
 from .._logging import logger
@@ -17,7 +17,14 @@ from ..exception import ToolJSONDecodeError
 
 
 _id_factory: Callable[[], str] = lambda: uuid.uuid4().hex
-_timestamp_factory: Callable[[], str] = lambda: datetime.now().isoformat()
+
+
+def _default_timestamp() -> str:
+    """Return the current UTC time as ISO 8601 with a ``Z`` suffix."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+_timestamp_factory: Callable[[], str] = _default_timestamp
 
 
 def set_id_factory(factory: Callable[[], str]) -> None:
@@ -52,9 +59,11 @@ def set_id_factory(factory: Callable[[], str]) -> None:
 def set_timestamp_factory(factory: Callable[[], str]) -> None:
     """Override the global timestamp factory used by all AgentScope entities.
 
+    The default factory emits UTC ISO 8601 strings suffixed with ``Z``.
+
     Args:
         factory (`Callable[[], str]`):
-            A no-arg callable returning a string ID.
+            A no-arg callable returning a timestamp string.
 
     Raises:
         TypeError: If ``factory`` is not callable.

--- a/src/agentscope/event/_event.py
+++ b/src/agentscope/event/_event.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 """Event types for agent execution."""
-from datetime import datetime
 from enum import StrEnum
 from typing import Any, Dict, Literal, List, Self, TypeAlias
 
 from pydantic import BaseModel, Field, ConfigDict, model_validator
 from typing_extensions import deprecated
 
-from .._utils._common import _generate_id
+from .._utils._common import _generate_id, _generate_timestamp
 from ..message import (
     DataBlock,
     TextBlock,
@@ -74,8 +73,8 @@ class EventBase(BaseModel):
 
     id: str = Field(default_factory=_generate_id)
     """Unique event identifier."""
-    created_at: str = Field(default_factory=lambda: datetime.now().isoformat())
-    """ISO 8601 timestamp of when the event was created."""
+    created_at: str = Field(default_factory=_generate_timestamp)
+    """UTC ISO 8601 timestamp (``Z`` suffix) of when the event was created."""
     metadata: Dict[str, Any] = Field(default_factory=dict)
     """Optional metadata attached to the event."""
 

--- a/src/agentscope/message/_base.py
+++ b/src/agentscope/message/_base.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 """The message class in agentscope."""
 import base64
-from datetime import datetime
 from typing import Literal, List, overload, Sequence, Self, TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field, model_validator
 
-from .._utils._common import _generate_id
+from .._utils._common import _generate_id, _generate_timestamp
 from ._block import (
     TextBlock,
     ThinkingBlock,
@@ -92,8 +91,8 @@ class Msg(BaseModel):
 
     metadata: dict = Field(default_factory=dict)
     """The metadata of the message"""
-    created_at: str = Field(default_factory=lambda: datetime.now().isoformat())
-    """The creation time of the message"""
+    created_at: str = Field(default_factory=_generate_timestamp)
+    """The creation time of the message (UTC ISO 8601 with ``Z`` suffix)."""
     usage: Usage | None = Field(default=None)
     """The token usage information of the message"""
 
@@ -552,7 +551,7 @@ def UserMsg(
         `Msg`:
             A :class:`Msg` instance with ``role="user"``.
     """
-    created_at = created_at or datetime.now().isoformat()
+    created_at = created_at or _generate_timestamp()
     if finished_at is None:
         finished_at = created_at
     return Msg(
@@ -615,7 +614,7 @@ def AssistantMsg(
         content=_to_blocks(content),
         role="assistant",
         metadata=metadata or {},
-        created_at=created_at or datetime.now().isoformat(),
+        created_at=created_at or _generate_timestamp(),
         finished_at=finished_at,
         finished_reason=finished_reason,
         structured_output=structured_output,
@@ -661,7 +660,7 @@ def SystemMsg(
         `Msg`:
             A :class:`Msg` instance with ``role="system"``.
     """
-    created_at = created_at or datetime.now().isoformat()
+    created_at = created_at or _generate_timestamp()
     if finished_at is None:
         finished_at = created_at
     return Msg(

--- a/tests/timestamp_factory_test.py
+++ b/tests/timestamp_factory_test.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""Tests for the configurable timestamp factory."""
+import re
+from datetime import datetime, timezone
+from unittest.async_case import IsolatedAsyncioTestCase
+
+from agentscope import set_timestamp_factory
+from agentscope.event import ReplyStartEvent, EventType
+from agentscope.message import Msg, TextBlock, ThinkingBlock
+
+_UTC_Z_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$",
+)
+
+
+class TimestampFactoryTest(IsolatedAsyncioTestCase):
+    """Tests for UTC timestamp generation."""
+
+    async def asyncSetUp(self) -> None:
+        """Save the current factory before each test."""
+        import agentscope._utils._common as common
+
+        # pylint: disable=protected-access
+        self._saved_factory = common._timestamp_factory
+
+    async def test_default_timestamp_is_utc_z(self) -> None:
+        """Default timestamps end with Z and parse as UTC."""
+        block = ThinkingBlock(thinking="hello")
+        self.assertRegex(block.created_at, _UTC_Z_RE)
+
+        msg = Msg(name="test", content=[TextBlock(text="hi")], role="user")
+        self.assertRegex(msg.created_at, _UTC_Z_RE)
+
+        event = ReplyStartEvent(
+            session_id="s1",
+            reply_id="r1",
+            name="agent",
+        )
+        self.assertRegex(event.created_at, _UTC_Z_RE)
+        self.assertEqual(event.type, EventType.REPLY_START)
+
+    async def test_custom_factory(self) -> None:
+        """``set_timestamp_factory`` overrides entity timestamps."""
+        set_timestamp_factory(lambda: "2026-01-01T00:00:00Z")
+
+        block = ThinkingBlock(thinking="hello")
+        self.assertEqual(block.created_at, "2026-01-01T00:00:00Z")
+
+    async def test_default_timestamp_near_utc_now(self) -> None:
+        """Default factory emits a time close to current UTC."""
+        before = datetime.now(timezone.utc)
+        block = ThinkingBlock(thinking="tick")
+        after = datetime.now(timezone.utc)
+        parsed = datetime.fromisoformat(block.created_at.replace("Z", "+00:00"))
+        self.assertGreaterEqual(parsed, before.replace(microsecond=0))
+        self.assertLessEqual(parsed, after)
+
+    async def asyncTearDown(self) -> None:
+        """Restore the original factory after each test."""
+        import agentscope._utils._common as common
+
+        # pylint: disable=protected-access
+        common._timestamp_factory = self._saved_factory


### PR DESCRIPTION
## Summary

Fixes incorrect thinking/reply elapsed badges (e.g. flashing **8h** while streaming in UTC+8, then snapping to **1s** after THINKING_BLOCK_END) when the Agent Service runs in UTC (Docker) and the browser is in a non-UTC timezone.

## Root cause

1. **Backend**: naive datetime.now().isoformat() timestamps without timezone (EventBase.created_at, some Msg defaults).
2. **Web UI**: while streaming, elapsed time mixed Date.now() (browser local) with 
ew Date(naive ISO) (parsed as local), producing a UTC-offset flash.

## Changes

- Python: default timestamp factory now emits **UTC ISO 8601 with Z suffix**; EventBase and Msg use _generate_timestamp.
- Web UI (examples/web_ui): add useElapsedSeconds hook with parseApiTimestamp(); use it in ThinkingBlockView and message footer badges.
- Tests: 	ests/timestamp_factory_test.py.

## Test plan

- [x] pytest tests/timestamp_factory_test.py
- [ ] Manual: Docker/UTC backend + UTC+8 browser, verify thinking header shows ~1s while streaming (not ~8h)


Made with [Cursor](https://cursor.com)