### PR TITLE
fix(agent): record compression usage in context

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -738,35 +738,41 @@ class Agent:
             # Update the context and summary
             self.state.summary = new_summary
             self.state.context = msgs_to_reserve
-            if (
-                res is not None
-                and res.usage is not None
-                and self.state.context
-            ):
-                last_msg = self.state.context[-1]
-                compression_usage = Usage(
-                    input_tokens=res.usage.input_tokens,
-                    output_tokens=res.usage.output_tokens,
-                    cache_input_tokens=res.usage.cache_input_tokens or 0,
-                    cache_creation_input_tokens=(
-                        res.usage.cache_creation_input_tokens or 0
-                    ),
-                )
-                if last_msg.usage is None:
-                    last_msg.usage = compression_usage
+
+            # The compression call is not covered by the model call events,
+            # so record its cost on the last retained message to keep it in
+            # the token accounting
+            if res is not None and res.usage is not None:
+                if not msgs_to_reserve:
+                    logger.warning(
+                        "[AGENT %s]: The whole context is compressed, so the "
+                        "compression usage (%d input, %d output tokens) is "
+                        "dropped.",
+                        self.name,
+                        res.usage.input_tokens,
+                        res.usage.output_tokens,
+                    )
                 else:
-                    last_msg.usage.input_tokens += (
-                        compression_usage.input_tokens
+                    last_msg = msgs_to_reserve[-1]
+                    usage = Usage(
+                        input_tokens=res.usage.input_tokens,
+                        output_tokens=res.usage.output_tokens,
+                        cache_input_tokens=res.usage.cache_input_tokens or 0,
+                        cache_creation_input_tokens=(
+                            res.usage.cache_creation_input_tokens or 0
+                        ),
                     )
-                    last_msg.usage.output_tokens += (
-                        compression_usage.output_tokens
-                    )
-                    last_msg.usage.cache_input_tokens += (
-                        compression_usage.cache_input_tokens
-                    )
-                    last_msg.usage.cache_creation_input_tokens += (
-                        compression_usage.cache_creation_input_tokens
-                    )
+                    if last_msg.usage is None:
+                        last_msg.usage = usage
+                    else:
+                        last_msg.usage.input_tokens += usage.input_tokens
+                        last_msg.usage.output_tokens += usage.output_tokens
+                        last_msg.usage.cache_input_tokens += (
+                            usage.cache_input_tokens
+                        )
+                        last_msg.usage.cache_creation_input_tokens += (
+                            usage.cache_creation_input_tokens
+                        )
 
             logger.info(
                 "[AGENT %s]: The context compression finished.",

--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -753,26 +753,18 @@ class Agent:
                         res.usage.output_tokens,
                     )
                 else:
-                    last_msg = msgs_to_reserve[-1]
-                    usage = Usage(
-                        input_tokens=res.usage.input_tokens,
-                        output_tokens=res.usage.output_tokens,
-                        cache_input_tokens=res.usage.cache_input_tokens or 0,
-                        cache_creation_input_tokens=(
-                            res.usage.cache_creation_input_tokens or 0
+                    msgs_to_reserve[-1].append_usage(
+                        Usage(
+                            input_tokens=res.usage.input_tokens,
+                            output_tokens=res.usage.output_tokens,
+                            cache_input_tokens=(
+                                res.usage.cache_input_tokens or 0
+                            ),
+                            cache_creation_input_tokens=(
+                                res.usage.cache_creation_input_tokens or 0
+                            ),
                         ),
                     )
-                    if last_msg.usage is None:
-                        last_msg.usage = usage
-                    else:
-                        last_msg.usage.input_tokens += usage.input_tokens
-                        last_msg.usage.output_tokens += usage.output_tokens
-                        last_msg.usage.cache_input_tokens += (
-                            usage.cache_input_tokens
-                        )
-                        last_msg.usage.cache_creation_input_tokens += (
-                            usage.cache_creation_input_tokens
-                        )
 
             logger.info(
                 "[AGENT %s]: The context compression finished.",
@@ -3484,17 +3476,8 @@ class Agent:
 
         self.state.append_context(self.name, persisted_blocks)
 
-        tail = self.state.context[-1]
         if msg_usage is not None:
-            if tail.usage is None:
-                tail.usage = msg_usage
-            else:
-                tail.usage.input_tokens += msg_usage.input_tokens
-                tail.usage.output_tokens += msg_usage.output_tokens
-                tail.usage.cache_input_tokens += msg_usage.cache_input_tokens
-                tail.usage.cache_creation_input_tokens += (
-                    msg_usage.cache_creation_input_tokens
-                )
+            self.state.context[-1].append_usage(msg_usage)
 
     def _get_last_msg(self) -> Msg | None:
         """Get the last message in the context that belongs to this agent."""

--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -738,6 +738,35 @@ class Agent:
             # Update the context and summary
             self.state.summary = new_summary
             self.state.context = msgs_to_reserve
+            if (
+                res is not None
+                and res.usage is not None
+                and self.state.context
+            ):
+                last_msg = self.state.context[-1]
+                compression_usage = Usage(
+                    input_tokens=res.usage.input_tokens,
+                    output_tokens=res.usage.output_tokens,
+                    cache_input_tokens=res.usage.cache_input_tokens or 0,
+                    cache_creation_input_tokens=(
+                        res.usage.cache_creation_input_tokens or 0
+                    ),
+                )
+                if last_msg.usage is None:
+                    last_msg.usage = compression_usage
+                else:
+                    last_msg.usage.input_tokens += (
+                        compression_usage.input_tokens
+                    )
+                    last_msg.usage.output_tokens += (
+                        compression_usage.output_tokens
+                    )
+                    last_msg.usage.cache_input_tokens += (
+                        compression_usage.cache_input_tokens
+                    )
+                    last_msg.usage.cache_creation_input_tokens += (
+                        compression_usage.cache_creation_input_tokens
+                    )
 
             logger.info(
                 "[AGENT %s]: The context compression finished.",

--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -740,31 +740,24 @@ class Agent:
             self.state.context = msgs_to_reserve
 
             # The compression call is not covered by the model call events,
-            # so record its cost on the last retained message to keep it in
-            # the token accounting
+            # so record its cost on the context tail to keep it in the token
+            # accounting
             if res is not None and res.usage is not None:
-                if not msgs_to_reserve:
-                    logger.warning(
-                        "[AGENT %s]: The whole context is compressed, so the "
-                        "compression usage (%d input, %d output tokens) is "
-                        "dropped.",
-                        self.name,
-                        res.usage.input_tokens,
-                        res.usage.output_tokens,
-                    )
-                else:
-                    msgs_to_reserve[-1].append_usage(
-                        Usage(
-                            input_tokens=res.usage.input_tokens,
-                            output_tokens=res.usage.output_tokens,
-                            cache_input_tokens=(
-                                res.usage.cache_input_tokens or 0
-                            ),
-                            cache_creation_input_tokens=(
-                                res.usage.cache_creation_input_tokens or 0
-                            ),
+                if not self.state.context:
+                    # The whole context is compressed, so carry the cost by an
+                    # empty message, which is skipped by the formatters
+                    self.state.append_context(self.name, [])
+
+                self.state.context[-1].append_usage(
+                    Usage(
+                        input_tokens=res.usage.input_tokens,
+                        output_tokens=res.usage.output_tokens,
+                        cache_input_tokens=res.usage.cache_input_tokens or 0,
+                        cache_creation_input_tokens=(
+                            res.usage.cache_creation_input_tokens or 0
                         ),
-                    )
+                    ),
+                )
 
             logger.info(
                 "[AGENT %s]: The context compression finished.",

--- a/src/agentscope/message/_base.py
+++ b/src/agentscope/message/_base.py
@@ -283,22 +283,16 @@ class Msg(BaseModel):
                 self.error = event.error
 
             case EventType.MODEL_CALL_END:
-                if self.usage is None:
-                    self.usage = Usage(
+                self.append_usage(
+                    Usage(
                         input_tokens=event.input_tokens,
                         output_tokens=event.output_tokens,
                         cache_input_tokens=event.cache_input_tokens,
                         cache_creation_input_tokens=(
                             event.cache_creation_input_tokens
                         ),
-                    )
-                else:
-                    self.usage.input_tokens += event.input_tokens
-                    self.usage.output_tokens += event.output_tokens
-                    self.usage.cache_input_tokens += event.cache_input_tokens
-                    self.usage.cache_creation_input_tokens += (
-                        event.cache_creation_input_tokens
-                    )
+                    ),
+                )
 
             case EventType.TEXT_BLOCK_START:
                 self.content.append(TextBlock(id=event.block_id, text=""))
@@ -511,6 +505,24 @@ class Msg(BaseModel):
                         result.finished_at = event.created_at
                     self.content.append(result)
 
+        return self
+
+    def append_usage(self, usage: Usage) -> Self:
+        """Accumulate the token usage of one model call into this message.
+
+        Args:
+            usage (`Usage`):
+                The token usage to be accumulated.
+        """
+        if self.usage is None:
+            self.usage = usage
+        else:
+            self.usage.input_tokens += usage.input_tokens
+            self.usage.output_tokens += usage.output_tokens
+            self.usage.cache_input_tokens += usage.cache_input_tokens
+            self.usage.cache_creation_input_tokens += (
+                usage.cache_creation_input_tokens
+            )
         return self
 
 

--- a/tests/compress_context_test.py
+++ b/tests/compress_context_test.py
@@ -11,7 +11,7 @@ from unittest.async_case import IsolatedAsyncioTestCase
 
 from utils import MockModel, AnyString
 
-from agentscope.model import ChatResponse, StructuredResponse
+from agentscope.model import ChatResponse, ChatUsage, StructuredResponse
 from agentscope.agent import Agent, ContextConfig, InjectionConfig
 from agentscope.state import AgentState
 from agentscope.message import (
@@ -26,6 +26,7 @@ from agentscope.message import (
     DataBlock,
     Base64Source,
     URLSource,
+    Usage,
 )
 from agentscope.tool import Toolkit
 from agentscope.workspace import LocalWorkspace
@@ -215,6 +216,64 @@ def _make_failing_compression_agent(
         toolkit=Toolkit(),
     )
     return agent, model
+
+
+def _make_usage_recording_compression_agent(
+    last_msg_usage: Usage | None = None,
+) -> Agent:
+    """Build an agent whose compression model response includes usage."""
+    model = MockModel(context_size=100)
+    last_msg = UserMsg(
+        "User",
+        "".join(["3" for _ in range(10 * 4)]),
+        id="3",
+    )
+    last_msg.usage = last_msg_usage
+    agent = Agent(
+        name="Friday",
+        system_prompt="".join(["0" for _ in range(20 * 4)]),
+        model=model,
+        context_config=ContextConfig(
+            trigger_ratio=0.7,
+            reserve_ratio=0.4,
+        ),
+        state=AgentState(
+            session_id="123",
+            context=[
+                UserMsg(
+                    "User",
+                    "".join(["1" for _ in range(30 * 4)]),
+                    id="1",
+                ),
+                AssistantMsg(
+                    "Friday",
+                    "".join(["2" for _ in range(10 * 4)]),
+                    id="2",
+                ),
+                last_msg,
+            ],
+        ),
+        toolkit=Toolkit(),
+    )
+    model.set_structured_response(
+        StructuredResponse(
+            content={
+                "task_overview": "1",
+                "current_state": "2",
+                "important_discoveries": "3",
+                "next_steps": "4",
+                "context_to_preserve": "5",
+            },
+            usage=ChatUsage(
+                input_tokens=123,
+                output_tokens=45,
+                time=0.1,
+                cache_input_tokens=6,
+                cache_creation_input_tokens=7,
+            ),
+        ),
+    )
+    return agent
 
 
 def _has_instruction_hint(
@@ -2410,6 +2469,47 @@ class ContextCompressionTest(IsolatedAsyncioTestCase):
                     "error": None,
                 },
             ],
+        )
+
+    async def test_context_compression_records_structured_usage(
+        self,
+    ) -> None:
+        """Compression model usage is accumulated onto retained context."""
+        agent = _make_usage_recording_compression_agent()
+
+        await agent.compress_context()
+
+        self.assertIsNotNone(agent.state.context[-1].usage)
+        self.assertEqual(agent.state.context[-1].usage.input_tokens, 123)
+        self.assertEqual(agent.state.context[-1].usage.output_tokens, 45)
+        self.assertEqual(agent.state.context[-1].usage.cache_input_tokens, 6)
+        self.assertEqual(
+            agent.state.context[-1].usage.cache_creation_input_tokens,
+            7,
+        )
+
+    async def test_context_compression_accumulates_structured_usage(
+        self,
+    ) -> None:
+        """Compression model usage is added to existing message usage."""
+        agent = _make_usage_recording_compression_agent(
+            Usage(
+                input_tokens=10,
+                output_tokens=20,
+                cache_input_tokens=3,
+                cache_creation_input_tokens=4,
+            ),
+        )
+
+        await agent.compress_context()
+
+        self.assertIsNotNone(agent.state.context[-1].usage)
+        self.assertEqual(agent.state.context[-1].usage.input_tokens, 133)
+        self.assertEqual(agent.state.context[-1].usage.output_tokens, 65)
+        self.assertEqual(agent.state.context[-1].usage.cache_input_tokens, 9)
+        self.assertEqual(
+            agent.state.context[-1].usage.cache_creation_input_tokens,
+            11,
         )
 
     async def test_summary_failure_truncates_context(self) -> None:

--- a/tests/compress_context_test.py
+++ b/tests/compress_context_test.py
@@ -2471,27 +2471,67 @@ class ContextCompressionTest(IsolatedAsyncioTestCase):
             ],
         )
 
-    async def test_context_compression_records_structured_usage(
-        self,
-    ) -> None:
-        """Compression model usage is accumulated onto retained context."""
+    async def test_context_compression_records_usage(self) -> None:
+        """The compression usage is recorded on the last retained message."""
         agent = _make_usage_recording_compression_agent()
 
         await agent.compress_context()
 
-        self.assertIsNotNone(agent.state.context[-1].usage)
-        self.assertEqual(agent.state.context[-1].usage.input_tokens, 123)
-        self.assertEqual(agent.state.context[-1].usage.output_tokens, 45)
-        self.assertEqual(agent.state.context[-1].usage.cache_input_tokens, 6)
-        self.assertEqual(
-            agent.state.context[-1].usage.cache_creation_input_tokens,
-            7,
+        self.assertListEqual(
+            [_.model_dump() for _ in agent.state.context],
+            [
+                {
+                    "id": "2",
+                    "created_at": AnyString(),
+                    "finished_at": None,
+                    "finished_reason": None,
+                    "structured_output": None,
+                    "error": None,
+                    "name": "Friday",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "id": AnyString(),
+                            "text": "2" * 40,
+                            "type": "text",
+                            "created_at": AnyString(),
+                            "finished_at": None,
+                        },
+                    ],
+                    "metadata": {},
+                    "usage": None,
+                },
+                {
+                    "id": "3",
+                    "created_at": AnyString(),
+                    "finished_at": AnyString(),
+                    "finished_reason": None,
+                    "structured_output": None,
+                    "error": None,
+                    "name": "User",
+                    "role": "user",
+                    "content": [
+                        {
+                            "id": AnyString(),
+                            "text": "3" * 40,
+                            "type": "text",
+                            "created_at": AnyString(),
+                            "finished_at": None,
+                        },
+                    ],
+                    "metadata": {},
+                    "usage": {
+                        "input_tokens": 123,
+                        "output_tokens": 45,
+                        "cache_input_tokens": 6,
+                        "cache_creation_input_tokens": 7,
+                    },
+                },
+            ],
         )
 
-    async def test_context_compression_accumulates_structured_usage(
-        self,
-    ) -> None:
-        """Compression model usage is added to existing message usage."""
+    async def test_context_compression_accumulates_usage(self) -> None:
+        """The compression usage is added to the existing message usage."""
         agent = _make_usage_recording_compression_agent(
             Usage(
                 input_tokens=10,
@@ -2503,13 +2543,109 @@ class ContextCompressionTest(IsolatedAsyncioTestCase):
 
         await agent.compress_context()
 
-        self.assertIsNotNone(agent.state.context[-1].usage)
-        self.assertEqual(agent.state.context[-1].usage.input_tokens, 133)
-        self.assertEqual(agent.state.context[-1].usage.output_tokens, 65)
-        self.assertEqual(agent.state.context[-1].usage.cache_input_tokens, 9)
-        self.assertEqual(
-            agent.state.context[-1].usage.cache_creation_input_tokens,
-            11,
+        self.assertListEqual(
+            [_.model_dump() for _ in agent.state.context],
+            [
+                {
+                    "id": "2",
+                    "created_at": AnyString(),
+                    "finished_at": None,
+                    "finished_reason": None,
+                    "structured_output": None,
+                    "error": None,
+                    "name": "Friday",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "id": AnyString(),
+                            "text": "2" * 40,
+                            "type": "text",
+                            "created_at": AnyString(),
+                            "finished_at": None,
+                        },
+                    ],
+                    "metadata": {},
+                    "usage": None,
+                },
+                {
+                    "id": "3",
+                    "created_at": AnyString(),
+                    "finished_at": AnyString(),
+                    "finished_reason": None,
+                    "structured_output": None,
+                    "error": None,
+                    "name": "User",
+                    "role": "user",
+                    "content": [
+                        {
+                            "id": AnyString(),
+                            "text": "3" * 40,
+                            "type": "text",
+                            "created_at": AnyString(),
+                            "finished_at": None,
+                        },
+                    ],
+                    "metadata": {},
+                    "usage": {
+                        "input_tokens": 133,
+                        "output_tokens": 65,
+                        "cache_input_tokens": 9,
+                        "cache_creation_input_tokens": 11,
+                    },
+                },
+            ],
+        )
+
+    async def test_context_compression_without_reserved_context(self) -> None:
+        """The compression usage is dropped when nothing is retained."""
+        model = MockModel(context_size=100)
+        agent = Agent(
+            name="Friday",
+            system_prompt="".join(["0" for _ in range(20 * 4)]),
+            model=model,
+            context_config=ContextConfig(
+                trigger_ratio=0.7,
+                reserve_ratio=0.4,
+            ),
+            state=AgentState(
+                session_id="123",
+                context=[
+                    UserMsg(
+                        "User",
+                        "".join(["1" for _ in range(55 * 4)]),
+                        id="1",
+                    ),
+                ],
+            ),
+            toolkit=Toolkit(),
+        )
+        model.set_structured_response(
+            StructuredResponse(
+                content={
+                    "task_overview": "1",
+                    "current_state": "2",
+                    "important_discoveries": "3",
+                    "next_steps": "4",
+                    "context_to_preserve": "5",
+                },
+                usage=ChatUsage(
+                    input_tokens=123,
+                    output_tokens=45,
+                    time=0.1,
+                ),
+            ),
+        )
+
+        # A reserve ratio above the trigger ratio compresses the whole context
+        with self.assertLogs("as", level="WARNING") as logs:
+            await agent.compress_context(
+                ContextConfig(trigger_ratio=0.7, reserve_ratio=0.89),
+            )
+
+        self.assertListEqual(agent.state.context, [])
+        self.assertIn(
+            "the compression usage (123 input, 45 output tokens) is dropped",
+            "\n".join(logs.output),
         )
 
     async def test_summary_failure_truncates_context(self) -> None:

--- a/tests/compress_context_test.py
+++ b/tests/compress_context_test.py
@@ -2597,7 +2597,8 @@ class ContextCompressionTest(IsolatedAsyncioTestCase):
         )
 
     async def test_context_compression_without_reserved_context(self) -> None:
-        """The compression usage is dropped when nothing is retained."""
+        """The compression usage is carried by an empty message when the
+        whole context is compressed."""
         model = MockModel(context_size=100)
         agent = Agent(
             name="Friday",
@@ -2637,15 +2638,32 @@ class ContextCompressionTest(IsolatedAsyncioTestCase):
         )
 
         # A reserve ratio above the trigger ratio compresses the whole context
-        with self.assertLogs("as", level="WARNING") as logs:
-            await agent.compress_context(
-                ContextConfig(trigger_ratio=0.7, reserve_ratio=0.89),
-            )
+        await agent.compress_context(
+            ContextConfig(trigger_ratio=0.7, reserve_ratio=0.89),
+        )
 
-        self.assertListEqual(agent.state.context, [])
-        self.assertIn(
-            "the compression usage (123 input, 45 output tokens) is dropped",
-            "\n".join(logs.output),
+        self.assertListEqual(
+            [_.model_dump() for _ in agent.state.context],
+            [
+                {
+                    "id": agent.state.reply_id,
+                    "created_at": AnyString(),
+                    "finished_at": None,
+                    "finished_reason": None,
+                    "structured_output": None,
+                    "error": None,
+                    "name": "Friday",
+                    "role": "assistant",
+                    "content": [],
+                    "metadata": {},
+                    "usage": {
+                        "input_tokens": 123,
+                        "output_tokens": 45,
+                        "cache_input_tokens": 0,
+                        "cache_creation_input_tokens": 0,
+                    },
+                },
+            ],
         )
 
     async def test_summary_failure_truncates_context(self) -> None:


### PR DESCRIPTION
## AgentScope Version

2.0.7

## Description

Refs #2151.

Context compression currently consumes `StructuredResponse.content` but drops
its `usage`. This change records the compression usage on the last retained
context message, following the behavior discussed in #2151.

If the message already has usage, the compression usage is added to it.
This PR does not change the compression event path.

Tests cover both recording new usage and accumulating onto existing usage.

Verified against current main after #2143 context-compression changes.

## Tests

```bash
python -m pytest tests/compress_context_test.py -q
# 21 passed, 2 subtests passed

pre-commit run --files \
  src/agentscope/agent/_agent.py \
  tests/compress_context_test.py

git diff --check
```

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the CONTRIBUTING.md
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated
- [x] Code is ready for review