### PR TITLE
fix(agent): emit final-only streaming text

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -1539,6 +1539,7 @@ class Agent:
             "data": [],
         }
         completed_response: ChatResponse | None = None
+        has_streamed_content = False
 
         # Check if res is an async generator (streaming response)
         if inspect.isasyncgen(res):
@@ -1546,8 +1547,31 @@ class Agent:
                 # Save the last chunk with completed response
                 if chunk.is_last:
                     completed_response = chunk
+                    if not has_streamed_content:
+                        # Surface final-only text without replaying aggregate
+                        # tool, thinking, or data content as duplicate deltas.
+                        text_blocks = [
+                            block
+                            for block in chunk.content
+                            if isinstance(block, TextBlock)
+                        ]
+                        if text_blocks:
+                            event_stream = (
+                                self._convert_chat_response_to_event(
+                                    block_ids,
+                                    ChatResponse(
+                                        content=text_blocks,
+                                        is_last=False,
+                                    ),
+                                )
+                            )
+                            async for evt in event_stream:
+                                yield evt
 
                 else:
+                    has_streamed_content = has_streamed_content or bool(
+                        chunk.content,
+                    )
                     # Convert the chunk into events
                     async for evt in self._convert_chat_response_to_event(
                         block_ids,

--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -1548,19 +1548,21 @@ class Agent:
                 if chunk.is_last:
                     completed_response = chunk
                     if not has_streamed_content:
-                        # Surface final-only text without replaying aggregate
-                        # tool, thinking, or data content as duplicate deltas.
-                        text_blocks = [
+                        # Surface final-only user-visible content without
+                        # replaying an aggregate response after streamed
+                        # chunks. Tool calls keep their existing acting-path
+                        # event contract.
+                        event_blocks = [
                             block
                             for block in chunk.content
-                            if isinstance(block, TextBlock)
+                            if not isinstance(block, ToolCallBlock)
                         ]
-                        if text_blocks:
+                        if event_blocks:
                             event_stream = (
                                 self._convert_chat_response_to_event(
                                     block_ids,
                                     ChatResponse(
-                                        content=text_blocks,
+                                        content=event_blocks,
                                         is_last=False,
                                     ),
                                 )
@@ -1569,9 +1571,7 @@ class Agent:
                                 yield evt
 
                 else:
-                    has_streamed_content = has_streamed_content or bool(
-                        chunk.content,
-                    )
+                    has_streamed_content = True
                     # Convert the chunk into events
                     async for evt in self._convert_chat_response_to_event(
                         block_ids,

--- a/tests/agent_basic_test.py
+++ b/tests/agent_basic_test.py
@@ -18,6 +18,8 @@ from agentscope.permission import (
     PermissionContext,
 )
 from agentscope.message import (
+    Base64Source,
+    DataBlock,
     TextBlock,
     ThinkingBlock,
     ToolCallBlock,
@@ -445,7 +447,17 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
             [
                 [
                     ChatResponse(
-                        content=[TextBlock(text="Hello world!")],
+                        content=[
+                            ThinkingBlock(thinking="Considering"),
+                            TextBlock(text="Hello world!"),
+                            DataBlock(
+                                id="data-1",
+                                source=Base64Source(
+                                    data="aW1hZ2U=",
+                                    media_type="image/png",
+                                ),
+                            ),
+                        ],
                         is_last=True,
                     ),
                 ],
@@ -473,6 +485,15 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
                 "model_name": "mock-model",
             },
             {
+                "type": "THINKING_BLOCK_START",
+                "block_id": AnyString(),
+            },
+            {
+                "type": "THINKING_BLOCK_DELTA",
+                "block_id": AnyString(),
+                "delta": "Considering",
+            },
+            {
                 "type": "TEXT_BLOCK_START",
                 "block_id": AnyString(),
             },
@@ -482,8 +503,27 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
                 "delta": "Hello world!",
             },
             {
+                "type": "DATA_BLOCK_START",
+                "block_id": "data-1",
+                "media_type": "image/png",
+            },
+            {
+                "type": "DATA_BLOCK_DELTA",
+                "block_id": "data-1",
+                "data": "aW1hZ2U=",
+                "media_type": "image/png",
+            },
+            {
                 "type": "TEXT_BLOCK_END",
                 "block_id": AnyString(),
+            },
+            {
+                "type": "THINKING_BLOCK_END",
+                "block_id": AnyString(),
+            },
+            {
+                "type": "DATA_BLOCK_END",
+                "block_id": "data-1",
             },
             {
                 "type": "MODEL_CALL_END",

--- a/tests/agent_basic_test.py
+++ b/tests/agent_basic_test.py
@@ -439,6 +439,72 @@ class AgentBasicTest(IsolatedAsyncioTestCase):
         context_dicts = [msg.model_dump() for msg in self.agent.state.context]
         self.assertListEqual(context_dicts, expected_context_after_reply)
 
+    async def test_final_only_streaming_response_emits_content(self) -> None:
+        """A streaming model may return its content only in the final chunk."""
+        self.model.set_responses(
+            [
+                [
+                    ChatResponse(
+                        content=[TextBlock(text="Hello world!")],
+                        is_last=True,
+                    ),
+                ],
+            ],
+        )
+
+        events = []
+        async for event in self.agent.reply_stream(
+            UserMsg(name="user", content="Hi"),
+        ):
+            events.append(event.model_dump())
+
+        session_id = self.agent.state.session_id
+        reply_id = self.agent.state.reply_id
+        event_base = self._get_event_base(reply_id)
+        expected_events = [
+            {
+                "type": "REPLY_START",
+                "session_id": session_id,
+                "name": "Friday",
+                "role": "assistant",
+            },
+            {
+                "type": "MODEL_CALL_START",
+                "model_name": "mock-model",
+            },
+            {
+                "type": "TEXT_BLOCK_START",
+                "block_id": AnyString(),
+            },
+            {
+                "type": "TEXT_BLOCK_DELTA",
+                "block_id": AnyString(),
+                "delta": "Hello world!",
+            },
+            {
+                "type": "TEXT_BLOCK_END",
+                "block_id": AnyString(),
+            },
+            {
+                "type": "MODEL_CALL_END",
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+                "finished_reason": "completed",
+            },
+            {
+                "type": "REPLY_END",
+                "error": None,
+                "session_id": session_id,
+                "finished_reason": "completed",
+            },
+        ]
+        self.assertListEqual(
+            events,
+            [{**event_base, **event} for event in expected_events],
+        )
+
     async def test_non_streaming_reasoning(self) -> None:
         """Test the non-streaming model inference without tool calls generated,
         only text in model response.


### PR DESCRIPTION
## AgentScope Version

2.0.7 (`main` at `142c3411`)

## Description

Fixes #2430.

A streaming `ChatModelBase` may legally return all text only in its final `ChatResponse`. `Agent._reasoning_impl()` previously stored that text in context but skipped event conversion for the final chunk, so `reply_stream()` callers received no text events.

This change:

- tracks whether the stream emitted any non-final content;
- emits block events for final-only text, thinking, and data content;
- leaves aggregate final chunks untouched after normal deltas, avoiding duplicate output;
- retains the existing final-only tool-call acting contract.


## Testing

- `python -m pytest tests/agent_basic_test.py tests/agent_injection_test.py tests/agent_interrupt_test.py tests/agent_structured_output_test.py -q` — 43 passed
- `pre-commit run --files src/agentscope/agent/_agent.py tests/agent_basic_test.py` — passed
- Full `pytest tests -q` was also attempted in a partial Windows dev environment: 1765 passed, 319 skipped, and 82 optional/integration tests failed because the complete `dev` extra could not be installed after the Windows `ripgrep` source build stalled. None of the Agent test modules failed.

No public API was added or changed, so no companion documentation update is required.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation has been updated (not applicable: no public API or documentation contract change)
- [x] Code is ready for review