### PR TITLE
feat(rag): support updating knowledge base chunker configuration

### DIFF
--- a/examples/web_ui/frontend/src/api/knowledgeBase.ts
+++ b/examples/web_ui/frontend/src/api/knowledgeBase.ts
@@ -192,7 +192,9 @@ export const knowledgeBaseApi = {
 		client.post<CreateKnowledgeBaseResponse>('/knowledge_bases/', body),
 
 	update: (knowledgeBaseId: string, body: UpdateKnowledgeBaseRequest) =>
-		client.patch<KnowledgeBaseView>(`/knowledge_bases/${knowledgeBaseId}`, body),
+		client.patch<KnowledgeBaseView>(`/knowledge_bases/${knowledgeBaseId}`, body, undefined, {
+			silent: true,
+		}),
 
 	delete: (knowledgeBaseId: string) => client.delete(`/knowledge_bases/${knowledgeBaseId}`),
 

--- a/examples/web_ui/frontend/src/api/types.ts
+++ b/examples/web_ui/frontend/src/api/types.ts
@@ -932,13 +932,14 @@ export interface CreateKnowledgeBaseResponse {
 }
 
 /**
- * Body for `PATCH /knowledge_bases/{id}`. Only mutable fields can be
- * sent; the embedding model is pinned at creation time and cannot
- * change because the underlying collection is sized to its dimension.
+ * Body for `PATCH /knowledge_bases/{id}`. Changing the chunker rebuilds
+ * every existing document. The embedding model remains pinned because
+ * the underlying collection is sized to its dimension.
  */
 export interface UpdateKnowledgeBaseRequest {
 	name?: string;
 	description?: string;
+	chunker_config?: ChunkerConfig;
 }
 
 /**

--- a/examples/web_ui/frontend/src/components/dialog/EditKnowledgeBaseDialog.tsx
+++ b/examples/web_ui/frontend/src/components/dialog/EditKnowledgeBaseDialog.tsx
@@ -1,7 +1,14 @@
-import { CheckCircle, CircleAlert, Loader2 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { CheckCircle, CircleAlert, Loader2, RefreshCw } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import type { KnowledgeBaseView } from '@/api';
+import type { ChunkerInfo, JSONSchema, KnowledgeBaseView } from '@/api';
+import {
+	type SchemaFormValue,
+	SchemaForm,
+	defaultValuesFromSchema,
+} from '@/components/form/SchemaForm';
+import { ChunkerSelect } from '@/components/select/ChunkerSelect';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert.tsx';
 import { Badge } from '@/components/ui/badge.tsx';
 import { Button } from '@/components/ui/button.tsx';
 import {
@@ -14,9 +21,12 @@ import {
 } from '@/components/ui/dialog.tsx';
 import { Field, FieldGroup, FieldLabel } from '@/components/ui/field.tsx';
 import { Input } from '@/components/ui/input.tsx';
+import { Separator } from '@/components/ui/separator.tsx';
 import { Textarea } from '@/components/ui/textarea.tsx';
+import { useChunkers } from '@/hooks/useChunkers';
 import { useKnowledgeBases } from '@/hooks/useKnowledgeBases';
 import { useTranslation } from '@/i18n/useI18n.ts';
+import { formatApiErrorForAlert } from '@/lib/api-error.ts';
 
 interface Props {
 	open: boolean;
@@ -25,27 +35,123 @@ interface Props {
 	onUpdated?: (view: KnowledgeBaseView) => void;
 }
 
+const NO_SKIP = new Set<string>();
+const HORIZONTAL_FIELD_WIDTH = '[&>[data-orientation=horizontal]>:last-child]:w-48';
+
+function formValues(parameters: Record<string, unknown>): Record<string, SchemaFormValue> {
+	return parameters as Record<string, SchemaFormValue>;
+}
+
+function canonicalize(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(canonicalize);
+	if (value !== null && typeof value === 'object') {
+		return Object.fromEntries(
+			Object.entries(value as Record<string, unknown>)
+				.sort(([left], [right]) => left.localeCompare(right))
+				.map(([key, nestedValue]) => [key, canonicalize(nestedValue)]),
+		);
+	}
+	return value;
+}
+
+function stableParameters(parameters: Record<string, unknown>): string {
+	return JSON.stringify(canonicalize(parameters));
+}
+
 /**
- * Dialog to edit a knowledge base's mutable fields. Embedding model
- * is shown as a read-only badge because it's pinned at creation time
- * (the underlying collection is sized to its dimension).
+ * Dialog to edit knowledge-base metadata and chunking. The embedding
+ * model remains read-only because its dimension sizes the collection.
  */
 export function EditKnowledgeBaseDialog({ open, onOpenChange, knowledgeBase, onUpdated }: Props) {
 	const { t } = useTranslation();
 	const { update } = useKnowledgeBases();
+	const { chunkers, loading: chunkersLoading } = useChunkers();
 	const [name, setName] = useState('');
 	const [description, setDescription] = useState('');
+	const [selectedChunkerType, setSelectedChunkerType] = useState('');
+	const [chunkerParams, setChunkerParams] = useState<Record<string, SchemaFormValue>>({});
 	const [submitting, setSubmitting] = useState(false);
 	const [errorKey, setErrorKey] = useState<string | null>(null);
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+	const selectedChunker = useMemo<ChunkerInfo | null>(
+		() => chunkers.find((chunker) => chunker.type === selectedChunkerType) ?? null,
+		[chunkers, selectedChunkerType],
+	);
+
+	const chunkerParamSchema = useMemo<JSONSchema | null>(
+		() => selectedChunker?.parameter_schema ?? null,
+		[selectedChunker],
+	);
+
+	const handleSelectChunker = useCallback(
+		(type: string) => {
+			setSelectedChunkerType(type);
+			const schema = chunkers.find((chunker) => chunker.type === type)?.parameter_schema;
+			setChunkerParams(schema ? defaultValuesFromSchema(schema, NO_SKIP) : {});
+		},
+		[chunkers],
+	);
+
+	const handleChunkerParamChange = useCallback((key: string, value: SchemaFormValue) => {
+		setChunkerParams((previous) => ({ ...previous, [key]: value }));
+	}, []);
 
 	useEffect(() => {
-		if (open && knowledgeBase) {
-			setName(knowledgeBase.name);
-			setDescription(knowledgeBase.description ?? '');
-			setErrorKey(null);
-			setSubmitting(false);
-		}
+		if (!open || !knowledgeBase) return;
+		setName(knowledgeBase.name);
+		setDescription(knowledgeBase.description ?? '');
+		setErrorKey(null);
+		setErrorMessage(null);
+		setSubmitting(false);
 	}, [open, knowledgeBase]);
+
+	useEffect(() => {
+		if (!open || !knowledgeBase || chunkersLoading) return;
+		const current = knowledgeBase.chunker_config;
+		if (current) {
+			const schema = chunkers.find(
+				(chunker) => chunker.type === current.type,
+			)?.parameter_schema;
+			setSelectedChunkerType(current.type);
+			setChunkerParams({
+				...(schema ? defaultValuesFromSchema(schema, NO_SKIP) : {}),
+				...formValues(current.parameters),
+			});
+		} else if (chunkers.length > 0) {
+			handleSelectChunker(chunkers[0].type);
+		} else {
+			setSelectedChunkerType('');
+			setChunkerParams({});
+		}
+	}, [open, knowledgeBase, chunkers, chunkersLoading, handleSelectChunker]);
+
+	const submittedParameters = useMemo<Record<string, unknown>>(() => {
+		const parameters: Record<string, unknown> = {};
+		for (const [key, value] of Object.entries(chunkerParams)) {
+			if (value !== undefined && value !== null && value !== '') parameters[key] = value;
+		}
+		return parameters;
+	}, [chunkerParams]);
+
+	const chunkerChanged = useMemo(() => {
+		if (!knowledgeBase || !selectedChunkerType) return false;
+		const current = knowledgeBase.chunker_config;
+		const currentType = current?.type ?? 'approx_token';
+		const currentSchema = chunkers.find(
+			(chunker) => chunker.type === currentType,
+		)?.parameter_schema;
+		const currentParameters = {
+			...(currentSchema ? defaultValuesFromSchema(currentSchema, NO_SKIP) : {}),
+			...(current?.parameters ?? {}),
+		};
+		return (
+			currentType !== selectedChunkerType ||
+			stableParameters(currentParameters) !== stableParameters(submittedParameters)
+		);
+	}, [chunkers, knowledgeBase, selectedChunkerType, submittedParameters]);
+
+	const willReindex = chunkerChanged && (knowledgeBase?.document_count ?? 0) > 0;
 
 	const handleSubmit = async () => {
 		if (!knowledgeBase) return;
@@ -54,15 +160,30 @@ export function EditKnowledgeBaseDialog({ open, onOpenChange, knowledgeBase, onU
 			setErrorKey('dialog-knowledge-base-edit.errors.nameRequired');
 			return;
 		}
+		if (chunkers.length > 0 && !selectedChunkerType) {
+			setErrorKey('dialog-knowledge-base-edit.errors.chunkerRequired');
+			return;
+		}
 		setErrorKey(null);
+		setErrorMessage(null);
 		setSubmitting(true);
 		try {
 			const view = await update(knowledgeBase.id, {
 				name: trimmedName,
 				description: description.trim(),
+				...(selectedChunkerType
+					? {
+							chunker_config: {
+								type: selectedChunkerType,
+								parameters: submittedParameters,
+							},
+						}
+					: {}),
 			});
 			onUpdated?.(view);
 			onOpenChange(false);
+		} catch (error) {
+			setErrorMessage(formatApiErrorForAlert(error));
 		} finally {
 			setSubmitting(false);
 		}
@@ -72,31 +193,27 @@ export function EditKnowledgeBaseDialog({ open, onOpenChange, knowledgeBase, onU
 		? `${knowledgeBase.embedding_model_config.model} · ${knowledgeBase.embedding_model_config.dimensions}d`
 		: '';
 
-	const chunkerLabel = (() => {
-		if (!knowledgeBase?.chunker_config) return null;
-		const cfg = knowledgeBase.chunker_config;
-		const typeLabel = t(`chunker-types.${cfg.type}.label`, { defaultValue: cfg.type });
-		const paramStr = Object.entries(cfg.parameters)
-			.map(([k, v]) => {
-				const paramLabel = t(`chunker-types.${cfg.type}.params.${k}.label`, {
-					defaultValue: k,
-				});
-				return `${paramLabel}=${v}`;
-			})
-			.join(', ');
-		return paramStr ? `${typeLabel} (${paramStr})` : typeLabel;
-	})();
-
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="!w-[500px] !max-w-[500px]">
+			<DialogContent className="!w-[560px] !max-w-[calc(100vw-2rem)] max-h-[calc(100vh-2rem)] overflow-y-auto">
 				<DialogHeader>
 					<DialogTitle>{t('dialog-knowledge-base-edit.title')}</DialogTitle>
 					<DialogDescription>
 						{t('dialog-knowledge-base-edit.description')}
 					</DialogDescription>
 				</DialogHeader>
-				<FieldGroup>
+				{willReindex && knowledgeBase && (
+					<Alert>
+						<RefreshCw className="size-4" />
+						<AlertTitle>{t('dialog-knowledge-base-edit.reindex.title')}</AlertTitle>
+						<AlertDescription>
+							{t('dialog-knowledge-base-edit.reindex.description', {
+								documents: knowledgeBase.document_count,
+							})}
+						</AlertDescription>
+					</Alert>
+				)}
+				<FieldGroup className={HORIZONTAL_FIELD_WIDTH}>
 					<Field>
 						<FieldLabel>{t('dialog-knowledge-base-edit.name.label')}</FieldLabel>
 						<Input
@@ -120,6 +237,7 @@ export function EditKnowledgeBaseDialog({ open, onOpenChange, knowledgeBase, onU
 							rows={3}
 						/>
 					</Field>
+					<Separator />
 					<Field orientation="horizontal">
 						<FieldLabel>
 							{t('dialog-knowledge-base-edit.embeddingModel.label')}
@@ -128,15 +246,51 @@ export function EditKnowledgeBaseDialog({ open, onOpenChange, knowledgeBase, onU
 							{embeddingModelLabel}
 						</Badge>
 					</Field>
-					{chunkerLabel && (
-						<Field orientation="horizontal">
-							<FieldLabel>{t('dialog-knowledge-base-edit.chunker.label')}</FieldLabel>
-							<Badge variant="secondary" className="font-mono">
-								{chunkerLabel}
-							</Badge>
-						</Field>
+					{chunkers.length > 0 && (
+						<>
+							<Field orientation="horizontal">
+								<FieldLabel>
+									{t('dialog-knowledge-base-edit.chunker.label')}
+								</FieldLabel>
+								<ChunkerSelect
+									value={selectedChunkerType}
+									chunkers={chunkers}
+									loading={chunkersLoading}
+									onChange={handleSelectChunker}
+									disabled={submitting}
+								/>
+							</Field>
+							{chunkerParamSchema && (
+								<SchemaForm
+									schema={chunkerParamSchema}
+									values={chunkerParams}
+									onChange={handleChunkerParamChange}
+									skipFields={NO_SKIP}
+									idPrefix="edit-chunker-param"
+									orientation="horizontal"
+									className={HORIZONTAL_FIELD_WIDTH}
+									labelFor={(key, property) =>
+										t(
+											`chunker-types.${selectedChunkerType}.params.${key}.label`,
+											{ defaultValue: '' },
+										) ||
+										property.title ||
+										undefined
+									}
+									descriptionFor={(key, property) =>
+										t(
+											`chunker-types.${selectedChunkerType}.params.${key}.description`,
+											{ defaultValue: '' },
+										) ||
+										property.description ||
+										undefined
+									}
+								/>
+							)}
+						</>
 					)}
 					{errorKey && <p className="text-destructive text-sm">{t(errorKey)}</p>}
+					{errorMessage && <p className="text-destructive text-sm">{errorMessage}</p>}
 				</FieldGroup>
 				<DialogFooter>
 					<Button
@@ -153,7 +307,11 @@ export function EditKnowledgeBaseDialog({ open, onOpenChange, knowledgeBase, onU
 						) : (
 							<CheckCircle className="size-3.5" />
 						)}
-						{submitting ? t('common.saving') : t('common.save')}
+						{submitting
+							? t('common.saving')
+							: willReindex
+								? t('dialog-knowledge-base-edit.reindex.submit')
+								: t('common.save')}
 					</Button>
 				</DialogFooter>
 			</DialogContent>

--- a/examples/web_ui/frontend/src/i18n/locales/en.json
+++ b/examples/web_ui/frontend/src/i18n/locales/en.json
@@ -286,7 +286,7 @@
 	},
 	"dialog-knowledge-base-edit": {
 		"title": "Edit knowledge base",
-		"description": "Update the knowledge base name and description.",
+		"description": "Update knowledge-base details and chunking.",
 		"name": {
 			"label": "Name",
 			"placeholder": "My knowledge base"
@@ -301,8 +301,14 @@
 		"chunker": {
 			"label": "Chunker"
 		},
+		"reindex": {
+			"title": "The knowledge base will be reindexed",
+			"description": "Saving will process {{documents}} document(s) again and incur new embedding-provider usage. Existing index entries remain searchable until each document is replaced.",
+			"submit": "Save and reindex"
+		},
 		"errors": {
-			"nameRequired": "Please give the knowledge base a name."
+			"nameRequired": "Please give the knowledge base a name.",
+			"chunkerRequired": "Please pick a chunking strategy."
 		}
 	},
 	"dialog-knowledge-base-delete": {

--- a/examples/web_ui/frontend/src/i18n/locales/zh.json
+++ b/examples/web_ui/frontend/src/i18n/locales/zh.json
@@ -286,7 +286,7 @@
 	},
 	"dialog-knowledge-base-edit": {
 		"title": "编辑知识库",
-		"description": "修改知识库的名称与描述。",
+		"description": "修改知识库信息与分块配置。",
 		"name": {
 			"label": "名称",
 			"placeholder": "我的知识库"
@@ -301,8 +301,14 @@
 		"chunker": {
 			"label": "分块策略"
 		},
+		"reindex": {
+			"title": "将重建知识库索引",
+			"description": "保存后将重新处理 {{documents}} 个文档，并产生新的 Embedding 调用费用。重建期间仍可搜索尚未被替换的旧索引。",
+			"submit": "保存并重建索引"
+		},
 		"errors": {
-			"nameRequired": "请填写知识库名称。"
+			"nameRequired": "请填写知识库名称。",
+			"chunkerRequired": "请选择分块策略。"
 		}
 	},
 	"dialog-knowledge-base-delete": {

--- a/examples/web_ui/frontend/src/pages/knowledge/index.tsx
+++ b/examples/web_ui/frontend/src/pages/knowledge/index.tsx
@@ -46,9 +46,10 @@ import { useKnowledgeBases } from '@/hooks/useKnowledgeBases.ts';
 interface DetailPanelProps {
 	knowledgeBase?: KnowledgeBaseView;
 	onTest?: () => void;
+	onEdit?: () => void;
 }
 
-function DetailPanel({ knowledgeBase, onTest }: DetailPanelProps) {
+function DetailPanel({ knowledgeBase, onTest, onEdit }: DetailPanelProps) {
 	const { t } = useTranslation();
 
 	if (!knowledgeBase) {
@@ -96,7 +97,7 @@ function DetailPanel({ knowledgeBase, onTest }: DetailPanelProps) {
 			{/* Configuration + documents */}
 			<div className="min-h-0 flex-1 overflow-y-auto p-[20px_18px_24px]">
 				<div className="flex flex-col gap-y-6">
-					<ConfigCard knowledgeBase={knowledgeBase} />
+					<ConfigCard knowledgeBase={knowledgeBase} onEdit={onEdit} />
 					<KnowledgeDocumentsPanel knowledgeBaseId={knowledgeBase.id} />
 				</div>
 			</div>
@@ -116,11 +117,16 @@ function ConfigItem({ label, value }: { label: string; value: string }) {
 }
 
 /**
- * Read-only card surfacing the full configuration pinned at creation
- * time — embedding model, chunker, credential — plus the aggregated
- * counts the list endpoint now serves (#2360).
+ * Configuration card surfacing the embedding model, current chunker,
+ * credential, plus aggregated counts derived from the knowledge base.
  */
-function ConfigCard({ knowledgeBase }: { knowledgeBase: KnowledgeBaseView }) {
+function ConfigCard({
+	knowledgeBase,
+	onEdit,
+}: {
+	knowledgeBase: KnowledgeBaseView;
+	onEdit?: () => void;
+}) {
 	const { t } = useTranslation();
 	const embedding = knowledgeBase.embedding_model_config;
 	const chunker = knowledgeBase.chunker_config;
@@ -148,9 +154,17 @@ function ConfigCard({ knowledgeBase }: { knowledgeBase: KnowledgeBaseView }) {
 
 	return (
 		<div className="flex flex-col gap-y-3">
-			<h3 className="text-[13.5px] font-medium text-foreground">
-				{t('knowledge.config.title')}
-			</h3>
+			<div className="flex min-h-6 items-center justify-between gap-x-3">
+				<h3 className="text-[13.5px] font-medium text-foreground">
+					{t('knowledge.config.title')}
+				</h3>
+				{knowledgeBase.editable && onEdit && (
+					<Button variant="ghost" size="xs" onClick={onEdit}>
+						<Pencil />
+						{t('common.edit')}
+					</Button>
+				)}
+			</div>
 			<div className="border-border bg-card grid grid-cols-2 gap-x-4 gap-y-3 rounded-lg border p-3 sm:grid-cols-3">
 				<ConfigItem label={t('knowledge.config.embeddingModel')} value={embedding.model} />
 				<ConfigItem
@@ -337,7 +351,11 @@ export const KnowledgePage = () => {
 				<SidebarFooter />
 			</Sidebar>
 			<main className="flex-1 min-h-0 overflow-hidden rounded-[22px] bg-card shadow-panel">
-				<DetailPanel knowledgeBase={selectedKb} onTest={() => setTestOpen(true)} />
+				<DetailPanel
+					knowledgeBase={selectedKb}
+					onTest={() => setTestOpen(true)}
+					onEdit={selectedKb ? () => setEditTarget(selectedKb) : undefined}
+				/>
 			</main>
 			<CreateKnowledgeBaseDialog
 				open={createDialogOpen}

--- a/src/agentscope/app/_app.py
+++ b/src/agentscope/app/_app.py
@@ -165,9 +165,10 @@ def create_app(
             ``knowledge_base_manager`` is set.
         knowledge_chunkers (`list[Type[ChunkerBase]] | None`, optional):
             The chunker classes users can choose from when creating a
-            knowledge base.  The chunker type and parameters are pinned
-            on the knowledge base record and reconstructed by the index
-            worker.  Defaults to ``[ApproxTokenChunker]`` when
+            knowledge base. The selected type and parameters are stored
+            on the knowledge base record, may be updated with a full
+            reindex, and are reconstructed by the index worker. Defaults
+            to ``[ApproxTokenChunker]`` when
             ``knowledge_base_manager`` is set.
         blob_store (`BlobStoreBase | None`, optional):
             Backend storing uploaded document bytes between the

--- a/src/agentscope/app/_router/_knowledge_base.py
+++ b/src/agentscope/app/_router/_knowledge_base.py
@@ -395,9 +395,9 @@ async def update_knowledge_base(
 ) -> KnowledgeBaseView:
     """Update mutable fields on a knowledge base.
 
-    Only ``name`` and ``description`` can be updated.  The embedding
-    model configuration is pinned at creation time and cannot be
-    changed.
+    ``name``, ``description``, and ``chunker_config`` can be updated.
+    Changing the chunker configuration reindexes every existing
+    document. The embedding model configuration remains pinned.
 
     Args:
         body (`UpdateKnowledgeBaseRequest`):
@@ -418,6 +418,7 @@ async def update_knowledge_base(
         knowledge_base_id=knowledge_base_id,
         name=body.name,
         description=body.description,
+        chunker_config=body.chunker_config,
     )
     # Only reachable via ``_require_edit`` inside the service, so the
     # caller definitionally has edit permission.

--- a/src/agentscope/app/_router/_schema/_knowledge_base.py
+++ b/src/agentscope/app/_router/_schema/_knowledge_base.py
@@ -35,8 +35,8 @@ class CreateKnowledgeBaseRequest(BaseModel):
         default=None,
         description=(
             "Chunker configuration determining how uploaded documents "
-            "are split into chunks.  Pinned at creation time and "
-            "cannot be changed afterwards.  Defaults to the first "
+            "are split into chunks. It can later be changed through "
+            "PATCH, which reindexes existing documents. Defaults to the first "
             "configured chunker with its default parameters."
         ),
     )
@@ -53,9 +53,10 @@ class CreateKnowledgeBaseResponse(BaseModel):
 class UpdateKnowledgeBaseRequest(BaseModel):
     """Request body for updating a knowledge base.
 
-    Only mutable fields can be set here.  The embedding model
-    configuration is pinned at creation time and cannot be changed —
-    switching it would invalidate every previously inserted vector.
+    The embedding model configuration is pinned at creation time and
+    cannot be changed — switching it would invalidate every previously
+    inserted vector. Changing the chunker configuration rebuilds every
+    existing document's index.
     """
 
     name: str | None = Field(
@@ -65,6 +66,13 @@ class UpdateKnowledgeBaseRequest(BaseModel):
     description: str | None = Field(
         default=None,
         description="New free-form description; omit to leave unchanged.",
+    )
+    chunker_config: ChunkerConfig | None = Field(
+        default=None,
+        description=(
+            "New chunker configuration; omit to leave unchanged. "
+            "Changing it reindexes every existing document."
+        ),
     )
 
 

--- a/src/agentscope/app/_service/_knowledge_base.py
+++ b/src/agentscope/app/_service/_knowledge_base.py
@@ -25,6 +25,7 @@ from fastapi import HTTPException, status
 from pydantic import ValidationError
 
 from ..access import ResourceKind
+from ..message_bus import MessageBusKeys
 from ..rag.knowledge_base_manager import (
     DimensionPolicyError,
     KnowledgeBaseNotFoundError,
@@ -42,6 +43,14 @@ from ._access import (
     KnowledgeBaseView,
     ResourceAccessService,
 )
+
+
+_IN_FLIGHT_DOCUMENT_STATUSES = {
+    "pending",
+    "parsing",
+    "chunking",
+    "indexing",
+}
 
 if TYPE_CHECKING:
     from ..rag.blob_store import BlobStoreBase
@@ -152,26 +161,8 @@ class KnowledgeBaseService:
                 invalid.
         """
         if chunker_config is None:
-            chunker_config = ChunkerConfig(
-                type=next(iter(self._chunkers_by_type)),
-                parameters={},
-            )
-        chunker_cls = self._chunkers_by_type.get(chunker_config.type)
-        if chunker_cls is None:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=(
-                    f"Unknown chunker type: {chunker_config.type!r}, "
-                    f"available: {sorted(self._chunkers_by_type)}"
-                ),
-            )
-        try:
-            chunker_cls.Parameters(**chunker_config.parameters)
-        except (TypeError, ValueError, ValidationError) as exc:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=f"Invalid chunker parameters: {exc}",
-            ) from exc
+            chunker_config = self._default_chunker_config()
+        self._validate_chunker_config(chunker_config)
 
         try:
             return await self._manager.create_knowledge_base(
@@ -304,25 +295,157 @@ class KnowledgeBaseService:
         knowledge_base_id: str,
         name: str | None = None,
         description: str | None = None,
+        chunker_config: ChunkerConfig | None = None,
     ) -> "KnowledgeBaseRecord":
-        """Update mutable fields on a knowledge base, raising 404 if absent.
+        """Update a knowledge base and rebuild changed chunking.
 
-        Only ``name`` and ``description`` are mutable.  The embedding
-        model configuration is pinned at creation time.
+        A changed chunker configuration resets every terminal document
+        and dispatches it through the existing indexing pipeline. An
+        in-flight document blocks the change so two configurations cannot
+        write the same knowledge base concurrently.
         """
         owner_id = await self._require_edit(user_id, knowledge_base_id)
+        async with self._bus.acquire_lock(
+            MessageBusKeys.knowledge_base_mutation_lock(
+                owner_id,
+                knowledge_base_id,
+            ),
+        ):
+            return await self._update_knowledge_base_locked(
+                owner_id=owner_id,
+                knowledge_base_id=knowledge_base_id,
+                name=name,
+                description=description,
+                chunker_config=chunker_config,
+            )
+
+    async def _update_knowledge_base_locked(
+        self,
+        owner_id: str,
+        knowledge_base_id: str,
+        name: str | None,
+        description: str | None,
+        chunker_config: ChunkerConfig | None,
+    ) -> "KnowledgeBaseRecord":
+        """Apply an update while holding the knowledge-base lock."""
+        documents: list[KnowledgeDocumentRecord] = []
+        chunker_changed = False
+        if chunker_config is not None:
+            self._validate_chunker_config(chunker_config)
+            current = await self._manager.get_knowledge_base(
+                owner_id,
+                knowledge_base_id,
+            )
+            if current is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Knowledge base {knowledge_base_id!r} not found.",
+                )
+            chunker_changed = not self._chunker_configs_match(
+                current.data.chunker_config,
+                chunker_config,
+            )
+            if chunker_changed:
+                documents = await self._storage.list_knowledge_documents(
+                    owner_id,
+                    knowledge_base_id,
+                )
+                in_flight = [
+                    document
+                    for document in documents
+                    if document.status in _IN_FLIGHT_DOCUMENT_STATUSES
+                ]
+                if in_flight:
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail=(
+                            "Cannot change the chunker while "
+                            f"{len(in_flight)} document(s) are being indexed."
+                        ),
+                    )
+
         record = await self._manager.update_knowledge_base(
             user_id=owner_id,
             knowledge_base_id=knowledge_base_id,
             name=name,
             description=description,
+            chunker_config=chunker_config,
         )
         if record is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Knowledge base {knowledge_base_id!r} not found.",
             )
+
+        if chunker_changed:
+            for document in documents:
+                document.status = "pending"
+                document.processing_node = None
+                document.lease_expires_at = None
+                document.data.error = None
+                document.data.chunk_count = 0
+                await self._storage.upsert_knowledge_document(
+                    owner_id,
+                    document,
+                )
+                await enqueue_index_task(
+                    self._bus,
+                    user_id=owner_id,
+                    knowledge_base_id=knowledge_base_id,
+                    document_id=document.id,
+                )
         return record
+
+    def _validate_chunker_config(
+        self,
+        chunker_config: ChunkerConfig,
+    ) -> None:
+        """Validate a persisted chunker type and parameter payload."""
+        chunker_cls = self._chunkers_by_type.get(chunker_config.type)
+        if chunker_cls is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=(
+                    f"Unknown chunker type: {chunker_config.type!r}, "
+                    f"available: {sorted(self._chunkers_by_type)}"
+                ),
+            )
+        try:
+            chunker_cls.Parameters(**chunker_config.parameters)
+        except (TypeError, ValueError, ValidationError) as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=f"Invalid chunker parameters: {exc}",
+            ) from exc
+
+    def _chunker_configs_match(
+        self,
+        current: ChunkerConfig | None,
+        requested: ChunkerConfig,
+    ) -> bool:
+        """Compare effective parameters, including schema defaults."""
+        if current is None:
+            current = self._default_chunker_config()
+        if current.type != requested.type:
+            return False
+        chunker_cls = self._chunkers_by_type.get(current.type)
+        if chunker_cls is None:
+            return False
+        try:
+            current_parameters = chunker_cls.Parameters(**current.parameters)
+            requested_parameters = chunker_cls.Parameters(
+                **requested.parameters,
+            )
+        except (TypeError, ValueError, ValidationError):
+            return False
+        return current_parameters == requested_parameters
+
+    def _default_chunker_config(self) -> ChunkerConfig:
+        """Build the configured default chunker payload."""
+        return ChunkerConfig(
+            type=next(iter(self._chunkers_by_type)),
+            parameters={},
+        )
 
     async def delete_knowledge_base(
         self,
@@ -424,23 +547,29 @@ class KnowledgeBaseService:
                 blob_uri=blob_uri,
             ),
         )
-        try:
-            stored = await self._storage.upsert_knowledge_document(
+        async with self._bus.acquire_lock(
+            MessageBusKeys.knowledge_base_mutation_lock(
                 owner_id,
-                record,
-            )
-        except Exception:
-            # Storage write failed — drop the blob so the orphan
-            # sweeper doesn't later see a referenced-by-nobody file.
-            await self._delete_blob_quietly(blob_uri)
-            raise
+                knowledge_base_id,
+            ),
+        ):
+            try:
+                stored = await self._storage.upsert_knowledge_document(
+                    owner_id,
+                    record,
+                )
+            except Exception:
+                # Storage write failed — drop the blob so the orphan
+                # sweeper doesn't later see a referenced-by-nobody file.
+                await self._delete_blob_quietly(blob_uri)
+                raise
 
-        await enqueue_index_task(
-            self._bus,
-            user_id=owner_id,
-            knowledge_base_id=knowledge_base_id,
-            document_id=document_id,
-        )
+            await enqueue_index_task(
+                self._bus,
+                user_id=owner_id,
+                knowledge_base_id=knowledge_base_id,
+                document_id=document_id,
+            )
         return stored
 
     async def list_documents(

--- a/src/agentscope/app/message_bus/_keys.py
+++ b/src/agentscope/app/message_bus/_keys.py
@@ -146,6 +146,26 @@ class MessageBusKeys:  # pylint: disable=too-many-public-methods
         return cls._SESSION_LOCK.format(sid=session_id)
 
     # ------------------------------------------------------------------
+    # Knowledge-base mutation lock
+    # ------------------------------------------------------------------
+
+    _KNOWLEDGE_BASE_MUTATION_LOCK = (
+        "agentscope:knowledge_base:mutation_lock:{uid}:{kbid}"
+    )
+
+    @classmethod
+    def knowledge_base_mutation_lock(
+        cls,
+        user_id: str,
+        knowledge_base_id: str,
+    ) -> str:
+        """Per-knowledge-base lock for configuration and documents."""
+        return cls._KNOWLEDGE_BASE_MUTATION_LOCK.format(
+            uid=user_id,
+            kbid=knowledge_base_id,
+        )
+
+    # ------------------------------------------------------------------
     # Session inbox
     # ------------------------------------------------------------------
 

--- a/src/agentscope/app/rag/knowledge_base_manager/_base.py
+++ b/src/agentscope/app/rag/knowledge_base_manager/_base.py
@@ -208,13 +208,14 @@ class KnowledgeBaseManagerBase(ABC):
         knowledge_base_id: str,
         name: str | None = None,
         description: str | None = None,
+        chunker_config: "ChunkerConfig | None" = None,
     ) -> "KnowledgeBaseRecord | None":
         """Update mutable fields on an existing knowledge base record.
 
-        Only ``name`` and ``description`` are mutable.  The embedding
-        model configuration and the underlying collection are pinned
-        for the lifetime of the record because changing either would
-        invalidate every previously inserted vector.
+        The embedding model configuration and the underlying collection
+        are pinned for the lifetime of the record because changing either
+        would invalidate every previously inserted vector. Reindex
+        orchestration for a changed chunker is owned by the service layer.
 
         Args:
             user_id (`str`):
@@ -226,6 +227,8 @@ class KnowledgeBaseManagerBase(ABC):
             description (`str | None`, optional):
                 New description; ``None`` leaves the description
                 unchanged.
+            chunker_config (`ChunkerConfig | None`, optional):
+                New chunker configuration; ``None`` leaves it unchanged.
 
         Returns:
             `KnowledgeBaseRecord | None`:
@@ -242,6 +245,8 @@ class KnowledgeBaseManagerBase(ABC):
             record.data.name = name
         if description is not None:
             record.data.description = description
+        if chunker_config is not None:
+            record.data.chunker_config = chunker_config
         return await self._storage.upsert_knowledge_base(user_id, record)
 
     @abstractmethod

--- a/src/agentscope/app/storage/_model/_knowledge_base.py
+++ b/src/agentscope/app/storage/_model/_knowledge_base.py
@@ -63,14 +63,15 @@ class KnowledgeBaseData(BaseModel):
     chunker_config: ChunkerConfig | None = Field(
         default=None,
         description=(
-            "Chunker configuration pinned at creation time. "
+            "Current chunker configuration. Updating it requires "
+            "reindexing every existing document. "
             "``None`` only for legacy records created before "
             "per-KB chunker support was introduced; the index "
             "worker falls back to ``ApproxTokenChunker()`` in "
             "that case.  New records always have an explicit value."
         ),
     )
-    """Chunker configuration pinned at creation time.
+    """Current chunker configuration.
 
     ``None`` only for legacy records; new creations always set this.
     """

--- a/tests/service_knowledge_base_update_test.py
+++ b/tests/service_knowledge_base_update_test.py
@@ -1,0 +1,461 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Unit tests for knowledge-base chunker configuration updates."""
+import asyncio
+import tempfile
+from io import BytesIO
+from typing import Any
+from unittest.async_case import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+import fakeredis.aioredis
+from fastapi import HTTPException
+
+from service_knowledge_base_upload_test import (
+    _FakeKbManager,
+    _FakeVectorStore,
+    _make_storage,
+)
+
+from agentscope.app._service._access import ResourceAccessService
+from agentscope.app._service._knowledge_base import KnowledgeBaseService
+from agentscope.app.access import DenyAllResourceAccessPolicy
+from agentscope.app.message_bus import InMemoryMessageBus, MessageBusKeys
+from agentscope.app.rag.blob_store import LocalBlobStore
+from agentscope.app.storage import (
+    ChunkerConfig,
+    EmbeddingModelConfig,
+    KnowledgeBaseData,
+    KnowledgeBaseRecord,
+    KnowledgeDocumentData,
+    KnowledgeDocumentRecord,
+)
+from agentscope.rag import ApproxTokenChunker
+
+
+class _AlternateApproxTokenChunker(ApproxTokenChunker):
+    """Second registered type used to verify chunker replacement."""
+
+    chunker_type = "alternate_approx_token"
+
+
+class KnowledgeBaseChunkerUpdateTest(IsolatedAsyncioTestCase):
+    """Verify configuration persistence and reindex dispatch semantics."""
+
+    async def asyncSetUp(self) -> None:
+        """Build the service with in-memory storage and message bus fakes."""
+        self._temporary_directory = tempfile.TemporaryDirectory()
+        self._redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+        self._storage = _make_storage(self._redis)
+        self._storage._client = self._redis
+        self._bus = InMemoryMessageBus()
+        self._manager = _FakeKbManager(
+            storage=self._storage,
+            vector_store=_FakeVectorStore(),
+        )
+        self._service = KnowledgeBaseService(
+            storage=self._storage,
+            knowledge_base_manager=self._manager,
+            blob_store=LocalBlobStore(self._temporary_directory.name),
+            message_bus=self._bus,
+            resource_access_service=ResourceAccessService(
+                self._storage,
+                DenyAllResourceAccessPolicy(),
+            ),
+            chunkers=[ApproxTokenChunker, _AlternateApproxTokenChunker],
+        )
+        self._original_chunker = ChunkerConfig(
+            type="approx_token",
+            parameters={},
+        )
+        record = KnowledgeBaseRecord(
+            user_id="user-1",
+            data=KnowledgeBaseData(
+                name="kb",
+                description="description",
+                embedding_model_config=EmbeddingModelConfig(
+                    type="openai_credential",
+                    credential_id="cred-1",
+                    model="text-embedding-3-small",
+                    dimensions=1,
+                ),
+                chunker_config=self._original_chunker,
+                collection_name="kb_collection",
+            ),
+        )
+        self._knowledge_base_id = record.id
+        await self._storage.upsert_knowledge_base("user-1", record)
+
+    async def asyncTearDown(self) -> None:
+        """Close in-memory resources."""
+        await self._bus.aclose()
+        await self._redis.aclose()
+        self._temporary_directory.cleanup()
+
+    async def _store_document(
+        self,
+        document_id: str,
+        document_status: str,
+    ) -> None:
+        """Persist one document with deliberately stale result metadata."""
+        record = KnowledgeDocumentRecord(
+            id=document_id,
+            user_id="user-1",
+            knowledge_base_id=self._knowledge_base_id,
+            status=document_status,
+            data=KnowledgeDocumentData(
+                filename=f"{document_id}.txt",
+                size=12,
+                content_type="text/plain",
+                blob_uri=f"local://kb/{document_id}",
+                error="old error",
+                chunk_count=3,
+            ),
+        )
+        await self._storage.upsert_knowledge_document("user-1", record)
+
+    async def test_empty_knowledge_base_updates_without_queueing(self) -> None:
+        """An empty knowledge base only needs a metadata update."""
+        requested = ChunkerConfig(
+            type="approx_token",
+            parameters={"chunk_size": 128, "overlap": 16},
+        )
+
+        updated = await self._service.update_knowledge_base(
+            user_id="user-1",
+            knowledge_base_id=self._knowledge_base_id,
+            chunker_config=requested,
+        )
+        queued = await self._bus.queue_drain(
+            MessageBusKeys.index_tasks_queue(),
+        )
+
+        self.assertEqual(updated.data.chunker_config, requested)
+        self.assertEqual(queued, [])
+
+    async def test_changed_chunker_resets_and_queues_terminal_documents(
+        self,
+    ) -> None:
+        """Ready and failed documents both enter a clean reindex pass."""
+        await self._store_document("doc-ready", "ready")
+        await self._store_document("doc-error", "error")
+        requested = ChunkerConfig(
+            type="alternate_approx_token",
+            parameters={"chunk_size": 64, "overlap": 8},
+        )
+
+        await self._service.update_knowledge_base(
+            user_id="user-1",
+            knowledge_base_id=self._knowledge_base_id,
+            chunker_config=requested,
+        )
+        documents = await self._storage.list_knowledge_documents(
+            "user-1",
+            self._knowledge_base_id,
+        )
+        queued = await self._bus.queue_drain(
+            MessageBusKeys.index_tasks_queue(),
+        )
+
+        document_state = sorted(
+            (
+                document.id,
+                document.status,
+                document.processing_node,
+                document.lease_expires_at,
+                document.data.error,
+                document.data.chunk_count,
+            )
+            for document in documents
+        )
+        self.assertEqual(
+            document_state,
+            [
+                ("doc-error", "pending", None, None, None, 0),
+                ("doc-ready", "pending", None, None, None, 0),
+            ],
+        )
+        self.assertEqual(
+            sorted(
+                (payload for _, payload in queued),
+                key=lambda item: item["document_id"],
+            ),
+            [
+                {
+                    "user_id": "user-1",
+                    "knowledge_base_id": self._knowledge_base_id,
+                    "document_id": "doc-error",
+                },
+                {
+                    "user_id": "user-1",
+                    "knowledge_base_id": self._knowledge_base_id,
+                    "document_id": "doc-ready",
+                },
+            ],
+        )
+
+    async def test_reindex_persists_each_document_before_enqueue(
+        self,
+    ) -> None:
+        """Each reset is immediately followed by its queue operation."""
+        await self._store_document("doc-ready", "ready")
+        await self._store_document("doc-error", "error")
+        events: list[tuple[str, str]] = []
+        original_upsert = self._storage.upsert_knowledge_document
+        original_queue_push = self._bus.queue_push
+
+        async def tracking_upsert(
+            user_id: str,
+            record: KnowledgeDocumentRecord,
+        ) -> KnowledgeDocumentRecord:
+            events.append(("upsert", record.id))
+            return await original_upsert(user_id, record)
+
+        async def tracking_queue_push(
+            key: str,
+            payload: dict,
+        ) -> None:
+            if key == MessageBusKeys.index_tasks_queue():
+                events.append(("enqueue", payload["document_id"]))
+            await original_queue_push(key, payload)
+
+        with (
+            patch.object(
+                self._storage,
+                "upsert_knowledge_document",
+                new=tracking_upsert,
+            ),
+            patch.object(
+                self._bus,
+                "queue_push",
+                new=tracking_queue_push,
+            ),
+        ):
+            await self._service.update_knowledge_base(
+                user_id="user-1",
+                knowledge_base_id=self._knowledge_base_id,
+                chunker_config=ChunkerConfig(
+                    type="alternate_approx_token",
+                    parameters={},
+                ),
+            )
+
+        paired_events = sorted(
+            (events[index], events[index + 1])
+            for index in range(0, len(events), 2)
+        )
+        self.assertEqual(
+            paired_events,
+            [
+                (
+                    ("upsert", "doc-error"),
+                    ("enqueue", "doc-error"),
+                ),
+                (
+                    ("upsert", "doc-ready"),
+                    ("enqueue", "doc-ready"),
+                ),
+            ],
+        )
+
+    async def test_upload_waits_for_chunker_update_lock(self) -> None:
+        """A document cannot enter storage during a chunker update."""
+        await self._store_document("doc-ready", "ready")
+        update_entered = asyncio.Event()
+        release_update = asyncio.Event()
+        blob_written = asyncio.Event()
+        original_update = self._manager.update_knowledge_base
+        original_write_stream = self._service._blob_store.write_stream
+
+        async def blocking_update(
+            **kwargs: Any,
+        ) -> KnowledgeBaseRecord | None:
+            update_entered.set()
+            await release_update.wait()
+            return await original_update(**kwargs)
+
+        async def tracking_write_stream(**kwargs: Any) -> str:
+            blob_uri = await original_write_stream(**kwargs)
+            blob_written.set()
+            return blob_uri
+
+        with (
+            patch.object(
+                self._manager,
+                "update_knowledge_base",
+                new=blocking_update,
+            ),
+            patch.object(
+                self._service._blob_store,
+                "write_stream",
+                new=tracking_write_stream,
+            ),
+        ):
+            update_task = asyncio.create_task(
+                self._service.update_knowledge_base(
+                    user_id="user-1",
+                    knowledge_base_id=self._knowledge_base_id,
+                    chunker_config=ChunkerConfig(
+                        type="alternate_approx_token",
+                        parameters={},
+                    ),
+                ),
+            )
+            await asyncio.wait_for(update_entered.wait(), timeout=1.0)
+            upload_task = asyncio.create_task(
+                self._service.register_document(
+                    user_id="user-1",
+                    knowledge_base_id=self._knowledge_base_id,
+                    filename="concurrent.txt",
+                    stream=BytesIO(b"content"),
+                    size=7,
+                    content_type="text/plain",
+                ),
+            )
+            await asyncio.wait_for(blob_written.wait(), timeout=1.0)
+            await asyncio.sleep(0)
+            documents_during_update = (
+                await self._storage.list_knowledge_documents(
+                    "user-1",
+                    self._knowledge_base_id,
+                )
+            )
+            self.assertEqual(
+                [document.id for document in documents_during_update],
+                ["doc-ready"],
+            )
+            self.assertFalse(upload_task.done())
+
+            release_update.set()
+            await update_task
+            uploaded = await upload_task
+
+        knowledge_base = await self._storage.get_knowledge_base(
+            "user-1",
+            self._knowledge_base_id,
+        )
+        documents = await self._storage.list_knowledge_documents(
+            "user-1",
+            self._knowledge_base_id,
+        )
+        self.assertIsNotNone(knowledge_base)
+        self.assertEqual(
+            knowledge_base.data.chunker_config,
+            ChunkerConfig(
+                type="alternate_approx_token",
+                parameters={},
+            ),
+        )
+        self.assertEqual(
+            sorted((document.id, document.status) for document in documents),
+            sorted(
+                [
+                    ("doc-ready", "pending"),
+                    (uploaded.id, "pending"),
+                ],
+            ),
+        )
+
+    async def test_unchanged_chunker_does_not_reindex(self) -> None:
+        """Equivalent configuration updates leave document state intact."""
+        await self._store_document("doc-ready", "ready")
+
+        await self._service.update_knowledge_base(
+            user_id="user-1",
+            knowledge_base_id=self._knowledge_base_id,
+            name="renamed",
+            chunker_config=ChunkerConfig(
+                type="approx_token",
+                parameters={"chunk_size": 512, "overlap": 50},
+            ),
+        )
+        document = await self._storage.get_knowledge_document(
+            "user-1",
+            self._knowledge_base_id,
+            "doc-ready",
+        )
+        queued = await self._bus.queue_drain(
+            MessageBusKeys.index_tasks_queue(),
+        )
+
+        self.assertIsNotNone(document)
+        self.assertEqual(
+            (
+                document.status,
+                document.data.error,
+                document.data.chunk_count,
+            ),
+            ("ready", "old error", 3),
+        )
+        self.assertEqual(queued, [])
+
+    async def test_default_chunker_follows_configured_order(self) -> None:
+        """Legacy records use the same default as the create path."""
+        service = KnowledgeBaseService(
+            storage=self._storage,
+            knowledge_base_manager=self._manager,
+            blob_store=LocalBlobStore(self._temporary_directory.name),
+            message_bus=self._bus,
+            resource_access_service=ResourceAccessService(
+                self._storage,
+                DenyAllResourceAccessPolicy(),
+            ),
+            chunkers=[_AlternateApproxTokenChunker, ApproxTokenChunker],
+        )
+
+        matches = service._chunker_configs_match(
+            None,
+            ChunkerConfig(
+                type="alternate_approx_token",
+                parameters={},
+            ),
+        )
+
+        self.assertEqual(matches, True)
+
+    async def test_in_flight_document_rejects_changed_chunker(self) -> None:
+        """A concurrent index pass blocks configuration replacement."""
+        await self._store_document("doc-pending", "pending")
+        requested = ChunkerConfig(
+            type="approx_token",
+            parameters={"chunk_size": 64, "overlap": 8},
+        )
+
+        with self.assertRaises(HTTPException) as raised:
+            await self._service.update_knowledge_base(
+                user_id="user-1",
+                knowledge_base_id=self._knowledge_base_id,
+                chunker_config=requested,
+            )
+
+        stored = await self._storage.get_knowledge_base(
+            "user-1",
+            self._knowledge_base_id,
+        )
+        self.assertEqual(raised.exception.status_code, 409)
+        self.assertIsNotNone(stored)
+        self.assertEqual(stored.data.chunker_config, self._original_chunker)
+
+    async def test_invalid_chunker_is_rejected_before_persistence(
+        self,
+    ) -> None:
+        """Parameter validation remains authoritative on update."""
+        requested = ChunkerConfig(
+            type="approx_token",
+            parameters={"chunk_size": 8, "overlap": 8},
+        )
+
+        with self.assertRaises(HTTPException) as raised:
+            await self._service.update_knowledge_base(
+                user_id="user-1",
+                knowledge_base_id=self._knowledge_base_id,
+                chunker_config=requested,
+            )
+
+        stored = await self._storage.get_knowledge_base(
+            "user-1",
+            self._knowledge_base_id,
+        )
+        self.assertEqual(raised.exception.status_code, 422)
+        self.assertIsNotNone(stored)
+        self.assertEqual(stored.data.chunker_config, self._original_chunker)

--- a/tests/service_knowledge_base_upload_test.py
+++ b/tests/service_knowledge_base_upload_test.py
@@ -263,6 +263,7 @@ class _FakeKbManager(KnowledgeBaseManagerBase):
                 name=name,
                 description=description,
                 embedding_model_config=embedding_model_config,
+                chunker_config=chunker_config,
                 collection_name="",
             ),
         )
@@ -499,3 +500,91 @@ class KnowledgeBaseUploadFlowTest(IsolatedAsyncioTestCase):
             )
             self.assertEqual(resp.status_code, 200, resp.text)
             self.assertEqual(resp.json()["items"], [])
+
+    async def test_chunker_update_reindexes_existing_document(self) -> None:
+        """PATCH persists chunking and drives a second worker pass."""
+        headers = {"X-User-ID": "user-1"}
+        with TestClient(self._app) as client:
+            uploaded = client.post(
+                f"/knowledge_bases/{self._kb_id}/documents",
+                files={
+                    "file": (
+                        "reindex.txt",
+                        b"abcdefgh01234567" * 16,
+                        "text/plain",
+                    ),
+                },
+                headers=headers,
+            )
+            self.assertEqual(uploaded.status_code, 201, uploaded.text)
+            document_id = uploaded.json()["document_id"]
+
+            deadline = 5.0
+            poll = 0.05
+            elapsed = 0.0
+            initial = None
+            while elapsed < deadline:
+                response = client.get(
+                    f"/knowledge_bases/{self._kb_id}/documents/status",
+                    params={"ids": document_id},
+                    headers=headers,
+                )
+                self.assertEqual(response.status_code, 200, response.text)
+                initial = response.json()["items"][0]
+                if initial["status"] in ("ready", "error"):
+                    break
+                await asyncio.sleep(poll)
+                elapsed += poll
+            self.assertIsNotNone(initial)
+            if initial is None:
+                self.fail("Initial indexing did not return a document.")
+            self.assertEqual(initial["status"], "ready", initial)
+            self.assertEqual(initial["chunk_count"], 1)
+
+            updated = client.patch(
+                f"/knowledge_bases/{self._kb_id}",
+                json={
+                    "chunker_config": {
+                        "type": "approx_token",
+                        "parameters": {
+                            "chunk_size": 4,
+                            "overlap": 0,
+                        },
+                    },
+                },
+                headers=headers,
+            )
+            self.assertEqual(updated.status_code, 200, updated.text)
+            self.assertEqual(
+                updated.json()["chunker_config"],
+                {
+                    "type": "approx_token",
+                    "parameters": {
+                        "chunk_size": 4,
+                        "overlap": 0,
+                    },
+                },
+            )
+
+            elapsed = 0.0
+            rebuilt = None
+            while elapsed < deadline:
+                response = client.get(
+                    f"/knowledge_bases/{self._kb_id}/documents/status",
+                    params={"ids": document_id},
+                    headers=headers,
+                )
+                self.assertEqual(response.status_code, 200, response.text)
+                rebuilt = response.json()["items"][0]
+                if rebuilt["status"] == "error":
+                    break
+                if rebuilt["status"] == "ready" and rebuilt["chunk_count"] > 1:
+                    break
+                await asyncio.sleep(poll)
+                elapsed += poll
+
+            self.assertIsNotNone(rebuilt)
+            if rebuilt is None:
+                self.fail("Reindexing did not return a document.")
+            self.assertEqual(rebuilt["status"], "ready", rebuilt)
+            self.assertEqual(rebuilt["chunk_count"], 16)


### PR DESCRIPTION
## AgentScope Version

2.0.7

## Description

### Summary

Enable users to update the chunker type and parameters of an existing knowledge base from the web UI.

### Changes

- Extend the knowledge base PATCH API to accept `chunker_config`.
- Validate chunker types and parameters before persistence.
- Reindex existing documents when the effective chunker configuration changes.
- Reject chunker changes while documents are already being indexed.
- Add a distributed knowledge-base mutation lock to prevent races with concurrent uploads.
- Persist and enqueue each document sequentially to reduce the reindex failure window.
- Reuse the configured default chunker when comparing legacy configurations.
- Add an edit entry to the knowledge base configuration card.
- Improve frontend parameter comparison with recursive key canonicalization.
- Prevent asynchronous chunker loading from resetting user input.
- Keep the embedding model and vector dimensions immutable.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review