### PR TITLE
fix(webui): auto-open task panel on first stateUpdated per session

### DIFF
--- a/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
+++ b/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
@@ -215,26 +215,27 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 		onTeamUpdated?.();
 	}, [refetchSessions, sessionId, onTeamUpdated]);
 
+	// Surface the plan panel the first time a session's tasks arrive over
+	// the stream, and only then — reopening it on every update would undo
+	// the user closing it. `state_updated` also fires for permission-only
+	// changes and always carries `tasks_context`, hence gating on a
+	// non-empty task list rather than the field being present.
+	const taskPanelOpenedForRef = useRef<string | null>(null);
 	const handleStateUpdated = useCallback(
 		(value: Record<string, unknown>) => {
 			if (value.tasks_context) {
 				const incoming = value.tasks_context as TaskContext;
-				setTasksContext((prev) => {
-					// Auto-open the plan panel on the first genuine task
-					// update per session so the user can see plan progress
-					// without having to manually open the panel.
-					if (!taskPanelAutoOpenedRef.current && incoming !== prev) {
-						taskPanelAutoOpenedRef.current = true;
-						setPanelLayout((layout) => openPanelInLayout(layout, 'plan'));
-					}
-					return incoming;
-				});
+				setTasksContext(incoming);
+				if (incoming.tasks.length > 0 && taskPanelOpenedForRef.current !== sessionId) {
+					taskPanelOpenedForRef.current = sessionId;
+					setPanelLayout((layout) => openPanelInLayout(layout, 'plan'));
+				}
 			}
 			if (value.permission_context) {
 				setPermissionContext(value.permission_context as PermissionContext);
 			}
 		},
-		[],
+		[sessionId],
 	);
 
 	const {
@@ -553,20 +554,15 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 	// reply started. Clearing on `!view` still matters so switching
 	// sessions cannot leak the previous session's tasks or rules.
 	const seededSessionRef = useRef<string | null>(null);
-	// Track whether we already auto-opened the task panel for the current
-	// session so we don't keep forcing it open on every subsequent update.
-	const taskPanelAutoOpenedRef = useRef(false);
 	useEffect(() => {
 		if (!view) {
 			seededSessionRef.current = null;
-			taskPanelAutoOpenedRef.current = false;
 			setTasksContext(null);
 			setPermissionContext(null);
 			return;
 		}
 		if (seededSessionRef.current === view.session.id) return;
 		seededSessionRef.current = view.session.id;
-		taskPanelAutoOpenedRef.current = false;
 		const state = view.session.state as Record<string, unknown> | undefined;
 		setTasksContext((state?.tasks_context as TaskContext) ?? null);
 		setPermissionContext((state?.permission_context as PermissionContext) ?? null);

--- a/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
+++ b/examples/web_ui/frontend/src/pages/chat/ChatViewport.tsx
@@ -215,14 +215,27 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 		onTeamUpdated?.();
 	}, [refetchSessions, sessionId, onTeamUpdated]);
 
-	const handleStateUpdated = useCallback((value: Record<string, unknown>) => {
-		if (value.tasks_context) {
-			setTasksContext(value.tasks_context as TaskContext);
-		}
-		if (value.permission_context) {
-			setPermissionContext(value.permission_context as PermissionContext);
-		}
-	}, []);
+	const handleStateUpdated = useCallback(
+		(value: Record<string, unknown>) => {
+			if (value.tasks_context) {
+				const incoming = value.tasks_context as TaskContext;
+				setTasksContext((prev) => {
+					// Auto-open the plan panel on the first genuine task
+					// update per session so the user can see plan progress
+					// without having to manually open the panel.
+					if (!taskPanelAutoOpenedRef.current && incoming !== prev) {
+						taskPanelAutoOpenedRef.current = true;
+						setPanelLayout((layout) => openPanelInLayout(layout, 'plan'));
+					}
+					return incoming;
+				});
+			}
+			if (value.permission_context) {
+				setPermissionContext(value.permission_context as PermissionContext);
+			}
+		},
+		[],
+	);
 
 	const {
 		msgs,
@@ -540,15 +553,20 @@ export function ChatViewport({ agentId, sessionId, onTeamUpdated }: ChatViewport
 	// reply started. Clearing on `!view` still matters so switching
 	// sessions cannot leak the previous session's tasks or rules.
 	const seededSessionRef = useRef<string | null>(null);
+	// Track whether we already auto-opened the task panel for the current
+	// session so we don't keep forcing it open on every subsequent update.
+	const taskPanelAutoOpenedRef = useRef(false);
 	useEffect(() => {
 		if (!view) {
 			seededSessionRef.current = null;
+			taskPanelAutoOpenedRef.current = false;
 			setTasksContext(null);
 			setPermissionContext(null);
 			return;
 		}
 		if (seededSessionRef.current === view.session.id) return;
 		seededSessionRef.current = view.session.id;
+		taskPanelAutoOpenedRef.current = false;
 		const state = view.session.state as Record<string, unknown> | undefined;
 		setTasksContext((state?.tasks_context as TaskContext) ?? null);
 		setPermissionContext((state?.permission_context as PermissionContext) ?? null);


### PR DESCRIPTION
## What Problem This Solves

When the agent creates or updates tasks during a reply, the backend pushes a `CustomEvent` with `name="state_updated"` containing the latest `tasks_context`. The `ChatViewport` component updates its local state, but the Task Panel (right-side dockable panel) stays closed unless the user manually opens it — defeating the purpose of real-time task tracking.

## Why This Change Was Made

`handleStateUpdated` now opens the `'plan'` panel via `openPanelInLayout` on the **first genuine task-data change** per session. The guard uses React's functional `setTasksContext(prev => ...)` updater to compare the incoming `tasks_context` by identity against the current state, so:

- Redundant `state_updated` events with the same `tasks_context` object do not re-trigger the open.
- A subsequent genuine update (new object reference) in the same session does not force the panel open again — the user may have deliberately closed it.

The guard resets on session switch (`seededSessionRef` change) and when the view clears, so each new session starts a fresh auto-open cycle.

## User Impact

Users now see the Task Panel open automatically when tasks are first created during a run, giving immediate visibility into plan progress without manual panel management. Subsequent task updates within the same session update the panel content in-place without forcing it back open if the user closed it.

## How Tested

- Verified the diff is a pure additive change to `handleStateUpdated` + one `useRef` + two reset lines in the existing seeding `useEffect`.
- The `openPanelInLayout` helper is already used by `handleTeamUpdated` for the same pattern; this applies the identical pattern for tasks.
- Frontend build (`tsc -b && vite build`) and lint (`eslint .`) should be run by CI; local node_modules were not available in this checkout.

## Refs

Closes #2095
