### PR TITLE
fix(webui): isolate sessions when switching agents

### DIFF
--- a/examples/web_ui/frontend/src/hooks/useMessages.ts
+++ b/examples/web_ui/frontend/src/hooks/useMessages.ts
@@ -256,6 +256,7 @@ export function useMessages(
 
 	// ── Lifecycle: fetch history + open SSE stream ──────────────────
 	useEffect(() => {
+		setLoadedKey(null);
 		msgsRef.current = [];
 		currentReplyRef.current = null;
 		setMsgs([]);

--- a/examples/web_ui/frontend/src/hooks/useMessages.ts
+++ b/examples/web_ui/frontend/src/hooks/useMessages.ts
@@ -527,23 +527,19 @@ export function useMessages(
 		[agentId, sessionId],
 	);
 
-	// True from the very first render after `sessionId` changes, because
-	// it compares props against what was fetched rather than tracking a
-	// flag an effect has yet to flip. `msgs` is still the previous
-	// session's until the effect clears it, so consumers must render the
-	// loading state in preference to `msgs`.
-	const loading =
-		agentId !== null && sessionId !== null && loadedKey !== `${agentId}:${sessionId}`;
+	const currentKey = agentId !== null && sessionId !== null ? `${agentId}:${sessionId}` : null;
+	const ownsConversation = currentKey !== null && loadedKey === currentKey;
+	const loading = currentKey !== null && !ownsConversation;
 
 	return {
-		msgs,
+		msgs: ownsConversation ? msgs : [],
 		loading,
-		phase,
-		error,
+		phase: ownsConversation ? phase : ('idle' as ReplyPhase),
+		error: ownsConversation ? error : null,
 		send,
 		onUserConfirm,
 		onSubagentConfirm,
-		subagentHitl,
+		subagentHitl: ownsConversation ? subagentHitl : [],
 		abort,
 		interrupt,
 	};

--- a/examples/web_ui/frontend/src/hooks/useSessions.ts
+++ b/examples/web_ui/frontend/src/hooks/useSessions.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
 import { sessionApi } from '../api';
 import type { SessionView, CreateSessionRequest, UpdateSessionRequest } from '../api';
@@ -16,9 +16,18 @@ import type { SessionView, CreateSessionRequest, UpdateSessionRequest } from '..
  *   helpers that all keep the local list in sync.
  */
 export function useSessions(agentId: string | null) {
-	const [sessions, setSessions] = useState<SessionView[]>([]);
-	const [loading, setLoading] = useState(false);
-	const [error, setError] = useState<Error | null>(null);
+	const [state, setState] = useState<{
+		agentId: string | null;
+		sessions: SessionView[];
+		loading: boolean;
+		error: Error | null;
+	}>({ agentId: null, sessions: [], loading: false, error: null });
+	const currentAgentIdRef = useRef(agentId);
+	const requestIdRef = useRef(0);
+	const ownsState = state.agentId === agentId;
+	const sessions = ownsState ? state.sessions : [];
+	const loading = agentId !== null && (!ownsState || state.loading);
+	const error = ownsState ? state.error : null;
 
 	/**
 	 * Reload the session list.
@@ -31,27 +40,50 @@ export function useSessions(agentId: string | null) {
 	 *   agent or the request failed.
 	 */
 	const refetch = useCallback(async (): Promise<SessionView[]> => {
-		if (!agentId) {
-			setSessions([]);
+		const requestedAgentId = agentId;
+		if (currentAgentIdRef.current !== requestedAgentId) return [];
+
+		const requestId = ++requestIdRef.current;
+		const isCurrent = () =>
+			requestId === requestIdRef.current && requestedAgentId === currentAgentIdRef.current;
+
+		if (!requestedAgentId) {
+			setState({ agentId: null, sessions: [], loading: false, error: null });
 			return [];
 		}
-		setLoading(true);
-		setError(null);
+		setState((prev) => ({
+			agentId: requestedAgentId,
+			sessions: prev.agentId === requestedAgentId ? prev.sessions : [],
+			loading: true,
+			error: null,
+		}));
 		try {
-			const res = await sessionApi.list(agentId);
-			setSessions(res.sessions);
+			const res = await sessionApi.list(requestedAgentId);
+			if (!isCurrent()) return [];
+			setState({
+				agentId: requestedAgentId,
+				sessions: res.sessions,
+				loading: false,
+				error: null,
+			});
 			return res.sessions;
 		} catch (e) {
-			setError(e as Error);
+			if (isCurrent()) {
+				setState((prev) => ({
+					agentId: requestedAgentId,
+					sessions: prev.agentId === requestedAgentId ? prev.sessions : [],
+					loading: false,
+					error: e as Error,
+				}));
+			}
 			return [];
-		} finally {
-			setLoading(false);
 		}
 	}, [agentId]);
 
 	useEffect(() => {
+		currentAgentIdRef.current = agentId;
 		refetch();
-	}, [refetch]);
+	}, [agentId, refetch]);
 
 	/** Creates a new session and refreshes the list. */
 	const create = useCallback(

--- a/examples/web_ui/frontend/src/pages/chat/index.tsx
+++ b/examples/web_ui/frontend/src/pages/chat/index.tsx
@@ -132,7 +132,9 @@ const ChatPageInner = () => {
 	const effectiveSessionId =
 		focusedMember && focusedMember.session_id
 			? focusedMember.session_id
-			: (urlSessionId ?? null);
+			: currentView
+				? (urlSessionId ?? null)
+				: null;
 
 	// Redirect: URL is missing an agent → pick the first one and rewrite
 	// the URL in-place (replace so we don't pollute history).


### PR DESCRIPTION
## AgentScope Version

`2.0.7`

## Description

Fixes [#2422](https://github.com/agentscope-ai/agentscope/issues/2422).

Fixes the Web UI session race that could show or request a previous agent's conversation after switching agents.

### Changes

- Associate session-list state with the agent it was loaded for.
- Ignore outdated session-list responses.
- Only select or load sessions verified to belong to the current agent.
- Hide the previous session's messages and state immediately after switching agents.

### How to Test

1. Open Agent A with an existing conversation.
2. Switch to Agent B, which has no sessions.
3. Verify the URL remains at `/chat/{agent_b_id}` and Agent A's conversation is not displayed.
4. Open `/chat/{agent_b_id}/{agent_a_session_id}` and verify Agent A's conversation is not loaded.

The frontend build and lint checks pass. The scenarios above were also verified manually.

### Screenshots

**Agent A with an existing conversation**

<img width="3024" height="1964" alt="c7dceeb09bbdaabc56becf72b96caf8a" src="https://github.com/user-attachments/assets/a4f55b45-68f0-4fda-9e35-3dacd188264b" />

**Agent B after switching, with no sessions**

<img width="3024" height="1964" alt="77b418f104d694a2f38cbe7b0edbe680" src="https://github.com/user-attachments/assets/420eb890-8b43-4013-8030-010e7d6eb0fc" />

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style (not applicable: frontend-only change)
- [x] Related documentation has been updated (not applicable: internal bug fix)
- [x] Code is ready for review
