### PR TITLE
fix(middleware): prevent KeyError in budget middleware when ReplyEndEvent is swallowed

### DIFF
--- a/src/agentscope/middleware/_budget.py
+++ b/src/agentscope/middleware/_budget.py
@@ -131,16 +131,21 @@ class ReplyBudgetControlMiddleware(MiddlewareBase):
 
             elif isinstance(event, ReplyEndEvent):
                 # Clean up the token counting number
-                agent.state.middle_context[middleware_key].pop(
+                agent.state.middle_context.get(middleware_key, {}).pop(
                     event.reply_id,
                     None,
                 )
 
             elif isinstance(event, ModelCallEndEvent):
-                # Update the used tokens
-                if middleware_key not in agent.state.middle_context:
-                    agent.state.middle_context[middleware_key] = {}
-                agent.state.middle_context[middleware_key][event.reply_id] += (
+                # Update the used tokens. Don't assume the counter exists:
+                # an outer middleware may swallow the ReplyEndEvent to force
+                # another reasoning round, and by then the counter for this
+                # reply has already been popped above.
+                bucket = agent.state.middle_context.setdefault(
+                    middleware_key,
+                    {},
+                )
+                bucket[event.reply_id] = bucket.get(event.reply_id, 0) + (
                     self.input_token_weight * event.input_tokens
                     + self.output_token_weight * event.output_tokens
                 )

--- a/tests/middleware_budget_test.py
+++ b/tests/middleware_budget_test.py
@@ -1,19 +1,23 @@
 # -*- coding: utf-8 -*-
 """Unit tests for BudgetControlMiddleware."""
-from typing import Any
+from typing import Any, AsyncGenerator, Callable
 from unittest.async_case import IsolatedAsyncioTestCase
 
 from utils import MockModel
 from agentscope.agent import Agent
 from agentscope.message import UserMsg, TextBlock, ToolCallBlock, HintBlock
-from agentscope.middleware import ReplyBudgetControlMiddleware
+from agentscope.middleware import MiddlewareBase, ReplyBudgetControlMiddleware
 from agentscope.model import ChatResponse, ChatUsage
 from agentscope.permission import (
     PermissionBehavior,
     PermissionContext,
     PermissionDecision,
 )
-from agentscope.event import UserConfirmResultEvent, ConfirmResult
+from agentscope.event import (
+    ConfirmResult,
+    ReplyEndEvent,
+    UserConfirmResultEvent,
+)
 from agentscope.tool import ToolBase, Toolkit, ToolChunk
 
 
@@ -357,6 +361,71 @@ class TestBudgetControlMiddleware(IsolatedAsyncioTestCase):
         middleware_key = await middleware.get_middleware_key()
         bucket = agent.state.middle_context.get(middleware_key, {})
         # All per-reply entries must have been cleaned up
+        self.assertEqual(len(bucket), 0)
+
+    async def test_swallowed_reply_end_does_not_crash_redo_round(self) -> None:
+        """A swallowed ReplyEndEvent must not crash the redo round.
+
+        An outer ``on_reply`` middleware may swallow the ``ReplyEndEvent``
+        to force another reasoning round (the pattern covered by
+        ``middleware_test.py::test_on_reply_middleware_swallow_reply_end``).
+        The budget middleware pops its counter when the ``ReplyEndEvent``
+        passes through it, and the redo round emits no new
+        ``ReplyStartEvent``, so the accumulation on ``ModelCallEndEvent``
+        must re-create the counter instead of raising ``KeyError``.
+        """
+
+        class SwallowOnceMiddleware(MiddlewareBase):
+            """Swallow the first ReplyEndEvent to force a redo round."""
+
+            def __init__(self) -> None:
+                """Initialize the swallow flag."""
+                self.swallowed = False
+
+            async def on_reply(
+                self,
+                agent: Agent,
+                input_kwargs: dict,
+                next_handler: Callable[..., AsyncGenerator],
+            ) -> AsyncGenerator:
+                """Swallow the first ReplyEndEvent, pass everything else."""
+                async for item in next_handler(**input_kwargs):
+                    if isinstance(item, ReplyEndEvent) and not self.swallowed:
+                        self.swallowed = True
+                        continue
+                    yield item
+
+        model = MockModel()
+        model.set_responses(
+            [
+                _response("first answer", input_tokens=10, output_tokens=5),
+                _response("second answer", input_tokens=20, output_tokens=8),
+            ],
+        )
+
+        middleware = ReplyBudgetControlMiddleware(token_budget=1000)
+        agent = Agent(
+            name="test_agent",
+            system_prompt="you are helpful",
+            model=model,
+            toolkit=self.toolkit,
+            middlewares=[
+                # Outer: swallows the first ReplyEndEvent
+                SwallowOnceMiddleware(),
+                # Inner: sees the ReplyEndEvent first and pops its counter
+                middleware,
+            ],
+        )
+
+        # Before the fix this raised KeyError from the budget middleware's
+        # ModelCallEndEvent branch during the redo round.
+        msg = await agent.reply(UserMsg("user", "hello"))
+
+        self.assertEqual(msg.get_text_content(), "second answer")
+
+        # The final (non-swallowed) ReplyEndEvent must clean the state up.
+        middleware_key = await middleware.get_middleware_key()
+        bucket = agent.state.middle_context.get(middleware_key, {})
         self.assertEqual(len(bucket), 0)
 
     async def test_token_accumulation_persists_across_hitl(self) -> None:


### PR DESCRIPTION
## AgentScope Version

2.0.7 (branched from main at e8c8d7b9)

## Description

Fixes #2418.

`ReplyBudgetControlMiddleware.on_reply` pops its per-reply cost counter when a
`ReplyEndEvent` passes through it. An outer `on_reply` middleware is allowed to
swallow that event to force another reasoning round (the pattern tested in
`middleware_test.py::test_on_reply_middleware_swallow_reply_end`), and the redo
round emits no new `ReplyStartEvent`, so nothing re-creates the counter. When the
redo round's `ModelCallEndEvent` arrives, the existing check only handles a missing
`middleware_key`. The outer dict is still there after the pop, just empty, so the
check passes and `agent.state.middle_context[middleware_key][event.reply_id] += ...`
raises `KeyError` and kills the whole reply. The issue has a repro script that
needs no API key.

Changes:

- `_budget.py`: accumulate on `ModelCallEndEvent` with `setdefault` and
  `.get(..., 0)` instead of assuming the counter exists. The cleanup pop on
  `ReplyEndEvent` gets the same guard, since the parked-interrupt path can emit a
  `ReplyEndEvent` before the middleware has ever seen a `ReplyStartEvent`.
- `middleware_budget_test.py`: regression test that puts a swallow-once middleware
  outside the budget middleware. It fails with the exact `KeyError` before the fix
  and passes after. It also checks that the final `ReplyEndEvent` still cleans the
  state up.

One tradeoff worth flagging: with this fix the counter restarts from zero after a
swallowed end, so the cost of earlier rounds no longer counts against the budget.
Keeping the full count would require moving cleanup from `ReplyEndEvent` to the
next `ReplyStartEvent`, which changes the cleanup timing that
`test_state_cleanup_after_reply` asserts. I picked the smaller change. If you want
the other behavior instead, I can rework it.

How to test:

```bash
pytest tests/middleware_budget_test.py   # 8 passed
pre-commit run --files src/agentscope/middleware/_budget.py tests/middleware_budget_test.py