### PR TITLE
feat(channel): add Discord discovery and send tools

### DIFF
--- a/src/agentscope/app/channel/_discord/_channel.py
+++ b/src/agentscope/app/channel/_discord/_channel.py
@@ -34,6 +34,9 @@ from .._base import (
 if TYPE_CHECKING:
     import discord
 
+    from ....tool import ToolBase
+    from ....workspace import WorkspaceBase
+
 # Discord's hard limit is 2000 characters per message.
 _MAX_LEN = 2000
 # Give up (and park in 'failed') after this many connects that never came up.
@@ -145,6 +148,12 @@ class DiscordChannel(ChannelBase):
 
                 intents = discord.Intents.default()
                 intents.message_content = True
+                # This client logs in for REST calls only and never opens a
+                # gateway connection. Enabling the privileged member intent
+                # here lets ``fetch_members`` validate member lookups without
+                # changing the listening client's backward-compatible
+                # gateway intents.
+                intents.members = True
                 client = discord.Client(intents=intents)
                 try:
                     await client.login(self._bot_token)
@@ -403,6 +412,116 @@ class DiscordChannel(ChannelBase):
                     )
         return results
 
+    async def list_tools(  # pylint: disable=unused-argument
+        self,
+        workspace: "WorkspaceBase",
+        channel_user_id: str | None = None,
+    ) -> list["ToolBase"]:
+        """Expose Discord discovery and cross-target send tools.
+
+        Args:
+            workspace (`WorkspaceBase`): Calling session workspace whose
+                backend is used for file reads.
+            channel_user_id (`str | None`, optional): The platform user the
+                session acts as. Discord tools use the bot's permissions
+                and do not depend on this value.
+
+        Returns:
+            `list[ToolBase]`: Discord agent-callable tools.
+        """
+        from ._tools import (
+            ListChats,
+            ListChatMembers,
+            SendFile,
+            SendMessage,
+        )
+
+        backend = workspace.get_backend()
+        return [
+            ListChats(self, backend),
+            ListChatMembers(self, backend),
+            SendMessage(self, backend),
+            SendFile(self, backend),
+        ]
+
+    async def list_chat_members(self, chat_id: str) -> list[dict]:
+        """List users who can view one Discord guild text channel.
+
+        Member enumeration uses Discord's REST endpoint and therefore
+        requires the privileged members intent to be enabled for the bot
+        application. Platform authorization errors intentionally propagate
+        to the tool result instead of masquerading as an empty member list.
+
+        Args:
+            chat_id (`str`): Discord guild text-channel id.
+
+        Returns:
+            `list[dict]`: Visible users as ``{user_id, name}`` mappings.
+        """
+        import discord
+
+        channel = await self._channel(chat_id)
+        if not isinstance(channel, discord.TextChannel):
+            return []
+        client = await self._ensure_client()
+        results: list[dict] = []
+        async for member in channel.guild.fetch_members(limit=None):
+            if member.id == client.user.id:
+                continue
+            if not channel.permissions_for(member).view_channel:
+                continue
+            results.append(
+                {
+                    "user_id": str(member.id),
+                    "name": member.display_name,
+                },
+            )
+        return results
+
+    async def send_message_to(self, target: str, text: str) -> bool:
+        """Send text to an explicit Discord channel or user target.
+
+        Args:
+            target (`str`): Encoded ``channel:<id>`` or ``user:<id>``.
+            text (`str`): Message text.
+
+        Returns:
+            `bool`: Whether the target was valid and every part was sent.
+        """
+        destination = await self._target(target)
+        if destination is None:
+            return False
+        for part in self._split_long_message(text):
+            if part:
+                await destination.send(part)
+        return True
+
+    async def send_file_to(
+        self,
+        target: str,
+        raw: bytes,
+        file_name: str,
+    ) -> bool:
+        """Send one in-memory file to a Discord channel or user.
+
+        Args:
+            target (`str`): Encoded ``channel:<id>`` or ``user:<id>``.
+            raw (`bytes`): File payload from the session workspace.
+            file_name (`str`): Display filename.
+
+        Returns:
+            `bool`: Whether the target was valid and the file was sent.
+        """
+        import discord
+
+        destination = await self._target(target)
+        if destination is None:
+            return False
+        await destination.send(
+            file=discord.File(io.BytesIO(raw), filename=file_name),
+        )
+        return True
+
     async def chat_kind(self, chat_id: str) -> ChatKind | None:
         """Private for a DM channel, group otherwise; ``None`` if the
         channel id can't be resolved.
@@ -431,6 +550,34 @@ class DiscordChannel(ChannelBase):
         return getattr(channel, "name", "") or "" if channel else ""
 
     # -- Helpers --
+
+    async def _target(
+        self,
+        target: str,
+    ) -> "discord.abc.Messageable | None":
+        """Resolve an encoded channel/user target to a send destination.
+
+        Args:
+            target (`str`): ``channel:<id>`` or ``user:<id>``.
+
+        Returns:
+            `discord.abc.Messageable | None`: Send destination or ``None``
+            for malformed and unsupported targets.
+        """
+        try:
+            target_type, raw_id = target.split(":", 1)
+            target_id = int(raw_id)
+        except (AttributeError, TypeError, ValueError):
+            return None
+        client = await self._ensure_client()
+        if target_type == "channel":
+            return client.get_channel(target_id) or await client.fetch_channel(
+                target_id,
+            )
+        if target_type == "user":
+            user = await client.fetch_user(target_id)
+            return await user.create_dm()
+        return None
 
     async def _channel(
         self,

--- a/src/agentscope/app/channel/_discord/_tools/__init__.py
+++ b/src/agentscope/app/channel/_discord/_tools/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+"""Agent-callable Discord discovery and send tools."""
+
+from ._list_chats import ListChats
+from ._list_chat_members import ListChatMembers
+from ._send_file import SendFile
+from ._send_message import SendMessage
+
+__all__ = ["ListChats", "ListChatMembers", "SendFile", "SendMessage"]

--- a/src/agentscope/app/channel/_discord/_tools/_base.py
+++ b/src/agentscope/app/channel/_discord/_tools/_base.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+"""Shared base and result helper for Discord agent tools."""
+
+from typing import Any, TYPE_CHECKING
+
+from .....message import TextBlock, ToolResultState
+from .....permission import (
+    PermissionBehavior,
+    PermissionContext,
+    PermissionDecision,
+)
+from .....tool import BackendBase, ToolBase, ToolChunk
+
+if TYPE_CHECKING:
+    from .._channel import DiscordChannel
+
+
+def _ack(accepted: bool, what: str) -> ToolChunk:
+    """Convert a Discord send result into a tool chunk.
+
+    Args:
+        accepted (`bool`): Whether Discord accepted the request.
+        what (`str`): Short description of the attempted operation.
+
+    Returns:
+        `ToolChunk`: Success or error result for the agent.
+    """
+    if accepted:
+        return ToolChunk(content=[TextBlock(text=f"Sent {what}.")])
+    return ToolChunk(
+        content=[
+            TextBlock(
+                text=f"Failed to send {what}: invalid Discord target.",
+            ),
+        ],
+        state=ToolResultState.ERROR,
+    )
+
+
+class _DiscordToolBase(ToolBase):
+    """Base for Discord tools bound to a channel and workspace."""
+
+    is_concurrency_safe: bool = False
+    is_state_injected: bool = False
+    is_external_tool: bool = False
+    is_mcp: bool = False
+    mcp_name: str | None = None
+
+    def __init__(
+        self,
+        channel: "DiscordChannel",
+        backend: BackendBase,
+    ) -> None:
+        """Bind the REST-capable channel and session workspace backend.
+
+        Args:
+            channel (`DiscordChannel`): Discord channel to query or send.
+            backend (`BackendBase`): Workspace backend for file reads.
+        """
+        super().__init__()
+        self._channel = channel
+        self._backend = backend
+
+    async def check_permissions(
+        self,
+        tool_input: dict[str, Any],
+        context: PermissionContext,
+    ) -> PermissionDecision:
+        """Allow lookups and ask before cross-target sends.
+
+        Args:
+            tool_input (`dict[str, Any]`): Proposed tool arguments.
+            context (`PermissionContext`): Session permission context.
+
+        Returns:
+            `PermissionDecision`: Read allow or send confirmation request.
+        """
+        del tool_input, context
+        if self.is_read_only:
+            return PermissionDecision(
+                behavior=PermissionBehavior.ALLOW,
+                message=f"{self.name} is a read-only lookup.",
+            )
+        return PermissionDecision(
+            behavior=PermissionBehavior.ASK,
+            message="Sending to another Discord channel or user needs the "
+            "user's confirmation.",
+        )

--- a/src/agentscope/app/channel/_discord/_tools/_list_chat_members.py
+++ b/src/agentscope/app/channel/_discord/_tools/_list_chat_members.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""ListChatMembers — discover visible Discord member targets."""
+
+import json
+
+from pydantic import Field
+
+from .....message import TextBlock
+from .....tool import ParamsBase, ToolChunk
+from ._base import _DiscordToolBase
+
+
+class _ListChatMembersParams(ParamsBase):
+    target: str = Field(
+        pattern=r"^channel:\d+$",
+        description="Channel target returned by ListChats.",
+    )
+
+
+class ListChatMembers(_DiscordToolBase):
+    """List users who can see a Discord guild text channel."""
+
+    name: str = "ListChatMembers"
+    description: str = """List members who can view one Discord guild text \
+channel.
+
+Pass a ``channel:<id>`` target returned by ``ListChats``. The output is a \
+JSON array of ``{target, name}``; copy a ``user:<id>`` target into a Send* \
+tool for a direct message. Discord requires the privileged members intent \
+for this lookup; authorization errors are returned as tool errors."""
+    is_read_only: bool = True
+    input_schema: dict = _ListChatMembersParams.model_json_schema()
+
+    async def __call__(self, target: str) -> ToolChunk:
+        """Return members visible in the selected guild channel.
+
+        Args:
+            target (`str`): ``channel:<id>`` from ``ListChats``.
+
+        Returns:
+            `ToolChunk`: JSON-encoded Discord user targets.
+        """
+        members = await self._channel.list_chat_members(
+            target.split(":", 1)[1],
+        )
+        items = [
+            {
+                "target": f"user:{member.get('user_id', '')}",
+                "name": member.get("name", ""),
+            }
+            for member in members
+        ]
+        return ToolChunk(
+            content=[TextBlock(text=json.dumps(items, ensure_ascii=False))],
+        )

--- a/src/agentscope/app/channel/_discord/_tools/_list_chats.py
+++ b/src/agentscope/app/channel/_discord/_tools/_list_chats.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""ListChats — discover Discord guild text-channel targets."""
+
+import json
+
+from pydantic import Field
+
+from .....message import TextBlock
+from .....tool import ParamsBase, ToolChunk
+from ._base import _DiscordToolBase
+
+
+class _ListChatsParams(ParamsBase):
+    query: str | None = Field(
+        default=None,
+        description="Optional case-insensitive substring to filter channels "
+        "by their guild and channel name.",
+    )
+
+
+class ListChats(_DiscordToolBase):
+    """List Discord guild text channels as ready-to-send targets."""
+
+    name: str = "ListChats"
+    description: str = """List Discord guild text channels visible to this \
+bot.
+
+Use this before sending to a server channel other than the current \
+conversation. The output is a JSON array of ``{target, name}``; copy the \
+``channel:<id>`` target verbatim into a Send* tool. Discord does not expose \
+an API for enumerating every existing DM channel."""
+    is_read_only: bool = True
+    input_schema: dict = _ListChatsParams.model_json_schema()
+
+    async def __call__(self, query: str | None = None) -> ToolChunk:
+        """Return visible guild channels filtered by ``query``.
+
+        Args:
+            query (`str | None`): Optional case-insensitive name filter.
+
+        Returns:
+            `ToolChunk`: JSON-encoded Discord channel targets.
+        """
+        chats = await self._channel.list_bot_chats()
+        needle = (query or "").lower()
+        items = [
+            {
+                "target": f"channel:{chat.get('chat_id', '')}",
+                "name": chat.get("name", ""),
+            }
+            for chat in chats
+            if not needle or needle in (chat.get("name", "") or "").lower()
+        ]
+        return ToolChunk(
+            content=[TextBlock(text=json.dumps(items, ensure_ascii=False))],
+        )

--- a/src/agentscope/app/channel/_discord/_tools/_send_file.py
+++ b/src/agentscope/app/channel/_discord/_tools/_send_file.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""SendFile — send a workspace file to a Discord channel or user."""
+
+from pathlib import Path
+
+from pydantic import Field
+
+from .....message import TextBlock, ToolResultState
+from .....tool import ParamsBase, ToolChunk
+from ._base import _ack, _DiscordToolBase
+
+
+class _SendFileParams(ParamsBase):
+    path: str = Field(
+        description="Absolute path to a file in the calling workspace.",
+    )
+    target: str = Field(
+        pattern=r"^(channel|user):\d+$",
+        description="Target returned by ListChats or ListChatMembers.",
+    )
+
+
+class SendFile(_DiscordToolBase):
+    """Send one workspace file to a Discord channel or user."""
+
+    name: str = "SendFile"
+    description: str = """Send a workspace file to a Discord guild channel \
+or user DM other than the current conversation.
+
+Obtain ``target`` from a discovery tool. The file is read from the current \
+session workspace, not the host filesystem. Images use this same file-send \
+path. This cross-target send requires user confirmation."""
+    is_read_only: bool = False
+    input_schema: dict = _SendFileParams.model_json_schema()
+
+    async def __call__(self, path: str, target: str) -> ToolChunk:
+        """Read one workspace file and send it to a Discord target.
+
+        Args:
+            path (`str`): Workspace file path.
+            target (`str`): Encoded Discord channel or user target.
+
+        Returns:
+            `ToolChunk`: Discord acceptance or workspace error.
+        """
+        try:
+            raw = await self._backend.read_file(path)
+        except Exception as error:  # pylint: disable=broad-except
+            return ToolChunk(
+                content=[
+                    TextBlock(
+                        text=f"SendFile: cannot read {path!r}: {error}",
+                    ),
+                ],
+                state=ToolResultState.ERROR,
+            )
+        file_name = Path(path).name
+        accepted = await self._channel.send_file_to(
+            target,
+            raw,
+            file_name,
+        )
+        return _ack(accepted, f"file {file_name} to {target}")

--- a/src/agentscope/app/channel/_discord/_tools/_send_message.py
+++ b/src/agentscope/app/channel/_discord/_tools/_send_message.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""SendMessage — send text to a Discord channel or user."""
+
+from pydantic import Field
+
+from .....tool import ParamsBase, ToolChunk
+from ._base import _ack, _DiscordToolBase
+
+
+class _SendMessageParams(ParamsBase):
+    target: str = Field(
+        pattern=r"^(channel|user):\d+$",
+        description="Target returned by ListChats or ListChatMembers.",
+    )
+    text: str = Field(min_length=1, description="Message text to send.")
+
+
+class SendMessage(_DiscordToolBase):
+    """Send text to a conversation other than the current one."""
+
+    name: str = "SendMessage"
+    description: str = """Send text to a Discord guild channel or user DM \
+other than the current conversation.
+
+Obtain ``target`` from ``ListChats`` or ``ListChatMembers`` and copy it \
+verbatim. Replies to the current conversation are delivered automatically. \
+This cross-target send requires user confirmation."""
+    is_read_only: bool = False
+    input_schema: dict = _SendMessageParams.model_json_schema()
+
+    async def __call__(self, target: str, text: str) -> ToolChunk:
+        """Send text to an encoded Discord target.
+
+        Args:
+            target (`str`): Encoded Discord channel or user target.
+            text (`str`): Message text.
+
+        Returns:
+            `ToolChunk`: Discord acceptance result.
+        """
+        accepted = await self._channel.send_message_to(target, text)
+        return _ack(accepted, f"message to {target}")

--- a/tests/channel_discord_test.py
+++ b/tests/channel_discord_test.py
@@ -1,0 +1,484 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for Discord agent-callable tools."""
+
+# pylint: disable=protected-access
+
+import json
+import sys
+from types import SimpleNamespace
+from typing import Any, AsyncIterator, cast
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+from agentscope.app.channel import DiscordChannel
+from agentscope.message import ToolResultState
+from agentscope.permission import PermissionBehavior, PermissionContext
+from agentscope.workspace import WorkspaceBase
+
+
+class _FakeBackend:
+    """Workspace backend that records reads and returns fixed files."""
+
+    def __init__(self, files: dict[str, bytes] | None = None) -> None:
+        self.files = files or {}
+        self.reads: list[str] = []
+
+    async def read_file(self, path: str) -> bytes:
+        """Return one configured file or raise ``FileNotFoundError``."""
+        self.reads.append(path)
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        return self.files[path]
+
+
+class _FakeWorkspace:
+    """Workspace wrapper exposing the fake backend."""
+
+    def __init__(self, backend: _FakeBackend | None = None) -> None:
+        self.backend = backend or _FakeBackend()
+
+    def get_backend(self) -> _FakeBackend:
+        """Return the fake backend."""
+        return self.backend
+
+
+class _FakeMember:
+    """Discord guild member with channel visibility metadata."""
+
+    def __init__(self, user_id: int, name: str, visible: bool = True) -> None:
+        self.id = user_id
+        self.display_name = name
+        self.visible = visible
+
+
+class _FakeGuild:
+    """Discord guild exposing REST channel and member iterators."""
+
+    def __init__(
+        self,
+        name: str,
+        channels: list["_FakeTextChannel"] | None = None,
+        members: list[_FakeMember] | None = None,
+    ) -> None:
+        self.name = name
+        self.channels = channels or []
+        self.members = members or []
+
+    async def fetch_channels(self) -> list["_FakeTextChannel"]:
+        """Return configured guild channels."""
+        return self.channels
+
+    async def fetch_members(
+        self,
+        limit: int | None = 1000,
+    ) -> AsyncIterator[_FakeMember]:
+        """Yield configured members up to ``limit``."""
+        count = 0
+        for member in self.members:
+            if limit is not None and count >= limit:
+                break
+            count += 1
+            yield member
+
+
+class _FakeTextChannel:
+    """Discord guild text channel that records sends."""
+
+    def __init__(
+        self,
+        channel_id: int,
+        name: str,
+        guild: _FakeGuild,
+    ) -> None:
+        self.id = channel_id
+        self.name = name
+        self.guild = guild
+        self.sent: list[dict[str, Any]] = []
+
+    def permissions_for(self, member: _FakeMember) -> SimpleNamespace:
+        """Return whether ``member`` can see this channel."""
+        return SimpleNamespace(view_channel=member.visible)
+
+    async def send(
+        self,
+        content: str | None = None,
+        *,
+        file: object | None = None,
+    ) -> None:
+        """Record one outbound Discord send."""
+        self.sent.append({"content": content, "file": file})
+
+
+class _FakeDMChannel:
+    """Discord DM channel that records sends."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+
+    async def send(
+        self,
+        content: str | None = None,
+        *,
+        file: object | None = None,
+    ) -> None:
+        """Record one outbound Discord send."""
+        self.sent.append({"content": content, "file": file})
+
+
+class _FakeUser:
+    """Discord user that can open one DM channel."""
+
+    def __init__(self, user_id: int, name: str) -> None:
+        self.id = user_id
+        self.display_name = name
+        self.dm = _FakeDMChannel()
+
+    async def create_dm(self) -> _FakeDMChannel:
+        """Return the user's DM channel."""
+        return self.dm
+
+
+class _FakeClient:
+    """REST-only Discord client for channel behavior tests."""
+
+    def __init__(
+        self,
+        guilds: list[_FakeGuild] | None = None,
+        channels: dict[int, _FakeTextChannel] | None = None,
+        users: dict[int, _FakeUser] | None = None,
+    ) -> None:
+        self.guilds = guilds or []
+        self.channels = channels or {}
+        self.cached_channels: dict[int, _FakeTextChannel] = {}
+        self.users = users or {}
+        self.user = SimpleNamespace(id=999)
+
+    async def fetch_guilds(self) -> AsyncIterator[_FakeGuild]:
+        """Yield configured guilds."""
+        for guild in self.guilds:
+            yield guild
+
+    def get_channel(self, channel_id: int) -> _FakeTextChannel | None:
+        """Keep cache empty so production uses the REST path."""
+        return self.cached_channels.get(channel_id)
+
+    async def fetch_channel(self, channel_id: int) -> _FakeTextChannel:
+        """Return one configured text channel."""
+        return self.channels[channel_id]
+
+    async def fetch_user(self, user_id: int) -> _FakeUser:
+        """Return one configured user."""
+        return self.users[user_id]
+
+
+class _FakeFile:
+    """Capture the bytes passed to ``discord.File``."""
+
+    def __init__(self, stream: Any, filename: str) -> None:
+        self.data = stream.read()
+        self.filename = filename
+
+
+class _FakeIntents:
+    """Discord intents used by the lazy REST client test."""
+
+    def __init__(self) -> None:
+        self.message_content = False
+        self.members = False
+
+    @classmethod
+    def default(cls) -> "_FakeIntents":
+        """Return default intents with privileged members disabled."""
+        return cls()
+
+
+class _FakeLoginClient:
+    """Discord client that records login and close operations."""
+
+    def __init__(self, intents: _FakeIntents) -> None:
+        self.intents = intents
+        self.logins: list[str] = []
+        self.closed = False
+
+    async def login(self, token: str) -> None:
+        """Record one REST login."""
+        self.logins.append(token)
+
+    async def close(self) -> None:
+        """Record client close."""
+        self.closed = True
+
+
+def _discord_module() -> SimpleNamespace:
+    """Build the runtime types used by Discord channel methods."""
+    return SimpleNamespace(
+        TextChannel=_FakeTextChannel,
+        DMChannel=_FakeDMChannel,
+        File=_FakeFile,
+    )
+
+
+async def _tools_by_name(
+    channel: DiscordChannel,
+    workspace: _FakeWorkspace,
+) -> dict[str, Any]:
+    """Resolve Discord tools by name."""
+    tools = await channel.list_tools(cast(WorkspaceBase, workspace))
+    return {tool.name: tool for tool in tools}
+
+
+def _channel() -> DiscordChannel:
+    """Create a Discord channel without connecting to Discord."""
+    return DiscordChannel(
+        "discord-1",
+        DiscordChannel.Credentials(
+            bot_token="token",
+            application_id="app-1",
+        ),
+        DiscordChannel.Config(),
+    )
+
+
+class DiscordToolExposureTest(IsolatedAsyncioTestCase):
+    """Discord exposes the issue #2248 tool surface."""
+
+    async def test_list_tools_exposes_discovery_and_send_tools(self) -> None:
+        """The channel must expose one focused four-tool chain."""
+        tools = await _channel().list_tools(_FakeWorkspace())
+
+        self.assertListEqual(
+            [tool.name for tool in tools],
+            ["ListChats", "ListChatMembers", "SendMessage", "SendFile"],
+        )
+
+    async def test_permissions_allow_reads_and_ask_before_sends(self) -> None:
+        """Read tools are allowed while cross-target sends require ASK."""
+        tools = await _tools_by_name(_channel(), _FakeWorkspace())
+
+        decisions = [
+            await tools[name].check_permissions({}, PermissionContext())
+            for name in [
+                "ListChats",
+                "ListChatMembers",
+                "SendMessage",
+                "SendFile",
+            ]
+        ]
+
+        self.assertListEqual(
+            [decision.behavior for decision in decisions],
+            [
+                PermissionBehavior.ALLOW,
+                PermissionBehavior.ALLOW,
+                PermissionBehavior.ASK,
+                PermissionBehavior.ASK,
+            ],
+        )
+
+    async def test_list_tools_accepts_the_service_sender_argument(
+        self,
+    ) -> None:
+        """The service passes a sender for private chats and None otherwise."""
+        for channel_user_id in (None, "user-7"):
+            with self.subTest(channel_user_id=channel_user_id):
+                tools = await _channel().list_tools(
+                    _FakeWorkspace(),
+                    channel_user_id,
+                )
+                self.assertListEqual(
+                    [tool.name for tool in tools],
+                    [
+                        "ListChats",
+                        "ListChatMembers",
+                        "SendMessage",
+                        "SendFile",
+                    ],
+                )
+                decisions = [
+                    await tool.check_permissions({}, PermissionContext())
+                    for tool in tools
+                ]
+                self.assertListEqual(
+                    [decision.behavior for decision in decisions],
+                    [
+                        PermissionBehavior.ALLOW,
+                        PermissionBehavior.ALLOW,
+                        PermissionBehavior.ASK,
+                        PermissionBehavior.ASK,
+                    ],
+                )
+
+    async def test_discovery_tools_return_ready_to_send_targets(self) -> None:
+        """Discovery output carries explicit channel and user targets."""
+        channel = _channel()
+        channel.list_bot_chats = AsyncMock(
+            return_value=[
+                {"chat_id": "10", "name": "Guild#general"},
+                {"chat_id": "20", "name": "Guild#finance"},
+            ],
+        )
+        channel.list_chat_members = AsyncMock(
+            return_value=[
+                {"user_id": "7", "name": "Alice"},
+                {"user_id": "8", "name": "Bob"},
+            ],
+        )
+        tools = await _tools_by_name(channel, _FakeWorkspace())
+
+        chats = await tools["ListChats"]("fin")
+        members = await tools["ListChatMembers"]("channel:20")
+
+        self.assertListEqual(
+            json.loads(chats.content[0].text),
+            [{"target": "channel:20", "name": "Guild#finance"}],
+        )
+        self.assertListEqual(
+            json.loads(members.content[0].text),
+            [
+                {"target": "user:7", "name": "Alice"},
+                {"target": "user:8", "name": "Bob"},
+            ],
+        )
+
+    async def test_send_message_tool_forwards_explicit_target(self) -> None:
+        """SendMessage preserves the discovered target and text."""
+        channel = _channel()
+        channel.send_message_to = AsyncMock(return_value=True)
+        tools = await _tools_by_name(channel, _FakeWorkspace())
+
+        result = await tools["SendMessage"]("user:7", "hello")
+
+        self.assertIn("Sent message", result.content[0].text)
+        channel.send_message_to.assert_awaited_once_with("user:7", "hello")
+
+
+class DiscordChannelToolBehaviorTest(IsolatedAsyncioTestCase):
+    """Discord REST helpers support tool discovery and explicit targets."""
+
+    async def test_lazy_rest_client_enables_member_queries_only_locally(
+        self,
+    ) -> None:
+        """The login-only client enables member REST without a gateway."""
+        module = SimpleNamespace(
+            Intents=_FakeIntents,
+            Client=_FakeLoginClient,
+        )
+        channel = _channel()
+
+        with patch.dict(sys.modules, {"discord": module}):
+            client = cast(_FakeLoginClient, await channel._ensure_client())
+
+        self.assertTrue(client.intents.message_content)
+        self.assertTrue(client.intents.members)
+        self.assertListEqual(client.logins, ["token"])
+
+    async def test_list_chat_members_filters_visibility_and_bot(self) -> None:
+        """Only visible humans become direct-message targets."""
+        guild = _FakeGuild(
+            "Guild",
+            members=[
+                _FakeMember(7, "Alice"),
+                _FakeMember(8, "Hidden", visible=False),
+                _FakeMember(999, "Bot"),
+            ],
+        )
+        text_channel = _FakeTextChannel(20, "finance", guild)
+        client = _FakeClient(channels={20: text_channel})
+        channel = _channel()
+
+        with (
+            patch.dict(sys.modules, {"discord": _discord_module()}),
+            patch.object(
+                channel,
+                "_ensure_client",
+                AsyncMock(return_value=client),
+            ),
+        ):
+            members = await channel.list_chat_members("20")
+
+        self.assertListEqual(
+            members,
+            [{"user_id": "7", "name": "Alice"}],
+        )
+
+    async def test_send_message_supports_channel_and_user_targets(
+        self,
+    ) -> None:
+        """Messages route to channels or DMs and split at Discord's limit."""
+        guild = _FakeGuild("Guild")
+        text_channel = _FakeTextChannel(20, "finance", guild)
+        user = _FakeUser(7, "Alice")
+        client = _FakeClient(channels={20: text_channel}, users={7: user})
+        channel = _channel()
+
+        with (
+            patch.dict(sys.modules, {"discord": _discord_module()}),
+            patch.object(
+                channel,
+                "_ensure_client",
+                AsyncMock(return_value=client),
+            ),
+        ):
+            channel_ok = await channel.send_message_to(
+                "channel:20",
+                "x" * 2001,
+            )
+            user_ok = await channel.send_message_to("user:7", "hello")
+            invalid = await channel.send_message_to("unknown:7", "ignored")
+
+        self.assertTrue(channel_ok)
+        self.assertTrue(user_ok)
+        self.assertFalse(invalid)
+        self.assertListEqual(
+            [item["content"] for item in text_channel.sent],
+            ["x" * 2000, "x"],
+        )
+        self.assertListEqual(
+            user.dm.sent,
+            [{"content": "hello", "file": None}],
+        )
+
+    async def test_send_file_uses_workspace_bytes_and_filename(self) -> None:
+        """SendFile reads the session backend and sends one Discord file."""
+        guild = _FakeGuild("Guild")
+        text_channel = _FakeTextChannel(20, "finance", guild)
+        client = _FakeClient(channels={20: text_channel})
+        channel = _channel()
+        backend = _FakeBackend({"/workspace/report.pdf": b"pdf"})
+        tools = await _tools_by_name(channel, _FakeWorkspace(backend))
+
+        with (
+            patch.dict(sys.modules, {"discord": _discord_module()}),
+            patch.object(
+                channel,
+                "_ensure_client",
+                AsyncMock(return_value=client),
+            ),
+        ):
+            result = await tools["SendFile"](
+                "/workspace/report.pdf",
+                "channel:20",
+            )
+
+        sent_file = cast(_FakeFile, text_channel.sent[0]["file"])
+        self.assertIn("Sent file", result.content[0].text)
+        self.assertListEqual(backend.reads, ["/workspace/report.pdf"])
+        self.assertEqual(sent_file.filename, "report.pdf")
+        self.assertEqual(sent_file.data, b"pdf")
+
+    async def test_send_file_reports_workspace_read_failure(self) -> None:
+        """A missing workspace file returns an error without a platform
+        call."""
+        channel = _channel()
+        tools = await _tools_by_name(channel, _FakeWorkspace())
+        channel.send_file_to = AsyncMock(return_value=True)
+
+        result = await tools["SendFile"](
+            "/workspace/missing.pdf",
+            "channel:20",
+        )
+
+        self.assertEqual(result.state, ToolResultState.ERROR)
+        self.assertIn("cannot read", result.content[0].text)
+        channel.send_file_to.assert_not_awaited()


### PR DESCRIPTION
## AgentScope Version

2.0.7.post1

## Description

Closes #2248.

This PR exposes Discord discovery and cross-target send tools through `DiscordChannel.list_tools`, following the existing Feishu and DingTalk tool architecture.

### What changed

- Add `ListChats`, `ListChatMembers`, `SendMessage`, and `SendFile` under a focused Discord `_tools` package.
- Represent send destinations explicitly as `channel:<id>` or `user:<id>` so discovery output can be copied directly into send tools.
- Reuse the existing REST-paginated guild/channel discovery path; Discord does not expose an API that enumerates every existing DM channel.
- Resolve channel sends through `fetch_channel` and user sends through `fetch_user` plus `create_dm`, so client-only channel instances do not depend on a Gateway cache.
- List only members who can view the selected guild text channel, excluding the bot itself.
- Read file payloads from the calling session's workspace backend and pass images through the same general Discord file-send path.
- Preserve the existing permission boundary: discovery tools are read-only and allowed, while cross-target sends require confirmation.

### Member-intent compatibility

Discord's REST member enumeration requires the privileged members intent. The login-only client used by `ChannelClients` enables that intent for member lookups, but it never opens a Gateway connection. The existing listening client keeps its previous default intents, so bots that have not enabled the privileged intent are not prevented from starting. If Discord rejects a member lookup, the platform exception is surfaced as a tool error rather than an empty result.

### Out of scope

- No new dependency or Discord configuration field.
- No change to inbound Gateway listening, message routing, approval cards, or automatic replies.
- No separate `SendImage` tool; Discord images are supported through `SendFile` as requested by the issue's general media boundary.
- No live Discord token or privileged-intent credential was used in local tests.

### Verification

- Pre-change regression run: 8 tests failed because `list_tools` returned no tools, the Discord member/send helpers were absent, and the lazy REST client did not enable member queries.
- Focused Discord and related Channel regression: `106 passed, 3 subtests passed`.
- Full test suite on current `main`: `2059 passed, 125 skipped, 378 subtests passed`.
- `pre-commit run --all-files`: all hooks passed, including mypy, Black, flake8, pylint, and Pyroma.
- `git diff --check`: passed.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation is covered by the agent-tool descriptions; there is no new public configuration or dependency requiring a documentation-repository change
- [x] Code is ready for review
