### PR TITLE
fix(example): disable uvicorn hot reload on Windows

### DIFF
--- a/examples/agent_service/main.py
+++ b/examples/agent_service/main.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """The example script to start the agent service."""
 import os
+import sys
 
 import uvicorn
 from fastapi.middleware import Middleware
@@ -165,10 +166,20 @@ so anything you want them to see MUST be sent through `TeamSay`.""",
 
 
 if __name__ == "__main__":
+    # On Windows, uvicorn's reload mode forces a SelectorEventLoop, which
+    # cannot spawn subprocesses — built-in tools like exec_shell would fail
+    # with NotImplementedError. Disable hot reload on Windows so the server
+    # keeps the default subprocess-capable ProactorEventLoop.
+    is_windows = sys.platform == "win32"
+    if is_windows:
+        print(
+            "Note: hot reload is disabled on Windows because uvicorn's "
+            "reload mode cannot spawn subprocesses (SelectorEventLoop).",
+        )
     # Start the service
     uvicorn.run(
         "main:app",
         host="0.0.0.0",
         port=8000,
-        reload=True,
+        reload=not is_windows,
     )

--- a/examples/agent_service/main.py
+++ b/examples/agent_service/main.py
@@ -166,20 +166,12 @@ so anything you want them to see MUST be sent through `TeamSay`.""",
 
 
 if __name__ == "__main__":
-    # On Windows, uvicorn's reload mode forces a SelectorEventLoop, which
-    # cannot spawn subprocesses — built-in tools like exec_shell would fail
-    # with NotImplementedError. Disable hot reload on Windows so the server
-    # keeps the default subprocess-capable ProactorEventLoop.
-    is_windows = sys.platform == "win32"
-    if is_windows:
-        print(
-            "Note: hot reload is disabled on Windows because uvicorn's "
-            "reload mode cannot spawn subprocesses (SelectorEventLoop).",
-        )
     # Start the service
     uvicorn.run(
         "main:app",
         host="0.0.0.0",
         port=8000,
-        reload=not is_windows,
+        # Hot reload forces a SelectorEventLoop on Windows, which cannot
+        # spawn the subprocesses that the builtin tools rely on
+        reload=sys.platform != "win32",
     )


### PR DESCRIPTION
## Description

Fixes #2423.

On Windows, `uvicorn.run(..., reload=True)` runs the server with `use_subprocess=True`, which makes uvicorn select a `SelectorEventLoop` — and `SelectorEventLoop` does not support `asyncio.create_subprocess_exec`. Built-in tools that spawn subprocesses (e.g. `exec_shell` in `tool/_builtin/_backend.py`) then fail with `NotImplementedError`, surfacing as the `/workspace/skill` 500 in the report.

Verified on Windows (uvicorn 0.52.4):

- `reload=True` → `_WindowsSelectorEventLoop`, `asyncio.create_subprocess_exec` → `NotImplementedError`
- `reload=False` → `ProactorEventLoop` (uvicorn's default on Windows), subprocesses work

Change: in the `examples/agent_service/main.py` entry point, disable hot reload when `sys.platform == "win32"` and print a short note. Other platforms keep `reload=True` unchanged.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md) document
- [x] The change is small and focused on one issue
- [x] I have verified the fix locally on Windows (see reproduction above)

---

> This PR was prepared with AI coding assistance; the reproduction, patch, and verification were reviewed and run locally by me on a Windows machine.
