### PR TITLE
fix(tracing): report interrupted chat responses

### DIFF
--- a/src/agentscope/middleware/_tracing/_extractor.py
+++ b/src/agentscope/middleware/_tracing/_extractor.py
@@ -12,7 +12,7 @@ from ._attributes import (
 )
 from ._converter import _convert_block_to_part
 from ._utils import _serialize_to_str
-from ...model import ChatResponse, ChatModelBase
+from ...model import ChatResponse, ChatModelBase, FinishedReason
 from ...event import (
     ExternalExecutionResultEvent,
     UserConfirmResultEvent,
@@ -289,7 +289,7 @@ def _get_llm_output_messages(
             ]
 
         parts = []
-        finish_reason = "stop"  # Default finish reason
+        finish_reason = _get_chat_response_finish_reason(chat_response)
 
         for block in chat_response.content:
             part = _convert_block_to_part(block)
@@ -319,6 +319,19 @@ def _get_llm_output_messages(
         ]
 
 
+def _get_chat_response_finish_reason(
+    chat_response: ChatResponse | None,
+) -> str:
+    """Get the finish reason to record for a chat response."""
+    if not isinstance(chat_response, ChatResponse):
+        return "unknown"
+
+    if chat_response.finished_reason == FinishedReason.INTERRUPTED:
+        return "interrupted"
+
+    return "stop"
+
+
 def _get_llm_response_attributes(
     chat_response: ChatResponse | None,
 ) -> Dict[str, Any]:
@@ -344,8 +357,9 @@ def _get_llm_response_attributes(
             "id",
             "unknown_id",
         ),
-        # FIXME: finish reason should be capture in chat response
-        SpanAttributes.GEN_AI_RESPONSE_FINISH_REASONS: '["stop"]',
+        SpanAttributes.GEN_AI_RESPONSE_FINISH_REASONS: _serialize_to_str(
+            [_get_chat_response_finish_reason(chat_response)],
+        ),
     }
     if hasattr(chat_response, "usage") and chat_response.usage:
         usage = chat_response.usage

--- a/tests/tracing_test.py
+++ b/tests/tracing_test.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 from typing import Any
+from unittest import TestCase
 from unittest.async_case import IsolatedAsyncioTestCase
 
 from opentelemetry import trace as otel_trace
@@ -29,7 +30,11 @@ from agentscope.message import (
     ToolResultState,
     UserMsg,
 )
-from agentscope.model import ChatResponse, ChatUsage
+from agentscope.middleware._tracing._attributes import SpanAttributes
+from agentscope.middleware._tracing._extractor import (
+    _get_llm_response_attributes,
+)
+from agentscope.model import ChatResponse, ChatUsage, FinishedReason
 from agentscope.permission import (
     PermissionContext,
     PermissionDecision,
@@ -135,6 +140,34 @@ class ExternalWeatherTool(ToolBase):
     async def execute(self, city: str) -> str:
         """Stub weather tool for tracing tests."""
         return f"{city}: sunny, 25°C."
+
+
+class TracingExtractorTest(TestCase):
+    """Tests for tracing attribute extraction helpers."""
+
+    def test_llm_response_tracing_uses_chat_response_finish_reason(
+        self,
+    ) -> None:
+        """LLM response tracing should preserve ChatResponse finish reason."""
+        response = ChatResponse(
+            content=[TextBlock(text="partial answer")],
+            is_last=True,
+            finished_reason=FinishedReason.INTERRUPTED,
+        )
+
+        attributes = _get_llm_response_attributes(response)
+        output_messages = json.loads(
+            attributes[SpanAttributes.GEN_AI_OUTPUT_MESSAGES],
+        )
+
+        self.assertEqual(
+            attributes[SpanAttributes.GEN_AI_RESPONSE_FINISH_REASONS],
+            '["interrupted"]',
+        )
+        self.assertEqual(
+            output_messages[0]["finish_reason"],
+            "interrupted",
+        )
 
 
 def _make_tool_call_response(tool_id: str, city: str) -> ChatResponse:


### PR DESCRIPTION
## AgentScope Version

2.0.7

## Description

Refs #2449.

LLM tracing currently records `stop` for every `ChatResponse`, including
responses interrupted by AgentScope.

This change records `interrupted` when
`ChatResponse.finished_reason == FinishedReason.INTERRUPTED`, while keeping
`stop` for normally completed responses.

Provider-native finish reasons are not currently available in `ChatResponse`,
so this PR does not change provider adapters or the tracing behavior of
completed responses.

## Tests

```bash
python -m pytest tests/tracing_test.py -q
# 19 passed

pre-commit run --files \
  src/agentscope/middleware/_tracing/_extractor.py \
  tests/tracing_test.py

git diff --check
```

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the CONTRIBUTING.md
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated
- [x] Code is ready for review
