### PR TITLE
fix(model): preserve encrypted_content on Responses reasoning items

### DIFF
--- a/src/agentscope/formatter/_openai_response_formatter.py
+++ b/src/agentscope/formatter/_openai_response_formatter.py
@@ -299,14 +299,25 @@ class OpenAIResponseFormatter(_OpenAIResponseFormatterBase):
                             if block.thinking
                             else []
                         )
-                        items.append(
-                            {
-                                "type": "reasoning",
-                                "id": reasoning_item_id,
-                                "summary": summary,
-                                "content": [],
-                            },
+                        reasoning_item: dict[str, Any] = {
+                            "type": "reasoning",
+                            "id": reasoning_item_id,
+                            "summary": summary,
+                            "content": [],
+                        }
+                        # Echo the encrypted reasoning payload back so
+                        # stateless upstreams (e.g. store=false Responses
+                        # providers) can validate the replayed item.
+                        encrypted_content = getattr(
+                            block,
+                            "encrypted_content",
+                            None,
                         )
+                        if encrypted_content:
+                            reasoning_item[
+                                "encrypted_content"
+                            ] = encrypted_content
+                        items.append(reasoning_item)
 
                 elif isinstance(block, ToolCallBlock):
                     function_calls.append(

--- a/src/agentscope/model/_openai_response/_model.py
+++ b/src/agentscope/model/_openai_response/_model.py
@@ -357,6 +357,14 @@ class OpenAIResponseModel(ChatModelBase):
                                     thinking="",
                                     block_id=thinking_id,
                                     reasoning_item_id=reasoning_item_id,
+                                    # Preserve the encrypted reasoning
+                                    # payload so multi-turn replay can
+                                    # echo it back to stateless upstreams.
+                                    encrypted_content=getattr(
+                                        output_item,
+                                        "encrypted_content",
+                                        None,
+                                    ),
                                 )
 
                 if delta_res.content or usage:
@@ -395,11 +403,25 @@ class OpenAIResponseModel(ChatModelBase):
                 # Keep even empty-summary reasoning items: the API requires
                 # reasoning_item_id to be echoed back in multi-turn history.
                 if combined_summary or reasoning_item_id:
+                    # Preserve encrypted_content so the formatter can echo
+                    # the reasoning item verbatim to stateless upstreams
+                    # (e.g. store=false Responses providers), which validate
+                    # replays against it.
+                    encrypted_content = getattr(
+                        item,
+                        "encrypted_content",
+                        None,
+                    )
                     content_blocks.append(
                         ThinkingBlock(
                             type="thinking",
                             thinking=combined_summary,
                             reasoning_item_id=reasoning_item_id,
+                            **(
+                                {"encrypted_content": encrypted_content}
+                                if encrypted_content
+                                else {}
+                            ),
                         ),
                     )
 

--- a/tests/formatter_openai_response_test.py
+++ b/tests/formatter_openai_response_test.py
@@ -395,6 +395,47 @@ class TestOpenAIResponseFormatter(IsolatedAsyncioTestCase):
             res,
         )
 
+    async def test_chat_formatter_thinking_echoes_encrypted_content(
+        self,
+    ) -> None:
+        """Reasoning replay includes encrypted_content when present.
+
+        Stateless upstreams (e.g. store=false Responses providers) validate
+        a replayed reasoning item against its encrypted payload; dropping it
+        makes every subsequent turn fail with a 400.
+        """
+        fmt = OpenAIResponseFormatter()
+        thinking = ThinkingBlock(thinking="my reasoning")
+        thinking.reasoning_item_id = "rs_001"
+        thinking.encrypted_content = "enc_payload_123"
+        msgs = [
+            AssistantMsg(
+                name="assistant",
+                content=[thinking, TextBlock(text="reply")],
+            ),
+        ]
+        res = await fmt.format(msgs)
+        self.assertListEqual(
+            [
+                {
+                    "type": "reasoning",
+                    "id": "rs_001",
+                    "summary": [
+                        {"type": "summary_text", "text": "my reasoning"},
+                    ],
+                    "content": [],
+                    "encrypted_content": "enc_payload_123",
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "reply"},
+                    ],
+                },
+            ],
+            res,
+        )
+
     async def test_chat_formatter_thinking_echoed_with_reasoning_item_id(
         self,
     ) -> None:

--- a/tests/model_openai_response_test.py
+++ b/tests/model_openai_response_test.py
@@ -49,6 +49,7 @@ def _mock_completion(
     reasoning_summary: Any = None,
     reasoning_id: str = "rs_test123",
     response_id: str = "resp-openai-1",
+    reasoning_encrypted_content: Any = None,
 ) -> MagicMock:
     """Build a mock non-streaming Responses API response."""
     output = []
@@ -57,6 +58,9 @@ def _mock_completion(
         reasoning_item = MagicMock()
         reasoning_item.type = "reasoning"
         reasoning_item.id = reasoning_id
+        # The real pydantic model defaults this to None; MagicMock would
+        # otherwise auto-create a truthy attribute for it.
+        reasoning_item.encrypted_content = reasoning_encrypted_content
         summary_texts = (
             reasoning_summary
             if isinstance(reasoning_summary, list)
@@ -298,6 +302,56 @@ class TestOpenAIResponseNonStream(IsolatedAsyncioTestCase):
             ),
         )
 
+    async def test_reasoning_encrypted_content_preserved(
+        self,
+    ) -> None:
+        """Reasoning item encrypted_content is kept for multi-turn replay.
+
+        Stateless upstreams (e.g. store=false Responses providers) validate
+        a replayed reasoning item against its encrypted payload, so parsing
+        must not drop it.
+        """
+        mock_create = AsyncMock(
+            return_value=_mock_completion(
+                reasoning_summary="Thinking step...",
+                text="Answer",
+                reasoning_id="rs_enc",
+                reasoning_encrypted_content="enc_payload_123",
+            ),
+        )
+        self.mock_client.responses.create = mock_create
+
+        result = await self.model([])
+
+        thinking_block = result.content[0]
+        self.assertIsInstance(thinking_block, ThinkingBlock)
+        self.assertEqual(thinking_block.reasoning_item_id, "rs_enc")
+        self.assertEqual(
+            getattr(thinking_block, "encrypted_content", None),
+            "enc_payload_123",
+        )
+
+    async def test_reasoning_without_encrypted_content_has_no_extra(
+        self,
+    ) -> None:
+        """Without encrypted_content, no extra field leaks onto the block."""
+        mock_create = AsyncMock(
+            return_value=_mock_completion(
+                reasoning_summary="Thinking step...",
+                text="Answer",
+                reasoning_id="rs_plain",
+            ),
+        )
+        self.mock_client.responses.create = mock_create
+
+        result = await self.model([])
+
+        thinking_block = result.content[0]
+        self.assertIsInstance(thinking_block, ThinkingBlock)
+        self.assertIsNone(
+            getattr(thinking_block, "encrypted_content", None),
+        )
+
     async def test_empty_reasoning_summary_response(
         self,
     ) -> None:
@@ -450,6 +504,7 @@ class TestOpenAIResponseStream(IsolatedAsyncioTestCase):
         reasoning_item = MagicMock()
         reasoning_item.type = "reasoning"
         reasoning_item.id = "rs_123"
+        reasoning_item.encrypted_content = None
 
         completed_resp = MagicMock()
         completed_resp.id = "resp-2"
@@ -536,6 +591,48 @@ class TestOpenAIResponseStream(IsolatedAsyncioTestCase):
             ],
         )
 
+    async def test_stream_reasoning_encrypted_content_preserved(
+        self,
+    ) -> None:
+        """Streamed reasoning items keep encrypted_content for replay."""
+        reasoning_item = MagicMock()
+        reasoning_item.type = "reasoning"
+        reasoning_item.id = "rs_stream_enc"
+        reasoning_item.encrypted_content = "enc_stream_payload"
+
+        completed_resp = MagicMock()
+        completed_resp.id = "resp-enc"
+        completed_resp.output = [reasoning_item]
+        completed_resp.usage = MagicMock()
+        completed_resp.usage.input_tokens = 10
+        completed_resp.usage.output_tokens = 5
+        completed_resp.usage.input_tokens_details = None
+
+        events = [
+            _make_event(
+                "response.reasoning_summary_text.delta",
+                delta="Thinking",
+                response=MagicMock(id="resp-enc"),
+            ),
+            _make_event("response.completed", response=completed_resp),
+        ]
+        mock_create = AsyncMock(
+            return_value=_MockAsyncEventStream(events),
+        )
+        self.mock_client.responses.create = mock_create
+
+        gen = await self.model([])
+        responses = [r async for r in gen]
+
+        final = responses[-1]
+        thinking_block = final.content[0]
+        self.assertIsInstance(thinking_block, ThinkingBlock)
+        self.assertEqual(thinking_block.reasoning_item_id, "rs_stream_enc")
+        self.assertEqual(
+            getattr(thinking_block, "encrypted_content", None),
+            "enc_stream_payload",
+        )
+
     async def test_stream_empty_reasoning_summary_keeps_reasoning_item_id(
         self,
     ) -> None:
@@ -543,6 +640,7 @@ class TestOpenAIResponseStream(IsolatedAsyncioTestCase):
         reasoning_item = MagicMock()
         reasoning_item.type = "reasoning"
         reasoning_item.id = "rs_empty"
+        reasoning_item.encrypted_content = None
 
         msg_item = MagicMock()
         msg_item.type = "message"


### PR DESCRIPTION
## Description

Fixes #2420.

Multi-turn conversations against a stateless Responses-API upstream (e.g. `store=false` providers such as OpenCode Zen/Go) fail on the second turn with:

```
400 invalid_request_error: Referenced reasoning item 'rs_...' was not found or has expired.
```

Root cause: `OpenAIResponseModel` drops the reasoning item's `encrypted_content` on parse, so the formatter replays a bare `{"type": "reasoning", id, summary, content: []}` that the upstream cannot validate.

- `_parse_completion_response` and the `response.completed` path of `_parse_stream_response` kept only `reasoning_item_id` + summary text.
- `OpenAIResponseFormatter` replayed the reasoning item without `encrypted_content`.

Changes:

- Parse (both paths): preserve `encrypted_content` on the `ThinkingBlock` via its existing `extra="allow"` provider-specific fields — the same mechanism already used for Anthropic's `signature`.
- Format: echo `encrypted_content` back on the replayed reasoning item when present. When absent, the emitted item is unchanged (no new key), so stateful OpenAI behaviour is untouched.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md) document
- [x] The change is small and focused on one issue
- [x] Tests added / updated and passing locally

## Verification

- Added regression tests: non-streaming parse, streaming parse (`response.completed`), and formatter replay each cover `encrypted_content` preservation; a fourth test asserts no extra key is emitted when the field is absent.
- Red → green: the three new preservation tests fail on unpatched `main` and pass with this change.
- Full related suites: `tests/model_openai_response_test.py`, `tests/formatter_openai_response_test.py`, `tests/formatter_openai_response_tool_result_test.py`, `tests/formatter_openai_chat_test.py` → 47/47 pass.
- `black --line-length=79` (23.3.0, per `.pre-commit-config.yaml`) and `flake8` clean on the touched files.
- Test mocks were also made faithful to the real SDK shape: MagicMock reasoning items now default `encrypted_content` to `None` instead of an auto-created truthy attribute.

---

> This PR was prepared with AI coding assistance; the analysis, patch, and verification were reviewed and run locally by me.
