### PR TITLE
feat(app): add revision-safe /clear command for web and channels

### DIFF
--- a/examples/web_ui/frontend/src/api/chat.ts
+++ b/examples/web_ui/frontend/src/api/chat.ts
@@ -20,6 +20,5 @@ export const chatApi = {
 	 * @param body - The chat request payload.
 	 * @returns A confirmation object ``{ status, session_id }``.
 	 */
-	trigger: (body: ChatRequest) =>
-		client.post<ChatTriggerResponse>('/chat/', body),
+	trigger: (body: ChatRequest) => client.post<ChatTriggerResponse>('/chat/', body),
 };

--- a/examples/web_ui/frontend/src/api/chat.ts
+++ b/examples/web_ui/frontend/src/api/chat.ts
@@ -1,5 +1,5 @@
 import { client } from './client';
-import type { ChatRequest } from './types';
+import type { ChatRequest, ChatTriggerResponse } from './types';
 
 /**
  * Chat API — fire-and-forget trigger for chat runs.
@@ -21,5 +21,5 @@ export const chatApi = {
 	 * @returns A confirmation object ``{ status, session_id }``.
 	 */
 	trigger: (body: ChatRequest) =>
-		client.post<{ status: string; session_id: string }>('/chat/', body),
+		client.post<ChatTriggerResponse>('/chat/', body),
 };

--- a/examples/web_ui/frontend/src/api/command.ts
+++ b/examples/web_ui/frontend/src/api/command.ts
@@ -1,0 +1,6 @@
+import { client } from './client';
+import type { CommandListResponse } from './types';
+
+export const commandApi = {
+	list: () => client.get<CommandListResponse>('/commands/'),
+};

--- a/examples/web_ui/frontend/src/api/index.ts
+++ b/examples/web_ui/frontend/src/api/index.ts
@@ -3,6 +3,8 @@ export { agentApi } from './agent';
 export { sessionApi, takeFreshlyCreated } from './session';
 export { credentialApi } from './credential';
 export { chatApi } from './chat';
+export { commandApi } from './command';
+export type { CommandInfo, CommandListResponse } from './types';
 export { workspaceApi } from './workspace';
 export { hubApi } from './hub';
 export { mcpApi } from './mcp';

--- a/examples/web_ui/frontend/src/api/types.ts
+++ b/examples/web_ui/frontend/src/api/types.ts
@@ -149,6 +149,7 @@ export interface SessionRecord extends RecordBase {
 	team_id: string | null;
 	config: SessionConfig;
 	state: AgentState;
+	conversation_revision: number;
 }
 
 export interface CreateSessionRequest {
@@ -169,6 +170,24 @@ export interface CreateSessionResponse {
 
 export interface InterruptSessionResponse {
 	session_id: string;
+}
+
+export interface CommandInfo {
+	name: string;
+	command: string;
+	aliases: string[];
+	description: string;
+	accepts_args: boolean;
+}
+
+export interface CommandListResponse {
+	commands: CommandInfo[];
+}
+
+export interface ChatTriggerResponse {
+	status: 'started' | 'command_completed';
+	session_id: string;
+	command?: string | null;
 }
 
 export interface UpdateSessionRequest {

--- a/examples/web_ui/frontend/src/components/chat/ChatContent.tsx
+++ b/examples/web_ui/frontend/src/components/chat/ChatContent.tsx
@@ -12,6 +12,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Button } from '../ui/button';
 import { DiffStats } from './tool-renderers/_shared';
 import type { GitStatus } from '@/api';
+import type { CommandInfo } from '@/api';
 import { ASMessageBubble } from '@/components/chat/ASMessageBubble.tsx';
 import { ConfirmCard } from '@/components/chat/ConfirmCard.tsx';
 import { FlipCard } from '@/components/chat/FlipCard.tsx';
@@ -57,6 +58,7 @@ interface ChatContentProps {
 		rules?: ToolCallBlock['suggested_rules'],
 	) => Promise<void>;
 	autoComplete?: (input: string) => string | null;
+	commands?: CommandInfo[];
 	className?: string;
 	/** Called when the user clicks the stop button. */
 	onInterrupt?: () => void;
@@ -94,6 +96,7 @@ const ChatContentComponent: React.FC<ChatContentProps> = ({
 	onSend,
 	onUserConfirm,
 	autoComplete,
+	commands,
 	className,
 	onInterrupt,
 	footerSlot,
@@ -246,6 +249,7 @@ const ChatContentComponent: React.FC<ChatContentProps> = ({
 						onSend={onSend}
 						disabled={disabled}
 						autoComplete={autoComplete}
+						commands={commands}
 						allowedInputTypes={allowedInputTypes}
 						fileProcessor={fileProcessor}
 						phase={phase}

--- a/examples/web_ui/frontend/src/components/chat/TextInput.tsx
+++ b/examples/web_ui/frontend/src/components/chat/TextInput.tsx
@@ -7,12 +7,14 @@ import {
 	XIcon,
 	FileText,
 	ArrowUp,
+	Terminal,
 } from 'lucide-react';
 import mime from 'mime';
 import React, {
 	useState,
 	useRef,
 	useMemo,
+	useEffect,
 	useLayoutEffect,
 	type KeyboardEvent,
 	useImperativeHandle,
@@ -21,6 +23,7 @@ import React, {
 
 import { Button } from '../ui/button';
 import { Kbd } from '../ui/kbd';
+import type { CommandInfo } from '@/api';
 import {
 	Attachment,
 	AttachmentAction,
@@ -52,6 +55,7 @@ interface TextInputProps {
 	onSend: (blocks: ContentBlock[]) => void;
 	placeholder?: string;
 	autoComplete?: (input: string) => string | null;
+	commands?: CommandInfo[];
 	disabled?: boolean;
 	className?: string;
 	/**
@@ -133,6 +137,7 @@ export const TextInput = forwardRef<TextInputRef, TextInputProps>(
 			onSend,
 			placeholder,
 			autoComplete,
+			commands = [],
 			disabled = false,
 			className,
 			allowedInputTypes,
@@ -148,6 +153,7 @@ export const TextInput = forwardRef<TextInputRef, TextInputProps>(
 		const [value, setValue] = useState('');
 		const [files, setFiles] = useState<ProcessedFile[]>([]);
 		const [isFocused, setIsFocused] = useState(false);
+		const [activeCommand, setActiveCommand] = useState(0);
 		const textareaRef = useRef<HTMLTextAreaElement>(null);
 		const fileInputRef = useRef<HTMLInputElement>(null);
 		const measureRef = useRef<HTMLSpanElement>(null);
@@ -202,7 +208,47 @@ export const TextInput = forwardRef<TextInputRef, TextInputProps>(
 			return '';
 		}, [value, autoComplete, isFocused]);
 
+		const commandMatches = useMemo(() => {
+			const query = value.trim().toLowerCase();
+			if (!isFocused || files.length > 0 || !query.startsWith('/') || /\s/.test(query)) {
+				return [];
+			}
+			return commands
+				.filter((command) => command.command.toLowerCase().startsWith(query))
+				.slice(0, 8);
+		}, [commands, files.length, isFocused, value]);
+
+		useEffect(() => setActiveCommand(0), [value, commandMatches.length]);
+
 		const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+			if (commandMatches.length > 0 && e.key === 'ArrowDown') {
+				e.preventDefault();
+				setActiveCommand((current) => (current + 1) % commandMatches.length);
+				return;
+			}
+			if (commandMatches.length > 0 && e.key === 'ArrowUp') {
+				e.preventDefault();
+				setActiveCommand(
+					(current) => (current - 1 + commandMatches.length) % commandMatches.length,
+				);
+				return;
+			}
+			if (commandMatches.length > 0 && e.key === 'Escape') {
+				e.preventDefault();
+				textareaRef.current?.blur();
+				return;
+			}
+			if (
+				commandMatches.length > 0 &&
+				(e.key === 'Tab' ||
+					(e.key === 'Enter' &&
+						value.trim().toLowerCase() !==
+							commandMatches[activeCommand].command.toLowerCase()))
+			) {
+				e.preventDefault();
+				setValue(commandMatches[activeCommand].command);
+				return;
+			}
 			// Tab key to select autocomplete
 			if (e.key === 'Tab' && suggestion) {
 				e.preventDefault();
@@ -326,6 +372,37 @@ export const TextInput = forwardRef<TextInputRef, TextInputProps>(
 		return (
 			<div className={cn('flex flex-col', className)}>
 				{headerSlot}
+				{commandMatches.length > 0 && (
+					<div
+						role="listbox"
+						aria-label="Slash commands"
+						className="mb-2 overflow-hidden rounded-xl border bg-popover p-1 shadow-lg"
+					>
+						{commandMatches.map((command, index) => (
+							<button
+								key={command.name}
+								type="button"
+								role="option"
+								aria-selected={index === activeCommand}
+								onMouseDown={(event) => event.preventDefault()}
+								onClick={() => {
+									setValue(command.command);
+									textareaRef.current?.focus();
+								}}
+								className={cn(
+									'flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left',
+									index === activeCommand && 'bg-muted',
+								)}
+							>
+								<Terminal className="size-4 text-muted-foreground" />
+								<span className="font-mono text-sm">{command.command}</span>
+								<span className="truncate text-xs text-muted-foreground">
+									{command.description}
+								</span>
+							</button>
+						))}
+					</div>
+				)}
 				<div
 					id="tour-chat-input"
 					className="flex w-full flex-col rounded-[28px] border bg-background px-2"

--- a/examples/web_ui/frontend/src/hooks/useCommands.ts
+++ b/examples/web_ui/frontend/src/hooks/useCommands.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+import { commandApi, type CommandInfo } from '@/api';
+
+let cachedCommands: CommandInfo[] | null = null;
+
+export function useCommands() {
+	const [commands, setCommands] = useState<CommandInfo[]>(cachedCommands ?? []);
+
+	useEffect(() => {
+		if (cachedCommands !== null) return;
+		commandApi
+			.list()
+			.then(({ commands: next }) => {
+				cachedCommands = next;
+				setCommands(next);
+			})
+			.catch(() => {
+				cachedCommands = [];
+			});
+	}, []);
+
+	return commands;
+}

--- a/examples/web_ui/frontend/src/hooks/useMessages.ts
+++ b/examples/web_ui/frontend/src/hooks/useMessages.ts
@@ -392,9 +392,7 @@ export function useMessages(
 
 			const userMsg = UserMsg({ name: 'user', content });
 			const text =
-				content.length === 1 && content[0].type === 'text'
-					? content[0].text.trim()
-					: '';
+				content.length === 1 && content[0].type === 'text' ? content[0].text.trim() : '';
 			const token = text.startsWith('/') ? text.split(/\s+/, 1)[0].toLowerCase() : '';
 			const commandIntent = optionsRef.current?.commands?.some(
 				(command) =>

--- a/examples/web_ui/frontend/src/hooks/useMessages.ts
+++ b/examples/web_ui/frontend/src/hooks/useMessages.ts
@@ -12,10 +12,12 @@ import { appendEvent, AssistantMsg, UserMsg } from '@agentscope-ai/agentscope/me
 import type { Msg, ContentBlock } from '@agentscope-ai/agentscope/message';
 import type { ToolCallBlock } from '@agentscope-ai/agentscope/message';
 import { useState, useCallback, useRef, useEffect } from 'react';
+import { toast } from 'sonner';
 
-import { sessionApi, takeFreshlyCreated } from '@/api';
-import { chatApi } from '@/api';
+import type { CommandInfo } from '@/api';
+import { chatApi, sessionApi, takeFreshlyCreated } from '@/api';
 import { useAudioManager } from '@/context/AudioContext';
+import { useTranslation } from '@/i18n/useI18n';
 
 /**
  * One pending subagent HITL request, projected from a team *member*
@@ -110,6 +112,7 @@ export function useMessages(
 	agentId: string | null,
 	sessionId: string | null,
 	options?: {
+		commands?: CommandInfo[];
 		/**
 		 * Called when a ``CUSTOM`` event with ``name="team_updated"``
 		 * arrives — the team membership has changed (TeamCreate /
@@ -124,8 +127,10 @@ export function useMessages(
 		 * ``tasks_context`` and ``permission_context``.
 		 */
 		onStateUpdated?: (value: Record<string, unknown>) => void;
+		onSessionCleared?: () => void;
 	},
 ) {
+	const { t } = useTranslation();
 	const [msgs, setMsgs] = useState<Msg[]>([]);
 	// The (agent, session) pair `msgs` actually belongs to. Loading is
 	// derived from it rather than set inside the fetch effect: an effect
@@ -137,6 +142,7 @@ export function useMessages(
 	const [error, setError] = useState<Error | null>(null);
 	// Pending subagent HITL cards projected onto this (leader) session.
 	const [subagentHitl, setSubagentHitl] = useState<SubagentHitlEntry[]>([]);
+	const [commandPending, setCommandPending] = useState(false);
 
 	const msgsRef = useRef<Msg[]>([]);
 	const currentReplyRef = useRef<Msg | null>(null);
@@ -145,6 +151,8 @@ export function useMessages(
 	// Timer that reverts ``interrupting`` back to ``idle`` if the
 	// terminating REPLY_END never arrives (dropped SSE frame, etc.).
 	const interruptTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const historyGenerationRef = useRef(0);
+	const clearNoticeRef = useRef(false);
 
 	const clearInterruptTimer = useCallback(() => {
 		if (interruptTimerRef.current !== null) {
@@ -159,6 +167,28 @@ export function useMessages(
 	useEffect(() => {
 		optionsRef.current = options;
 	}, [options]);
+	const resetForClear = useCallback(
+		(value?: Record<string, unknown>) => {
+			historyGenerationRef.current += 1;
+			msgsRef.current = [];
+			currentReplyRef.current = null;
+			setMsgs([]);
+			setSubagentHitl([]);
+			setPhase('idle');
+			setCommandPending(false);
+			clearInterruptTimer();
+			audioManager?.disposeAll();
+			if (value) {
+				optionsRef.current?.onStateUpdated?.(value);
+			}
+			optionsRef.current?.onSessionCleared?.();
+			if (!clearNoticeRef.current) {
+				clearNoticeRef.current = true;
+				toast.success(t('chat.conversationCleared'));
+			}
+		},
+		[audioManager, clearInterruptTimer, t],
+	);
 	const scheduleUpdate = useCallback(() => {
 		if (rafRef.current !== null) return;
 		rafRef.current = requestAnimationFrame(() => {
@@ -178,6 +208,8 @@ export function useMessages(
 					optionsRef.current?.onTeamUpdated?.();
 				} else if (custom.name === 'state_updated' && custom.value) {
 					optionsRef.current?.onStateUpdated?.(custom.value as Record<string, unknown>);
+				} else if (custom.name === 'session_cleared') {
+					resetForClear(custom.value as Record<string, unknown> | undefined);
 				} else if (custom.name === 'subagent_require_user_confirm') {
 					// A team member is asking for confirmation; show (or
 					// refresh) its card on this leader view. Dedup by
@@ -251,11 +283,13 @@ export function useMessages(
 
 			scheduleUpdate();
 		},
-		[scheduleUpdate, audioManager, clearInterruptTimer],
+		[scheduleUpdate, audioManager, clearInterruptTimer, resetForClear],
 	);
 
 	// ── Lifecycle: fetch history + open SSE stream ──────────────────
 	useEffect(() => {
+		historyGenerationRef.current += 1;
+		clearNoticeRef.current = false;
 		msgsRef.current = [];
 		currentReplyRef.current = null;
 		setMsgs([]);
@@ -263,6 +297,7 @@ export function useMessages(
 		clearInterruptTimer();
 		setPhase('idle');
 		setSubagentHitl([]);
+		setCommandPending(false);
 		audioManager?.disposeAll();
 
 		if (!agentId || !sessionId) return;
@@ -272,6 +307,7 @@ export function useMessages(
 		let cancelled = false;
 
 		(async () => {
+			const generation = historyGenerationRef.current;
 			// 1. Fetch persisted history — unless this tab just created the
 			// session, in which case there is provably none.
 			if (takeFreshlyCreated(sessionId)) {
@@ -279,7 +315,7 @@ export function useMessages(
 			} else {
 				try {
 					const { messages, is_running } = await sessionApi.messages(sessionId, agentId);
-					if (cancelled) return;
+					if (cancelled || generation !== historyGenerationRef.current) return;
 					msgsRef.current = messages;
 					// If a reply is in flight (running on a worker) OR the
 					// tail msg is parked on a pending tool_call (awaiting
@@ -355,20 +391,44 @@ export function useMessages(
 			if (!agentId || !sessionId) return;
 
 			const userMsg = UserMsg({ name: 'user', content });
-			msgsRef.current = [...msgsRef.current, userMsg];
-			scheduleUpdate();
+			const text =
+				content.length === 1 && content[0].type === 'text'
+					? content[0].text.trim()
+					: '';
+			const token = text.startsWith('/') ? text.split(/\s+/, 1)[0].toLowerCase() : '';
+			const commandIntent = optionsRef.current?.commands?.some(
+				(command) =>
+					command.command.toLowerCase() === token ||
+					command.aliases.some((alias) => `/${alias.toLowerCase()}` === token),
+			);
+			if (!commandIntent) {
+				msgsRef.current = [...msgsRef.current, userMsg];
+				scheduleUpdate();
+			} else {
+				clearNoticeRef.current = false;
+				setCommandPending(true);
+			}
 
 			try {
-				await chatApi.trigger({
+				const response = await chatApi.trigger({
 					agent_id: agentId,
 					session_id: sessionId,
 					input: userMsg,
 				});
+				if (commandIntent && response.status === 'started') {
+					msgsRef.current = [...msgsRef.current, userMsg];
+					scheduleUpdate();
+				}
+				if (response.status === 'command_completed') {
+					resetForClear();
+				}
 			} catch (e) {
 				setError(e as Error);
+			} finally {
+				if (commandIntent) setCommandPending(false);
 			}
 		},
-		[agentId, sessionId, scheduleUpdate],
+		[agentId, sessionId, scheduleUpdate, resetForClear],
 	);
 
 	/**
@@ -546,5 +606,6 @@ export function useMessages(
 		subagentHitl,
 		abort,
 		interrupt,
+		commandPending,
 	};
 }

--- a/examples/web_ui/frontend/src/i18n/locales/en.json
+++ b/examples/web_ui/frontend/src/i18n/locales/en.json
@@ -136,6 +136,7 @@
 	},
 	"chat": {
 		"inputPlaceholder": "Type a message...",
+		"conversationCleared": "Conversation cleared",
 		"confirmToolCall": "Allow this action?",
 		"subagentConfirmTitle": "{{name}} requests confirmation",
 		"newSession": "New Session",

--- a/examples/web_ui/frontend/src/i18n/locales/zh.json
+++ b/examples/web_ui/frontend/src/i18n/locales/zh.json
@@ -136,6 +136,7 @@
 	},
 	"chat": {
 		"inputPlaceholder": "输入消息...",
+		"conversationCleared": "会话已清空",
 		"confirmToolCall": "允许此操作？",
 		"subagentConfirmTitle": "{{name}} 请求确认",
 		"newSession": "新会话",

--- a/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
+++ b/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
@@ -49,6 +49,7 @@ import {
 } from '@/components/ui/resizable.tsx';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { useAvailableModels } from '@/hooks/useAvailableModels';
+import { useCommands } from '@/hooks/useCommands';
 import { useKnowledgeBaseMiddlewareSchema } from '@/hooks/useKnowledgeBaseMiddlewareSchema';
 import { useKnowledgeBases } from '@/hooks/useKnowledgeBases';
 import { useMessages } from '@/hooks/useMessages';
@@ -223,6 +224,7 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 			setPermissionContext(value.permission_context as PermissionContext);
 		}
 	}, []);
+	const commands = useCommands();
 
 	const {
 		msgs,
@@ -233,9 +235,14 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 		onSubagentConfirm,
 		subagentHitl,
 		interrupt,
+		commandPending,
 	} = useMessages(agentId, sessionId, {
+		commands,
 		onTeamUpdated: handleTeamUpdated,
 		onStateUpdated: handleStateUpdated,
+		onSessionCleared: () => {
+			void refetchSessions();
+		},
 	});
 	const {
 		mcps,
@@ -803,7 +810,8 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 									git={workspaceStatus?.git ?? null}
 									onRefreshGit={refetchWorkspaceStatus}
 									phase={phase}
-									disabled={selectedModel === null}
+									disabled={selectedModel === null || commandPending}
+									commands={commands}
 									onSend={send}
 									onUserConfirm={onUserConfirm}
 									onInterrupt={interrupt}

--- a/src/agentscope/app/_app.py
+++ b/src/agentscope/app/_app.py
@@ -13,6 +13,7 @@ from ._router import (
     agent_router,
     channel_router,
     chat_router,
+    command_router,
     credential_router,
     health_router,
     hub_router,
@@ -379,6 +380,7 @@ def create_app(
     for router in (
         agent_router,
         chat_router,
+        command_router,
         credential_router,
         health_router,
         hub_router,

--- a/src/agentscope/app/_bus_ops.py
+++ b/src/agentscope/app/_bus_ops.py
@@ -85,6 +85,7 @@ async def enqueue_run_trigger(
     | UserInterruptEvent
     | Msg
     | None = None,
+    conversation_revision: int | None = None,
 ) -> None:
     """Enqueue a typed run trigger and signal dispatchers.
 
@@ -123,6 +124,18 @@ async def enqueue_run_trigger(
             ``model_dump(mode="json")`` internally — callers pass the
             event object, not a pre-serialised dict.
     """
+    if (
+        kind
+        in (
+            MessageBusKeys.WAKEUP_KIND_MESSAGE,
+            MessageBusKeys.WAKEUP_KIND_RESUME,
+        )
+        and conversation_revision is None
+    ):
+        raise ValueError(
+            f"A {kind!r} trigger requires conversation_revision.",
+        )
+
     await bus.queue_push(
         MessageBusKeys.wakeup_queue(),
         {
@@ -131,6 +144,7 @@ async def enqueue_run_trigger(
             "agent_id": agent_id,
             "kind": kind,
             "input": inputs.model_dump(mode="json") if inputs else None,
+            "conversation_revision": conversation_revision,
         },
     )
     await bus.publish(MessageBusKeys.wakeup_signal(), {})
@@ -167,6 +181,7 @@ async def deliver_to_inbox(
     session_id: str,
     agent_id: str,
     payload: dict,
+    conversation_revision: int | None = None,
 ) -> None:
     """Push a payload to a session inbox and wake the session if no run
     is currently consuming it.
@@ -188,7 +203,20 @@ async def deliver_to_inbox(
         MessageBusKeys.inbox_lock(session_id),
         ttl_secs=MessageBusKeys.INBOX_LOCK_TTL_SECS,
     ):
-        await bus.queue_push(MessageBusKeys.inbox(session_id), payload)
+        barriers = await bus.registry_getall(
+            MessageBusKeys.session_reset_barrier(session_id),
+        )
+        if barriers:
+            return
+        entry = (
+            payload
+            if conversation_revision is None
+            else {
+                "conversation_revision": conversation_revision,
+                "payload": payload,
+            }
+        )
+        await bus.queue_push(MessageBusKeys.inbox(session_id), entry)
         consumer = await bus.registry_get(
             MessageBusKeys.inbox_consumer(session_id),
             MessageBusKeys.INBOX_CONSUMER_FIELD,
@@ -200,6 +228,7 @@ async def deliver_to_inbox(
             user_id=user_id,
             session_id=session_id,
             agent_id=agent_id,
+            conversation_revision=conversation_revision,
         )
 
 
@@ -287,6 +316,7 @@ async def abandon_inbox_consumer(
     user_id: str,
     session_id: str,
     agent_id: str,
+    conversation_revision: int,
 ) -> None:
     """Give up the consumer registration without having drained the
     inbox, waking the session when payloads are still queued.
@@ -305,6 +335,8 @@ async def abandon_inbox_consumer(
             The session being abandoned.
         agent_id (`str`):
             The agent that owns the session.
+        conversation_revision (`int`):
+            The revision owned by the run handing off the inbox.
     """
     pending = await has_pending_inbox_or_release(bus, session_id)
     if not pending:
@@ -319,6 +351,7 @@ async def abandon_inbox_consumer(
         user_id=user_id,
         session_id=session_id,
         agent_id=agent_id,
+        conversation_revision=conversation_revision,
     )
 
 

--- a/src/agentscope/app/_command/__init__.py
+++ b/src/agentscope/app/_command/__init__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""Built-in slash-command metadata and parsing."""
+
+from ._dispatcher import (
+    CommandContext,
+    CommandResult,
+    dispatch_command,
+)
+from ._registry import (
+    BUILTIN_COMMANDS,
+    CommandMatch,
+    CommandSpec,
+    list_commands,
+    parse_command,
+)
+
+__all__ = [
+    "BUILTIN_COMMANDS",
+    "CommandContext",
+    "CommandMatch",
+    "CommandResult",
+    "CommandSpec",
+    "dispatch_command",
+    "list_commands",
+    "parse_command",
+]

--- a/src/agentscope/app/_command/_dispatcher.py
+++ b/src/agentscope/app/_command/_dispatcher.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""Execution boundary shared by HTTP and channel slash commands."""
+
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Literal, TYPE_CHECKING
+
+from ._registry import CommandMatch, list_commands
+
+if TYPE_CHECKING:
+    from .._service._session import SessionService
+
+
+@dataclass(frozen=True)
+class CommandContext:
+    """Carry the authenticated scope of a slash command."""
+
+    user_id: str
+    agent_id: str
+    session_id: str
+    source: Literal["http", "channel"]
+    command_message_id: str
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """Describe a completed command without creating chat history."""
+
+    name: str
+    root_session_id: str
+    affected_session_ids: tuple[str, ...]
+    message: str
+
+
+CommandHandler = Callable[
+    [CommandContext, "SessionService"],
+    Awaitable[CommandResult],
+]
+
+
+async def _clear(
+    context: CommandContext,
+    session_service: "SessionService",
+) -> CommandResult:
+    """Execute the built-in conversation reset command."""
+    affected = await session_service.clear_conversation(
+        context.user_id,
+        context.agent_id,
+        context.session_id,
+    )
+    return CommandResult(
+        name="clear",
+        root_session_id=context.session_id,
+        affected_session_ids=affected,
+        message="Conversation cleared.",
+    )
+
+
+_HANDLERS: dict[str, CommandHandler] = {"clear": _clear}
+_COMMAND_NAMES = {spec.name for spec in list_commands()}
+if set(_HANDLERS) != _COMMAND_NAMES:
+    raise RuntimeError(
+        f"Slash command registry and handlers differ: "
+        f"commands={sorted(_COMMAND_NAMES)!r}, "
+        f"handlers={sorted(_HANDLERS)!r}.",
+    )
+
+
+async def dispatch_command(
+    match: CommandMatch,
+    context: CommandContext,
+    session_service: "SessionService",
+) -> CommandResult:
+    """Execute a recognized command through its registered handler."""
+    handler = _HANDLERS.get(match.spec.name)
+    if handler is None:
+        raise RuntimeError(
+            f"Slash command {match.spec.name!r} has no handler.",
+        )
+    return await handler(context, session_service)

--- a/src/agentscope/app/_command/_registry.py
+++ b/src/agentscope/app/_command/_registry.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""Static registry for service-owned slash commands."""
+
+from dataclasses import dataclass
+
+from ...message import Msg, TextBlock
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    """Describe one built-in slash command."""
+
+    name: str
+    description: str
+    aliases: tuple[str, ...] = ()
+    accepts_args: bool = False
+
+
+@dataclass(frozen=True)
+class CommandMatch:
+    """Represent a recognized command and its raw arguments."""
+
+    spec: CommandSpec
+    args: str
+    message: Msg
+
+
+BUILTIN_COMMANDS = (
+    CommandSpec(
+        name="clear",
+        description="Clear the current conversation context",
+    ),
+)
+
+
+def _build_index() -> dict[str, CommandSpec]:
+    """Build the immutable name and alias lookup."""
+    result: dict[str, CommandSpec] = {}
+    for spec in BUILTIN_COMMANDS:
+        names = (spec.name, *spec.aliases)
+        for name in names:
+            key = name.casefold().strip()
+            if not key:
+                raise ValueError("Slash command names cannot be empty.")
+            if key in result:
+                raise ValueError(f"Duplicate slash command name {name!r}.")
+            result[key] = spec
+    return result
+
+
+_COMMAND_INDEX = _build_index()
+
+
+def parse_command(value: object) -> CommandMatch | None:
+    """Return a match for one plain user message, otherwise ``None``."""
+    message: Msg | None = None
+    if isinstance(value, Msg):
+        message = value
+    elif (
+        isinstance(value, list)
+        and len(value) == 1
+        and isinstance(value[0], Msg)
+    ):
+        message = value[0]
+    if message is None or message.role != "user":
+        return None
+    if len(message.content) != 1 or not isinstance(
+        message.content[0],
+        TextBlock,
+    ):
+        return None
+
+    text = message.content[0].text.strip()
+    if not text.startswith("/") or text.startswith("//"):
+        return None
+    parts = text[1:].split(maxsplit=1)
+    if not parts:
+        return None
+    command = parts[0]
+    args = parts[1].strip() if len(parts) == 2 else ""
+    spec = _COMMAND_INDEX.get(command.casefold())
+    if spec is None:
+        return None
+    return CommandMatch(spec=spec, args=args, message=message)
+
+
+def list_commands() -> tuple[CommandSpec, ...]:
+    """Return command metadata in stable name order."""
+    return tuple(sorted(BUILTIN_COMMANDS, key=lambda item: item.name))

--- a/src/agentscope/app/_lifespan.py
+++ b/src/agentscope/app/_lifespan.py
@@ -105,6 +105,13 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         )
         app.state.resource_access_service = resource_access_service
 
+        session_service = SessionService(
+            storage=storage,
+            message_bus=message_bus,
+            workspace_manager=workspace_manager,
+        )
+        app.state.session_service = session_service
+
         # Channel wiring is built here (before ChatService) so the chat
         # service can hand the client factory to get_toolkit: a session
         # that came from a channel gets that channel's platform tools.
@@ -147,6 +154,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                         storage=storage,
                         message_bus=message_bus,
                         workspace_manager=workspace_manager,
+                        session_service=session_service,
+                        channel_clients=channel_clients,
                     ),
                 )
         app.state.channel_clients = channel_clients
@@ -167,12 +176,6 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             channel_clients=channel_clients,
         )
         app.state.chat_service = chat_service
-
-        app.state.session_service = SessionService(
-            storage=storage,
-            message_bus=message_bus,
-            workspace_manager=workspace_manager,
-        )
 
         app.state.workspace_service = WorkspaceService(
             storage=storage,

--- a/src/agentscope/app/_manager/_scheduler/_scheduler_manager.py
+++ b/src/agentscope/app/_manager/_scheduler/_scheduler_manager.py
@@ -259,6 +259,7 @@ class SchedulerManager:
                     session_id=session.id,
                     agent_id=record.agent_id,
                     payload=hint.model_dump(mode="json"),
+                    conversation_revision=session.conversation_revision,
                 )
 
                 logger.info(

--- a/src/agentscope/app/_manager/_wakeup_dispatcher.py
+++ b/src/agentscope/app/_manager/_wakeup_dispatcher.py
@@ -206,6 +206,7 @@ class WakeupDispatcher:
                 agent_id=agent_id,
                 kind=kind,
                 raw_input=payload.get("input"),
+                raw_revision=payload.get("conversation_revision"),
             )
 
     async def _dispatch_one(
@@ -215,6 +216,7 @@ class WakeupDispatcher:
         agent_id: str,
         kind: str,
         raw_input: dict | None,
+        raw_revision: int | None,
     ) -> None:
         """Dispatch a single trigger entry by its ``kind``.
 
@@ -236,6 +238,14 @@ class WakeupDispatcher:
         # ``resume`` and ``message`` both carry input that must be
         # delivered — never dropped while the session is busy.
         carries_input = is_resume or is_message
+        if carries_input and not isinstance(raw_revision, int):
+            logger.warning(
+                "WakeupDispatcher: dropping %s trigger for session %s "
+                "without a valid conversation revision.",
+                kind,
+                session_id,
+            )
+            return
 
         # Parse the carried input early so every downstream path
         # (lock-retry, spawn-retry) receives a typed object rather than a
@@ -272,6 +282,56 @@ class WakeupDispatcher:
                 )
                 return
 
+        session_record = await self._storage.get_session(
+            user_id,
+            agent_id,
+            session_id,
+        )
+        if session_record is None:
+            logger.warning(
+                "WakeupDispatcher: dropping %s trigger for deleted "
+                "session %s (agent %s, user %s).",
+                kind,
+                session_id,
+                agent_id,
+                user_id,
+            )
+            await publish_session_event(
+                self._bus,
+                session_id,
+                ReplyEndEvent(
+                    session_id=session_id,
+                    reply_id="",
+                    finished_reason=ReplyFinishedReason.ERROR,
+                    error=ErrorInfo(
+                        type=ErrorType.INTERNAL,
+                        message="Session no longer exists.",
+                    ),
+                ).model_dump(mode="json"),
+            )
+            return
+        if session_record.agent_id != agent_id:
+            logger.warning(
+                "WakeupDispatcher: dropping %s trigger for session %s "
+                "because the agent does not match.",
+                kind,
+                session_id,
+            )
+            return
+        if (
+            isinstance(raw_revision, int)
+            and raw_revision != session_record.conversation_revision
+        ):
+            logger.info(
+                "WakeupDispatcher: dropping stale %s trigger for session "
+                "%s at revision %s; current revision is %d.",
+                kind,
+                session_id,
+                raw_revision,
+                session_record.conversation_revision,
+            )
+            return
+
         if await self._bus.is_locked(
             MessageBusKeys.session_lock(session_id),
         ):
@@ -289,42 +349,7 @@ class WakeupDispatcher:
                 agent_id,
                 kind,
                 input_msg,
-            )
-            return
-
-        # Orphan guard: the queue is unaware of session lifecycle. A
-        # trigger enqueued before the session was deleted (e.g. by a
-        # BG-task completion callback or a schedule trigger) will still
-        # arrive here. Drop it rather than letting ChatService.run crash
-        # on a missing storage record.
-        if (
-            await self._storage.get_session(user_id, agent_id, session_id)
-            is None
-        ):
-            logger.warning(
-                "WakeupDispatcher: dropping %s trigger for session %s "
-                "(agent %s, user %s) — session no longer exists in "
-                "storage; it was likely enqueued before the session was "
-                "deleted.",
-                kind,
-                session_id,
-                agent_id,
-                user_id,
-            )
-            # Surface an error on the event stream so collectors (e.g. the
-            # channel gateway) fail fast instead of waiting for a timeout.
-            await publish_session_event(
-                self._bus,
-                session_id,
-                ReplyEndEvent(
-                    session_id=session_id,
-                    reply_id="",
-                    finished_reason=ReplyFinishedReason.ERROR,
-                    error=ErrorInfo(
-                        type=ErrorType.INTERNAL,
-                        message="Session no longer exists.",
-                    ),
-                ).model_dump(mode="json"),
+                raw_revision,
             )
             return
 
@@ -335,6 +360,7 @@ class WakeupDispatcher:
                     session_id=session_id,
                     agent_id=agent_id,
                     input_msg=input_msg,
+                    accepted_revision=raw_revision,
                 ),
                 session_id=session_id,
                 name=f"{kind}-run:{session_id}",
@@ -350,6 +376,7 @@ class WakeupDispatcher:
                 agent_id,
                 kind,
                 input_msg,
+                raw_revision,
             )
 
     def _schedule_retry(
@@ -363,6 +390,7 @@ class WakeupDispatcher:
         | UserInterruptEvent
         | Msg
         | None,
+        conversation_revision: int | None,
     ) -> None:
         """Re-enqueue an input-carrying (``resume``/``message``) trigger
         after a short backoff.
@@ -395,6 +423,7 @@ class WakeupDispatcher:
                     agent_id=agent_id,
                     kind=kind,  # type: ignore[arg-type]  # resume | message
                     inputs=input_msg,
+                    conversation_revision=conversation_revision,
                 )
             except asyncio.CancelledError:
                 pass

--- a/src/agentscope/app/_router/__init__.py
+++ b/src/agentscope/app/_router/__init__.py
@@ -3,6 +3,7 @@
 from ._agent import agent_router
 from ._channel import channel_router
 from ._chat import chat_router
+from ._command import command_router
 from ._credential import credential_router
 from ._embedding_model import embedding_model_router
 from ._health import health_router
@@ -23,6 +24,7 @@ __all__ = [
     "embedding_model_router",
     "tts_model_router",
     "chat_router",
+    "command_router",
     "credential_router",
     "health_router",
     "hub_router",

--- a/src/agentscope/app/_router/_chat.py
+++ b/src/agentscope/app/_router/_chat.py
@@ -27,23 +27,66 @@ from ..deps import (
     get_chat_service,
     get_current_user_id,
     get_message_bus,
+    get_session_service,
+    get_storage,
 )
 from ._schema import ChatRequest, ChatTriggerResponse
 from .._manager import ChatRunRegistry
 from .._service import (
     ChatService,
+    SessionService,
     SessionProjection,
     SubagentHitlProjector,
 )
 from ..message_bus import MessageBus, MessageBusKeys
+from ..storage import SessionRecord, StorageBase
 from .._bus_ops import enqueue_run_trigger
 from ...event import UserConfirmResultEvent, ExternalExecutionResultEvent
+from ...message import ToolCallState
+from .._command import CommandContext, dispatch_command, parse_command
 
 chat_router = APIRouter(
     prefix="/chat",
     tags=["chat"],
     responses={404: {"description": "Not found"}},
 )
+
+
+def _is_current_hitl_result(
+    session: SessionRecord,
+    event: UserConfirmResultEvent | ExternalExecutionResultEvent,
+) -> bool:
+    """Whether an HITL result still targets the parked session state."""
+    if session.state.reply_id != event.reply_id or not session.state.context:
+        return False
+
+    last_msg = session.state.context[-1]
+    if last_msg.role != "assistant":
+        return False
+    tool_calls = last_msg.get_content_blocks("tool_call")
+    result_ids = {
+        block.id for block in last_msg.get_content_blocks("tool_result")
+    }
+
+    if isinstance(event, UserConfirmResultEvent):
+        awaiting_ids = {
+            block.id
+            for block in tool_calls
+            if block.state == ToolCallState.ASKING
+        }
+        incoming_ids = {
+            result.tool_call.id for result in event.confirm_results
+        }
+    else:
+        awaiting_ids = {
+            block.id
+            for block in tool_calls
+            if block.state == ToolCallState.SUBMITTED
+            and block.id not in result_ids
+        }
+        incoming_ids = {result.id for result in event.execution_results}
+
+    return bool(awaiting_ids) and incoming_ids.issubset(awaiting_ids)
 
 
 @chat_router.post(
@@ -57,6 +100,8 @@ async def chat(
     chat_service: ChatService = Depends(get_chat_service),
     chat_run_registry: ChatRunRegistry = Depends(get_chat_run_registry),
     message_bus: MessageBus = Depends(get_message_bus),
+    storage: StorageBase = Depends(get_storage),
+    session_service: SessionService = Depends(get_session_service),
 ) -> ChatTriggerResponse:
     """Trigger a chat run for the specified session.
 
@@ -98,6 +143,41 @@ async def chat(
             Only direct-spawn paths (new messages / ``None``) can raise
             this; the enqueued resume path never does.
     """
+    command = parse_command(request.input)
+    if command is not None:
+        if command.args and not command.spec.accepts_args:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"/{command.spec.name} does not accept arguments.",
+            )
+        try:
+            result = await dispatch_command(
+                command,
+                CommandContext(
+                    user_id=user_id,
+                    agent_id=request.agent_id,
+                    session_id=request.session_id,
+                    source="http",
+                    command_message_id=command.message.id,
+                ),
+                session_service,
+            )
+        except KeyError as error:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=str(error),
+            ) from error
+        except RuntimeError as error:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=str(error),
+            ) from error
+        return ChatTriggerResponse(
+            status="command_completed",
+            session_id=result.root_session_id,
+            command=result.name,
+        )
+
     # ------------------------------------------------------------------
     # HITL resume — route to the owning session, then enqueue.
     #
@@ -125,6 +205,21 @@ async def chat(
             run_session_id = target["worker_session_id"]
             run_agent_id = target["worker_agent_id"]
 
+        target_session = await storage.get_session(
+            user_id,
+            run_agent_id,
+            run_session_id,
+        )
+        if target_session is None or target_session.agent_id != run_agent_id:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Session {run_session_id!r} not found.",
+            )
+        if not _is_current_hitl_result(target_session, request.input):
+            return ChatTriggerResponse(
+                status="started",
+                session_id=run_session_id,
+            )
         await enqueue_run_trigger(
             message_bus,
             user_id=user_id,
@@ -132,6 +227,7 @@ async def chat(
             agent_id=run_agent_id,
             kind=MessageBusKeys.WAKEUP_KIND_RESUME,
             inputs=request.input,
+            conversation_revision=target_session.conversation_revision,
         )
         return ChatTriggerResponse(status="started", session_id=run_session_id)
 
@@ -139,6 +235,24 @@ async def chat(
     # New user message(s) / None — spawn directly. The registry's
     # single-run-per-session rule is the desired double-submit guard.
     # ------------------------------------------------------------------
+    session = await storage.get_session(
+        user_id,
+        request.agent_id,
+        request.session_id,
+    )
+    if session is None or session.agent_id != request.agent_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Session {request.session_id!r} not found.",
+        )
+    if await message_bus.registry_getall(
+        MessageBusKeys.session_reset_barrier(request.session_id),
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Session is resetting.",
+        )
+
     try:
         chat_run_registry.spawn(
             chat_service.run(
@@ -146,6 +260,7 @@ async def chat(
                 session_id=request.session_id,
                 agent_id=request.agent_id,
                 input_msg=request.input,
+                accepted_revision=session.conversation_revision,
             ),
             session_id=request.session_id,
         )

--- a/src/agentscope/app/_router/_command.py
+++ b/src/agentscope/app/_router/_command.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""Slash-command discovery endpoint."""
+
+from fastapi import APIRouter
+
+from .._command import list_commands
+from ._schema import CommandInfo, CommandListResponse
+
+command_router = APIRouter(prefix="/commands", tags=["commands"])
+
+
+@command_router.get("/", response_model=CommandListResponse)
+async def commands() -> CommandListResponse:
+    """List built-in slash commands exposed by the service."""
+    return CommandListResponse(
+        commands=[
+            CommandInfo(
+                name=spec.name,
+                command=f"/{spec.name}",
+                aliases=list(spec.aliases),
+                description=spec.description,
+                accepts_args=spec.accepts_args,
+            )
+            for spec in list_commands()
+        ],
+    )

--- a/src/agentscope/app/_router/_schema/__init__.py
+++ b/src/agentscope/app/_router/_schema/__init__.py
@@ -11,6 +11,7 @@ from ._channel import (
     UpdateChannelRequest,
 )
 from ._chat import ChatRequest, ChatTriggerResponse
+from ._command import CommandInfo, CommandListResponse
 from ._health import ComponentStatus, HealthResponse
 from ._hub import HubInfo
 from ._hub_mcp import InstallMCPRequest, MCPView, UpdateMCPRequest
@@ -127,6 +128,8 @@ __all__ = [
     # Chat
     "ChatRequest",
     "ChatTriggerResponse",
+    "CommandInfo",
+    "CommandListResponse",
     # Credential
     "CreateCredentialRequest",
     "CreateCredentialResponse",

--- a/src/agentscope/app/_router/_schema/_chat.py
+++ b/src/agentscope/app/_router/_schema/_chat.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """The chat endpoint schema."""
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 from ....message import Msg
@@ -36,10 +38,17 @@ class ChatTriggerResponse(BaseModel):
     run arrive separately via the session's SSE stream endpoint.
     """
 
-    status: str = Field(
+    status: Literal["started", "command_completed"] = Field(
         default="started",
-        description='Always ``"started"`` when the trigger succeeded.',
+        description=(
+            '``"started"`` for chat runs or ``"command_completed"`` '
+            "for synchronous commands."
+        ),
     )
     session_id: str = Field(
         description="Echo of the session id the run was started for.",
+    )
+    command: str | None = Field(
+        default=None,
+        description="Completed slash command, when status identifies one.",
     )

--- a/src/agentscope/app/_router/_schema/_command.py
+++ b/src/agentscope/app/_router/_schema/_command.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+"""Slash-command API schemas."""
+
+from pydantic import BaseModel
+
+
+class CommandInfo(BaseModel):
+    """Public metadata for one slash command."""
+
+    name: str
+    command: str
+    aliases: list[str]
+    description: str
+    accepts_args: bool
+
+
+class CommandListResponse(BaseModel):
+    """Response containing all built-in commands."""
+
+    commands: list[CommandInfo]

--- a/src/agentscope/app/_router/_session.py
+++ b/src/agentscope/app/_router/_session.py
@@ -805,11 +805,38 @@ async def stream_session_events(
         )
 
     async def _sse_generator() -> AsyncGenerator[str, None]:
-        # 1. Replay buffered events from the current run (if any).
-        for _entry_id, event in await message_bus.log_read(
+        # Subscribe before replay so an event published during bootstrap
+        # lands either in the replay snapshot, the live queue, or both.
+        # Entry ids remove the deliberate overlap.
+        queue: asyncio.Queue[dict | None] = asyncio.Queue()
+        ready = asyncio.Event()
+
+        async def _feeder() -> None:
+            """Read live events into the bootstrap-safe local queue."""
+            try:
+                async for evt in message_bus.subscribe(
+                    MessageBusKeys.session_events(session_id),
+                    on_ready=ready.set,
+                ):
+                    await queue.put(evt)
+            except asyncio.CancelledError:
+                pass
+            finally:
+                ready.set()
+                await queue.put(None)
+
+        feeder_task = asyncio.create_task(
+            _feeder(),
+            name=f"sse-feeder:{session_id}",
+        )
+        await ready.wait()
+
+        replay_ids: set[str] = set()
+        for entry_id, event in await message_bus.log_read(
             MessageBusKeys.session_events(session_id),
             max_count=MessageBusKeys.SESSION_REPLAY_MAX_LEN,
         ):
+            replay_ids.add(entry_id)
             yield f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
 
         # 1b. Inject pending subagent HITL cards projected onto this
@@ -853,39 +880,6 @@ async def stream_session_events(
 
             yield f"data: {data}\n\n"
 
-        # 2. Live subscribe via a background feeder task that pushes
-        #    events into a queue. The main loop reads from the queue
-        #    with a timeout so we can interleave heartbeat frames.
-        #
-        #    We avoid calling ``wait_for(__anext__())`` on the async
-        #    generator directly because cancelling a suspended
-        #    ``__anext__`` leaves the generator in a "running" state
-        #    that prevents ``aclose()`` from working.
-        queue: asyncio.Queue[dict | None] = asyncio.Queue()
-
-        async def _feeder() -> None:
-            """Read from the bus subscription and forward to the queue.
-
-            Pushes ``None`` as a sentinel when the subscription ends
-            (which in practice only happens if the bus shuts down).
-            """
-            try:
-                async for evt in message_bus.subscribe(
-                    MessageBusKeys.session_events(session_id),
-                ):
-                    await queue.put(
-                        {k: v for k, v in evt.items() if k != "_entry_id"},
-                    )
-            except asyncio.CancelledError:
-                pass
-            finally:
-                await queue.put(None)
-
-        feeder_task = asyncio.create_task(
-            _feeder(),
-            name=f"sse-feeder:{session_id}",
-        )
-
         try:
             while True:
                 try:
@@ -895,7 +889,16 @@ async def stream_session_events(
                     )
                     if item is None:
                         break
-                    yield f"data: {json.dumps(item, ensure_ascii=False)}\n\n"
+                    entry_id = item.get("_entry_id")
+                    if entry_id in replay_ids:
+                        continue
+                    payload = {
+                        key: value
+                        for key, value in item.items()
+                        if key != "_entry_id"
+                    }
+                    data = json.dumps(payload, ensure_ascii=False)
+                    yield f"data: {data}\n\n"
                 except asyncio.TimeoutError:
                     yield ":\n\n"
         finally:

--- a/src/agentscope/app/_service/_chat.py
+++ b/src/agentscope/app/_service/_chat.py
@@ -235,6 +235,7 @@ class ChatService:
         | ExternalExecutionResultEvent
         | UserInterruptEvent
         | None = None,
+        accepted_revision: int | None = None,
     ) -> None:
         """Drive a chat run to completion.
 
@@ -276,7 +277,13 @@ class ChatService:
                   results and ends the reply (Case B, no reasoning).
         """
         try:
-            await self._run_impl(user_id, session_id, agent_id, input_msg)
+            await self._run_impl(
+                user_id,
+                session_id,
+                agent_id,
+                input_msg,
+                accepted_revision,
+            )
         except Exception as e:
             logger.exception(
                 "ChatService.run failed for user_id=%s session_id=%s "
@@ -413,12 +420,20 @@ class ChatService:
                     ensure_ascii=False,
                 ),
             )
+            leader_session = await self._storage.get_session(
+                user_id,
+                team_ctx.leader_agent_id,
+                team_ctx.leader_session_id,
+            )
+            if leader_session is None:
+                return
             await deliver_to_inbox(
                 self._message_bus,
                 user_id=user_id,
                 session_id=team_ctx.leader_session_id,
                 agent_id=team_ctx.leader_agent_id,
                 payload=hint.model_dump(mode="json"),
+                conversation_revision=(leader_session.conversation_revision),
             )
         except Exception:  # pylint: disable=broad-except
             logger.exception(
@@ -573,6 +588,7 @@ class ChatService:
             agent_id=agent_id,
             kind=MessageBusKeys.WAKEUP_KIND_RESUME,
             inputs=UserInterruptEvent(reply_id=session.state.reply_id),
+            conversation_revision=session.conversation_revision,
         )
 
     @staticmethod
@@ -643,6 +659,7 @@ class ChatService:
         | ExternalExecutionResultEvent
         | UserInterruptEvent
         | None,
+        accepted_revision: int | None = None,
     ) -> None:
         """The actual chat-run body; wrapped by :meth:`run` for error
         swallowing. Separated so the try/except doesn't bury the
@@ -700,6 +717,33 @@ class ChatService:
                             f"agent {agent_id!r}."
                         ),
                     )
+                if session_record.agent_id != agent_id:
+                    raise HTTPException(
+                        status_code=404,
+                        detail=f"Session {session_id!r} not found.",
+                    )
+                barriers = await self._message_bus.registry_getall(
+                    MessageBusKeys.session_reset_barrier(session_id),
+                )
+                if barriers:
+                    logger.info(
+                        "Dropping run for session %s while it is resetting.",
+                        session_id,
+                    )
+                    return
+                if (
+                    accepted_revision is not None
+                    and accepted_revision
+                    != session_record.conversation_revision
+                ):
+                    logger.info(
+                        "Dropping stale input for session %s: accepted at "
+                        "revision %d, current revision %d.",
+                        session_id,
+                        accepted_revision,
+                        session_record.conversation_revision,
+                    )
+                    return
                 worker_name = agent_record.data.name
 
                 # -------------------------------------------------------------
@@ -791,7 +835,10 @@ class ChatService:
                 # in-process retrigger plumbing is needed here.
                 # -------------------------------------------------------------
                 middlewares: list = [
-                    InboxMiddleware(self._message_bus),
+                    InboxMiddleware(
+                        self._message_bus,
+                        session_record.conversation_revision,
+                    ),
                     StateChangeMiddleware(
                         message_bus=self._message_bus,
                         session_id=session_id,
@@ -801,6 +848,9 @@ class ChatService:
                         message_bus=self._message_bus,
                         user_id=user_id,
                         agent_id=agent_id,
+                        conversation_revision=(
+                            session_record.conversation_revision
+                        ),
                     ),
                 ]
                 # Equip the member middleware for loop control
@@ -1239,6 +1289,9 @@ class ChatService:
                         user_id=user_id,
                         session_id=session_id,
                         agent_id=agent_id,
+                        conversation_revision=(
+                            session_record.conversation_revision
+                        ),
                     )
 
                 # The last turn's reply is only in ``reply_msgs`` when the

--- a/src/agentscope/app/_service/_session.py
+++ b/src/agentscope/app/_service/_session.py
@@ -46,9 +46,14 @@ component that touches both in the same call. Storage code never
 imports the bus; bus code never imports storage.
 """
 import asyncio
+import json
+import uuid
+from contextlib import AsyncExitStack
+from dataclasses import dataclass
 from enum import StrEnum
 
 from ..message_bus import MessageBus, MessageBusKeys
+from .._bus_ops import publish_session_event
 from ..storage import StorageBase
 from ..workspace_manager import WorkspaceManagerBase
 from ..storage._utils import _ensure_team_members
@@ -56,6 +61,34 @@ from ._session_projection import SessionProjection
 from ._projectors import SubagentHitlProjector
 from ..._logging import logger
 from ...message import ToolCallState
+from ...event import CustomEvent
+from ...state import AgentState
+
+
+@dataclass(frozen=True)
+class SessionResetTarget:
+    """Identify one session selected by a clear operation."""
+
+    user_id: str
+    agent_id: str
+    session_id: str
+    role: str
+
+
+async def _refresh_barriers_once(
+    bus: MessageBus,
+    targets: list[SessionResetTarget],
+    operation_id: str,
+    value: str,
+) -> None:
+    """Create or refresh one clear operation's barrier fields."""
+    for target in targets:
+        await bus.registry_set(
+            MessageBusKeys.session_reset_barrier(target.session_id),
+            operation_id,
+            value,
+            ttl_secs=MessageBusKeys.SESSION_RESET_BARRIER_TTL_SECS,
+        )
 
 
 class SessionStatus(StrEnum):
@@ -322,6 +355,256 @@ class SessionService:
     # ``delete_session`` so the cancel + bus-purge logic exists in
     # exactly one place.
     # ------------------------------------------------------------------
+
+    async def clear_conversation(
+        self,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> tuple[str, ...]:
+        """Reset one conversation, cascading from a team leader.
+
+        The operation preserves session configuration, permissions,
+        workspace contents, MCP state, and team topology. It clears only
+        conversation state, persisted messages, and transient bus state.
+
+        Team resets are an idempotent saga rather than a cross-session
+        transaction. Resolved targets commit independently; after partial
+        success this method raises ``RuntimeError`` without rolling back
+        completed targets, and callers may safely retry the whole clear.
+        """
+        root = await self._storage.get_session(user_id, agent_id, session_id)
+        if root is None or root.agent_id != agent_id:
+            raise KeyError(f"Session {session_id!r} not found.")
+
+        targets = [
+            SessionResetTarget(user_id, agent_id, session_id, "standalone"),
+        ]
+        resolution_failures: list[str] = []
+        is_team_clear = False
+        if root.team_id is not None:
+            team = await self._storage.get_team(user_id, root.team_id)
+            if team is not None and team.session_id == session_id:
+                is_team_clear = True
+                targets[0] = SessionResetTarget(
+                    user_id,
+                    agent_id,
+                    session_id,
+                    "leader",
+                )
+                members = await _ensure_team_members(
+                    self._storage,
+                    user_id,
+                    team,
+                )
+                for member in members:
+                    record = await self._storage.get_session(
+                        member.owner_id,
+                        member.agent_id,
+                        member.session_id,
+                    )
+                    if (
+                        record is None
+                        or record.agent_id != member.agent_id
+                        or record.team_id != team.id
+                    ):
+                        resolution_failures.append(member.session_id)
+                        # pylint: disable-next=logging-fstring-interpolation
+                        logger.warning(
+                            f"Skipping unresolved team member session "
+                            f"{member.session_id} while clearing leader "
+                            f"session {session_id}.",
+                        )
+                        continue
+                    targets.append(
+                        SessionResetTarget(
+                            record.user_id,
+                            member.agent_id,
+                            member.session_id,
+                            "worker",
+                        ),
+                    )
+
+        deduped = {target.session_id: target for target in targets}
+        targets = [deduped[key] for key in sorted(deduped)]
+        operation_id = uuid.uuid4().hex
+        barrier_value = json.dumps(
+            {"root_session_id": session_id},
+            ensure_ascii=False,
+        )
+        heartbeat_stop = asyncio.Event()
+
+        async def _refresh_barriers() -> None:
+            """Keep every target barrier alive until reset finishes."""
+            while not heartbeat_stop.is_set():
+                for target in targets:
+                    await self._bus.registry_set(
+                        MessageBusKeys.session_reset_barrier(
+                            target.session_id,
+                        ),
+                        operation_id,
+                        barrier_value,
+                        ttl_secs=(
+                            MessageBusKeys.SESSION_RESET_BARRIER_TTL_SECS
+                        ),
+                    )
+                try:
+                    await asyncio.wait_for(heartbeat_stop.wait(), timeout=10)
+                except asyncio.TimeoutError:
+                    continue
+
+        heartbeat: asyncio.Task[None] | None = None
+        try:
+            await _refresh_barriers_once(
+                self._bus,
+                targets,
+                operation_id,
+                barrier_value,
+            )
+            heartbeat = asyncio.create_task(
+                _refresh_barriers(),
+                name=f"session-clear-barrier:{session_id}",
+            )
+            released = await asyncio.gather(
+                *(
+                    self.cancel_session_run(target.session_id)
+                    for target in targets
+                ),
+            )
+            if not all(released):
+                raise RuntimeError("A session run did not stop in time.")
+
+            failures = list(resolution_failures)
+            completed: list[str] = []
+            async with AsyncExitStack() as locks:
+                for target in targets:
+                    await locks.enter_async_context(
+                        self._bus.acquire_lock(
+                            MessageBusKeys.session_lock(target.session_id),
+                            ttl_secs=MessageBusKeys.SESSION_RUN_TTL_SECS,
+                        ),
+                    )
+                for target in targets:
+                    try:
+                        await self._reset_conversation_target(
+                            target,
+                            root_session_id=session_id,
+                            scope="team" if is_team_clear else "session",
+                        )
+                        completed.append(target.session_id)
+                    except Exception:  # pylint: disable=broad-except
+                        failures.append(target.session_id)
+                        logger.exception(
+                            "Failed to clear session %s.",
+                            target.session_id,
+                        )
+            if failures:
+                raise RuntimeError(
+                    f"Conversation reset failed for {len(failures)} "
+                    f"session(s).",
+                )
+            return tuple(completed)
+        finally:
+            heartbeat_stop.set()
+            if heartbeat is not None:
+                heartbeat.cancel()
+                await asyncio.gather(heartbeat, return_exceptions=True)
+            await asyncio.gather(
+                *(
+                    self._bus.registry_del(
+                        MessageBusKeys.session_reset_barrier(
+                            target.session_id,
+                        ),
+                        operation_id,
+                    )
+                    for target in targets
+                ),
+            )
+
+    async def _reset_conversation_target(
+        self,
+        target: SessionResetTarget,
+        *,
+        root_session_id: str,
+        scope: str,
+    ) -> None:
+        """Reset one already-locked target and publish its clear event."""
+
+        async def _reset_and_publish() -> None:
+            """Finish a reset after it starts despite caller cancellation."""
+            existing = await self._storage.get_session(
+                target.user_id,
+                target.agent_id,
+                target.session_id,
+            )
+            if existing is None or existing.agent_id != target.agent_id:
+                raise KeyError(f"Session {target.session_id!r} not found.")
+
+            state = AgentState(
+                session_id=existing.id,
+                permission_context=(
+                    existing.state.permission_context.model_copy(deep=True)
+                ),
+            )
+            updated = await self._storage.reset_session_conversation(
+                target.user_id,
+                target.agent_id,
+                target.session_id,
+                state,
+                existing.conversation_revision,
+            )
+
+            await self._purge_subagent_hitl(
+                target.user_id,
+                target.agent_id,
+                target.session_id,
+            )
+            await self._bus.queue_delete(
+                MessageBusKeys.inbox(target.session_id),
+            )
+            await self._bus.registry_drop(
+                MessageBusKeys.inbox_consumer(target.session_id),
+            )
+            await self._bus.registry_drop(
+                MessageBusKeys.bg_tasks(target.session_id),
+            )
+            await self._bus.log_trim(
+                MessageBusKeys.session_events(target.session_id),
+            )
+            event = CustomEvent(
+                name="session_cleared",
+                value={
+                    "root_session_id": root_session_id,
+                    "session_id": target.session_id,
+                    "scope": scope,
+                    "conversation_revision": updated.conversation_revision,
+                    "tasks_context": state.tasks_context.model_dump(
+                        mode="json",
+                    ),
+                    "permission_context": (
+                        state.permission_context.model_dump(mode="json")
+                    ),
+                },
+            )
+            await publish_session_event(
+                self._bus,
+                target.session_id,
+                event.model_dump(mode="json"),
+            )
+
+        reset_task = asyncio.create_task(_reset_and_publish())
+        try:
+            await asyncio.shield(reset_task)
+        except asyncio.CancelledError:
+            try:
+                await reset_task
+            except Exception:  # pylint: disable=broad-except
+                # pylint: disable-next=logging-fstring-interpolation
+                logger.exception(
+                    f"Failed to finish session {target.session_id} after "
+                    f"cancellation.",
+                )
+            raise
 
     async def delete_session(
         self,

--- a/src/agentscope/app/_tool/_agent_create.py
+++ b/src/agentscope/app/_tool/_agent_create.py
@@ -498,6 +498,7 @@ optional):
                 session_id=worker_session.id,
                 agent_id=worker_agent.id,
                 payload=hint.model_dump(mode="json"),
+                conversation_revision=worker_session.conversation_revision,
             )
 
             return ToolChunk(

--- a/src/agentscope/app/_tool/_agent_invite.py
+++ b/src/agentscope/app/_tool/_agent_invite.py
@@ -436,6 +436,7 @@ class AgentInvite(_TeamToolBase):
                 session_id=borrowed.id,
                 agent_id=invited.id,
                 payload=hint.model_dump(mode="json"),
+                conversation_revision=borrowed.conversation_revision,
             )
 
             return ToolChunk(

--- a/src/agentscope/app/_tool/_team_say.py
+++ b/src/agentscope/app/_tool/_team_say.py
@@ -280,12 +280,20 @@ class TeamSay(_TeamToolBase):
             payload = hint.model_dump(mode="json")
 
             for sid, aid in recipients:
+                target = await self._storage.get_session(
+                    self._user_id,
+                    aid,
+                    sid,
+                )
+                if target is None:
+                    continue
                 await deliver_to_inbox(
                     self._message_bus,
                     user_id=self._user_id,
                     session_id=sid,
                     agent_id=aid,
                     payload=payload,
+                    conversation_revision=target.conversation_revision,
                 )
 
             count = len(recipients)

--- a/src/agentscope/app/channel/_base.py
+++ b/src/agentscope/app/channel/_base.py
@@ -331,6 +331,14 @@ class ChannelBase(ABC):
             events (`AsyncIterator[dict]`): The run's session events.
         """
 
+    async def send_notice(self, event: ChannelEvent, text: str) -> None:
+        """Send a non-conversation service notice to the source chat.
+
+        Custom channels written before slash commands may leave this
+        unsupported without becoming abstract.
+        """
+        raise NotImplementedError
+
     def _render(
         self,
         reply: Msg | None,

--- a/src/agentscope/app/channel/_decision.py
+++ b/src/agentscope/app/channel/_decision.py
@@ -20,7 +20,7 @@ async def _load_awaiting(
     user_id: str,
     agent_id: str,
     session_id: str,
-) -> tuple[list[ToolCallBlock], str]:
+) -> tuple[list[ToolCallBlock], str, int]:
     """Load a session's ASKING tool calls and its current reply id.
 
     Args:
@@ -40,13 +40,13 @@ async def _load_awaiting(
     )
     agent = await storage.get_agent(user_id=user_id, agent_id=agent_id)
     if session is None or agent is None:
-        return [], ""
+        return [], "", 0
     asking = [
         tc
         for tc in session.state.get_awaiting_tool_calls(agent.data.name)
         if tc.state == ToolCallState.ASKING
     ]
-    return asking, session.state.reply_id
+    return asking, session.state.reply_id, session.conversation_revision
 
 
 async def resume_after_decision(
@@ -77,7 +77,7 @@ async def resume_after_decision(
     Returns:
         `bool`: Whether a resume was enqueued.
     """
-    asking, reply_id = await _load_awaiting(
+    asking, reply_id, revision = await _load_awaiting(
         storage,
         user_id=user_id,
         agent_id=agent_id,
@@ -98,5 +98,6 @@ async def resume_after_decision(
                 ConfirmResult(confirmed=approved, tool_call=tool_call),
             ],
         ),
+        conversation_revision=revision,
     )
     return True

--- a/src/agentscope/app/channel/_dingtalk/_channel.py
+++ b/src/agentscope/app/channel/_dingtalk/_channel.py
@@ -386,6 +386,10 @@ class DingTalkChannel(ChannelBase):
                 reply.name if reply else "",
             )
 
+    async def send_notice(self, event: ChannelEvent, text: str) -> None:
+        """Post a plain service notice without an Agent reply stream."""
+        await self._api().send_text(event.chat_id, text)
+
     def _has_streaming_text(self, reply: Msg) -> bool:
         """Whether the partial reply contains text enabled for display."""
         for block in reply.content:

--- a/src/agentscope/app/channel/_discord/_channel.py
+++ b/src/agentscope/app/channel/_discord/_channel.py
@@ -354,6 +354,12 @@ class DiscordChannel(ChannelBase):
         if confirm is not None:
             await self._present_confirm(event, confirm)
 
+    async def send_notice(self, event: ChannelEvent, text: str) -> None:
+        """Post a plain service notice without an Agent reply stream."""
+        channel = await self._channel(event.chat_id)
+        if channel is not None:
+            await channel.send(text)
+
     async def _present_confirm(
         self,
         event: ChannelEvent,

--- a/src/agentscope/app/channel/_feishu/_channel.py
+++ b/src/agentscope/app/channel/_feishu/_channel.py
@@ -731,6 +731,15 @@ class FeishuChannel(ChannelBase):
         if confirm is not None:
             await self._present_confirm(event, confirm)
 
+    async def send_notice(self, event: ChannelEvent, text: str) -> None:
+        """Post a plain service notice without an Agent reply stream."""
+        await self._send(
+            event.channel_message_id,
+            event.chat_id,
+            "text",
+            json.dumps({"text": text}, ensure_ascii=False),
+        )
+
     async def _finish_card(
         self,
         event: ChannelEvent,

--- a/src/agentscope/app/channel/_gateway.py
+++ b/src/agentscope/app/channel/_gateway.py
@@ -22,18 +22,22 @@ from ..._logging import logger
 from ...message import DataBlock, HintBlock, TextBlock, UserMsg
 from ...permission import PermissionContext, PermissionMode
 from ...state import AgentState
-from .._bus_ops import enqueue_run_trigger
+from .._bus_ops import deliver_to_inbox, enqueue_run_trigger
 from ..message_bus import MessageBus, MessageBusKeys
 from ..storage import (
     ChannelRecord,
     ChatModelConfig,
     SessionConfig,
+    SessionRecord,
     SessionScope,
     SessionSource,
     StorageBase,
 )
 from ..workspace_manager import WorkspaceManagerBase
+from .._command import CommandContext, dispatch_command, parse_command
+from .._service._session import SessionService
 from ._base import ChannelEvent, ChannelConfirmationResultEvent
+from ._clients import ChannelClients
 from ._decision import resume_after_decision
 from ._routing import resolve
 
@@ -51,6 +55,8 @@ class ChannelGateway:
         storage: StorageBase,
         message_bus: MessageBus,
         workspace_manager: WorkspaceManagerBase,
+        session_service: SessionService | None = None,
+        channel_clients: ChannelClients | None = None,
     ) -> None:
         """Bind storage, the message bus, and the workspace manager.
 
@@ -63,6 +69,8 @@ class ChannelGateway:
         self._storage = storage
         self._bus = message_bus
         self._workspace_manager = workspace_manager
+        self._session_service = session_service
+        self._channel_clients = channel_clients
 
     async def process(
         self,
@@ -176,6 +184,7 @@ class ChannelGateway:
 
     # -- Message path --
 
+    # pylint: disable-next=too-many-return-statements
     async def _handle_message(self, event: ChannelEvent) -> None:
         """Aggregate buffered media, then inject a hint into a live run
         or start a fresh user turn on an idle session.
@@ -202,12 +211,114 @@ class ChannelGateway:
         if content is None:
             return  # media buffered; nothing to run until a text message
 
+        command = parse_command(
+            UserMsg(name=event.channel_user_id, content=content),
+        )
+        if command is not None:
+            channel = (
+                await self._channel_clients.get(event.channel_id)
+                if self._channel_clients is not None
+                else None
+            )
+            if command.args and not command.spec.accepts_args:
+                if channel is not None:
+                    await channel.send_notice(
+                        event,
+                        f"/{command.spec.name} does not accept arguments.",
+                    )
+                return
+            session = await self._storage.get_session(
+                record.user_id,
+                agent_id,
+                session_id,
+            )
+            if session is None:
+                if channel is not None:
+                    await channel.send_notice(event, "Conversation is empty.")
+                return
+            if self._session_service is None:
+                return
+            try:
+                result = await dispatch_command(
+                    command,
+                    CommandContext(
+                        user_id=record.user_id,
+                        agent_id=agent_id,
+                        session_id=session_id,
+                        source="channel",
+                        command_message_id=command.message.id,
+                    ),
+                    self._session_service,
+                )
+            except KeyError:
+                # pylint: disable-next=logging-fstring-interpolation
+                logger.warning(
+                    f"Channel command /{command.spec.name} targeted a "
+                    f"missing session {session_id}.",
+                )
+                if channel is not None:
+                    await channel.send_notice(
+                        event,
+                        "Conversation no longer exists.",
+                    )
+                return
+            except RuntimeError:
+                # pylint: disable-next=logging-fstring-interpolation
+                logger.exception(
+                    f"Channel command /{command.spec.name} did not "
+                    f"complete for session {session_id}.",
+                )
+                if channel is not None:
+                    await channel.send_notice(
+                        event,
+                        "Conversation clear did not fully complete. "
+                        "Please retry.",
+                    )
+                return
+            except Exception:  # pylint: disable=broad-except
+                # pylint: disable-next=logging-fstring-interpolation
+                logger.exception(
+                    f"Channel command /{command.spec.name} failed for "
+                    f"session {session_id}.",
+                )
+                if channel is not None:
+                    await channel.send_notice(
+                        event,
+                        "Conversation could not be cleared. Please retry.",
+                    )
+                return
+            if channel is not None:
+                await channel.send_notice(event, result.message)
+            return
+
+        if await self._bus.registry_getall(
+            MessageBusKeys.session_reset_barrier(session_id),
+        ):
+            channel = (
+                await self._channel_clients.get(event.channel_id)
+                if self._channel_clients is not None
+                else None
+            )
+            if channel is not None:
+                await channel.send_notice(event, "Conversation is resetting.")
+            return
+
         # A reply already in flight → inject the input as a hint so the
         # live run folds it in. Otherwise start a fresh user turn.
         if await self._bus.is_locked(MessageBusKeys.session_lock(session_id)):
-            await self._bus.queue_push(
-                MessageBusKeys.inbox(session_id),
-                HintBlock(
+            session = await self._storage.get_session(
+                record.user_id,
+                agent_id,
+                session_id,
+            )
+            if session is None:
+                return
+            await deliver_to_inbox(
+                self._bus,
+                user_id=record.user_id,
+                session_id=session_id,
+                agent_id=agent_id,
+                payload=HintBlock(
                     hint=content,
                     source=json.dumps(
                         {
@@ -218,10 +329,17 @@ class ChannelGateway:
                         ensure_ascii=False,
                     ),
                 ).model_dump(mode="json"),
+                conversation_revision=session.conversation_revision,
             )
             return
 
-        await self._ensure_session(record, agent_id, session_id, event, scope)
+        session = await self._ensure_session(
+            record,
+            agent_id,
+            session_id,
+            event,
+            scope,
+        )
         # Deliver as a genuine user turn; the run's output is streamed
         # back by the dispatcher's forward loop, not collected here.
         await enqueue_run_trigger(
@@ -231,6 +349,7 @@ class ChannelGateway:
             agent_id=agent_id,
             kind=MessageBusKeys.WAKEUP_KIND_MESSAGE,
             inputs=UserMsg(name=event.channel_user_id, content=content),
+            conversation_revision=session.conversation_revision,
         )
 
     async def _aggregate_media(
@@ -271,8 +390,8 @@ class ChannelGateway:
         session_id: str,
         event: ChannelEvent,
         scope: SessionScope,
-    ) -> None:
-        """Create the derived session if absent (idempotent across nodes).
+    ) -> SessionRecord:
+        """Return the derived session, creating it if absent.
 
         Args:
             record (`ChannelRecord`): The owning channel record.
@@ -280,6 +399,9 @@ class ChannelGateway:
             session_id (`str`): The derived session id.
             event (`ChannelEvent`): The originating message.
             scope (`SessionScope`): How the session is grouped.
+
+        Returns:
+            `SessionRecord`: The existing or newly created channel session.
         """
         existing = await self._storage.get_session(
             user_id=record.user_id,
@@ -287,7 +409,7 @@ class ChannelGateway:
             session_id=session_id,
         )
         if existing is not None:
-            return
+            return existing
 
         fallback = record.session.fallback_chat_model_config
         session_config = SessionConfig(
@@ -309,7 +431,7 @@ class ChannelGateway:
                 mode=PermissionMode(record.session.permission_mode),
             ),
         )
-        await self._storage.upsert_session(
+        return await self._storage.upsert_session(
             user_id=record.user_id,
             agent_id=agent_id,
             config=session_config,

--- a/src/agentscope/app/message_bus/_keys.py
+++ b/src/agentscope/app/message_bus/_keys.py
@@ -145,6 +145,16 @@ class MessageBusKeys:  # pylint: disable=too-many-public-methods
         """Per-session distributed-lock key."""
         return cls._SESSION_LOCK.format(sid=session_id)
 
+    _SESSION_RESET_BARRIER = "agentscope:session:reset:{sid}"
+
+    SESSION_RESET_BARRIER_TTL_SECS = 30
+    """Sliding lifetime of a clear-operation barrier."""
+
+    @classmethod
+    def session_reset_barrier(cls, session_id: str) -> str:
+        """Registry namespace for active clear operations."""
+        return cls._SESSION_RESET_BARRIER.format(sid=session_id)
+
     # ------------------------------------------------------------------
     # Session inbox
     # ------------------------------------------------------------------

--- a/src/agentscope/app/message_bus/_redis_message_bus.py
+++ b/src/agentscope/app/message_bus/_redis_message_bus.py
@@ -403,9 +403,14 @@ class RedisMessageBus(MessageBus):
             ttl_secs (`int | None`, optional):
                 Refresh the key's expiry (sliding TTL).
         """
-        await self._client.hset(namespace, field, value)
-        if ttl_secs is not None:
-            await self._client.expire(namespace, ttl_secs)
+        if ttl_secs is None:
+            await self._client.hset(namespace, field, value)
+            return
+
+        async with self._client.pipeline(transaction=True) as pipe:
+            pipe.hset(namespace, field, value)
+            pipe.expire(namespace, ttl_secs)
+            await pipe.execute()
 
     async def registry_del(self, namespace: str, field: str) -> None:
         """Remove ``field`` from the Redis Hash at ``namespace``.

--- a/src/agentscope/app/middleware/_inbox_middleware.py
+++ b/src/agentscope/app/middleware/_inbox_middleware.py
@@ -41,6 +41,7 @@ class InboxMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
     def __init__(
         self,
         message_bus: MessageBus,
+        conversation_revision: int = 0,
         max_count: int = 100,
     ) -> None:
         """Initialise the middleware.
@@ -52,6 +53,7 @@ class InboxMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
                 Maximum entries drained per reasoning step.
         """
         self._bus = message_bus
+        self._conversation_revision = conversation_revision
         self._max_count = max_count
 
     async def on_reasoning(  # type: ignore[override]
@@ -84,10 +86,20 @@ class InboxMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
         )
 
         if entries:
-            hint_blocks = [
-                HintBlock.model_validate(payload)
-                for _entry_id, payload in entries
-            ]
+            hint_blocks: list[HintBlock] = []
+            for _entry_id, entry in entries:
+                if "conversation_revision" not in entry:
+                    if self._conversation_revision != 0:
+                        continue
+                    payload = entry
+                elif (
+                    entry.get("conversation_revision")
+                    != self._conversation_revision
+                ):
+                    continue
+                else:
+                    payload = entry.get("payload")
+                hint_blocks.append(HintBlock.model_validate(payload))
 
             logger.info(
                 "InboxMiddleware: injecting %d HintBlock(s) into context "

--- a/src/agentscope/app/middleware/_tool_offload_middleware.py
+++ b/src/agentscope/app/middleware/_tool_offload_middleware.py
@@ -68,6 +68,8 @@ class ToolOffloadMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
         timeout_secs (`float`, defaults to ``10.0``):
             Maximum seconds to wait for a tool execution before
             offloading it to the background.
+        conversation_revision (`int`, defaults to ``0``):
+            Conversation generation that owns background results.
     """
 
     def __init__(
@@ -77,6 +79,8 @@ class ToolOffloadMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
         user_id: str,
         agent_id: str,
         timeout_secs: float = 10.0,
+        *,
+        conversation_revision: int = 0,
     ) -> None:
         """Bind dependencies.
 
@@ -91,11 +95,14 @@ class ToolOffloadMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
                 Agent record id (not the display name).
             timeout_secs (`float`, defaults to ``10.0``):
                 Tool execution timeout before offloading to background.
+            conversation_revision (`int`, defaults to ``0``):
+                Conversation generation that owns background results.
         """
         self._bg_manager = bg_manager
         self._message_bus = message_bus
         self._user_id = user_id
         self._agent_id = agent_id
+        self._conversation_revision = conversation_revision
         self._timeout_secs = timeout_secs
 
     # ------------------------------------------------------------------
@@ -351,6 +358,7 @@ class ToolOffloadMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
                 session_id=session_id,
                 agent_id=self._agent_id,
                 payload=hint.model_dump(mode="json"),
+                conversation_revision=self._conversation_revision,
             )
 
         asyncio.create_task(_deliver_when_done())

--- a/src/agentscope/app/storage/__init__.py
+++ b/src/agentscope/app/storage/__init__.py
@@ -2,7 +2,7 @@
 """The storage module in agentscope."""
 from typing import TYPE_CHECKING
 
-from ._base import StorageBase
+from ._base import SessionRevisionConflict, StorageBase
 from ._redis_storage import RedisStorage
 from ._model import (
     AgentData,
@@ -67,6 +67,7 @@ def __getattr__(name: str) -> object:
 
 __all__ = [
     "StorageBase",
+    "SessionRevisionConflict",
     "RedisStorage",
     "AsyncSQLAlchemyStorage",
     # The ORM models

--- a/src/agentscope/app/storage/_base.py
+++ b/src/agentscope/app/storage/_base.py
@@ -26,6 +26,10 @@ from ...message import Msg
 from ...state import AgentState
 
 
+class SessionRevisionConflict(RuntimeError):
+    """Raised when a conversation reset targets a stale revision."""
+
+
 class StorageBase(ABC):
     """The storage abstract base class."""
 
@@ -448,6 +452,17 @@ class StorageBase(ABC):
             session_id (`str`): The session id.
             state (`AgentState`): The new agent state to persist.
         """
+
+    @abstractmethod
+    async def reset_session_conversation(
+        self,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+        state: AgentState,
+        expected_revision: int,
+    ) -> SessionRecord:
+        """Atomically replace conversation state and delete its messages."""
 
     @abstractmethod
     async def list_sessions(

--- a/src/agentscope/app/storage/_model/_session.py
+++ b/src/agentscope/app/storage/_model/_session.py
@@ -220,3 +220,6 @@ class SessionRecord(_RecordBase):
 
     state: AgentState = Field(default_factory=AgentState)
     """Mutable runtime state, updated after each chat turn."""
+
+    conversation_revision: int = 0
+    """Logical conversation generation, incremented by every clear."""

--- a/src/agentscope/app/storage/_redis_storage.py
+++ b/src/agentscope/app/storage/_redis_storage.py
@@ -8,7 +8,7 @@ from typing import Any, TYPE_CHECKING, Self
 
 from pydantic import BaseModel
 
-from ._base import StorageBase
+from ._base import SessionRevisionConflict, StorageBase
 from ._model import (
     AgentRecord,
     ChannelRecord,
@@ -970,6 +970,63 @@ class RedisStorage(StorageBase):
         record.state = state
         record.updated_at = datetime.now()
         await self._set_with_ttl(key, record.model_dump_json())
+
+    async def reset_session_conversation(
+        self,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+        state: AgentState,
+        expected_revision: int,
+    ) -> SessionRecord:
+        """Atomically replace state and remove messages with WATCH/MULTI."""
+        session_key = self._key(
+            self.key_config.session,
+            user_id=user_id,
+            session_id=session_id,
+        )
+        messages_key = self._key(
+            self.key_config.messages,
+            user_id=user_id,
+            session_id=session_id,
+        )
+
+        async with self._client.pipeline(transaction=True) as pipe:
+            for _ in range(3):
+                try:
+                    await pipe.watch(session_key)
+                    raw = await pipe.get(session_key)
+                    if not raw:
+                        await pipe.unwatch()
+                        raise KeyError(f"Session {session_id!r} not found.")
+                    record = SessionRecord.model_validate_json(raw)
+                    if record.agent_id != agent_id:
+                        await pipe.unwatch()
+                        raise KeyError(f"Session {session_id!r} not found.")
+                    if record.conversation_revision != expected_revision:
+                        await pipe.unwatch()
+                        raise SessionRevisionConflict(
+                            f"Session {session_id!r} revision changed from "
+                            f"{expected_revision} to "
+                            f"{record.conversation_revision}.",
+                        )
+                    record.state = state
+                    record.conversation_revision += 1
+                    record.updated_at = datetime.now()
+                    pipe.multi()
+                    pipe.set(session_key, record.model_dump_json())
+                    pipe.delete(messages_key)
+                    if self.key_ttl is not None:
+                        pipe.expire(session_key, self.key_ttl)
+                    await pipe.execute()
+                    return record
+                except _watch_error():
+                    continue
+
+        raise SessionRevisionConflict(
+            f"Session {session_id!r} was concurrently modified; "
+            f"WATCH failed after 3 reset retries.",
+        )
 
     async def list_sessions(
         self,

--- a/src/agentscope/app/storage/_sql/_storage.py
+++ b/src/agentscope/app/storage/_sql/_storage.py
@@ -19,7 +19,7 @@ need no dialect-specific timezone handling.
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Self
 
-from .._base import StorageBase
+from .._base import SessionRevisionConflict, StorageBase
 from .._model import (
     AgentRecord,
     ChannelRecord,
@@ -1137,6 +1137,58 @@ class AsyncSQLAlchemyStorage(StorageBase):
             row.payload = new_row.payload
             row.updated_at = new_row.updated_at
             await sess.commit()
+
+    async def reset_session_conversation(
+        self,
+        user_id: str,
+        agent_id: str,
+        session_id: str,
+        state: AgentState,
+        expected_revision: int,
+    ) -> SessionRecord:
+        """Reset state and messages in one SQL transaction.
+
+        The application session lock serializes writers. The revision
+        check detects stale callers within that supported lock contract;
+        it is intentionally not a database-wide CAS independent of the
+        message bus.
+        """
+        from sqlalchemy import delete, select
+
+        async with self._session() as sess:
+            row = (
+                await sess.execute(
+                    select(SessionRow).where(
+                        SessionRow.id == session_id,
+                        SessionRow.user_id == user_id,
+                        SessionRow.agent_id == agent_id,
+                    ),
+                )
+            ).scalar_one_or_none()
+            if row is None:
+                raise KeyError(f"Session {session_id!r} not found.")
+
+            record = _to_record(row, SessionRecord)
+            if record.conversation_revision != expected_revision:
+                raise SessionRevisionConflict(
+                    f"Session {session_id!r} revision changed from "
+                    f"{expected_revision} to "
+                    f"{record.conversation_revision}.",
+                )
+
+            record.state = state
+            record.conversation_revision += 1
+            record.updated_at = _utcnow()
+            new_row = _from_record(SessionRow, record)
+            row.payload = new_row.payload
+            row.updated_at = new_row.updated_at
+            await sess.execute(
+                delete(MessageRow).where(
+                    MessageRow.session_id == session_id,
+                ),
+            )
+            await sess.commit()
+            return record
 
     async def list_sessions(
         self,

--- a/tests/channel_gateway_test.py
+++ b/tests/channel_gateway_test.py
@@ -378,6 +378,168 @@ class WorkspaceIsolationTest(IsolatedAsyncioTestCase):
         )
 
 
+class ChannelSlashCommandTest(IsolatedAsyncioTestCase):
+    """Channel slash commands bypass inbox and model triggers."""
+
+    async def test_clear_uses_shared_dispatcher_and_sends_notice(self) -> None:
+        """A channel clear resets the resolved session directly."""
+        record = _channel_record("user")
+
+        class _Storage:
+            """Return the configured channel and its derived session."""
+
+            async def get_channel(self, _channel_id: str) -> ChannelRecord:
+                return record
+
+            async def get_session(
+                self,
+                user_id: str,
+                agent_id: str,
+                session_id: str,
+            ) -> SessionRecord:
+                return SessionRecord(
+                    id=session_id,
+                    user_id=user_id,
+                    agent_id=agent_id,
+                    config=SessionConfig(workspace_id="workspace"),
+                )
+
+        class _SessionService:
+            """Record the clear scope selected by the gateway."""
+
+            def __init__(self) -> None:
+                self.calls: list[tuple[str, str, str]] = []
+                self.error: Exception | None = None
+
+            async def clear_conversation(
+                self,
+                user_id: str,
+                agent_id: str,
+                session_id: str,
+            ) -> tuple[str, ...]:
+                self.calls.append((user_id, agent_id, session_id))
+                if self.error is not None:
+                    raise self.error
+                return (session_id,)
+
+        class _NoticeChannel(_FakeChannel):
+            """Capture service notices without persisting a message."""
+
+            def __init__(self) -> None:
+                super().__init__()
+                self.notices: list[str] = []
+
+            async def send_notice(
+                self,
+                _event: ChannelEvent,
+                text: str,
+            ) -> None:
+                self.notices.append(text)
+
+        class _Clients:
+            """Return the one outbound channel used by the test."""
+
+            def __init__(self, channel: _NoticeChannel) -> None:
+                self.channel = channel
+
+            async def get(self, _channel_id: str) -> _NoticeChannel:
+                return self.channel
+
+        bus = InMemoryMessageBus()
+        service = _SessionService()
+        channel = _NoticeChannel()
+        gateway = ChannelGateway(
+            storage=_Storage(),
+            message_bus=bus,
+            workspace_manager=_WM(isolation=IsolationPolicy.PER_AGENT),
+            session_service=service,
+            channel_clients=_Clients(channel),
+        )
+
+        event = ChannelEvent(
+            channel_id=record.id,
+            channel_user_id="channel-user",
+            chat_id="chat",
+            content=[TextBlock(text="/clear")],
+        )
+        await gateway.process(event)
+
+        self.assertEqual(len(service.calls), 1)
+        self.assertEqual(service.calls[0][:2], ("user", "agent-x"))
+        self.assertEqual(channel.notices, ["Conversation cleared."])
+        self.assertEqual(
+            await bus.queue_drain(MessageBusKeys.wakeup_queue()),
+            [],
+        )
+
+        service.error = RuntimeError("partial clear")
+        channel.notices.clear()
+        await gateway.process(event)
+        self.assertEqual(
+            channel.notices,
+            ["Conversation clear did not fully complete. Please retry."],
+        )
+
+        service.error = KeyError("missing session")
+        channel.notices.clear()
+        await gateway.process(event)
+        self.assertEqual(
+            channel.notices,
+            ["Conversation no longer exists."],
+        )
+
+
+class ChannelSessionLookupTest(IsolatedAsyncioTestCase):
+    """Normal channel messages reuse the session loaded during ensure."""
+
+    async def test_idle_message_loads_existing_session_once(self) -> None:
+        """Avoid a second Storage read solely to obtain the revision."""
+        record = _channel_record("user")
+
+        class _Storage:
+            """Return one existing session and count authoritative reads."""
+
+            def __init__(self) -> None:
+                self.get_session_calls = 0
+
+            async def get_channel(self, _channel_id: str) -> ChannelRecord:
+                """Return the channel under test."""
+                return record
+
+            async def get_session(self, **kwargs: Any) -> SessionRecord:
+                """Return the existing derived channel session."""
+                self.get_session_calls += 1
+                return SessionRecord(
+                    id=kwargs["session_id"],
+                    user_id=kwargs["user_id"],
+                    agent_id=kwargs["agent_id"],
+                    config=SessionConfig(workspace_id="workspace"),
+                    conversation_revision=4,
+                )
+
+        storage = _Storage()
+        bus = InMemoryMessageBus()
+        gateway = ChannelGateway(
+            storage=storage,
+            message_bus=bus,
+            workspace_manager=_WM(isolation=IsolationPolicy.PER_AGENT),
+        )
+
+        await gateway.process(
+            ChannelEvent(
+                channel_id=record.id,
+                channel_user_id="channel-user",
+                chat_id="chat",
+                content=[TextBlock(text="hello")],
+            ),
+        )
+
+        wakeups = await bus.queue_drain(MessageBusKeys.wakeup_queue())
+        self.assertEqual(storage.get_session_calls, 1)
+        self.assertEqual(len(wakeups), 1)
+        self.assertEqual(wakeups[0][1]["conversation_revision"], 4)
+
+
 class FeishuPostParseTest(IsolatedAsyncioTestCase):
     """Feishu rich-text ``post`` flattens to ordered text + data blocks."""
 
@@ -560,6 +722,7 @@ class DecisionRoutingTest(IsolatedAsyncioTestCase):
                 "session_id": "the-parked-session",
                 "agent_id": "agent-x",
                 "kind": MessageBusKeys.WAKEUP_KIND_RESUME,
+                "conversation_revision": 0,
                 "input": {
                     "id": event["id"],
                     "created_at": event["created_at"],

--- a/tests/service_inbox_handoff_test.py
+++ b/tests/service_inbox_handoff_test.py
@@ -138,9 +138,22 @@ class TestInboxHandoff(IsolatedAsyncioTestCase):
             user_id="u",
             session_id=self.sid,
             agent_id="a",
+            conversation_revision=7,
         )
 
-        self.assertEqual(len(await self._wakeups()), 1)
+        self.assertEqual(
+            await self._wakeups(),
+            [
+                {
+                    "user_id": "u",
+                    "session_id": self.sid,
+                    "agent_id": "a",
+                    "kind": MessageBusKeys.WAKEUP_KIND_WAKE,
+                    "input": None,
+                    "conversation_revision": 7,
+                },
+            ],
+        )
         self.assertIsNone(
             await self.bus.registry_get(
                 MessageBusKeys.inbox_consumer(self.sid),
@@ -157,6 +170,30 @@ class TestInboxHandoff(IsolatedAsyncioTestCase):
             user_id="u",
             session_id=self.sid,
             agent_id="a",
+            conversation_revision=7,
         )
 
+        self.assertEqual(await self._wakeups(), [])
+
+    async def test_reset_barrier_rejects_new_delivery(self) -> None:
+        """No inbox payload can enter after the clear cutover point."""
+        await self.bus.registry_set(
+            MessageBusKeys.session_reset_barrier(self.sid),
+            "operation",
+            "{}",
+        )
+
+        await deliver_to_inbox(
+            self.bus,
+            user_id="u",
+            session_id=self.sid,
+            agent_id="a",
+            payload={"type": "hint", "hint": "late"},
+            conversation_revision=0,
+        )
+
+        self.assertEqual(
+            await self.bus.queue_drain(MessageBusKeys.inbox(self.sid)),
+            [],
+        )
         self.assertEqual(await self._wakeups(), [])

--- a/tests/service_message_bus_test.py
+++ b/tests/service_message_bus_test.py
@@ -14,7 +14,12 @@ from unittest import IsolatedAsyncioTestCase
 
 import fakeredis.aioredis
 
-from agentscope.app.message_bus import MessageBus, RedisMessageBus
+from agentscope.app._bus_ops import publish_session_event
+from agentscope.app.message_bus import (
+    MessageBus,
+    MessageBusKeys,
+    RedisMessageBus,
+)
 
 
 def _make_bus(
@@ -289,6 +294,44 @@ class TestSessionDomainHelpers(IsolatedAsyncioTestCase):
         # Live subscriber saw it without the internal _entry_id key.
         self.assertEqual(received, [{"hello": "world"}])
 
+    async def test_session_event_live_payload_carries_replay_entry_id(
+        self,
+    ) -> None:
+        """The canonical publisher gives replay and live events one id."""
+        session_id = "session-entry-id"
+        key = MessageBusKeys.session_events(session_id)
+        ready = asyncio.Event()
+        received: list[dict] = []
+
+        async def _consume() -> None:
+            """Capture one raw live payload without compatibility stripping."""
+            async for payload in self.bus.subscribe(
+                key,
+                on_ready=ready.set,
+            ):
+                received.append(payload)
+                break
+
+        consumer = asyncio.create_task(_consume())
+        await asyncio.wait_for(ready.wait(), timeout=2)
+        event = {"name": "session_cleared"}
+
+        entry_id = await publish_session_event(
+            self.bus,
+            session_id,
+            event,
+        )
+        await asyncio.wait_for(consumer, timeout=2)
+
+        self.assertEqual(
+            await self.bus.log_read(key),
+            [(entry_id, event)],
+        )
+        self.assertEqual(
+            received,
+            [{"name": "session_cleared", "_entry_id": entry_id}],
+        )
+
     async def test_session_is_running_reflects_session_run(self) -> None:
         """``session_is_running`` returns True while inside
         ``session_run`` and False after."""
@@ -468,6 +511,64 @@ class TestRegistryPrimitive(IsolatedAsyncioTestCase):
         await self.bus.registry_set("ns", "f", "v", ttl_secs=3600)
         ttl_refreshed = await self.fr.ttl("ns")
         self.assertGreater(ttl_refreshed, 60)
+
+    async def test_set_with_ttl_uses_atomic_transaction(self) -> None:
+        """Queue the hash write and expiry in one Redis transaction."""
+
+        class _Pipeline:
+            """Record commands queued before transaction execution."""
+
+            def __init__(self) -> None:
+                self.commands: list[tuple[str, tuple[object, ...]]] = []
+                self.executed = False
+
+            async def __aenter__(self) -> "_Pipeline":
+                return self
+
+            async def __aexit__(self, *args: object) -> None:
+                return None
+
+            def hset(self, *args: object) -> "_Pipeline":
+                """Queue one hash write."""
+                self.commands.append(("hset", args))
+                return self
+
+            def expire(self, *args: object) -> "_Pipeline":
+                """Queue one expiry update."""
+                self.commands.append(("expire", args))
+                return self
+
+            async def execute(self) -> list[object]:
+                """Mark the queued transaction as executed."""
+                self.executed = True
+                return []
+
+        class _Client:
+            """Expose only the transactional path expected by this test."""
+
+            def __init__(self) -> None:
+                self.pipe = _Pipeline()
+                self.transaction: bool | None = None
+
+            def pipeline(self, *, transaction: bool) -> _Pipeline:
+                """Return the recording transaction pipeline."""
+                self.transaction = transaction
+                return self.pipe
+
+        client = _Client()
+        self.bus._client = client
+
+        await self.bus.registry_set("ns", "field", "value", ttl_secs=30)
+
+        self.assertEqual(client.transaction, True)
+        self.assertEqual(
+            client.pipe.commands,
+            [
+                ("hset", ("ns", "field", "value")),
+                ("expire", ("ns", 30)),
+            ],
+        )
+        self.assertEqual(client.pipe.executed, True)
 
     async def test_set_without_ttl_leaves_namespace_persistent(
         self,

--- a/tests/service_scheduler_test.py
+++ b/tests/service_scheduler_test.py
@@ -154,7 +154,9 @@ class TestSchedulerFireDelivery(_SchedulerFireTestBase):
         # Inbox has the wrapped HintBlock.
         inbox = await self.bus.inbox_drain(session.id, max_count=10)
         self.assertEqual(len(inbox), 1)
-        hint = inbox[0][1]
+        envelope = inbox[0][1]
+        self.assertEqual(envelope["conversation_revision"], 0)
+        hint = envelope["payload"]
         self.assertDictEqual(
             hint,
             {
@@ -182,6 +184,7 @@ class TestSchedulerFireDelivery(_SchedulerFireTestBase):
                 "user_id": record.user_id,
                 "kind": "wake",
                 "input": None,
+                "conversation_revision": 0,
             },
         )
 
@@ -238,6 +241,7 @@ class TestSchedulerFireStatefulMode(_SchedulerFireTestBase):
                     "user_id": record.user_id,
                     "kind": "wake",
                     "input": None,
+                    "conversation_revision": 0,
                 },
                 {
                     "session_id": sessions[0].id,
@@ -245,6 +249,7 @@ class TestSchedulerFireStatefulMode(_SchedulerFireTestBase):
                     "user_id": record.user_id,
                     "kind": "wake",
                     "input": None,
+                    "conversation_revision": 0,
                 },
             ],
         )

--- a/tests/service_session_clear_test.py
+++ b/tests/service_session_clear_test.py
@@ -1,0 +1,459 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Integration tests for conversation reset orchestration."""
+
+import asyncio
+from contextlib import AsyncExitStack
+from unittest import IsolatedAsyncioTestCase
+
+import fakeredis.aioredis
+
+from agentscope.app._service import SessionService
+from agentscope.app.message_bus import InMemoryMessageBus, MessageBusKeys
+from agentscope.app.storage import (
+    ChatModelConfig,
+    RedisStorage,
+    SessionConfig,
+    SessionRecord,
+    TeamData,
+    TeamMember,
+    TeamRecord,
+)
+from agentscope.message import UserMsg
+from agentscope.permission import PermissionContext, PermissionMode
+from agentscope.state import AgentState
+
+
+def _make_storage() -> RedisStorage:
+    """Create a fakeredis-backed storage instance."""
+    storage = RedisStorage.__new__(RedisStorage)
+    storage._client = fakeredis.aioredis.FakeRedis(
+        decode_responses=True,
+    )
+    storage.key_ttl = None
+    storage.key_config = RedisStorage.KeyConfig()
+    return storage
+
+
+def _session_config(workspace_id: str) -> SessionConfig:
+    """Build session configuration whose fields must survive clear."""
+    return SessionConfig(
+        workspace_id=workspace_id,
+        name=f"Conversation {workspace_id}",
+        chat_model_config=ChatModelConfig(
+            type="openai",
+            credential_id="credential",
+            model="model",
+            parameters={},
+        ),
+    )
+
+
+class SessionClearTest(IsolatedAsyncioTestCase):
+    """Verify standalone and leader-team clear semantics."""
+
+    async def asyncSetUp(self) -> None:
+        self._stack = AsyncExitStack()
+        self.storage = _make_storage()
+        self._stack.push_async_callback(self.storage._client.aclose)
+        self.bus = await self._stack.enter_async_context(InMemoryMessageBus())
+        self.service = SessionService(self.storage, self.bus)
+
+    async def asyncTearDown(self) -> None:
+        await self._stack.aclose()
+
+    async def _seed_conversation(
+        self,
+        agent_id: str,
+        session_id: str,
+        workspace_id: str,
+    ) -> PermissionContext:
+        """Create one session with durable and transient history."""
+        permission = PermissionContext(mode=PermissionMode.DONT_ASK)
+        await self.storage.upsert_session(
+            "user",
+            agent_id,
+            _session_config(workspace_id),
+            session_id=session_id,
+        )
+        state = AgentState(
+            session_id=session_id,
+            summary="summary",
+            context=[UserMsg(name="user", content="context")],
+            permission_context=permission,
+            middle_context={"memory": True},
+        )
+        await self.storage.update_session_state(
+            "user",
+            agent_id,
+            session_id,
+            state,
+        )
+        await self.storage.upsert_message(
+            "user",
+            session_id,
+            UserMsg(name="user", content="history"),
+        )
+        await self.bus.queue_push(
+            MessageBusKeys.inbox(session_id),
+            {"stale": True},
+        )
+        await self.bus.log_append(
+            MessageBusKeys.session_events(session_id),
+            {"type": "old"},
+        )
+        return permission
+
+    async def test_standalone_clear_preserves_configuration(self) -> None:
+        """A clear resets history but keeps identity and permissions."""
+        permission = await self._seed_conversation(
+            "agent",
+            "session",
+            "workspace",
+        )
+
+        cleared = await self.service.clear_conversation(
+            "user",
+            "agent",
+            "session",
+        )
+
+        record = await self.storage.get_session(
+            "user",
+            "agent",
+            "session",
+        )
+        messages = await self.storage.list_messages("user", "session")
+        events = await self.bus.log_read(
+            MessageBusKeys.session_events("session"),
+        )
+        self.assertEqual(cleared, ("session",))
+        self.assertEqual(record.config, _session_config("workspace"))
+        self.assertEqual(record.conversation_revision, 1)
+        self.assertEqual(record.state.session_id, "session")
+        self.assertEqual(record.state.context, [])
+        self.assertEqual(record.state.summary, "")
+        self.assertEqual(record.state.middle_context, {})
+        self.assertEqual(record.state.permission_context, permission)
+        self.assertEqual(messages, ([], False))
+        self.assertEqual(
+            [event[1]["name"] for event in events],
+            ["session_cleared"],
+        )
+        self.assertEqual(
+            await self.bus.queue_drain(
+                MessageBusKeys.inbox("session"),
+            ),
+            [],
+        )
+
+    async def test_leader_clear_cascades_to_current_workers(self) -> None:
+        """Clearing a leader resets the whole current team roster."""
+        await self._seed_conversation(
+            "leader-agent",
+            "leader-session",
+            "leader-workspace",
+        )
+        await self._seed_conversation(
+            "worker-agent",
+            "worker-session",
+            "worker-workspace",
+        )
+        team = TeamRecord(
+            id="team",
+            user_id="user",
+            session_id="leader-session",
+            leader_agent_id="leader-agent",
+            data=TeamData(
+                name="team",
+                members=[
+                    TeamMember(
+                        owner_id="user",
+                        agent_id="worker-agent",
+                        session_id="worker-session",
+                        role="invited",
+                    ),
+                ],
+            ),
+        )
+        await self.storage.upsert_team("user", team)
+        await self.storage.set_session_team_id(
+            "user",
+            "leader-session",
+            team.id,
+        )
+        await self.storage.set_session_team_id(
+            "user",
+            "worker-session",
+            team.id,
+        )
+
+        cleared = await self.service.clear_conversation(
+            "user",
+            "leader-agent",
+            "leader-session",
+        )
+
+        leader = await self.storage.get_session(
+            "user",
+            "leader-agent",
+            "leader-session",
+        )
+        worker = await self.storage.get_session(
+            "user",
+            "worker-agent",
+            "worker-session",
+        )
+        self.assertEqual(
+            cleared,
+            ("leader-session", "worker-session"),
+        )
+        self.assertEqual(leader.conversation_revision, 1)
+        self.assertEqual(worker.conversation_revision, 1)
+        self.assertEqual(leader.team_id, team.id)
+        self.assertEqual(worker.team_id, team.id)
+        self.assertEqual(leader.state.context, [])
+        self.assertEqual(worker.state.context, [])
+        self.assertEqual(
+            await self.storage.list_messages("user", "leader-session"),
+            ([], False),
+        )
+        self.assertEqual(
+            await self.storage.list_messages("user", "worker-session"),
+            ([], False),
+        )
+
+    async def test_concurrent_clears_serialize_and_remove_barriers(
+        self,
+    ) -> None:
+        """Concurrent clears both complete without losing a barrier."""
+        await self._seed_conversation(
+            "agent",
+            "session",
+            "workspace",
+        )
+
+        results = await asyncio.gather(
+            self.service.clear_conversation(
+                "user",
+                "agent",
+                "session",
+            ),
+            self.service.clear_conversation(
+                "user",
+                "agent",
+                "session",
+            ),
+        )
+
+        record = await self.storage.get_session(
+            "user",
+            "agent",
+            "session",
+        )
+        barriers = await self.bus.registry_getall(
+            MessageBusKeys.session_reset_barrier("session"),
+        )
+        self.assertEqual(results, [("session",), ("session",)])
+        self.assertEqual(record.conversation_revision, 2)
+        self.assertEqual(record.state.context, [])
+        self.assertEqual(barriers, {})
+
+    async def test_cancellation_after_commit_finishes_cleanup(self) -> None:
+        """Cancellation waits for cleanup and the clear event after commit."""
+        await self._seed_conversation(
+            "agent",
+            "session",
+            "workspace",
+        )
+        original_reset = self.storage.reset_session_conversation
+        commit_finished = asyncio.Event()
+        release_commit = asyncio.Event()
+
+        async def _delayed_reset(
+            *args: object,
+            **kwargs: object,
+        ) -> SessionRecord:
+            updated = await original_reset(*args, **kwargs)
+            commit_finished.set()
+            await release_commit.wait()
+            return updated
+
+        self.storage.reset_session_conversation = _delayed_reset
+        clear_task = asyncio.create_task(
+            self.service.clear_conversation(
+                "user",
+                "agent",
+                "session",
+            ),
+        )
+        await asyncio.wait_for(commit_finished.wait(), timeout=1)
+
+        clear_task.cancel()
+        release_commit.set()
+        with self.assertRaises(asyncio.CancelledError):
+            await clear_task
+
+        record = await self.storage.get_session(
+            "user",
+            "agent",
+            "session",
+        )
+        events = await self.bus.log_read(
+            MessageBusKeys.session_events("session"),
+        )
+        self.assertEqual(record.conversation_revision, 1)
+        self.assertEqual(
+            await self.bus.queue_drain(MessageBusKeys.inbox("session")),
+            [],
+        )
+        self.assertEqual(
+            [event[1]["name"] for event in events],
+            ["session_cleared"],
+        )
+        self.assertEqual(
+            await self.bus.registry_getall(
+                MessageBusKeys.session_reset_barrier("session"),
+            ),
+            {},
+        )
+
+    async def test_barrier_is_removed_after_session_lock(self) -> None:
+        """Do not remove the barrier while clear holds the session lock."""
+        await self._seed_conversation(
+            "agent",
+            "session",
+            "workspace",
+        )
+        barrier_key = MessageBusKeys.session_reset_barrier("session")
+        session_lock = MessageBusKeys.session_lock("session")
+        original_registry_del = self.bus.registry_del
+        lock_states: list[bool] = []
+
+        async def _tracked_registry_del(key: str, field: str) -> None:
+            if key == barrier_key:
+                lock_states.append(await self.bus.is_locked(session_lock))
+            await original_registry_del(key, field)
+
+        self.bus.registry_del = _tracked_registry_del
+
+        await self.service.clear_conversation(
+            "user",
+            "agent",
+            "session",
+        )
+
+        self.assertEqual(lock_states, [False])
+
+    async def test_initial_barrier_cancellation_cleans_written_field(
+        self,
+    ) -> None:
+        """Clean a barrier written just before its initial set is cancelled."""
+        await self._seed_conversation(
+            "agent",
+            "session",
+            "workspace",
+        )
+        original_registry_set = self.bus.registry_set
+
+        async def _set_then_cancel(
+            namespace: str,
+            field: str,
+            value: str,
+            *,
+            ttl_secs: int | None = None,
+        ) -> None:
+            await original_registry_set(
+                namespace,
+                field,
+                value,
+                ttl_secs=ttl_secs,
+            )
+            raise asyncio.CancelledError
+
+        self.bus.registry_set = _set_then_cancel
+
+        with self.assertRaises(asyncio.CancelledError):
+            await self.service.clear_conversation(
+                "user",
+                "agent",
+                "session",
+            )
+
+        self.assertEqual(
+            await self.bus.registry_getall(
+                MessageBusKeys.session_reset_barrier("session"),
+            ),
+            {},
+        )
+
+    async def test_stale_team_member_does_not_block_resolved_targets(
+        self,
+    ) -> None:
+        """Report a stale roster entry after resetting healthy targets."""
+        await self._seed_conversation(
+            "leader-agent",
+            "leader-session",
+            "leader-workspace",
+        )
+        await self._seed_conversation(
+            "worker-agent",
+            "worker-session",
+            "worker-workspace",
+        )
+        team = TeamRecord(
+            id="team",
+            user_id="user",
+            session_id="leader-session",
+            leader_agent_id="leader-agent",
+            data=TeamData(
+                name="team",
+                members=[
+                    TeamMember(
+                        owner_id="user",
+                        agent_id="worker-agent",
+                        session_id="worker-session",
+                        role="invited",
+                    ),
+                    TeamMember(
+                        owner_id="user",
+                        agent_id="missing-agent",
+                        session_id="missing-session",
+                        role="invited",
+                    ),
+                ],
+            ),
+        )
+        await self.storage.upsert_team("user", team)
+        await self.storage.set_session_team_id(
+            "user",
+            "leader-session",
+            team.id,
+        )
+        await self.storage.set_session_team_id(
+            "user",
+            "worker-session",
+            team.id,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "1 session"):
+            await self.service.clear_conversation(
+                "user",
+                "leader-agent",
+                "leader-session",
+            )
+
+        leader = await self.storage.get_session(
+            "user",
+            "leader-agent",
+            "leader-session",
+        )
+        worker = await self.storage.get_session(
+            "user",
+            "worker-agent",
+            "worker-session",
+        )
+        self.assertEqual(leader.conversation_revision, 1)
+        self.assertEqual(worker.conversation_revision, 1)
+        self.assertEqual(leader.state.context, [])
+        self.assertEqual(worker.state.context, [])

--- a/tests/service_team_failure_report_test.py
+++ b/tests/service_team_failure_report_test.py
@@ -240,7 +240,14 @@ class TeamFailureReportTest(IsolatedAsyncioTestCase):
         entries = await self.bus.queue_drain(
             MessageBusKeys.inbox(self.leader_session.id),
         )
-        return [payload for _entry_id, payload in entries]
+        delivered: list[dict] = []
+        for _entry_id, entry in entries:
+            self.assertEqual(
+                entry["conversation_revision"],
+                self.leader_session.conversation_revision,
+            )
+            delivered.append(entry["payload"])
+        return delivered
 
     def _events(
         self,
@@ -420,7 +427,11 @@ class TeamFailureReportTest(IsolatedAsyncioTestCase):
             MessageBusKeys.inbox(self.leader_session.id),
         )
         self.assertEqual(len(entries), 1)
+        self.assertEqual(
+            entries[0][1]["conversation_revision"],
+            self.leader_session.conversation_revision,
+        )
         self.assertIn(
             "Error: boom.",
-            entries[0][1]["hint"],
+            entries[0][1]["payload"]["hint"],
         )

--- a/tests/service_team_tools_test.py
+++ b/tests/service_team_tools_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=protected-access
+# pylint: disable=protected-access, attribute-defined-outside-init
 """Tests for the four framework-builtin team tools — :class:`TeamCreate`,
 :class:`AgentCreate`, :class:`TeamSay`, :class:`TeamDelete`.
 
@@ -59,6 +59,7 @@ def _make_storage(
             return self
 
         async def aclose(self) -> None:
+            """Detach the shared fake Redis client."""
             self._client = None
 
     return _S()
@@ -77,6 +78,7 @@ def _make_bus(
             return self
 
         async def aclose(self) -> None:
+            """Detach the shared fake Redis client."""
             self._client = None
 
     return _B()
@@ -309,7 +311,11 @@ class TestAgentCreate(_TeamToolsTestBase):
             max_count=10,
         )
         self.assertEqual(len(inbox), 1)
-        hint_payload = inbox[0][1]
+        self.assertEqual(
+            inbox[0][1]["conversation_revision"],
+            worker_sessions[0].conversation_revision,
+        )
+        hint_payload = inbox[0][1]["payload"]
         self.assertDictEqual(
             hint_payload,
             {
@@ -335,6 +341,9 @@ class TestAgentCreate(_TeamToolsTestBase):
                 "user_id": self.user_id,
                 "kind": "wake",
                 "input": None,
+                "conversation_revision": (
+                    worker_sessions[0].conversation_revision
+                ),
             },
         )
 
@@ -971,8 +980,13 @@ class TestTeamSay(_TeamToolsTestBase):
         other_inbox = await self.bus.inbox_drain(other_sid, max_count=10)
         self.assertEqual(len(target_inbox), 1)
         self.assertEqual(len(other_inbox), 0)
+        self.assertEqual(
+            target_inbox[0][1]["conversation_revision"],
+            0,
+        )
+        hint_payload = target_inbox[0][1]["payload"]
         self.assertDictEqual(
-            target_inbox[0][1],
+            hint_payload,
             {
                 "type": "hint",
                 "id": AnyString(),
@@ -982,7 +996,7 @@ class TestTeamSay(_TeamToolsTestBase):
                 "source": AnyString(),
             },
         )
-        self.assertIn("hi w1", target_inbox[0][1]["hint"])
+        self.assertIn("hi w1", hint_payload["hint"])
 
         # Wakeup for the target only.
         wakeups = await self.bus.dequeue_wakeups(max_count=10)
@@ -995,6 +1009,7 @@ class TestTeamSay(_TeamToolsTestBase):
                     "user_id": self.user_id,
                     "kind": "wake",
                     "input": None,
+                    "conversation_revision": 0,
                 },
             ],
         )
@@ -1177,7 +1192,14 @@ class TestTeamSay(_TeamToolsTestBase):
             max_count=10,
         )
         self.assertEqual(len(leader_inbox), 1)
-        self.assertIn("task done", leader_inbox[0][1]["hint"])
+        self.assertEqual(
+            leader_inbox[0][1]["conversation_revision"],
+            self.leader_session.conversation_revision,
+        )
+        self.assertIn(
+            "task done",
+            leader_inbox[0][1]["payload"]["hint"],
+        )
 
         # Wakeup was enqueued for the leader.
         wakeups = await self.bus.dequeue_wakeups(max_count=10)
@@ -1190,6 +1212,9 @@ class TestTeamSay(_TeamToolsTestBase):
                     "user_id": self.user_id,
                     "kind": "wake",
                     "input": None,
+                    "conversation_revision": (
+                        self.leader_session.conversation_revision
+                    ),
                 },
             ],
         )
@@ -1460,7 +1485,14 @@ class TestAgentInviteSuccess(_AgentInviteTestBase):
         # Initial prompt was delivered to the borrowed session only.
         inbox = await self.bus.inbox_drain(member.session_id, max_count=10)
         self.assertEqual(len(inbox), 1)
-        self.assertIn("please look up X", inbox[0][1]["hint"])
+        self.assertEqual(
+            inbox[0][1]["conversation_revision"],
+            borrowed.conversation_revision,
+        )
+        self.assertIn(
+            "please look up X",
+            inbox[0][1]["payload"]["hint"],
+        )
         # Monday's primary session inbox is untouched.
         primary_inbox = await self.bus.inbox_drain(
             self.monday_session.id,

--- a/tests/service_wakeup_dispatcher_test.py
+++ b/tests/service_wakeup_dispatcher_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=protected-access
+# pylint: disable=protected-access,missing-function-docstring,unused-argument
 """Tests for :class:`WakeupDispatcher` — one-per-process consumer of the
 shared wake-up queue + signal channel.
 
@@ -16,11 +16,13 @@ Verifies the four behaviours that callers rely on:
 """
 import asyncio
 from contextlib import asynccontextmanager
+from types import SimpleNamespace
 from typing import Any, AsyncGenerator, Callable
 from unittest import IsolatedAsyncioTestCase
 
 from agentscope.app._manager import ChatRunRegistry, WakeupDispatcher
 from agentscope.app.message_bus import MessageBus, MessageBusKeys
+from agentscope.message import UserMsg
 
 
 class _FakeStorage:
@@ -33,6 +35,7 @@ class _FakeStorage:
 
     def __init__(self) -> None:
         self.missing_session_ids: set[str] = set()
+        self.revisions: dict[str, int] = {}
 
     async def get_session(
         self,
@@ -43,7 +46,10 @@ class _FakeStorage:
         """Get a session id from the orphan guard."""
         if session_id in self.missing_session_ids:
             return None
-        return object()
+        return SimpleNamespace(
+            agent_id=_agent_id,
+            conversation_revision=self.revisions.get(session_id, 0),
+        )
 
 
 class _FakeBus(MessageBus):
@@ -205,6 +211,7 @@ class _FakeChatService:
         session_id: str,
         agent_id: str,
         input_msg: Any = None,
+        accepted_revision: int | None = None,
     ) -> None:
         """Record the call and signal a waiter."""
         self.calls.append(
@@ -213,6 +220,7 @@ class _FakeChatService:
                 "session_id": session_id,
                 "agent_id": agent_id,
                 "input_msg": input_msg,
+                "accepted_revision": accepted_revision,
             },
         )
         self.notify.set()
@@ -254,6 +262,7 @@ class TestWakeupDispatcherDispatch(IsolatedAsyncioTestCase):
                     "session_id": "s1",
                     "agent_id": "a1",
                     "input_msg": None,
+                    "accepted_revision": None,
                 },
             ],
         )
@@ -284,6 +293,7 @@ class TestWakeupDispatcherDispatch(IsolatedAsyncioTestCase):
                     "session_id": "pre",
                     "agent_id": "a",
                     "input_msg": None,
+                    "accepted_revision": None,
                 },
             ],
         )
@@ -342,8 +352,76 @@ class TestWakeupDispatcherDispatch(IsolatedAsyncioTestCase):
                     "session_id": "s2",
                     "agent_id": "a",
                     "input_msg": None,
+                    "accepted_revision": None,
                 },
             ],
+        )
+
+    async def test_stale_message_revision_is_dropped(self) -> None:
+        """A queued user message cannot cross a clear boundary."""
+        bus = _FakeBus()
+        chat = _FakeChatService()
+        storage = _FakeStorage()
+        storage.revisions["session"] = 1
+
+        async with WakeupDispatcher(
+            message_bus=bus,
+            storage=storage,
+            chat_service=chat,
+            chat_run_registry=ChatRunRegistry(),
+        ):
+            await bus.queue_push(
+                MessageBusKeys.wakeup_queue(),
+                {
+                    "user_id": "user",
+                    "session_id": "session",
+                    "agent_id": "agent",
+                    "kind": MessageBusKeys.WAKEUP_KIND_MESSAGE,
+                    "input": UserMsg(
+                        name="user",
+                        content="old input",
+                    ).model_dump(mode="json"),
+                    "conversation_revision": 0,
+                },
+            )
+            await bus.publish(MessageBusKeys.wakeup_signal(), {})
+            await asyncio.sleep(0.05)
+
+        self.assertEqual(chat.calls, [])
+
+    async def test_current_message_revision_is_dispatched(self) -> None:
+        """A post-clear message runs with its accepted revision."""
+        bus = _FakeBus()
+        chat = _FakeChatService()
+        storage = _FakeStorage()
+        storage.revisions["session"] = 1
+        message = UserMsg(name="user", content="new input")
+
+        async with WakeupDispatcher(
+            message_bus=bus,
+            storage=storage,
+            chat_service=chat,
+            chat_run_registry=ChatRunRegistry(),
+        ):
+            await bus.queue_push(
+                MessageBusKeys.wakeup_queue(),
+                {
+                    "user_id": "user",
+                    "session_id": "session",
+                    "agent_id": "agent",
+                    "kind": MessageBusKeys.WAKEUP_KIND_MESSAGE,
+                    "input": message.model_dump(mode="json"),
+                    "conversation_revision": 1,
+                },
+            )
+            await bus.publish(MessageBusKeys.wakeup_signal(), {})
+            await asyncio.wait_for(chat.notify.wait(), timeout=2.0)
+
+        self.assertEqual(len(chat.calls), 1)
+        self.assertEqual(chat.calls[0]["accepted_revision"], 1)
+        self.assertEqual(
+            chat.calls[0]["input_msg"].model_dump(mode="json"),
+            message.model_dump(mode="json"),
         )
 
     async def test_deleted_session_skipped(self) -> None:
@@ -380,6 +458,7 @@ class TestWakeupDispatcherDispatch(IsolatedAsyncioTestCase):
                     "session_id": "live",
                     "agent_id": "a",
                     "input_msg": None,
+                    "accepted_revision": None,
                 },
             ],
         )
@@ -410,6 +489,7 @@ class TestWakeupDispatcherDispatch(IsolatedAsyncioTestCase):
                     "agent_id": "wa1",
                     "kind": MessageBusKeys.WAKEUP_KIND_RESUME,
                     "input": event.model_dump(mode="json"),
+                    "conversation_revision": 0,
                 },
             )
             await bus.publish(MessageBusKeys.wakeup_signal(), {})
@@ -451,6 +531,7 @@ class TestWakeupDispatcherDispatch(IsolatedAsyncioTestCase):
                     "agent_id": "wa1",
                     "kind": MessageBusKeys.WAKEUP_KIND_RESUME,
                     "input": event.model_dump(mode="json"),
+                    "conversation_revision": 0,
                 },
             )
             await bus.publish(MessageBusKeys.wakeup_signal(), {})

--- a/tests/slash_command_test.py
+++ b/tests/slash_command_test.py
@@ -1,0 +1,313 @@
+# -*- coding: utf-8 -*-
+"""Tests for the service-owned slash command registry."""
+
+from typing import Any, cast
+from unittest import IsolatedAsyncioTestCase, TestCase
+
+from agentscope.app._command import (
+    CommandContext,
+    dispatch_command,
+    list_commands,
+    parse_command,
+)
+from agentscope.app._router._chat import chat as chat_route
+from agentscope.app._router._command import commands as command_list_route
+from agentscope.app._router._schema import ChatRequest
+from agentscope.app.message_bus import InMemoryMessageBus, MessageBusKeys
+from agentscope.app.storage import SessionConfig, SessionRecord
+from agentscope.event import ConfirmResult, UserConfirmResultEvent
+from agentscope.message import (
+    Msg,
+    TextBlock,
+    ToolCallBlock,
+    ToolCallState,
+    UserMsg,
+)
+from agentscope.state import AgentState
+
+
+class SlashCommandRegistryTest(TestCase):
+    """Exercise command discovery and strict input recognition."""
+
+    def test_registry_exposes_clear_metadata(self) -> None:
+        """The discovery registry has one stable built-in command."""
+        self.assertEqual(
+            list_commands(),
+            (
+                list_commands()[0].__class__(
+                    name="clear",
+                    description="Clear the current conversation context",
+                ),
+            ),
+        )
+
+    def test_parser_recognizes_plain_user_command(self) -> None:
+        """Whitespace and command case are normalized."""
+        message = UserMsg(
+            name="user",
+            content=[TextBlock(text="  /ClEaR  ")],
+        )
+
+        match = parse_command(message)
+
+        self.assertIsNotNone(match)
+        self.assertEqual(match.spec, list_commands()[0])
+        self.assertEqual(match.args, "")
+        self.assertIs(match.message, message)
+
+    def test_parser_preserves_arguments_for_validation(self) -> None:
+        """The router receives the unconsumed argument string."""
+        match = parse_command(
+            [UserMsg(name="user", content="/clear now please")],
+        )
+
+        self.assertIsNotNone(match)
+        self.assertEqual(match.args, "now please")
+
+    def test_non_commands_fall_through(self) -> None:
+        """Unknown, escaped, and non-plain inputs remain chat input."""
+        values = [
+            UserMsg(name="user", content="/unknown"),
+            UserMsg(name="user", content="//clear"),
+            UserMsg(name="user", content="/"),
+            UserMsg(
+                name="user",
+                content=[
+                    TextBlock(text="/clear"),
+                    TextBlock(text="attached content"),
+                ],
+            ),
+        ]
+
+        self.assertEqual(
+            [parse_command(value) for value in values],
+            [None] * 4,
+        )
+
+
+class SlashCommandRouteTest(IsolatedAsyncioTestCase):
+    """Verify commands are handled before chat execution."""
+
+    async def test_discovery_matches_registry(self) -> None:
+        """The discovery endpoint serializes the registry contract."""
+        response = await command_list_route()
+
+        self.assertEqual(
+            response.model_dump(),
+            {
+                "commands": [
+                    {
+                        "name": "clear",
+                        "command": "/clear",
+                        "aliases": [],
+                        "description": (
+                            "Clear the current conversation context"
+                        ),
+                        "accepts_args": False,
+                    },
+                ],
+            },
+        )
+
+    async def test_clear_bypasses_chat_run(self) -> None:
+        """The chat route delegates clear directly to SessionService."""
+
+        class _ClearService:
+            """Record clear calls made by the route."""
+
+            def __init__(self) -> None:
+                self.calls: list[tuple[str, str, str]] = []
+
+            async def clear_conversation(
+                self,
+                user_id: str,
+                agent_id: str,
+                session_id: str,
+            ) -> tuple[str, ...]:
+                """Record and complete a clear command."""
+                self.calls.append((user_id, agent_id, session_id))
+                return (session_id,)
+
+        service = _ClearService()
+        unused = cast(Any, object())
+
+        response = await chat_route(
+            ChatRequest(
+                agent_id="agent",
+                session_id="session",
+                input=UserMsg(name="user", content="/clear"),
+            ),
+            user_id="user",
+            chat_service=unused,
+            chat_run_registry=unused,
+            message_bus=unused,
+            storage=unused,
+            session_service=cast(Any, service),
+        )
+
+        self.assertEqual(service.calls, [("user", "agent", "session")])
+        self.assertEqual(
+            response.model_dump(),
+            {
+                "status": "command_completed",
+                "session_id": "session",
+                "command": "clear",
+            },
+        )
+
+    async def test_dispatcher_returns_structured_result(self) -> None:
+        """The shared dispatcher exposes affected sessions and notice."""
+
+        class _ClearService:
+            """Return a deterministic team clear result."""
+
+            def __init__(self) -> None:
+                self.assertions: tuple[str, str, str] | None = None
+
+            async def clear_conversation(
+                self,
+                user_id: str,
+                agent_id: str,
+                session_id: str,
+            ) -> tuple[str, ...]:
+                """Return the root and one worker target."""
+                self.assertions = (user_id, agent_id, session_id)
+                return (session_id, "worker")
+
+        message = UserMsg(name="user", content="/clear")
+        match = parse_command(message)
+        self.assertIsNotNone(match)
+        service = _ClearService()
+
+        result = await dispatch_command(
+            match,
+            CommandContext(
+                user_id="user",
+                agent_id="agent",
+                session_id="session",
+                source="http",
+                command_message_id=message.id,
+            ),
+            cast(Any, service),
+        )
+
+        self.assertEqual(service.assertions, ("user", "agent", "session"))
+        self.assertEqual(
+            result.__dict__,
+            {
+                "name": "clear",
+                "root_session_id": "session",
+                "affected_session_ids": ("session", "worker"),
+                "message": "Conversation cleared.",
+            },
+        )
+
+
+class HitlResumeRouteTest(IsolatedAsyncioTestCase):
+    """Stale approvals do not start a run after conversation clear."""
+
+    @staticmethod
+    def _request(tool_call: ToolCallBlock) -> ChatRequest:
+        """Build one approval request for the supplied tool call."""
+        return ChatRequest(
+            agent_id="agent",
+            session_id="session",
+            input=UserConfirmResultEvent(
+                reply_id="reply",
+                confirm_results=[
+                    ConfirmResult(
+                        confirmed=True,
+                        tool_call=tool_call,
+                    ),
+                ],
+            ),
+        )
+
+    async def _trigger(self, session: SessionRecord) -> tuple[Any, list]:
+        """Call the route and return its response and queued triggers."""
+
+        class _Storage:
+            """Return the session state under test."""
+
+            async def get_session(self, *args: object) -> SessionRecord:
+                """Return the configured session."""
+                del args
+                return session
+
+        tool_call = ToolCallBlock(
+            id="tool-call",
+            name="shell",
+            input="{}",
+            state=ToolCallState.ASKING,
+        )
+        bus = InMemoryMessageBus()
+        unused = cast(Any, object())
+        response = await chat_route(
+            self._request(tool_call),
+            user_id="user",
+            chat_service=unused,
+            chat_run_registry=unused,
+            message_bus=bus,
+            storage=cast(Any, _Storage()),
+            session_service=unused,
+        )
+        entries = await bus.queue_drain(MessageBusKeys.wakeup_queue())
+        return response, entries
+
+    async def test_cleared_approval_is_ignored(self) -> None:
+        """An approval whose reply was cleared never reaches dispatcher."""
+        session = SessionRecord(
+            id="session",
+            user_id="user",
+            agent_id="agent",
+            config=SessionConfig(workspace_id="workspace"),
+            state=AgentState(session_id="session"),
+            conversation_revision=1,
+        )
+
+        response, entries = await self._trigger(session)
+
+        self.assertEqual(
+            response.model_dump(),
+            {
+                "status": "started",
+                "session_id": "session",
+                "command": None,
+            },
+        )
+        self.assertEqual(entries, [])
+
+    async def test_current_approval_is_enqueued(self) -> None:
+        """A matching parked approval keeps the existing resume path."""
+        session = SessionRecord(
+            id="session",
+            user_id="user",
+            agent_id="agent",
+            config=SessionConfig(workspace_id="workspace"),
+            state=AgentState(
+                session_id="session",
+                reply_id="reply",
+                context=[
+                    Msg(
+                        name="agent",
+                        role="assistant",
+                        content=[
+                            ToolCallBlock(
+                                id="tool-call",
+                                name="shell",
+                                input="{}",
+                                state=ToolCallState.ASKING,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            conversation_revision=4,
+        )
+
+        response, entries = await self._trigger(session)
+
+        self.assertEqual(response.status, "started")
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0][1]["kind"], "resume")
+        self.assertEqual(entries[0][1]["conversation_revision"], 4)

--- a/tests/storage_redis_test.py
+++ b/tests/storage_redis_test.py
@@ -17,6 +17,7 @@ from agentscope.app.storage import (
     SessionSource,
     TeamData,
     TeamRecord,
+    SessionRevisionConflict,
 )
 from agentscope.app.storage import MCPRecord, SkillRecord
 from agentscope.credential import OllamaCredential
@@ -322,6 +323,84 @@ class TestSession(IsolatedAsyncioTestCase):
         )
         records = await self.storage.list_sessions(self.user_id, "agent-B")
         self.assertEqual(records, [])
+
+    async def test_reset_conversation_is_atomic(self) -> None:
+        """Reset state and messages while advancing the revision."""
+        session = await self.storage.upsert_session(
+            self.user_id,
+            self.agent_id,
+            make_session_config(self.workspace_id),
+        )
+        old_state = AgentState(
+            session_id=session.id,
+            summary="old summary",
+            context=[UserMsg(name="alice", content="old context")],
+        )
+        await self.storage.update_session_state(
+            self.user_id,
+            self.agent_id,
+            session.id,
+            old_state,
+        )
+        await self.storage.upsert_message(
+            self.user_id,
+            session.id,
+            UserMsg(name="alice", content="persisted"),
+        )
+        fresh_state = AgentState(session_id=session.id)
+
+        updated = await self.storage.reset_session_conversation(
+            self.user_id,
+            self.agent_id,
+            session.id,
+            fresh_state,
+            expected_revision=0,
+        )
+
+        fetched = await self.storage.get_session(
+            self.user_id,
+            self.agent_id,
+            session.id,
+        )
+        messages = await self.storage.list_messages(
+            self.user_id,
+            session.id,
+        )
+        self.assertEqual(updated.model_dump(), fetched.model_dump())
+        self.assertEqual(fetched.state.model_dump(), fresh_state.model_dump())
+        self.assertEqual(fetched.conversation_revision, 1)
+        self.assertEqual(fetched.config, session.config)
+        self.assertEqual(fetched.created_at, session.created_at)
+        self.assertEqual(messages, ([], False))
+        survivor = UserMsg(name="alice", content="new generation")
+        await self.storage.upsert_message(
+            self.user_id,
+            session.id,
+            survivor,
+        )
+        before_conflict = fetched.model_dump()
+        with self.assertRaises(SessionRevisionConflict):
+            await self.storage.reset_session_conversation(
+                self.user_id,
+                self.agent_id,
+                session.id,
+                AgentState(session_id=session.id),
+                expected_revision=0,
+            )
+        after_conflict = await self.storage.get_session(
+            self.user_id,
+            self.agent_id,
+            session.id,
+        )
+        remaining = await self.storage.list_messages(
+            self.user_id,
+            session.id,
+        )
+        self.assertEqual(after_conflict.model_dump(), before_conflict)
+        self.assertEqual(
+            [message.model_dump() for message in remaining[0]],
+            [survivor.model_dump()],
+        )
 
 
 class TestMessage(IsolatedAsyncioTestCase):

--- a/tests/storage_sql_test.py
+++ b/tests/storage_sql_test.py
@@ -38,6 +38,7 @@ from agentscope.app.storage import (
     SessionConfig,
     SessionSettings,
     SessionSource,
+    SessionRevisionConflict,
     SkillRecord,
     AsyncSQLAlchemyStorage,
     TeamData,
@@ -389,6 +390,88 @@ class AsyncSQLAlchemyStorageTest(IsolatedAsyncioTestCase):
                 "no-such-session",
                 AgentState(),
             )
+
+    async def test_reset_conversation_is_atomic(self) -> None:
+        """Reset state and messages in the same SQL transaction."""
+        from agentscope.state import AgentState
+
+        agent = _agent_record("user-1")
+        await self.storage.upsert_agent("user-1", agent)
+        session = await self.storage.upsert_session(
+            user_id="user-1",
+            agent_id=agent.id,
+            config=_session_config(),
+        )
+        old_state = AgentState(
+            session_id=session.id,
+            summary="old summary",
+            context=[UserMsg(name="alice", content="old context")],
+        )
+        await self.storage.update_session_state(
+            "user-1",
+            agent.id,
+            session.id,
+            old_state,
+        )
+        await self.storage.upsert_message(
+            "user-1",
+            session.id,
+            UserMsg(name="alice", content="persisted"),
+        )
+        fresh_state = AgentState(session_id=session.id)
+
+        updated = await self.storage.reset_session_conversation(
+            "user-1",
+            agent.id,
+            session.id,
+            fresh_state,
+            expected_revision=0,
+        )
+
+        fetched = await self.storage.get_session(
+            "user-1",
+            agent.id,
+            session.id,
+        )
+        messages = await self.storage.list_messages(
+            "user-1",
+            session.id,
+        )
+        self.assertEqual(updated.model_dump(), fetched.model_dump())
+        self.assertEqual(fetched.state.model_dump(), fresh_state.model_dump())
+        self.assertEqual(fetched.conversation_revision, 1)
+        self.assertEqual(fetched.config, session.config)
+        self.assertEqual(fetched.created_at, session.created_at)
+        self.assertEqual(messages, ([], False))
+        survivor = UserMsg(name="alice", content="new generation")
+        await self.storage.upsert_message(
+            "user-1",
+            session.id,
+            survivor,
+        )
+        before_conflict = fetched.model_dump()
+        with self.assertRaises(SessionRevisionConflict):
+            await self.storage.reset_session_conversation(
+                "user-1",
+                agent.id,
+                session.id,
+                AgentState(session_id=session.id),
+                expected_revision=0,
+            )
+        after_conflict = await self.storage.get_session(
+            "user-1",
+            agent.id,
+            session.id,
+        )
+        remaining = await self.storage.list_messages(
+            "user-1",
+            session.id,
+        )
+        self.assertEqual(after_conflict.model_dump(), before_conflict)
+        self.assertEqual(
+            [message.model_dump() for message in remaining[0]],
+            [survivor.model_dump()],
+        )
 
     # ------------------------------------------------------------------
     # Messages

--- a/tests/tool_offload_middleware_test.py
+++ b/tests/tool_offload_middleware_test.py
@@ -183,12 +183,14 @@ class ToolOffloadMiddlewareTest(IsolatedAsyncioTestCase):
         # delivery look like somebody was already going to drain it.
         message_bus = MagicMock(spec=MessageBus)
         message_bus.registry_get = AsyncMock(return_value=None)
+        message_bus.registry_getall = AsyncMock(return_value={})
         middleware = ToolOffloadMiddleware(
             bg_manager=self.bg_manager,
             message_bus=message_bus,
             user_id="u",
             agent_id="a",
             timeout_secs=timeout_secs,
+            conversation_revision=7,
         )
         agent = Agent(
             name="test_agent",
@@ -307,7 +309,9 @@ class ToolOffloadMiddlewareTest(IsolatedAsyncioTestCase):
             if c.args[0] == MessageBusKeys.inbox(agent.state.session_id)
         ]
         self.assertEqual(len(inbox_calls), 1)
-        _, hint_dict = inbox_calls[0].args
+        _, envelope = inbox_calls[0].args
+        self.assertEqual(envelope["conversation_revision"], 7)
+        hint_dict = envelope["payload"]
         session_id_called = agent.state.session_id
         self.assertEqual(session_id_called, agent.state.session_id)
         self.maxDiff = None
@@ -373,6 +377,21 @@ class ToolOffloadMiddlewareTest(IsolatedAsyncioTestCase):
         self.assertEqual(payload["user_id"], "u")
         self.assertEqual(payload["session_id"], agent.state.session_id)
         self.assertEqual(payload["agent_id"], "a")
+        self.assertEqual(payload["conversation_revision"], 7)
+
+    async def test_legacy_positional_timeout_remains_compatible(self) -> None:
+        """The former fifth positional argument still configures timeout."""
+        message_bus = MagicMock(spec=MessageBus)
+        middleware = ToolOffloadMiddleware(
+            self.bg_manager,
+            message_bus,
+            "u",
+            "a",
+            0.25,
+        )
+
+        self.assertEqual(middleware._timeout_secs, 0.25)
+        self.assertEqual(middleware._conversation_revision, 0)
 
     async def test_tool_stop_cancels_background_task(self) -> None:
         """ToolStop tool cancels the running background asyncio task."""


### PR DESCRIPTION
## AgentScope Version

2.0.7

## Description

### Summary

Add a built-in `/clear` slash command that resets conversation state while preserving session configuration, permissions, workspace data, MCP state, and team topology.

The command is supported by both the web UI and channel integrations, with safeguards for concurrent runs, pending tool approvals, background tasks, and distributed deployments.

### Key Changes

- Add a shared slash-command registry and dispatcher.
- Add command discovery and execution APIs.
- Support `/clear` in the web UI and channel message paths.
- Reset persisted messages and conversation state atomically.
- Increment `conversation_revision` after every successful clear.
- Cascade leader clears across resolvable team-member sessions.
- Publish `session_cleared` events for UI synchronization.
- Clear inbox, replay, HITL projections, and background-task state.
- Provide user-visible channel notices when clearing fails.
- Limit command autocomplete results and validate registry/handler consistency.

### Concurrency and Safety

- Use reset barriers and session locks to prevent messages from crossing the clear boundary.
- Keep Redis barrier creation atomic and ensure barriers are cleaned up after failures or cancellation.
- Complete post-commit cleanup and event publication even if the caller is cancelled.
- Drop stale messages, retries, wakeups, and tool-approval results using conversation revisions.
- Validate HTTP HITL results against the authoritative parked session state before enqueueing.
- Treat team clearing as an idempotent saga so partial successes can be safely retried.
- Preserve compatibility for direct `ToolOffloadMiddleware` construction.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review