### PR TITLE
feat(rag): add configurable recursive token chunking

### DIFF
--- a/examples/agent_service/main.py
+++ b/examples/agent_service/main.py
@@ -20,7 +20,11 @@ from agentscope.app.workspace_manager import LocalWorkspaceManager
 from agentscope.mcp import MCPClient, StdioMCPConfig, HttpMCPConfig
 from agentscope.middleware import AgenticMemoryMiddleware, MiddlewareBase
 from agentscope.permission import PermissionContext, PermissionMode
-from agentscope.rag import ApproxTokenChunker, QdrantStore
+from agentscope.rag import (
+    ApproxTokenChunker,
+    QdrantStore,
+    RecursiveTokenChunker,
+)
 from agentscope.workspace import WorkspaceBase
 
 default_mcps = [
@@ -100,7 +104,7 @@ app = create_app(
     ),
     # Chunker classes users can pick from when creating a knowledge base;
     # the chosen type and parameters are pinned on the knowledge base.
-    knowledge_chunkers=[ApproxTokenChunker],
+    knowledge_chunkers=[ApproxTokenChunker, RecursiveTokenChunker],
     # Resource hubs the UI browses under /hub. Neither needs credentials
     # of its own — an individual MCP card declares whatever key it wants
     # from the user in its ``inputs_schema``. Passing a ClawHub token

--- a/examples/web_ui/frontend/src/api/types.ts
+++ b/examples/web_ui/frontend/src/api/types.ts
@@ -366,6 +366,7 @@ export interface SessionView {
  */
 export interface JSONSchemaProperty {
 	type?: string;
+	items?: JSONSchemaProperty;
 	format?: string;
 	description?: string;
 	default?: unknown;
@@ -378,6 +379,8 @@ export interface JSONSchemaProperty {
 	maximum?: number;
 	exclusiveMinimum?: number;
 	exclusiveMaximum?: number;
+	minItems?: number;
+	maxItems?: number;
 }
 
 export interface JSONSchema {

--- a/examples/web_ui/frontend/src/components/dialog/CreateKnowledgeBaseDialog.tsx
+++ b/examples/web_ui/frontend/src/components/dialog/CreateKnowledgeBaseDialog.tsx
@@ -196,7 +196,7 @@ export function CreateKnowledgeBaseDialog({
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="!w-[500px] !max-w-[500px]">
+			<DialogContent className="max-h-[calc(100vh-2rem)] !w-[calc(100vw-2rem)] !max-w-[500px] overflow-y-auto">
 				<DialogHeader>
 					<DialogTitle>{t('dialog-knowledge-base-create.title')}</DialogTitle>
 					<DialogDescription>

--- a/examples/web_ui/frontend/src/components/dialog/EditKnowledgeBaseDialog.tsx
+++ b/examples/web_ui/frontend/src/components/dialog/EditKnowledgeBaseDialog.tsx
@@ -17,6 +17,7 @@ import { Input } from '@/components/ui/input.tsx';
 import { Textarea } from '@/components/ui/textarea.tsx';
 import { useKnowledgeBases } from '@/hooks/useKnowledgeBases';
 import { useTranslation } from '@/i18n/useI18n.ts';
+import { formatChunkerParameterValue } from '@/utils/chunker.ts';
 
 interface Props {
 	open: boolean;
@@ -81,7 +82,7 @@ export function EditKnowledgeBaseDialog({ open, onOpenChange, knowledgeBase, onU
 				const paramLabel = t(`chunker-types.${cfg.type}.params.${k}.label`, {
 					defaultValue: k,
 				});
-				return `${paramLabel}=${v}`;
+				return `${paramLabel}=${formatChunkerParameterValue(v)}`;
 			})
 			.join(', ');
 		return paramStr ? `${typeLabel} (${paramStr})` : typeLabel;
@@ -89,7 +90,7 @@ export function EditKnowledgeBaseDialog({ open, onOpenChange, knowledgeBase, onU
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="!w-[500px] !max-w-[500px]">
+			<DialogContent className="max-h-[calc(100vh-2rem)] !w-[calc(100vw-2rem)] !max-w-[500px] overflow-y-auto">
 				<DialogHeader>
 					<DialogTitle>{t('dialog-knowledge-base-edit.title')}</DialogTitle>
 					<DialogDescription>
@@ -131,9 +132,9 @@ export function EditKnowledgeBaseDialog({ open, onOpenChange, knowledgeBase, onU
 					{chunkerLabel && (
 						<Field orientation="horizontal">
 							<FieldLabel>{t('dialog-knowledge-base-edit.chunker.label')}</FieldLabel>
-							<Badge variant="secondary" className="font-mono">
+							<div className="bg-secondary text-secondary-foreground min-w-0 max-w-[70%] rounded-lg px-2.5 py-1.5 font-mono text-xs leading-relaxed break-words whitespace-normal">
 								{chunkerLabel}
-							</Badge>
+							</div>
 						</Field>
 					)}
 					{errorKey && <p className="text-destructive text-sm">{t(errorKey)}</p>}

--- a/examples/web_ui/frontend/src/components/form/SchemaForm.tsx
+++ b/examples/web_ui/frontend/src/components/form/SchemaForm.tsx
@@ -1,6 +1,8 @@
+import { Plus, Trash2 } from 'lucide-react';
 import type { ReactNode } from 'react';
 
 import type { JSONSchema, JSONSchemaProperty } from '@/api';
+import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
 	Field,
@@ -18,10 +20,11 @@ import {
 	SelectValue,
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
+import { useTranslation } from '@/i18n/useI18n.ts';
 
 const DEFAULT_SKIP_FIELDS = new Set(['id', 'type']);
 
-export type SchemaFormValue = string | number | boolean | null | undefined;
+export type SchemaFormValue = string | number | boolean | string[] | null | undefined;
 
 interface Props {
 	schema: JSONSchema;
@@ -65,6 +68,16 @@ function inferStep(type: string): number | string | undefined {
 	return undefined;
 }
 
+/** Render control characters as editable, single-line escape sequences. */
+function displayStringArrayItem(value: string): string {
+	return value.replace(/\r/g, '\\r').replace(/\n/g, '\\n').replace(/\t/g, '\\t');
+}
+
+/** Restore supported control-character escapes before schema submission. */
+function parseStringArrayItem(value: string): string {
+	return value.replace(/\\r/g, '\r').replace(/\\n/g, '\n').replace(/\\t/g, '\t');
+}
+
 /** Extract initial values from a JSON Schema's `default` fields. */
 export function defaultValuesFromSchema(
 	schema: JSONSchema,
@@ -92,6 +105,7 @@ export function SchemaForm({
 	orientation = 'vertical',
 	className,
 }: Props) {
+	const { t } = useTranslation();
 	const entries = Object.entries(schema.properties ?? {}).filter(
 		([key, prop]) => !skipFields.has(key) && prop.const === undefined,
 	);
@@ -106,6 +120,8 @@ export function SchemaForm({
 				const isPassword = prop.format === 'password';
 				const isTextarea = prop.format === 'textarea';
 				const isNumber = type === 'number' || type === 'integer';
+				const isStringArray =
+					type === 'array' && prop.items && effectiveType(prop.items) === 'string';
 				const enumOpts = enumValues(prop);
 
 				const label = labelFor?.(key, prop) ?? prop.title ?? key.replace(/_/g, ' ');
@@ -213,6 +229,74 @@ export function SchemaForm({
 							}}
 							placeholder={placeholder}
 						/>,
+					);
+				}
+
+				if (isStringArray) {
+					const items = Array.isArray(current)
+						? current.filter((item): item is string => typeof item === 'string')
+						: [];
+					const minimumItems = prop.minItems ?? 0;
+					const maximumItems = prop.maxItems;
+
+					return wrap(
+						<div className="space-y-1.5">
+							<div className="max-h-44 space-y-1.5 overflow-y-auto pr-1">
+								{items.map((item, index) => (
+									<div key={index} className="flex items-center gap-1.5">
+										<Input
+											id={index === 0 ? fieldId : `${fieldId}-${index}`}
+											className="font-mono"
+											value={displayStringArrayItem(item)}
+											placeholder={'""'}
+											onChange={(event) => {
+												const next = [...items];
+												next[index] = parseStringArrayItem(
+													event.target.value,
+												);
+												onChange(key, next);
+											}}
+										/>
+										<Button
+											type="button"
+											variant="ghost"
+											size="icon-sm"
+											className="text-muted-foreground hover:text-destructive"
+											disabled={items.length <= minimumItems}
+											aria-label={t('schema-form.array.remove', {
+												index: index + 1,
+											})}
+											tooltip={t('schema-form.array.remove', {
+												index: index + 1,
+											})}
+											onClick={() => {
+												onChange(
+													key,
+													items.filter(
+														(_, itemIndex) => itemIndex !== index,
+													),
+												);
+											}}
+										>
+											<Trash2 />
+										</Button>
+									</div>
+								))}
+							</div>
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								className="w-full border-dashed text-muted-foreground"
+								disabled={
+									maximumItems !== undefined && items.length >= maximumItems
+								}
+								onClick={() => onChange(key, [...items, ''])}
+							>
+								<Plus />
+								{t('schema-form.array.add')}
+							</Button>
+						</div>,
 					);
 				}
 

--- a/examples/web_ui/frontend/src/i18n/locales/en.json
+++ b/examples/web_ui/frontend/src/i18n/locales/en.json
@@ -454,6 +454,29 @@
 					"description": "Number of approximate tokens shared between consecutive chunks."
 				}
 			}
+		},
+		"recursive_token": {
+			"label": "Recursive Token",
+			"params": {
+				"chunk_size": {
+					"label": "Chunk Size",
+					"description": "Maximum number of approximate tokens per chunk."
+				},
+				"overlap": {
+					"label": "Overlap",
+					"description": "Number of approximate tokens shared between consecutive chunks."
+				},
+				"separators": {
+					"label": "Separator Priority",
+					"description": "Applied from coarse to fine; use \\n for newline separators."
+				}
+			}
+		}
+	},
+	"schema-form": {
+		"array": {
+			"add": "Add item",
+			"remove": "Remove item {{index}}"
 		}
 	},
 	"dimension-select": {

--- a/examples/web_ui/frontend/src/i18n/locales/zh.json
+++ b/examples/web_ui/frontend/src/i18n/locales/zh.json
@@ -454,6 +454,29 @@
 					"description": "相邻分块之间共享的近似 Token 数量。"
 				}
 			}
+		},
+		"recursive_token": {
+			"label": "递归 Token 分块",
+			"params": {
+				"chunk_size": {
+					"label": "块大小",
+					"description": "每个分块的最大近似 Token 数量。"
+				},
+				"overlap": {
+					"label": "重叠大小",
+					"description": "相邻分块之间共享的近似 Token 数量。"
+				},
+				"separators": {
+					"label": "分隔符优先级",
+					"description": "按从粗到细的顺序切分；换行符使用 \\n 表示。"
+				}
+			}
+		}
+	},
+	"schema-form": {
+		"array": {
+			"add": "添加一项",
+			"remove": "删除第 {{index}} 项"
 		}
 	},
 	"dimension-select": {

--- a/examples/web_ui/frontend/src/pages/knowledge/index.tsx
+++ b/examples/web_ui/frontend/src/pages/knowledge/index.tsx
@@ -42,6 +42,8 @@ import {
 	SidebarMenuItem,
 } from '@/components/ui/sidebar.tsx';
 import { useKnowledgeBases } from '@/hooks/useKnowledgeBases.ts';
+import { cn } from '@/lib/utils.ts';
+import { formatChunkerParameterValue } from '@/utils/chunker.ts';
 
 interface DetailPanelProps {
 	knowledgeBase?: KnowledgeBaseView;
@@ -104,11 +106,27 @@ function DetailPanel({ knowledgeBase, onTest }: DetailPanelProps) {
 	);
 }
 
-function ConfigItem({ label, value }: { label: string; value: string }) {
+function ConfigItem({
+	label,
+	value,
+	wrap = false,
+	className,
+}: {
+	label: string;
+	value: string;
+	wrap?: boolean;
+	className?: string;
+}) {
 	return (
-		<div className="flex min-w-0 flex-col gap-y-0.5">
+		<div className={cn('flex min-w-0 flex-col gap-y-0.5', className)}>
 			<span className="text-muted-foreground text-xs">{label}</span>
-			<span className="truncate text-sm text-foreground" title={value}>
+			<span
+				className={cn(
+					'text-sm text-foreground',
+					wrap ? 'break-words whitespace-normal' : 'truncate',
+				)}
+				title={value}
+			>
 				{value}
 			</span>
 		</div>
@@ -138,13 +156,21 @@ function ConfigCard({ knowledgeBase }: { knowledgeBase: KnowledgeBaseView }) {
 				})
 			: null;
 
-	const chunkerValue = chunker
-		? Object.keys(chunker.parameters).length > 0
-			? `${chunker.type} · ${Object.entries(chunker.parameters)
-					.map(([k, v]) => `${k}=${String(v)}`)
-					.join(', ')}`
-			: chunker.type
-		: '—';
+	const chunkerValue = (() => {
+		if (!chunker) return '—';
+		const typeLabel = t(`chunker-types.${chunker.type}.label`, {
+			defaultValue: chunker.type,
+		});
+		const parameters = Object.entries(chunker.parameters)
+			.map(([key, value]) => {
+				const parameterLabel = t(`chunker-types.${chunker.type}.params.${key}.label`, {
+					defaultValue: key,
+				});
+				return `${parameterLabel}=${formatChunkerParameterValue(value)}`;
+			})
+			.join(', ');
+		return parameters ? `${typeLabel} · ${parameters}` : typeLabel;
+	})();
 
 	return (
 		<div className="flex flex-col gap-y-3">
@@ -161,7 +187,12 @@ function ConfigCard({ knowledgeBase }: { knowledgeBase: KnowledgeBaseView }) {
 					label={t('knowledge.config.credential')}
 					value={knowledgeBase.credential_name ?? embedding.credential_id}
 				/>
-				<ConfigItem label={t('knowledge.config.chunker')} value={chunkerValue} />
+				<ConfigItem
+					label={t('knowledge.config.chunker')}
+					value={chunkerValue}
+					wrap
+					className="col-span-2 sm:col-span-3"
+				/>
 				<ConfigItem
 					label={t('knowledge.config.counts')}
 					value={t('knowledge.config.countsValue', {

--- a/examples/web_ui/frontend/src/utils/chunker.ts
+++ b/examples/web_ui/frontend/src/utils/chunker.ts
@@ -1,0 +1,10 @@
+/** Format persisted chunker parameters without losing control characters. */
+export function formatChunkerParameterValue(value: unknown): string {
+	if (Array.isArray(value)) {
+		return `[${value.map((item) => JSON.stringify(item)).join(', ')}]`;
+	}
+	if (value !== null && typeof value === 'object') {
+		return JSON.stringify(value);
+	}
+	return String(value);
+}

--- a/src/agentscope/app/_app.py
+++ b/src/agentscope/app/_app.py
@@ -32,7 +32,13 @@ from .message_bus import MessageBus
 from .storage import StorageBase
 from ..agent import Agent
 from ..credential import CredentialFactory, CredentialBase
-from ..rag import ApproxTokenChunker, ChunkerBase, ParserBase, TextParser
+from ..rag import (
+    ApproxTokenChunker,
+    ChunkerBase,
+    ParserBase,
+    RecursiveTokenChunker,
+    TextParser,
+)
 
 from .._logging import logger
 from .._version import __version__
@@ -167,7 +173,8 @@ def create_app(
             The chunker classes users can choose from when creating a
             knowledge base.  The chunker type and parameters are pinned
             on the knowledge base record and reconstructed by the index
-            worker.  Defaults to ``[ApproxTokenChunker]`` when
+            worker. Defaults to
+            ``[ApproxTokenChunker, RecursiveTokenChunker]`` when
             ``knowledge_base_manager`` is set.
         blob_store (`BlobStoreBase | None`, optional):
             Backend storing uploaded document bytes between the
@@ -324,7 +331,7 @@ def create_app(
         chunker_classes = list(
             knowledge_chunkers
             if knowledge_chunkers is not None
-            else [ApproxTokenChunker],
+            else [ApproxTokenChunker, RecursiveTokenChunker],
         )
         # Backward compatibility: the deprecated ``knowledge_chunker``
         # instance is only used for its class.

--- a/src/agentscope/app/_service/_index_worker.py
+++ b/src/agentscope/app/_service/_index_worker.py
@@ -30,7 +30,7 @@ from typing import Any, TYPE_CHECKING
 from pydantic import ValidationError
 
 from ..._logging import logger
-from ...rag import ApproxTokenChunker
+from ...rag import ApproxTokenChunker, RecursiveTokenChunker
 
 if TYPE_CHECKING:
     from ..rag.blob_store import BlobStoreBase
@@ -158,7 +158,7 @@ class IndexWorker:
             chunkers (`list[type[ChunkerBase]] | None`, optional):
                 The chunker classes that can be rebuilt from a knowledge
                 base's ``chunker_config``.  Defaults to
-                ``[ApproxTokenChunker]``.
+                ``[ApproxTokenChunker, RecursiveTokenChunker]``.
             max_concurrency (`int`, defaults to ``4``):
                 Maximum number of documents processed concurrently by
                 this worker.  Higher values trade memory for
@@ -180,7 +180,9 @@ class IndexWorker:
                 still accepted for backward compatibility; only its
                 class is used.
         """
-        chunker_classes = list(chunkers or [ApproxTokenChunker])
+        chunker_classes = list(
+            chunkers or [ApproxTokenChunker, RecursiveTokenChunker],
+        )
         if "chunker" in kwargs:
             logger.warning(
                 "The `chunker` argument of IndexWorker is deprecated, "

--- a/src/agentscope/app/_service/_knowledge_base.py
+++ b/src/agentscope/app/_service/_knowledge_base.py
@@ -35,7 +35,7 @@ from ..storage import (
     KnowledgeDocumentRecord,
 )
 from ..._logging import logger
-from ...rag import ApproxTokenChunker, Chunk
+from ...rag import ApproxTokenChunker, Chunk, RecursiveTokenChunker
 from .._bus_ops import enqueue_index_task
 from ._access import (
     KnowledgeBaseStatusCounts,
@@ -102,7 +102,8 @@ class KnowledgeBaseService:
             chunkers (`list[type[ChunkerBase]] | None`, optional):
                 The chunker classes users can choose from when creating
                 a knowledge base; used to validate ``chunker_config``.
-                Defaults to ``[ApproxTokenChunker]``.
+                Defaults to
+                ``[ApproxTokenChunker, RecursiveTokenChunker]``.
         """
         self._storage = storage
         self._manager = knowledge_base_manager
@@ -110,7 +111,10 @@ class KnowledgeBaseService:
         self._bus = message_bus
         self._access = resource_access_service
         self._chunkers_by_type = {
-            cls.chunker_type: cls for cls in (chunkers or [ApproxTokenChunker])
+            cls.chunker_type: cls
+            for cls in (
+                chunkers or [ApproxTokenChunker, RecursiveTokenChunker]
+            )
         }
 
     # ------------------------------------------------------------------

--- a/src/agentscope/rag/__init__.py
+++ b/src/agentscope/rag/__init__.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 """The retrieval-augmented generation (RAG) module in AgentScope."""
 
-from ._chunker import ApproxTokenChunker, ChunkerBase
+from ._chunker import (
+    ApproxTokenChunker,
+    ChunkerBase,
+    RecursiveTokenChunker,
+)
 from ._document import (
     Section,
     Chunk,
@@ -48,4 +52,5 @@ __all__ = [
     "QdrantStore",
     "KnowledgeBase",
     "MongoDBStore",
+    "RecursiveTokenChunker",
 ]

--- a/src/agentscope/rag/_chunker/__init__.py
+++ b/src/agentscope/rag/_chunker/__init__.py
@@ -3,8 +3,10 @@
 
 from ._approx_token_chunker import ApproxTokenChunker
 from ._base import ChunkerBase
+from ._recursive_token_chunker import RecursiveTokenChunker
 
 __all__ = [
     "ApproxTokenChunker",
     "ChunkerBase",
+    "RecursiveTokenChunker",
 ]

--- a/src/agentscope/rag/_chunker/_recursive_token_chunker.py
+++ b/src/agentscope/rag/_chunker/_recursive_token_chunker.py
@@ -1,0 +1,295 @@
+# -*- coding: utf-8 -*-
+"""A token-aware chunker that preserves natural text boundaries."""
+from bisect import bisect_left, bisect_right
+from itertools import accumulate
+
+from pydantic import ConfigDict, Field, model_validator
+
+from ._base import ChunkerBase
+from .._document import Chunk, Section
+from ...message import DataBlock, TextBlock
+
+
+_DEFAULT_SEPARATORS = [
+    "\n\n",
+    "\n",
+    "。",
+    "！",
+    "？",
+    ". ",
+    "! ",
+    "? ",
+    "；",
+    "; ",
+    "，",
+    ", ",
+    " ",
+    "",
+]
+
+
+class RecursiveTokenChunker(ChunkerBase):
+    """Recursively split text while enforcing an approximate token limit.
+
+    Text that already fits within ``chunk_size`` is returned unchanged.
+    Oversized text is split using the configured separators from coarse to
+    fine, and only pieces that remain oversized recurse to the next finer
+    separator. The resulting short pieces are merged back together up to the
+    approximate token budget. If no separator can reduce an oversized piece,
+    it is split with character-safe UTF-8 byte windows. ``overlap`` is applied
+    when consecutive chunks are formed without exceeding the budget.
+
+    The token estimate matches :class:`ApproxTokenChunker`: four UTF-8 bytes
+    are treated as one token. Chunks never cross input Section boundaries,
+    and DataBlock content passes through unchanged.
+    """
+
+    chunker_type = "recursive_token"
+
+    class Parameters(ChunkerBase.Parameters):
+        """The tunable parameters of recursive token chunking."""
+
+        model_config = ConfigDict(extra="forbid")
+
+        chunk_size: int = Field(
+            default=512,
+            ge=1,
+            title="Chunk Size",
+            description=("Maximum number of approximate tokens per chunk."),
+        )
+        overlap: int = Field(
+            default=50,
+            ge=0,
+            title="Overlap",
+            description=(
+                "Number of approximate tokens shared between "
+                "consecutive chunks."
+            ),
+        )
+        separators: list[str] = Field(
+            default_factory=lambda: list(_DEFAULT_SEPARATORS),
+            min_length=1,
+            title="Separators",
+            description=(
+                "Separator hierarchy used from coarse to fine. An empty "
+                "string enables the final character-level fallback."
+            ),
+            json_schema_extra={"default": list(_DEFAULT_SEPARATORS)},
+        )
+
+        @model_validator(mode="after")
+        def _overlap_less_than_chunk_size(
+            self,
+        ) -> "RecursiveTokenChunker.Parameters":
+            if self.overlap >= self.chunk_size:
+                raise ValueError(
+                    "overlap must be less than chunk_size, got "
+                    f"overlap={self.overlap}, "
+                    f"chunk_size={self.chunk_size}.",
+                )
+            return self
+
+    def __init__(
+        self,
+        parameters: "RecursiveTokenChunker.Parameters | None" = None,
+    ) -> None:
+        """Initialize the recursive token chunker.
+
+        Args:
+            parameters (`RecursiveTokenChunker.Parameters | None`, optional):
+                The chunker parameters. Defaults to ``Parameters()``.
+        """
+        super().__init__(parameters)
+
+    @property
+    def chunk_size(self) -> int:
+        """The maximum approximate token count of each chunk."""
+        return self.parameters.chunk_size
+
+    @property
+    def overlap(self) -> int:
+        """The approximate token overlap between consecutive chunks."""
+        return self.parameters.overlap
+
+    @property
+    def separators(self) -> list[str]:
+        """The configured separator hierarchy."""
+        return self.parameters.separators
+
+    async def chunk(self, sections: list[Section]) -> list[Chunk]:
+        """Split Sections into recursively bounded Chunks.
+
+        Args:
+            sections (`list[Section]`):
+                The Sections produced by a parser.
+
+        Returns:
+            `list[Chunk]`:
+                Chunks in document order with continuous indices.
+        """
+        chunks: list[Chunk] = []
+        for section in sections:
+            contents: list[TextBlock | DataBlock]
+            if isinstance(section.content, TextBlock):
+                contents = [
+                    TextBlock(text=piece)
+                    for piece in self._split_text(section.content.text)
+                ]
+            else:
+                contents = [section.content]
+
+            chunks.extend(
+                Chunk(
+                    content=content,
+                    source=section.source,
+                    chunk_index=0,
+                    total_chunks=0,
+                    metadata=dict(section.metadata),
+                )
+                for content in contents
+            )
+
+        for index, chunk in enumerate(chunks):
+            chunk.chunk_index = index
+            chunk.total_chunks = len(chunks)
+
+        return chunks
+
+    def _split_text(self, text: str) -> list[str]:
+        """Split text with natural boundaries and a byte-based budget."""
+        if self._fits_budget(text):
+            return [text]
+
+        splits = self._split_recursively(text, self.separators)
+        return self._merge_splits(splits)
+
+    def _split_recursively(
+        self,
+        text: str,
+        separators: list[str],
+    ) -> list[str]:
+        """Recursively reduce oversized text with finer separators."""
+        if self._fits_budget(text) or not separators:
+            return [text]
+
+        separator = separators[0]
+        remaining = separators[1:]
+        if separator == "":
+            return [text]
+
+        results: list[str] = []
+        for split in self._split_by_separator(text, separator):
+            if self._fits_budget(split):
+                results.append(split)
+            else:
+                results.extend(
+                    self._split_recursively(split, remaining),
+                )
+        return results
+
+    @staticmethod
+    def _split_by_separator(text: str, separator: str) -> list[str]:
+        """Split text while retaining each separator in the left piece."""
+        pieces = text.split(separator)
+        return [
+            f"{piece}{separator}" if index < len(pieces) - 1 else piece
+            for index, piece in enumerate(pieces)
+            if piece or index < len(pieces) - 1
+        ]
+
+    def _merge_splits(self, splits: list[str]) -> list[str]:
+        """Merge short splits and apply overlap at chunk boundaries."""
+        chunks: list[str] = []
+        current = ""
+
+        for split in splits:
+            if not split:
+                continue
+            if not self._fits_budget(split):
+                if current:
+                    chunks.append(current)
+                forced = self._force_split(
+                    self._with_overlap(current, split),
+                )
+                chunks.extend(forced[:-1])
+                current = forced[-1]
+                continue
+
+            if self._fits_budget(f"{current}{split}"):
+                current = f"{current}{split}"
+                continue
+
+            if current:
+                chunks.append(current)
+                current = self._with_overlap(current, split)
+            else:
+                current = split
+
+        if current:
+            chunks.append(current)
+        return chunks
+
+    def _with_overlap(self, previous: str, next_split: str) -> str:
+        """Prefix a split with the largest overlap that still fits."""
+        if not previous or self.overlap == 0:
+            return next_split
+
+        available = self._budget_bytes - self._byte_size(next_split)
+        if available <= 0:
+            return next_split
+
+        overlap_bytes = min(self.overlap * 4, available)
+        return f"{self._suffix_by_bytes(previous, overlap_bytes)}{next_split}"
+
+    def _force_split(self, text: str) -> list[str]:
+        """Split oversized text into UTF-8-safe overlapping windows."""
+        byte_offsets = [0, *accumulate(len(c.encode("utf-8")) for c in text)]
+        overlap_bytes = self.overlap * 4
+        pieces: list[str] = []
+        start = 0
+
+        while start < len(text):
+            end = (
+                bisect_right(
+                    byte_offsets,
+                    byte_offsets[start] + self._budget_bytes,
+                )
+                - 1
+            )
+            end = max(end, start + 1)
+            pieces.append(text[start:end])
+            if end >= len(text):
+                break
+
+            target = byte_offsets[end] - overlap_bytes
+            next_start = bisect_left(byte_offsets, target)
+            start = max(next_start, start + 1)
+
+        return pieces
+
+    def _fits_budget(self, text: str) -> bool:
+        """Return whether text fits the approximate token budget."""
+        return self._byte_size(text) <= self._budget_bytes
+
+    @property
+    def _budget_bytes(self) -> int:
+        """The approximate token budget expressed as UTF-8 bytes."""
+        return self.chunk_size * 4
+
+    @staticmethod
+    def _byte_size(text: str) -> int:
+        """Return the UTF-8 byte size used by the token approximation."""
+        return len(text.encode("utf-8"))
+
+    @staticmethod
+    def _suffix_by_bytes(text: str, budget: int) -> str:
+        """Return the longest character-safe suffix within a byte budget."""
+        suffix: list[str] = []
+        used = 0
+        for character in reversed(text):
+            size = len(character.encode("utf-8"))
+            if used + size > budget:
+                break
+            suffix.append(character)
+            used += size
+        return "".join(reversed(suffix))

--- a/tests/rag_chunker_recursive_token_test.py
+++ b/tests/rag_chunker_recursive_token_test.py
@@ -1,0 +1,297 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the RecursiveTokenChunker class."""
+from unittest.async_case import IsolatedAsyncioTestCase
+
+from pydantic import ValidationError
+
+from utils import AnyString
+
+from agentscope.message import Base64Source, DataBlock, TextBlock
+from agentscope.rag import Chunk, RecursiveTokenChunker, Section
+
+
+def _dump_chunks(chunks: list[Chunk]) -> list[dict]:
+    """Convert chunks into plain dictionaries for comparison.
+
+    Args:
+        chunks (`list[Chunk]`):
+            The chunks to convert.
+
+    Returns:
+        `list[dict]`:
+            The serialized chunk structures.
+    """
+    return [chunk.model_dump() for chunk in chunks]
+
+
+def _text_chunk(
+    text: str,
+    source: str,
+    index: int,
+    total: int,
+    metadata: dict | None = None,
+) -> dict:
+    """Build the complete expected structure of a text chunk.
+
+    Args:
+        text (`str`):
+            Expected text content.
+        source (`str`):
+            Expected source name.
+        index (`int`):
+            Expected chunk index.
+        total (`int`):
+            Expected total chunk count.
+        metadata (`dict | None`, optional):
+            Expected metadata.
+
+    Returns:
+        `dict`:
+            The expected serialized chunk.
+    """
+    return {
+        "content": {
+            "type": "text",
+            "text": text,
+            "id": AnyString(),
+            "created_at": AnyString(),
+            "finished_at": None,
+        },
+        "source": source,
+        "chunk_index": index,
+        "total_chunks": total,
+        "metadata": metadata or {},
+    }
+
+
+def _make_chunker(
+    chunk_size: int,
+    overlap: int,
+    separators: list[str] | None = None,
+) -> RecursiveTokenChunker:
+    """Build a recursive chunker with explicit typed parameters."""
+    parameters = {
+        "chunk_size": chunk_size,
+        "overlap": overlap,
+    }
+    if separators is not None:
+        parameters["separators"] = separators
+    return RecursiveTokenChunker(
+        RecursiveTokenChunker.Parameters(**parameters),
+    )
+
+
+class RecursiveTokenChunkerTest(IsolatedAsyncioTestCase):
+    """Test recursive, token-aware chunking behavior."""
+
+    async def test_short_text_single_chunk(self) -> None:
+        """Short text should produce one complete chunk."""
+        chunker = _make_chunker(chunk_size=512, overlap=50)
+        sections = [
+            Section(
+                content=TextBlock(text="Hello world!"),
+                source="a.txt",
+                metadata={"page": 1},
+            ),
+        ]
+
+        chunks = await chunker.chunk(sections)
+
+        self.assertEqual(
+            _dump_chunks(chunks),
+            [
+                _text_chunk(
+                    "Hello world!",
+                    "a.txt",
+                    0,
+                    1,
+                    {"page": 1},
+                ),
+            ],
+        )
+
+    async def test_recursive_separator_priority(self) -> None:
+        """Paragraph boundaries should be preferred and preserved."""
+        chunker = _make_chunker(chunk_size=5, overlap=0)
+        text = "alpha beta.\n\ngamma delta.\n\nomega"
+        sections = [Section(content=TextBlock(text=text), source="b.txt")]
+
+        chunks = await chunker.chunk(sections)
+
+        self.assertEqual(
+            _dump_chunks(chunks),
+            [
+                _text_chunk("alpha beta.\n\n", "b.txt", 0, 2),
+                _text_chunk("gamma delta.\n\nomega", "b.txt", 1, 2),
+            ],
+        )
+
+    async def test_short_sentences_are_merged(self) -> None:
+        """Short sentence splits should be packed up to the budget."""
+        chunker = _make_chunker(chunk_size=4, overlap=0)
+        sections = [
+            Section(
+                content=TextBlock(text="One. Two. Three. Four."),
+                source="sentences.txt",
+            ),
+        ]
+
+        chunks = await chunker.chunk(sections)
+
+        self.assertEqual(
+            _dump_chunks(chunks),
+            [
+                _text_chunk("One. Two. ", "sentences.txt", 0, 2),
+                _text_chunk("Three. Four.", "sentences.txt", 1, 2),
+            ],
+        )
+
+    async def test_chinese_sentence_boundaries(self) -> None:
+        """Chinese punctuation should form natural split boundaries."""
+        chunker = _make_chunker(chunk_size=5, overlap=0)
+        sections = [
+            Section(
+                content=TextBlock(text="甲乙。丙丁。戊己。庚辛。"),
+                source="zh.txt",
+            ),
+        ]
+
+        chunks = await chunker.chunk(sections)
+
+        self.assertEqual(
+            _dump_chunks(chunks),
+            [
+                _text_chunk("甲乙。丙丁。", "zh.txt", 0, 2),
+                _text_chunk("戊己。庚辛。", "zh.txt", 1, 2),
+            ],
+        )
+
+    async def test_character_fallback_with_overlap(self) -> None:
+        """Unbroken text should use UTF-8-safe overlapping windows."""
+        chunker = _make_chunker(chunk_size=2, overlap=1)
+        sections = [
+            Section(
+                content=TextBlock(text="abcdefghijklmnopqrst"),
+                source="c.txt",
+            ),
+        ]
+
+        chunks = await chunker.chunk(sections)
+
+        expected_texts = [
+            "abcdefgh",
+            "efghijkl",
+            "ijklmnop",
+            "mnopqrst",
+        ]
+        self.assertEqual(
+            _dump_chunks(chunks),
+            [
+                _text_chunk(text, "c.txt", index, 4)
+                for index, text in enumerate(expected_texts)
+            ],
+        )
+
+    async def test_data_block_and_section_isolation(self) -> None:
+        """DataBlock content and separate Sections should stay isolated."""
+        chunker = _make_chunker(chunk_size=2, overlap=0)
+        data_block = DataBlock(
+            source=Base64Source(data="aGk=", media_type="image/png"),
+        )
+        sections = [
+            Section(content=TextBlock(text="first second"), source="d.pdf"),
+            Section(
+                content=data_block,
+                source="d.pdf",
+                metadata={"page": 2},
+            ),
+            Section(content=TextBlock(text="tail"), source="d.pdf"),
+        ]
+
+        chunks = await chunker.chunk(sections)
+
+        self.assertEqual(
+            _dump_chunks(chunks),
+            [
+                _text_chunk("first ", "d.pdf", 0, 4),
+                _text_chunk("second", "d.pdf", 1, 4),
+                {
+                    "content": {
+                        "type": "data",
+                        "id": AnyString(),
+                        "created_at": AnyString(),
+                        "finished_at": None,
+                        "source": {
+                            "type": "base64",
+                            "data": "aGk=",
+                            "media_type": "image/png",
+                        },
+                        "name": None,
+                    },
+                    "source": "d.pdf",
+                    "chunk_index": 2,
+                    "total_chunks": 4,
+                    "metadata": {"page": 2},
+                },
+                _text_chunk("tail", "d.pdf", 3, 4),
+            ],
+        )
+        self.assertIs(chunks[2].content, data_block)
+
+    def test_parameters_and_schema(self) -> None:
+        """Parameters should validate and expose a frontend schema."""
+        parameters = RecursiveTokenChunker.Parameters(
+            chunk_size=8,
+            overlap=2,
+            separators=["|", ""],
+        )
+        chunker = RecursiveTokenChunker(parameters)
+
+        self.assertEqual(
+            {
+                "chunk_size": chunker.chunk_size,
+                "overlap": chunker.overlap,
+                "separators": chunker.separators,
+            },
+            {
+                "chunk_size": 8,
+                "overlap": 2,
+                "separators": ["|", ""],
+            },
+        )
+        schema = RecursiveTokenChunker.Parameters.model_json_schema()
+        self.assertEqual(
+            set(schema["properties"]),
+            {"chunk_size", "overlap", "separators"},
+        )
+        self.assertEqual(
+            schema["properties"]["separators"]["default"],
+            [
+                "\n\n",
+                "\n",
+                "。",
+                "！",
+                "？",
+                ". ",
+                "! ",
+                "? ",
+                "；",
+                "; ",
+                "，",
+                ", ",
+                " ",
+                "",
+            ],
+        )
+
+        with self.assertRaises(ValidationError):
+            RecursiveTokenChunker.Parameters(
+                chunk_size=8,
+                overlap=8,
+            )
+        with self.assertRaises(ValidationError):
+            RecursiveTokenChunker.Parameters(
+                chunk_size=8,
+                overlap=0,
+                separators=[],
+            )

--- a/tests/service_knowledge_base_upload_test.py
+++ b/tests/service_knowledge_base_upload_test.py
@@ -42,7 +42,7 @@ from agentscope.app.storage import (
     RedisStorage,
 )
 from agentscope.app.workspace_manager._base import WorkspaceManagerBase
-from agentscope.rag import VectorStoreBase
+from agentscope.rag import RecursiveTokenChunker, VectorStoreBase
 from agentscope.rag._vdb._vector_store import (
     DocumentSummary,
     VectorRecord,
@@ -499,3 +499,31 @@ class KnowledgeBaseUploadFlowTest(IsolatedAsyncioTestCase):
             )
             self.assertEqual(resp.status_code, 200, resp.text)
             self.assertEqual(resp.json()["items"], [])
+
+    async def test_default_chunker_registry(self) -> None:
+        """The API should expose both built-in chunker strategies."""
+        headers = {"X-User-ID": "user-1"}
+        self.assertEqual(
+            [
+                chunker.chunker_type
+                for chunker in self._app.state.knowledge_chunkers
+            ],
+            ["approx_token", "recursive_token"],
+        )
+
+        with TestClient(self._app) as client:
+            resp = client.get(
+                "/knowledge_bases/chunkers",
+                headers=headers,
+            )
+
+        self.assertEqual(resp.status_code, 200, resp.text)
+        payload = resp.json()
+        self.assertEqual(
+            [chunker["type"] for chunker in payload["chunkers"]],
+            ["approx_token", "recursive_token"],
+        )
+        self.assertEqual(
+            payload["chunkers"][1]["parameter_schema"],
+            RecursiveTokenChunker.Parameters.model_json_schema(),
+        )


### PR DESCRIPTION
## AgentScope Version

2.0.7

## Description

### Summary

This PR introduces `RecursiveTokenChunker`, a configurable chunking strategy that preserves natural text boundaries while enforcing an approximate token budget.

### Changes

- Add `RecursiveTokenChunker` with:
  - Recursive separator-based splitting from coarse to fine
  - Greedy merging of short splits up to `chunk_size`
  - Configurable overlap between consecutive chunks
  - UTF-8-safe window fallback for text without usable separators
  - Isolation between input sections
  - Passthrough handling for non-text data blocks
- Register the new chunker in the RAG and knowledge base services.
- Persist and restore the selected chunker configuration.
- Add schema-driven chunker configuration to the web UI.
- Support editing string-array parameters such as `separators`.
- Display complete, localized chunker configuration after knowledge base creation.
- Add English and Chinese translations.
- Add unit and service-level test coverage.

### Chunking behavior

Text that already fits within `chunk_size` remains unchanged. Oversized text is recursively split using the configured separator hierarchy, and only pieces that remain oversized continue to the next finer separator.

Short pieces are greedily merged without exceeding the configured budget. If an oversized piece cannot be reduced using the available separators, the chunker falls back to UTF-8-safe overlapping windows.

Token size is approximated using four UTF-8 bytes per token, consistent with `ApproxTokenChunker`.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review