### PR TITLE
fix(app): use Proactor event loop on Windows for LocalBackend subprocesses

### DIFF
--- a/examples/agent_service/README.md
+++ b/examples/agent_service/README.md
@@ -62,11 +62,12 @@ pnpm dev
 
 After that, you can set the API endpoint `http://localhost:8000` in the Web UI and start experiencing the agent service.
 
-> **Windows note:** keep `reload=False` when running `python main.py` on
-> Windows. Uvicorn's reloader can select an asyncio event loop that does
-> not support subprocesses, which breaks local workspace routes (skills,
-> MCP listing, etc.). AgentScope now sets a subprocess-capable loop
-> policy during `create_app()`, but the reloader may still win the race.
+> **Windows note:** On Windows, Python's
+> [`SelectorEventLoop` does not support subprocesses](https://docs.python.org/3/library/asyncio-platforms.html#windows);
+> only `ProactorEventLoop` does. Uvicorn's `reload=True` forces the
+> selector loop, which breaks AgentScope's `LocalWorkspace` (skills, MCP
+> listing, shell tools, etc.). This example disables reload on Windows;
+> AgentScope also sets `WindowsProactorEventLoopPolicy` in `create_app()`.
 
 <img src="https://gw.alicdn.com/imgextra/i2/O1CN01Phmg1G1brIVC8WXyU_!!6000000003518-2-tps-2938-1736.png" alt="Web UI Screenshot" width="100%">
 

--- a/examples/agent_service/README.md
+++ b/examples/agent_service/README.md
@@ -62,6 +62,12 @@ pnpm dev
 
 After that, you can set the API endpoint `http://localhost:8000` in the Web UI and start experiencing the agent service.
 
+> **Windows note:** keep `reload=False` when running `python main.py` on
+> Windows. Uvicorn's reloader can select an asyncio event loop that does
+> not support subprocesses, which breaks local workspace routes (skills,
+> MCP listing, etc.). AgentScope now sets a subprocess-capable loop
+> policy during `create_app()`, but the reloader may still win the race.
+
 <img src="https://gw.alicdn.com/imgextra/i2/O1CN01Phmg1G1brIVC8WXyU_!!6000000003518-2-tps-2938-1736.png" alt="Web UI Screenshot" width="100%">
 
 ## What Next

--- a/examples/agent_service/main.py
+++ b/examples/agent_service/main.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """The example script to start the agent service."""
 import os
+import sys
 
 import uvicorn
 from fastapi.middleware import Middleware
@@ -170,5 +171,7 @@ if __name__ == "__main__":
         "main:app",
         host="0.0.0.0",
         port=8000,
-        reload=True,
+        # Uvicorn reload on Windows can install a selector loop before the
+        # worker imports the app, breaking LocalWorkspace subprocess I/O.
+        reload=sys.platform != "win32",
     )

--- a/examples/agent_service/main.py
+++ b/examples/agent_service/main.py
@@ -171,7 +171,8 @@ if __name__ == "__main__":
         "main:app",
         host="0.0.0.0",
         port=8000,
-        # Uvicorn reload on Windows can install a selector loop before the
-        # worker imports the app, breaking LocalWorkspace subprocess I/O.
+        # Uvicorn reload on Windows forces WindowsSelectorEventLoopPolicy,
+        # which does not support asyncio subprocesses (see Python docs).
+        # LocalWorkspace / LocalBackend need ProactorEventLoop instead.
         reload=sys.platform != "win32",
     )

--- a/src/agentscope/_utils/_asyncio.py
+++ b/src/agentscope/_utils/_asyncio.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""Asyncio helpers shared across AgentScope."""
+import asyncio
+import sys
+
+
+def ensure_windows_proactor_event_loop_policy() -> None:
+    """Use an event loop policy that supports subprocesses on Windows.
+
+    :class:`~agentscope.tool.LocalBackend` and several workspace code paths
+    spawn subprocesses via ``asyncio.create_subprocess_exec``. On Windows the
+    legacy :class:`asyncio.SelectorEventLoop` raises
+    :exc:`NotImplementedError` for subprocess transport, while
+    :class:`asyncio.ProactorEventLoop` (selected by
+    :class:`asyncio.WindowsProactorEventLoopPolicy`) does not.
+
+    Uvicorn and some test runners may install a selector-based loop before
+    AgentScope code runs. Call this **before** the running loop is created —
+    for example at app factory time or when importing the local backend.
+    """
+    if sys.platform != "win32":
+        return
+
+    policy = asyncio.get_event_loop_policy()
+    if isinstance(policy, asyncio.WindowsProactorEventLoopPolicy):
+        return
+
+    asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())

--- a/src/agentscope/_utils/_asyncio.py
+++ b/src/agentscope/_utils/_asyncio.py
@@ -7,16 +7,18 @@ import sys
 def ensure_windows_proactor_event_loop_policy() -> None:
     """Use an event loop policy that supports subprocesses on Windows.
 
-    :class:`~agentscope.tool.LocalBackend` and several workspace code paths
-    spawn subprocesses via ``asyncio.create_subprocess_exec``. On Windows the
-    legacy :class:`asyncio.SelectorEventLoop` raises
-    :exc:`NotImplementedError` for subprocess transport, while
-    :class:`asyncio.ProactorEventLoop` (selected by
-    :class:`asyncio.WindowsProactorEventLoopPolicy`) does not.
+    Per the `Python asyncio platform notes
+    <https://docs.python.org/3/library/asyncio-platforms.html#windows>`_,
+    :class:`asyncio.SelectorEventLoop` does **not** support subprocesses on
+    Windows, while :class:`asyncio.ProactorEventLoop` does.
+    :class:`asyncio.WindowsProactorEventLoopPolicy` has been the default
+    since Python 3.8, but uvicorn's reload mode (and some test runners) may
+    replace it with :class:`asyncio.WindowsSelectorEventLoopPolicy`.
 
-    Uvicorn and some test runners may install a selector-based loop before
-    AgentScope code runs. Call this **before** the running loop is created —
-    for example at app factory time or when importing the local backend.
+    :class:`~agentscope.tool.LocalBackend` and local workspace code paths
+    spawn subprocesses via ``asyncio.create_subprocess_exec``. Call this
+    helper **before** the running loop is created — for example in
+    :func:`~agentscope.app.create_app` or when importing the local backend.
     """
     if sys.platform != "win32":
         return

--- a/src/agentscope/app/_app.py
+++ b/src/agentscope/app/_app.py
@@ -35,6 +35,7 @@ from ..credential import CredentialFactory, CredentialBase
 from ..rag import ApproxTokenChunker, ChunkerBase, ParserBase, TextParser
 
 from .._logging import logger
+from .._utils._asyncio import ensure_windows_proactor_event_loop_policy
 from .._version import __version__
 
 
@@ -275,6 +276,8 @@ def create_app(
     """
     from fastapi import FastAPI, Request, status
     from fastapi.responses import JSONResponse
+
+    ensure_windows_proactor_event_loop_policy()
 
     # Register any user-supplied credential types before the app starts
     for cls in extra_credentials or []:

--- a/src/agentscope/tool/_builtin/_backend.py
+++ b/src/agentscope/tool/_builtin/_backend.py
@@ -807,12 +807,14 @@ class LocalBackend(BackendBase):
                 **kwargs,
             )
         except NotImplementedError as exc:
+            # Windows SelectorEventLoop does not implement subprocess
+            # transport (Python docs: asyncio platform support). Uvicorn
+            # reload=True forces that loop; use ProactorEventLoop instead.
             raise RuntimeError(
                 "asyncio subprocesses are not supported by the current "
-                "event loop on Windows. Call "
-                "agentscope._utils._asyncio.ensure_windows_proactor_event_loop_policy() "
-                "before the event loop is created, and avoid uvicorn "
-                "reload=True on Windows when using LocalWorkspace.",
+                "event loop on Windows. Use WindowsProactorEventLoopPolicy "
+                "(the Python 3.8+ default) and avoid uvicorn reload=True, "
+                "which installs SelectorEventLoop and breaks LocalBackend.",
             ) from exc
         except (FileNotFoundError, NotADirectoryError, OSError) as exc:
             # The executable could not be found or spawned. A shell would

--- a/src/agentscope/tool/_builtin/_backend.py
+++ b/src/agentscope/tool/_builtin/_backend.py
@@ -46,6 +46,10 @@ from typing import Any, AsyncIterator
 
 import aiofiles
 
+from ..._utils._asyncio import ensure_windows_proactor_event_loop_policy
+
+ensure_windows_proactor_event_loop_policy()
+
 # Chunk size for streamed reads. Large enough that a big file does not
 # turn into thousands of awaits, small enough to stay off the heap.
 DEFAULT_READ_CHUNK_SIZE = 1024 * 1024
@@ -802,6 +806,14 @@ class LocalBackend(BackendBase):
                 stderr=asyncio.subprocess.PIPE,
                 **kwargs,
             )
+        except NotImplementedError as exc:
+            raise RuntimeError(
+                "asyncio subprocesses are not supported by the current "
+                "event loop on Windows. Call "
+                "agentscope._utils._asyncio.ensure_windows_proactor_event_loop_policy() "
+                "before the event loop is created, and avoid uvicorn "
+                "reload=True on Windows when using LocalWorkspace.",
+            ) from exc
         except (FileNotFoundError, NotADirectoryError, OSError) as exc:
             # The executable could not be found or spawned. A shell would
             # have returned 127 ("command not found"); mirror that so

--- a/tests/asyncio_windows_policy_test.py
+++ b/tests/asyncio_windows_policy_test.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""Tests for Windows asyncio subprocess compatibility helpers."""
+import asyncio
+import sys
+import unittest
+
+from agentscope._utils._asyncio import ensure_windows_proactor_event_loop_policy
+
+
+class TestWindowsProactorEventLoopPolicy(unittest.TestCase):
+    """Ensure subprocess-capable loop policy is selected on Windows."""
+
+    def test_idempotent_on_windows(self) -> None:
+        ensure_windows_proactor_event_loop_policy()
+        ensure_windows_proactor_event_loop_policy()
+        if sys.platform == "win32":
+            self.assertIsInstance(
+                asyncio.get_event_loop_policy(),
+                asyncio.WindowsProactorEventLoopPolicy,
+            )
+
+    @unittest.skipUnless(sys.platform == "win32", "Windows-only")
+    def test_local_backend_exec_shell_runs_subprocess(self) -> None:
+        """Regression for agent-service workspace routes on Windows."""
+
+        async def run() -> None:
+            from agentscope.tool import LocalBackend
+
+            backend = LocalBackend()
+            result = await backend.exec_shell(
+                [sys.executable, "-c", "print('ok')"],
+            )
+            self.assertTrue(result.ok())
+            self.assertIn(b"ok", result.stdout)
+
+        asyncio.run(run())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

On Windows, Agent Service workspace routes (`/workspace/skill`, MCP listing, shell tools, etc.) can raise `NotImplementedError` from `asyncio.create_subprocess_exec`.

**Root cause (documented behavior):**
- Per [Python asyncio platform notes](https://docs.python.org/3/library/asyncio-platforms.html#windows), `SelectorEventLoop` does **not** support subprocesses on Windows; only `ProactorEventLoop` does.
- `WindowsProactorEventLoopPolicy` has been the default since Python 3.8, but **uvicorn `reload=True`** installs `WindowsSelectorEventLoopPolicy` (see [encode/uvicorn#529](https://github.com/encode/uvicorn/issues/529)), which breaks `LocalBackend.exec_shell`.

**Fix:**
- Add `ensure_windows_proactor_event_loop_policy()` and call it from `create_app()` and when importing the local backend module.
- Convert the opaque `NotImplementedError` into a clear `RuntimeError` with actionable guidance.
- Disable uvicorn reload on Windows in `examples/agent_service/main.py`, and document the limitation in the example README with a link to the Python docs.
- Add a Windows regression test for `LocalBackend.exec_shell`.

## Test plan

- [x] `python -m unittest tests.asyncio_windows_policy_test -v` on Windows
- [x] Start `examples/agent_service/main.py` without reload and confirm `/workspace/skill` returns 200 (no `NotImplementedError`)
- [ ] CI unit tests on Linux remain green (no Windows-only regressions)

## References

- https://docs.python.org/3/library/asyncio-platforms.html#windows
- https://github.com/encode/uvicorn/issues/529