### PR TITLE
chore: bump version to 2.0.7.post1

### DIFF
--- a/src/agentscope/_version.py
+++ b/src/agentscope/_version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """The version of agentscope."""
 
-__version__ = "2.0.7"
+__version__ = "2.0.7.post1"


### PR DESCRIPTION
Bump the AgentScope version from `2.0.7` to `2.0.7.post1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQXbg68DsdRXvKxWVjGrC6