### PR TITLE
Fix confirmation card overlapping chat messages

### DIFF
--- a/examples/web_ui/frontend/src/components/chat/ChatContent.tsx
+++ b/examples/web_ui/frontend/src/components/chat/ChatContent.tsx
@@ -217,7 +217,7 @@ const ChatContentComponent: React.FC<ChatContentProps> = ({
 				<div className="relative min-w-full max-w-full w-full">
 					<FlipCard
 						visible={toConfirmedToolCalls.length > 0 || footerSlot !== null}
-						className="absolute bottom-full left-0 right-0 mb-2 z-50"
+						className="relative z-10 mb-2 max-h-[40vh] w-full overflow-y-auto"
 					>
 						{toConfirmedToolCalls.length > 0 ? (
 							<ConfirmCard


### PR DESCRIPTION
## Summary

The confirmation card was absolutely positioned above the composer, which caused it to overlap and obscure the latest chat messages.

This change keeps the confirmation card in the normal layout flow and limits its height to 40vh with vertical scrolling. The conversation remains visible while large confirmation content can still be reviewed.

## Testing

- `pnpm build` (from `examples/web_ui/frontend`)
