### PR TITLE
docs(examples): fix broken relative link to _types.py in mem0 README

### DIFF
--- a/examples/long_term_memory/mem0/README.md
+++ b/examples/long_term_memory/mem0/README.md
@@ -305,7 +305,7 @@ yourself and pass `Mem0Middleware` into its `middlewares=[...]`. For
 production deployments via `agentscope.app` (the FastAPI service
 layer), the `user_id` already flows through the framework from the
 `X-User-ID` HTTP header. Hook in through the
-[`extra_agent_middlewares`](../../../../src/agentscope/app/_types.py)
+[`extra_agent_middlewares`](../../../src/agentscope/app/_types.py)
 factory:
 
 ```python


### PR DESCRIPTION
## Description

**Background:** In the mem0 long-term-memory example README, the "Service-mode integration" section links the `extra_agent_middlewares` factory to its type definition in `_types.py`.

**Problem:** The relative link uses one `../` too many. From `examples/long_term_memory/mem0/README.md`, the path `../../../../src/agentscope/app/_types.py` (four `../`) climbs one level *above* the repository root, so the link renders as a 404 on GitHub.

```
examples/long_term_memory/mem0/  ->  ../ long_term_memory  ->  ../ examples  ->  ../ <repo root>  ->  ../ (overshoots)
```

**Fix:** Drop one `../` so the link points at `../../../src/agentscope/app/_types.py`, which correctly resolves to `src/agentscope/app/_types.py` -- the file where the `AgentMiddlewareFactory` type alias (the type of the `extra_agent_middlewares` parameter) is defined. Docs-only, one-character-family change; no code or behavior affected.

**How to verify:**
- Before: from `examples/long_term_memory/mem0/`, `../../../../src/agentscope/app/_types.py` normalizes to `src/agentscope/app/_types.py` *outside* the repo root -> does not exist.
- After: `../../../src/agentscope/app/_types.py` normalizes to `<repo>/src/agentscope/app/_types.py` -> exists and contains `AgentMiddlewareFactory = (...)`.
- Confirmed `_types.py` is the intended target: the README link text is `extra_agent_middlewares`, whose type `AgentMiddlewareFactory` is defined there; the sibling `examples/agent_service` example uses the same factory parameter.
