### PR TITLE
fix(scheduler): validate schedules before persisting

### DIFF
--- a/src/agentscope/app/_manager/_scheduler/_scheduler_manager.py
+++ b/src/agentscope/app/_manager/_scheduler/_scheduler_manager.py
@@ -3,7 +3,7 @@
 import json
 from collections.abc import Callable, Coroutine
 
-from typing import Self
+from typing import TYPE_CHECKING, Self
 
 from ....message import HintBlock
 from ....permission import PermissionContext
@@ -22,6 +22,9 @@ from ...storage import (
     SessionConfig,
     SessionSource,
 )
+
+if TYPE_CHECKING:
+    from apscheduler.triggers.cron import CronTrigger
 
 
 class SchedulerManager:
@@ -281,6 +284,34 @@ class SchedulerManager:
     # Schedule management
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _create_cron_trigger(record: ScheduleRecord) -> "CronTrigger":
+        """Build and validate the APScheduler cron trigger."""
+        from apscheduler.triggers.cron import CronTrigger
+
+        fields = record.data.cron_expression.split()
+        if len(fields) != 5:
+            raise ValueError(
+                "Expected a 5-field cron expression, got "
+                f"{record.data.cron_expression!r}",
+            )
+        minute, hour, day, month, day_of_week = fields
+
+        return CronTrigger(
+            minute=minute,
+            hour=hour,
+            day=day,
+            month=month,
+            day_of_week=day_of_week,
+            timezone=record.data.timezone,
+            start_date=record.data.started_at,
+            end_date=record.data.ended_at,
+        )
+
+    def validate_schedule(self, record: ScheduleRecord) -> None:
+        """Validate a schedule without mutating storage or APScheduler."""
+        self._create_cron_trigger(record)
+
     async def register_schedule(self, record: ScheduleRecord) -> str:
         """Persist-and-register a schedule record with APScheduler.
 
@@ -297,8 +328,6 @@ class SchedulerManager:
                 The APScheduler job ID (equal to ``record.id``).
         """
 
-        from apscheduler.triggers.cron import CronTrigger
-
         logger.info(
             "Registering schedule %s(%s) cron=%s tz=%s",
             record.id,
@@ -311,27 +340,12 @@ class SchedulerManager:
         # the 5 parsed fields and ``timezone`` — it has no parameter for
         # ``start_date`` / ``end_date``.  Parse the expression ourselves so
         # the configured activation window is honoured.
-        fields = record.data.cron_expression.split()
-        if len(fields) != 5:
-            raise ValueError(
-                "Expected a 5-field cron expression, got "
-                f"{record.data.cron_expression!r}",
-            )
-        minute, hour, day, month, day_of_week = fields
+        cron_trigger = self._create_cron_trigger(record)
 
         trigger = self._build_trigger(record)
         job = self._scheduler.add_job(
             trigger,
-            trigger=CronTrigger(
-                minute=minute,
-                hour=hour,
-                day=day,
-                month=month,
-                day_of_week=day_of_week,
-                timezone=record.data.timezone,
-                start_date=record.data.started_at,
-                end_date=record.data.ended_at,
-            ),
+            trigger=cron_trigger,
             id=record.id,
             name=record.data.name,
             misfire_grace_time=300,

--- a/src/agentscope/app/_manager/_scheduler/_tools/_schedule_create.py
+++ b/src/agentscope/app/_manager/_scheduler/_tools/_schedule_create.py
@@ -141,7 +141,8 @@ to complete the task independently.
                 The storage backend used to persist the schedule record.
             scheduler_manager (`Any`):
                 The scheduler manager used to register the APScheduler job.
-                Must expose a ``register_schedule(record)`` coroutine.
+                Must expose ``validate_schedule(record)`` and a
+                ``register_schedule(record)`` coroutine.
         """
         self._user_id = user_id
         self._agent_id = agent_id
@@ -232,6 +233,7 @@ to complete the task independently.
             ),
         )
 
+        self._scheduler_manager.validate_schedule(record)
         await self._storage.upsert_schedule(self._user_id, record)
         await self._scheduler_manager.register_schedule(record)
 

--- a/src/agentscope/app/_router/_schedule.py
+++ b/src/agentscope/app/_router/_schedule.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Schedule router — CRUD endpoints for scheduled agent tasks."""
 from datetime import datetime
+from zoneinfo import ZoneInfoNotFoundError
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
@@ -33,6 +34,20 @@ schedule_router = APIRouter(
     tags=["schedule"],
     responses={404: {"description": "Not found"}},
 )
+
+
+def _validate_schedule(
+    scheduler: SchedulerManager,
+    record: ScheduleRecord,
+) -> None:
+    """Map invalid APScheduler configuration to an HTTP 422 response."""
+    try:
+        scheduler.validate_schedule(record)
+    except (ValueError, ZoneInfoNotFoundError) as error:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(error),
+        ) from error
 
 
 @schedule_router.get(
@@ -120,6 +135,7 @@ async def create_schedule(
             started_at=datetime.now(),
         ),
     )
+    _validate_schedule(scheduler, record)
     await storage.upsert_schedule(user_id, record)
 
     if record.data.enabled:
@@ -173,6 +189,7 @@ async def update_schedule(
     updated_record = existing.model_copy(
         update={"data": updated_data, "updated_at": datetime.now()},
     )
+    _validate_schedule(scheduler, updated_record)
     await storage.upsert_schedule(user_id, updated_record)
 
     # Always remove the existing job first; re-register only if still enabled.

--- a/tests/service_schedule_validation_test.py
+++ b/tests/service_schedule_validation_test.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Tests for validating schedules before mutating persistent state."""
+from datetime import datetime
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import AsyncMock, Mock
+
+from fastapi import HTTPException
+
+from agentscope.app._manager import SchedulerManager
+from agentscope.app._manager._scheduler._tools import ScheduleCreate
+from agentscope.app._router._schedule import create_schedule, update_schedule
+from agentscope.app._router._schema import (
+    CreateScheduleRequest,
+    UpdateScheduleRequest,
+)
+from agentscope.app.storage import (
+    ChatModelConfig,
+    ScheduleData,
+    ScheduleRecord,
+)
+
+
+def _chat_model_config() -> ChatModelConfig:
+    return ChatModelConfig(
+        type="dashscope_credential",
+        credential_id="credential-id",
+        model="model-name",
+        parameters={},
+    )
+
+
+def _schedule_record(cron_expression: str = "0 0 * * *") -> ScheduleRecord:
+    return ScheduleRecord(
+        user_id="user-id",
+        agent_id="agent-id",
+        data=ScheduleData(
+            name="schedule",
+            cron_expression=cron_expression,
+            timezone="UTC",
+            started_at=datetime(2026, 1, 1),
+            chat_model_config=_chat_model_config(),
+        ),
+    )
+
+
+class TestSchedulerValidation(TestCase):
+    """The manager validates cron configuration without adding a job."""
+
+    def test_invalid_cron_does_not_add_scheduler_job(self) -> None:
+        """Invalid cron input does not create an APScheduler job."""
+        manager = SchedulerManager(Mock(), Mock(), Mock())
+
+        with self.assertRaisesRegex(ValueError, "5-field cron expression"):
+            manager.validate_schedule(_schedule_record("not a cron"))
+
+        self.assertEqual(manager._scheduler.get_jobs(), [])
+
+
+class TestScheduleMutationOrdering(IsolatedAsyncioTestCase):
+    """Invalid schedules are rejected before persistence or job mutation."""
+
+    async def test_create_rejects_invalid_schedule_before_persisting(
+        self,
+    ) -> None:
+        """The create endpoint returns 422 before writing storage."""
+        storage = AsyncMock()
+        access = AsyncMock()
+        scheduler = Mock()
+        scheduler.validate_schedule.side_effect = ValueError("invalid cron")
+        body = CreateScheduleRequest(
+            name="invalid",
+            cron_expression="not a cron",
+            agent_id="agent-id",
+            chat_model_config=_chat_model_config(),
+        )
+
+        with self.assertRaises(HTTPException) as context:
+            await create_schedule(
+                body,
+                user_id="user-id",
+                storage=storage,
+                access=access,
+                scheduler=scheduler,
+            )
+
+        self.assertEqual(context.exception.status_code, 422)
+        storage.upsert_schedule.assert_not_awaited()
+
+    async def test_update_rejects_invalid_schedule_before_mutating(
+        self,
+    ) -> None:
+        """A failed update preserves storage and the current job."""
+        storage = AsyncMock()
+        storage.get_schedule.return_value = _schedule_record()
+        scheduler = Mock()
+        scheduler.validate_schedule.side_effect = ValueError("invalid cron")
+
+        with self.assertRaises(HTTPException) as context:
+            await update_schedule(
+                "schedule-id",
+                UpdateScheduleRequest(cron_expression="not a cron"),
+                user_id="user-id",
+                storage=storage,
+                scheduler=scheduler,
+            )
+
+        self.assertEqual(context.exception.status_code, 422)
+        storage.upsert_schedule.assert_not_awaited()
+        scheduler.remove_schedule.assert_not_called()
+
+    async def test_agent_tool_validates_before_persisting(self) -> None:
+        """The agent tool validates before writing its schedule record."""
+        storage = AsyncMock()
+        scheduler = Mock()
+        scheduler.validate_schedule.side_effect = ValueError("invalid cron")
+        tool = ScheduleCreate(
+            user_id="user-id",
+            agent_id="agent-id",
+            chat_model_config=_chat_model_config(),
+            storage=storage,
+            scheduler_manager=scheduler,
+        )
+
+        with self.assertRaisesRegex(ValueError, "invalid cron"):
+            await tool(name="invalid", cron_expression="not a cron")
+
+        storage.upsert_schedule.assert_not_awaited()


### PR DESCRIPTION
## AgentScope Version

2.0.7 (current main: 9983e76)

## Description

Schedule creation and update currently persist records before APScheduler validates the cron expression, timezone, and activation window. Invalid configuration can therefore leave an orphaned record, and a failed update can replace stored data and remove the existing valid job.

This PR:

- extracts the existing CronTrigger construction into one side-effect-free validation path;
- validates HTTP create and update requests before storage or scheduler mutation, returning HTTP 422 for invalid configuration;
- validates the agent-facing ScheduleCreate tool before persistence;
- keeps runtime registration on the same CronTrigger construction path to prevent validation drift.

Validation:

- `uv run --isolated --extra service --with pytest --with fakeredis pytest -q tests/service_schedule_validation_test.py tests/service_scheduler_test.py` — 10 passed.
- `uvx pre-commit run --files ...` on all four changed files — all hooks passed, including mypy, Black, flake8, pylint, and Pyroma.
- `git diff --check` — passed.

No public API or documentation change is required; this restores the documented invalid-request behavior.

AI assistance was used during implementation. I reviewed the complete diff and ran the validation above.

Fixes #2441

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the CONTRIBUTING.md
- [x] Docstrings are in Google style
- [x] Related documentation has been considered; no documentation update is required
- [x] Code is ready for review