### PR TITLE
feat(mcp): support runtime MCP headers in Docker workspaces

### DIFF
--- a/src/agentscope/mcp/_mcp_client.py
+++ b/src/agentscope/mcp/_mcp_client.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
 """Unified MCP client implementation for AgentScope."""
 import re
-from contextlib import AsyncExitStack, _AsyncGeneratorContextManager
-from typing import Any, TYPE_CHECKING
+from contextlib import (
+    AbstractAsyncContextManager,
+    asynccontextmanager,
+    AsyncExitStack,
+)
+from typing import Any, AsyncGenerator, ClassVar, TYPE_CHECKING
 from urllib.parse import urlsplit
 
 import httpx
@@ -10,6 +14,7 @@ import mcp.types
 from mcp import ClientSession, stdio_client, StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamable_http_client
+from mcp.shared._httpx_utils import create_mcp_http_client
 from pydantic import Field, BaseModel, PrivateAttr
 
 from ._config import StdioMCPConfig, HttpMCPConfig
@@ -67,6 +72,23 @@ class MCPClient(BaseModel):
 
     """
 
+    _RUNTIME_HEADER_DENYLIST: ClassVar[frozenset[str]] = frozenset(
+        {
+            "accept",
+            "connection",
+            "content-length",
+            "content-type",
+            "host",
+            "last-event-id",
+            "mcp-protocol-version",
+            "mcp-session-id",
+            "transfer-encoding",
+        },
+    )
+    _RUNTIME_HEADER_NAME_PATTERN: ClassVar[re.Pattern[str]] = re.compile(
+        r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+",
+    )
+
     name: str = Field(
         title="MCP Name",
         description="The MCP name.",
@@ -105,6 +127,10 @@ class MCPClient(BaseModel):
     _stack: AsyncExitStack | None = PrivateAttr(default=None)
     _is_connected: bool = PrivateAttr(default=False)
     _cached_tools: list[mcp.types.Tool] | None = PrivateAttr(default=None)
+    _runtime_headers: dict[str, str] = PrivateAttr(default_factory=dict)
+    _runtime_header_names: frozenset[str] = PrivateAttr(
+        default_factory=frozenset,
+    )
 
     @property
     def is_connected(self) -> bool:
@@ -181,7 +207,7 @@ class MCPClient(BaseModel):
 
     def _create_http_client(
         self,
-    ) -> _AsyncGeneratorContextManager[Any]:
+    ) -> AbstractAsyncContextManager[Any]:
         """Create an HTTP MCP client (SSE or streamable HTTP)."""
         config = self.mcp_config
 
@@ -199,17 +225,137 @@ class MCPClient(BaseModel):
                 timeout=config.timeout,
             )
 
-        # StreamableHTTP transport
-        http_client = None
-        if config.headers or config.timeout:
+        return self._create_streamable_http_client()
+
+    @asynccontextmanager
+    async def _create_streamable_http_client(
+        self,
+    ) -> AsyncGenerator[Any, None]:
+        """Create an owned HTTP client with live header injection."""
+        config = self.mcp_config
+        if config.headers is None and config.timeout is None:
+            http_client = create_mcp_http_client()
+        else:
             http_client = httpx.AsyncClient(
                 headers=config.headers,
                 timeout=config.timeout,
             )
-        return streamable_http_client(
-            url=config.url,
-            http_client=http_client,
+        http_client.event_hooks["request"].append(
+            self._inject_runtime_headers,
         )
+
+        async with http_client:
+            async with streamable_http_client(
+                url=config.url,
+                http_client=http_client,
+            ) as transport:
+                yield transport
+
+    async def _inject_runtime_headers(
+        self,
+        request: httpx.Request,
+    ) -> None:
+        """Apply a runtime-header snapshot to a same-origin request."""
+        configured_url = httpx.URL(self.mcp_config.url)
+        same_origin = (
+            request.url.scheme,
+            request.url.host,
+            request.url.port,
+        ) == (
+            configured_url.scheme,
+            configured_url.host,
+            configured_url.port,
+        )
+
+        # Redirect requests inherit ordinary custom headers. Remove every
+        # name ever owned by the runtime layer before deciding whether the
+        # current request may receive a fresh snapshot.
+        runtime_header_names = self._runtime_header_names
+        for name in runtime_header_names:
+            request.headers.pop(name, None)
+        if not same_origin:
+            return
+
+        # Restore configured values that may have been shadowed by a prior
+        # runtime snapshot, then apply the current complete replacement map.
+        for name, value in (self.mcp_config.headers or {}).items():
+            if name.lower() in runtime_header_names:
+                request.headers[name] = value
+        request.headers.update(dict(self._runtime_headers))
+
+    async def set_runtime_headers(
+        self,
+        headers: dict[str, str],
+    ) -> None:
+        """Replace headers applied to subsequent Streamable HTTP requests.
+
+        This method replaces the complete runtime header map instead of
+        merging it. An empty map removes all runtime overrides, so static
+        headers from :attr:`mcp_config` apply again. It can be called before
+        connecting a local stateful client, or at any time for a stateless
+        client.
+
+        The update applies to subsequent outbound requests to the configured
+        MCP origin. Runtime headers are not forwarded across cross-origin
+        redirects. A request already in progress may have read the previous
+        header snapshot. SSE transport is not supported because its headers
+        are fixed when the stream is established.
+
+        Runtime headers are live instance state. They are intentionally
+        excluded from ``model_dump`` and workspace persistence.
+
+        Args:
+            headers (`dict[str, str]`):
+                The complete runtime header map. An empty dict clears it.
+
+        Raises:
+            `ValueError`:
+                The client is not Streamable HTTP, a header is invalid, or
+                a header is owned by the HTTP/MCP transport.
+        """
+        if self.mcp_config.type != "http_mcp":
+            raise ValueError(
+                "Runtime headers require an HTTP MCP client.",
+            )
+        path = urlsplit(self.mcp_config.url).path
+        if path.endswith("/sse") or path.endswith("/messages/"):
+            raise ValueError(
+                "Runtime headers currently support only Streamable HTTP.",
+            )
+        if not isinstance(headers, dict):
+            raise ValueError("Runtime headers must be a dict of strings.")
+
+        validated: dict[str, str] = {}
+        for name, value in headers.items():
+            if not isinstance(name, str) or not isinstance(value, str):
+                raise ValueError(
+                    "Runtime headers must be a dict of strings.",
+                )
+            if name.lower() in self._RUNTIME_HEADER_DENYLIST:
+                raise ValueError(
+                    f"Runtime header {name!r} is owned by the transport.",
+                )
+            invalid_value = any(
+                (ord(char) < 32 and char != "\t") or ord(char) == 127
+                for char in value
+            )
+            try:
+                value.encode("ascii")
+            except UnicodeEncodeError:
+                invalid_value = True
+            if (
+                self._RUNTIME_HEADER_NAME_PATTERN.fullmatch(name) is None
+                or invalid_value
+            ):
+                raise ValueError(
+                    f"Runtime header {name!r} is invalid.",
+                )
+            validated[name] = value
+
+        self._runtime_header_names = self._runtime_header_names.union(
+            name.lower() for name in validated
+        )
+        self._runtime_headers = validated
 
     async def connect(self) -> None:
         """Connect to the MCP server (for stateful connections only).
@@ -299,7 +445,7 @@ class MCPClient(BaseModel):
             self._is_connected = False
             logger.info("MCP closed: %s", self.name)
 
-    def _get_client_gen(self) -> _AsyncGeneratorContextManager[Any]:
+    def _get_client_gen(self) -> AbstractAsyncContextManager[Any]:
         """Get client generator for stateless connections."""
         if self.mcp_config.type == "stdio_mcp":
             return self._client

--- a/src/agentscope/mcp/_mcp_client.py
+++ b/src/agentscope/mcp/_mcp_client.py
@@ -42,6 +42,11 @@ class MCPClient(BaseModel):
     - _stack: AsyncExitStack for managing connection lifecycle
     - _is_connected: Connection state flag
     - _cached_tools: Cached list of tools
+    - _http_client: The live HTTP client, while a Streamable HTTP
+      transport is open
+    - _static_headers: The HTTP client's headers before any runtime override
+    - _runtime_headers: Headers overriding the configured ones, see
+      :meth:`set_runtime_headers`
 
     Example:
 
@@ -72,20 +77,7 @@ class MCPClient(BaseModel):
 
     """
 
-    _RUNTIME_HEADER_DENYLIST: ClassVar[frozenset[str]] = frozenset(
-        {
-            "accept",
-            "connection",
-            "content-length",
-            "content-type",
-            "host",
-            "last-event-id",
-            "mcp-protocol-version",
-            "mcp-session-id",
-            "transfer-encoding",
-        },
-    )
-    _RUNTIME_HEADER_NAME_PATTERN: ClassVar[re.Pattern[str]] = re.compile(
+    _HEADER_NAME_PATTERN: ClassVar[re.Pattern[str]] = re.compile(
         r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+",
     )
 
@@ -127,10 +119,9 @@ class MCPClient(BaseModel):
     _stack: AsyncExitStack | None = PrivateAttr(default=None)
     _is_connected: bool = PrivateAttr(default=False)
     _cached_tools: list[mcp.types.Tool] | None = PrivateAttr(default=None)
+    _http_client: httpx.AsyncClient | None = PrivateAttr(default=None)
+    _static_headers: httpx.Headers | None = PrivateAttr(default=None)
     _runtime_headers: dict[str, str] = PrivateAttr(default_factory=dict)
-    _runtime_header_names: frozenset[str] = PrivateAttr(
-        default_factory=frozenset,
-    )
 
     @property
     def is_connected(self) -> bool:
@@ -210,15 +201,7 @@ class MCPClient(BaseModel):
     ) -> AbstractAsyncContextManager[Any]:
         """Create an HTTP MCP client (SSE or streamable HTTP)."""
         config = self.mcp_config
-
-        # Determine transport from the URL *path* only. Inspecting the full
-        # URL with endswith would misdetect SSE endpoints whose URL carries
-        # a query string (e.g. https://mcp.amap.com/sse?key=API_KEY): such
-        # URLs no longer end with '/sse' and would fall through to the
-        # streamable HTTP transport, which then fails to handshake against
-        # an SSE server with 'Session terminated'.
-        path = urlsplit(config.url).path
-        if path.endswith("/sse") or path.endswith("/messages/"):
+        if self._is_sse:
             return sse_client(
                 url=config.url,
                 headers=config.headers,
@@ -227,82 +210,61 @@ class MCPClient(BaseModel):
 
         return self._create_streamable_http_client()
 
+    @property
+    def _is_sse(self) -> bool:
+        """Whether the configured URL points at the SSE transport.
+
+        Only the URL *path* is inspected: an SSE endpoint carrying a query
+        string (e.g. ``https://mcp.amap.com/sse?key=API_KEY``) does not end
+        with ``/sse``, and would otherwise fall through to streamable HTTP
+        and fail the handshake with 'Session terminated'.
+        """
+        path = urlsplit(self.mcp_config.url).path
+        return path.endswith("/sse") or path.endswith("/messages/")
+
     @asynccontextmanager
     async def _create_streamable_http_client(
         self,
     ) -> AsyncGenerator[Any, None]:
-        """Create an owned HTTP client with live header injection."""
+        """Create an owned HTTP client that runtime headers can update."""
         config = self.mcp_config
-        if config.headers is None and config.timeout is None:
-            http_client = create_mcp_http_client()
-        else:
-            http_client = httpx.AsyncClient(
-                headers=config.headers,
-                timeout=config.timeout,
-            )
-        http_client.event_hooks["request"].append(
-            self._inject_runtime_headers,
+        client = create_mcp_http_client(
+            headers=config.headers,
+            timeout=config.timeout,
         )
+        # Snapshot before overlaying: clearing runtime headers restores it.
+        self._static_headers = httpx.Headers(client.headers)
+        client.headers.update(self._runtime_headers)
+        self._http_client = client
 
-        async with http_client:
-            async with streamable_http_client(
-                url=config.url,
-                http_client=http_client,
-            ) as transport:
-                yield transport
-
-    async def _inject_runtime_headers(
-        self,
-        request: httpx.Request,
-    ) -> None:
-        """Apply a runtime-header snapshot to a same-origin request."""
-        configured_url = httpx.URL(self.mcp_config.url)
-        same_origin = (
-            request.url.scheme,
-            request.url.host,
-            request.url.port,
-        ) == (
-            configured_url.scheme,
-            configured_url.host,
-            configured_url.port,
-        )
-
-        # Redirect requests inherit ordinary custom headers. Remove every
-        # name ever owned by the runtime layer before deciding whether the
-        # current request may receive a fresh snapshot.
-        runtime_header_names = self._runtime_header_names
-        for name in runtime_header_names:
-            request.headers.pop(name, None)
-        if not same_origin:
-            return
-
-        # Restore configured values that may have been shadowed by a prior
-        # runtime snapshot, then apply the current complete replacement map.
-        for name, value in (self.mcp_config.headers or {}).items():
-            if name.lower() in runtime_header_names:
-                request.headers[name] = value
-        request.headers.update(dict(self._runtime_headers))
+        try:
+            async with client:
+                async with streamable_http_client(
+                    url=config.url,
+                    http_client=client,
+                ) as transport:
+                    yield transport
+        finally:
+            if self._http_client is client:
+                self._http_client = None
 
     async def set_runtime_headers(
         self,
         headers: dict[str, str],
     ) -> None:
-        """Replace headers applied to subsequent Streamable HTTP requests.
+        """Replace the headers sent with subsequent HTTP requests.
 
-        This method replaces the complete runtime header map instead of
-        merging it. An empty map removes all runtime overrides, so static
-        headers from :attr:`mcp_config` apply again. It can be called before
-        connecting a local stateful client, or at any time for a stateless
-        client.
+        The map is replaced rather than merged: an empty map drops all
+        runtime overrides, so the static headers from :attr:`mcp_config`
+        apply again. Runtime headers are live instance state, excluded
+        from ``model_dump`` and workspace persistence.
 
-        The update applies to subsequent outbound requests to the configured
-        MCP origin. Runtime headers are not forwarded across cross-origin
-        redirects. A request already in progress may have read the previous
-        header snapshot. SSE transport is not supported because its headers
-        are fixed when the stream is established.
-
-        Runtime headers are live instance state. They are intentionally
-        excluded from ``model_dump`` and workspace persistence.
+        The update reaches the next outbound request without reconnecting.
+        Two things it cannot reach: a request already in flight, and the
+        long-lived GET stream of a Streamable HTTP session, whose headers
+        are fixed when the stream is established. Headers owned by the
+        transport (``mcp-session-id``, ``content-type``, ...) are set per
+        request and always win over the ones set here.
 
         Args:
             headers (`dict[str, str]`):
@@ -310,52 +272,36 @@ class MCPClient(BaseModel):
 
         Raises:
             `ValueError`:
-                The client is not Streamable HTTP, a header is invalid, or
-                a header is owned by the HTTP/MCP transport.
+                The client is not Streamable HTTP, or a header name or
+                value is not valid on the wire.
         """
-        if self.mcp_config.type != "http_mcp":
+        if self.mcp_config.type != "http_mcp" or self._is_sse:
             raise ValueError(
-                "Runtime headers require an HTTP MCP client.",
-            )
-        path = urlsplit(self.mcp_config.url).path
-        if path.endswith("/sse") or path.endswith("/messages/"):
-            raise ValueError(
-                "Runtime headers currently support only Streamable HTTP.",
+                "Runtime headers require a Streamable HTTP MCP client.",
             )
         if not isinstance(headers, dict):
             raise ValueError("Runtime headers must be a dict of strings.")
 
-        validated: dict[str, str] = {}
+        # httpx accepts illegal names and CRLF in values, and only h11
+        # rejects them mid-request, so validate before storing.
         for name, value in headers.items():
             if not isinstance(name, str) or not isinstance(value, str):
-                raise ValueError(
-                    "Runtime headers must be a dict of strings.",
-                )
-            if name.lower() in self._RUNTIME_HEADER_DENYLIST:
-                raise ValueError(
-                    f"Runtime header {name!r} is owned by the transport.",
-                )
-            invalid_value = any(
-                (ord(char) < 32 and char != "\t") or ord(char) == 127
-                for char in value
-            )
-            try:
-                value.encode("ascii")
-            except UnicodeEncodeError:
-                invalid_value = True
+                raise ValueError("Runtime headers must be a dict of strings.")
             if (
-                self._RUNTIME_HEADER_NAME_PATTERN.fullmatch(name) is None
-                or invalid_value
-            ):
-                raise ValueError(
-                    f"Runtime header {name!r} is invalid.",
+                not self._HEADER_NAME_PATTERN.fullmatch(name)
+                or not value.isascii()
+                or any(
+                    (ord(char) < 32 and char != "\t") or ord(char) == 127
+                    for char in value
                 )
-            validated[name] = value
+            ):
+                raise ValueError(f"Runtime header {name!r} is invalid.")
 
-        self._runtime_header_names = self._runtime_header_names.union(
-            name.lower() for name in validated
-        )
-        self._runtime_headers = validated
+        self._runtime_headers = dict(headers)
+        if self._http_client is not None:
+            merged = httpx.Headers(self._static_headers)
+            merged.update(self._runtime_headers)
+            self._http_client.headers = merged
 
     async def connect(self) -> None:
         """Connect to the MCP server (for stateful connections only).

--- a/src/agentscope/mcp/_mcp_client.py
+++ b/src/agentscope/mcp/_mcp_client.py
@@ -42,11 +42,9 @@ class MCPClient(BaseModel):
     - _stack: AsyncExitStack for managing connection lifecycle
     - _is_connected: Connection state flag
     - _cached_tools: Cached list of tools
-    - _http_client: The live HTTP client, while a Streamable HTTP
-      transport is open
-    - _static_headers: The HTTP client's headers before any runtime override
-    - _runtime_headers: Headers overriding the configured ones, see
-      :meth:`set_runtime_headers`
+    - _http_client: The live HTTP client, while one is open
+    - _static_headers: Its headers before any runtime override
+    - _runtime_headers: See :meth:`set_runtime_headers`
 
     Example:
 
@@ -77,9 +75,11 @@ class MCPClient(BaseModel):
 
     """
 
-    _HEADER_NAME_PATTERN: ClassVar[re.Pattern[str]] = re.compile(
+    # RFC 7230 token, and a field value of visible ASCII plus tab.
+    _HEADER_NAME: ClassVar[re.Pattern[str]] = re.compile(
         r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+",
     )
+    _HEADER_VALUE: ClassVar[re.Pattern[str]] = re.compile(r"[\t\x20-\x7e]*")
 
     name: str = Field(
         title="MCP Name",
@@ -212,12 +212,9 @@ class MCPClient(BaseModel):
 
     @property
     def _is_sse(self) -> bool:
-        """Whether the configured URL points at the SSE transport.
-
-        Only the URL *path* is inspected: an SSE endpoint carrying a query
-        string (e.g. ``https://mcp.amap.com/sse?key=API_KEY``) does not end
-        with ``/sse``, and would otherwise fall through to streamable HTTP
-        and fail the handshake with 'Session terminated'.
+        """Whether the configured URL points at the SSE transport. Only
+        the path is inspected, so a query string (``/sse?key=...``) still
+        resolves to SSE rather than falling through to streamable HTTP.
         """
         path = urlsplit(self.mcp_config.url).path
         return path.endswith("/sse") or path.endswith("/messages/")
@@ -228,10 +225,13 @@ class MCPClient(BaseModel):
     ) -> AsyncGenerator[Any, None]:
         """Create an owned HTTP client that runtime headers can update."""
         config = self.mcp_config
-        client = create_mcp_http_client(
-            headers=config.headers,
-            timeout=config.timeout,
-        )
+        if config.headers or config.timeout:
+            client = httpx.AsyncClient(
+                headers=config.headers,
+                timeout=config.timeout,
+            )
+        else:
+            client = create_mcp_http_client()
         # Snapshot before overlaying: clearing runtime headers restores it.
         self._static_headers = httpx.Headers(client.headers)
         client.headers.update(self._runtime_headers)
@@ -280,20 +280,16 @@ class MCPClient(BaseModel):
                 "Runtime headers require a Streamable HTTP MCP client.",
             )
         if not isinstance(headers, dict):
-            raise ValueError("Runtime headers must be a dict of strings.")
+            raise ValueError("Runtime headers must be a dict.")
 
         # httpx accepts illegal names and CRLF in values, and only h11
         # rejects them mid-request, so validate before storing.
         for name, value in headers.items():
-            if not isinstance(name, str) or not isinstance(value, str):
-                raise ValueError("Runtime headers must be a dict of strings.")
             if (
-                not self._HEADER_NAME_PATTERN.fullmatch(name)
-                or not value.isascii()
-                or any(
-                    (ord(char) < 32 and char != "\t") or ord(char) == 127
-                    for char in value
-                )
+                not isinstance(name, str)
+                or not isinstance(value, str)
+                or not self._HEADER_NAME.fullmatch(name)
+                or not self._HEADER_VALUE.fullmatch(value)
             ):
                 raise ValueError(f"Runtime header {name!r} is invalid.")
 

--- a/src/agentscope/mcp/_mcp_client.py
+++ b/src/agentscope/mcp/_mcp_client.py
@@ -13,8 +13,10 @@ import httpx
 import mcp.types
 from mcp import ClientSession, stdio_client, StdioServerParameters
 from mcp.client.sse import sse_client
-from mcp.client.streamable_http import streamable_http_client
-from mcp.shared._httpx_utils import create_mcp_http_client
+from mcp.client.streamable_http import (
+    create_mcp_http_client,
+    streamable_http_client,
+)
 from pydantic import Field, BaseModel, PrivateAttr
 
 from ._config import StdioMCPConfig, HttpMCPConfig
@@ -75,6 +77,12 @@ class MCPClient(BaseModel):
 
     """
 
+    # httpx derives these from the request URL and body with setdefault,
+    # so a client-level value silently wins and breaks routing or framing.
+    # The headers MCP itself sends are set per request and need no guard.
+    _RESERVED_HEADERS: ClassVar[frozenset[str]] = frozenset(
+        {"connection", "content-length", "host", "transfer-encoding"},
+    )
     # RFC 7230 token, and a field value of visible ASCII plus tab.
     _HEADER_NAME: ClassVar[re.Pattern[str]] = re.compile(
         r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+",
@@ -260,11 +268,13 @@ class MCPClient(BaseModel):
         from ``model_dump`` and workspace persistence.
 
         The update reaches the next outbound request without reconnecting.
-        Two things it cannot reach: a request already in flight, and the
-        long-lived GET stream of a Streamable HTTP session, whose headers
-        are fixed when the stream is established. Headers owned by the
-        transport (``mcp-session-id``, ``content-type``, ...) are set per
-        request and always win over the ones set here.
+        Two things it cannot reach: a call already under way, which keeps
+        the snapshot it started with, and the long-lived GET stream of a
+        Streamable HTTP session, whose headers are fixed when the stream
+        is established. Headers MCP sends itself (``mcp-session-id``,
+        ``content-type``, ...) are set per request and always win over
+        the ones set here; the few httpx derives from the URL and body
+        are rejected outright.
 
         Args:
             headers (`dict[str, str]`):
@@ -272,8 +282,8 @@ class MCPClient(BaseModel):
 
         Raises:
             `ValueError`:
-                The client is not Streamable HTTP, or a header name or
-                value is not valid on the wire.
+                The client is not Streamable HTTP, or a header is
+                invalid or owned by the HTTP layer.
         """
         if self.mcp_config.type != "http_mcp" or self._is_sse:
             raise ValueError(
@@ -292,6 +302,10 @@ class MCPClient(BaseModel):
                 or not self._HEADER_VALUE.fullmatch(value)
             ):
                 raise ValueError(f"Runtime header {name!r} is invalid.")
+            if name.lower() in self._RESERVED_HEADERS:
+                raise ValueError(
+                    f"Runtime header {name!r} is owned by the HTTP layer.",
+                )
 
         self._runtime_headers = dict(headers)
         if self._http_client is not None:

--- a/src/agentscope/tool/_adapters.py
+++ b/src/agentscope/tool/_adapters.py
@@ -3,7 +3,7 @@
 import inspect
 import json
 import re
-from contextlib import _AsyncGeneratorContextManager
+from contextlib import AbstractAsyncContextManager
 from datetime import timedelta
 from typing import Callable, Any, AsyncGenerator, Generator
 
@@ -202,7 +202,7 @@ class MCPTool(ToolBase):
         self,
         mcp_name: str,
         tool: mcp.types.Tool,
-        client_gen: Callable[..., _AsyncGeneratorContextManager[Any]]
+        client_gen: Callable[..., AbstractAsyncContextManager[Any]]
         | None = None,
         session: Any | None = None,
         timeout: float | None = None,
@@ -215,7 +215,7 @@ class MCPTool(ToolBase):
                 The name of the MCP server instance.
             tool (`mcp.types.Tool`):
                 The MCP tool definition.
-            client_gen (`Callable[..., _AsyncGeneratorContextManager[Any]] \
+            client_gen (`Callable[..., AbstractAsyncContextManager[Any]] \
             | None`, optional):
                 The MCP client generator function for stateless clients.
                 Either this or ``session`` must be provided.

--- a/src/agentscope/workspace/_gateway_client.py
+++ b/src/agentscope/workspace/_gateway_client.py
@@ -182,6 +182,7 @@ class GatewayMCPClient(MCPClient):
       is never called — no stdio context manager is built).
     * ``connect`` registers the MCP on the gateway via ``POST /mcps``.
     * ``close`` deregisters via ``DELETE /mcps/{name}``.
+    * ``set_runtime_headers`` updates the registered live client.
     * ``list_raw_tools`` / ``get_tool`` fetch and wrap upstream tools.
     """
 
@@ -301,6 +302,51 @@ class GatewayMCPClient(MCPClient):
             if not ignore_errors:
                 raise
         self._is_connected = False
+
+    async def set_runtime_headers(
+        self,
+        headers: dict[str, str],
+    ) -> None:
+        """Replace headers on the registered gateway-side MCP client.
+
+        Unlike a local client, the gateway proxy must already be connected so
+        that the live client exists in the workspace. The complete runtime
+        header map is replaced, and an empty map clears all runtime overrides.
+
+        Args:
+            headers (`dict[str, str]`):
+                The complete runtime header map. An empty dict clears it.
+
+        Raises:
+            `ValueError`:
+                The gateway rejects an invalid or unsupported header update.
+            `RuntimeError`:
+                The proxy is not connected or the gateway request fails.
+        """
+        if not self._is_connected:
+            raise RuntimeError(
+                f"MCP {self.name!r} is not connected. Call connect() first.",
+            )
+        assert self._gateway is not None
+        status, body = await self._gateway.exec_request(
+            "PUT",
+            f"/mcps/{self.name}/runtime-headers",
+            params={
+                "agent_id": self._agent_id,
+                "session_id": self._session_id,
+            },
+            body={"headers": headers},
+        )
+        if status == 400:
+            raise ValueError(
+                f"gateway rejected runtime headers for "
+                f"MCP {self.name!r}: {_safe_detail(status, body)}",
+            )
+        if status >= 400:
+            raise RuntimeError(
+                f"gateway failed to update runtime headers for "
+                f"MCP {self.name!r}: {_safe_detail(status, body)}",
+            )
 
     # ── tool discovery ────────────────────────────────────────────
 

--- a/src/agentscope/workspace/_gateway_client.py
+++ b/src/agentscope/workspace/_gateway_client.py
@@ -269,6 +269,11 @@ class GatewayMCPClient(MCPClient):
             )
         self._is_connected = True
 
+        # model_dump carries no runtime headers, so a reconnect would
+        # silently fall back to the configured ones.
+        if self._runtime_headers:
+            await self.set_runtime_headers(self._runtime_headers)
+
     async def close(self, ignore_errors: bool = True) -> None:
         """Deregister this MCP via ``DELETE /mcps/{name}``.
 
@@ -309,9 +314,9 @@ class GatewayMCPClient(MCPClient):
     ) -> None:
         """Replace headers on the registered gateway-side MCP client.
 
-        Unlike a local client, the gateway proxy must already be connected so
-        that the live client exists in the workspace. The complete runtime
-        header map is replaced, and an empty map clears all runtime overrides.
+        Unlike a local client, the proxy must already be connected so that
+        the live client exists in the workspace. :meth:`connect` replays the
+        headers, so they survive a reconnect.
 
         Args:
             headers (`dict[str, str]`):
@@ -337,6 +342,12 @@ class GatewayMCPClient(MCPClient):
             },
             body={"headers": headers},
         )
+        if status == 404:
+            raise RuntimeError(
+                f"gateway has no runtime-headers route, or no live client "
+                f"for MCP {self.name!r}: the workspace image may predate "
+                f"the endpoint, or the gateway has restarted",
+            )
         if status == 400:
             raise ValueError(
                 f"gateway rejected runtime headers for "
@@ -347,6 +358,7 @@ class GatewayMCPClient(MCPClient):
                 f"gateway failed to update runtime headers for "
                 f"MCP {self.name!r}: {_safe_detail(status, body)}",
             )
+        self._runtime_headers = dict(headers)
 
     # ── tool discovery ────────────────────────────────────────────
 

--- a/src/agentscope/workspace/_gateway_client.py
+++ b/src/agentscope/workspace/_gateway_client.py
@@ -253,6 +253,10 @@ class GatewayMCPClient(MCPClient):
             )
         assert self._gateway is not None
         body = self.model_dump(mode="json")
+        if self._runtime_headers:
+            # model_dump cannot carry them, and the gateway connects to
+            # the MCP server inside this request.
+            body["runtime_headers"] = self._runtime_headers
         status, resp_body = await self._gateway.exec_request(
             "POST",
             "/mcps",
@@ -268,11 +272,6 @@ class GatewayMCPClient(MCPClient):
                 f"{_safe_detail(status, resp_body)}",
             )
         self._is_connected = True
-
-        # model_dump carries no runtime headers, so a reconnect would
-        # silently fall back to the configured ones.
-        if self._runtime_headers:
-            await self.set_runtime_headers(self._runtime_headers)
 
     async def close(self, ignore_errors: bool = True) -> None:
         """Deregister this MCP via ``DELETE /mcps/{name}``.
@@ -315,8 +314,8 @@ class GatewayMCPClient(MCPClient):
         """Replace headers on the registered gateway-side MCP client.
 
         Unlike a local client, the proxy must already be connected so that
-        the live client exists in the workspace. :meth:`connect` replays the
-        headers, so they survive a reconnect.
+        the live client exists in the workspace. :meth:`connect` sends them
+        with the registration, so they survive a reconnect.
 
         Args:
             headers (`dict[str, str]`):

--- a/src/agentscope/workspace/_mcp_gateway/_mcp_gateway_app.py
+++ b/src/agentscope/workspace/_mcp_gateway/_mcp_gateway_app.py
@@ -15,6 +15,7 @@ Endpoints::
     GET    /mcps                       # [MCPClient.model_dump(), ...]
     POST   /mcps                       # body: MCPClient.model_dump()
     DELETE /mcps/{name}
+    PUT    /mcps/{name}/runtime-headers
     GET    /mcps/{name}/tools
     POST   /mcps/{name}/tools/{tool}   # body: {arguments: {...}}
 
@@ -33,7 +34,7 @@ import asyncio
 import secrets
 from typing import Any
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import PlainTextResponse
 
 from agentscope.mcp import MCPClient
@@ -153,6 +154,29 @@ def _build_app(
             if client.is_stateful and client.is_connected:
                 await client.close()
         return {"ok": True}
+
+    @app.put("/mcps/{name}/runtime-headers", status_code=204)
+    async def _set_runtime_headers(
+        name: str,
+        request: Request,
+        agent_id: str = "",
+        session_id: str = "",
+    ) -> Response:
+        """Replace live headers without rebuilding the MCP client."""
+        body = await request.json()
+        headers = body.get("headers") if isinstance(body, dict) else None
+        if not isinstance(headers, dict):
+            raise HTTPException(
+                400,
+                "headers must be a JSON object",
+            )
+        try:
+            async with state.lock:
+                client = _lookup(agent_id, session_id, name)
+                await client.set_runtime_headers(headers)
+        except ValueError as e:
+            raise HTTPException(400, str(e)) from e
+        return Response(status_code=204)
 
     @app.get("/mcps/{name}/tools")
     async def _list_tools(

--- a/src/agentscope/workspace/_mcp_gateway/_mcp_gateway_app.py
+++ b/src/agentscope/workspace/_mcp_gateway/_mcp_gateway_app.py
@@ -14,6 +14,7 @@ Endpoints::
     GET    /health
     GET    /mcps                       # [MCPClient.model_dump(), ...]
     POST   /mcps                       # body: MCPClient.model_dump()
+                                       #   (+ optional runtime_headers)
     DELETE /mcps/{name}
     PUT    /mcps/{name}/runtime-headers
     GET    /mcps/{name}/tools
@@ -48,11 +49,20 @@ class _State:
         self.lock = asyncio.Lock()
 
 
-async def _build_client(spec: dict[str, Any]) -> MCPClient:
+async def _build_client(
+    spec: dict[str, Any],
+    runtime_headers: dict[str, str] | None = None,
+) -> MCPClient:
     """Validate a spec into an ``MCPClient``, connect if stateful,
     and prime its tool cache.
+
+    ``runtime_headers`` are applied before connecting: a rotated
+    credential has to be in place for the handshake below, and it is
+    not part of ``spec`` because it must never be persisted.
     """
     client = MCPClient.model_validate(spec)
+    if runtime_headers:
+        await client.set_runtime_headers(runtime_headers)
     if client.is_stateful:
         await client.connect()
     await client.list_raw_tools()
@@ -121,6 +131,7 @@ def _build_app(
         session_id: str = "",
     ) -> dict[str, Any]:
         body = await request.json()
+        runtime_headers = body.pop("runtime_headers", None)
         name = body.get("name", "")
         if not name:
             raise HTTPException(400, "name required")
@@ -133,9 +144,11 @@ def _build_app(
                     f"session={session_id!r}",
                 )
             try:
-                by_name[name] = await _build_client(body)
+                by_name[name] = await _build_client(body, runtime_headers)
             except HTTPException:
                 raise
+            except ValueError as e:
+                raise HTTPException(400, str(e)) from e
             except Exception as e:  # noqa: BLE001
                 raise HTTPException(500, f"connect failed: {e}") from e
         return {"ok": True}

--- a/tests/mcp_runtime_headers_test.py
+++ b/tests/mcp_runtime_headers_test.py
@@ -1,0 +1,665 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Tests for live MCP HTTP header updates."""
+from contextlib import asynccontextmanager
+import unittest
+from typing import Any, AsyncGenerator
+from unittest.async_case import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+import httpx
+from fastapi.testclient import TestClient
+
+from agentscope.mcp import HttpMCPConfig, MCPClient
+from agentscope.workspace._gateway_client import GatewayClient
+from agentscope.workspace._mcp_gateway._mcp_gateway_app import (
+    _State,
+    _build_app,
+)
+
+
+class MCPRuntimeHeadersTest(IsolatedAsyncioTestCase):
+    """Runtime headers are request-scoped, not serialized config."""
+
+    async def test_stateful_streamable_http_uses_runtime_headers(self) -> None:
+        """One live HTTP client sees each complete replacement map."""
+        captured: dict[str, Any] = {}
+
+        @asynccontextmanager
+        async def fake_streamable_http_client(
+            url: str,
+            *,
+            http_client: httpx.AsyncClient,
+        ) -> AsyncGenerator[tuple[object, object, object], None]:
+            captured["url"] = url
+            captured["http_client"] = http_client
+            yield object(), object(), object()
+
+        client = MCPClient(
+            name="runtime_headers",
+            is_stateful=True,
+            mcp_config=HttpMCPConfig(
+                url="https://example.com/mcp",
+                headers={
+                    "Authorization": "Bearer static",
+                    "X-Static": "static",
+                },
+            ),
+        )
+
+        with patch(
+            "agentscope.mcp._mcp_client.streamable_http_client",
+            fake_streamable_http_client,
+        ):
+            async with client._create_http_client():
+                http_client = captured["http_client"]
+                request = http_client.build_request(
+                    "POST",
+                    "https://example.com/mcp",
+                )
+                for hook in http_client.event_hooks["request"]:
+                    await hook(request)
+                first = {
+                    key: request.headers[key]
+                    for key in (
+                        "Authorization",
+                        "X-Static",
+                        "X-Runtime",
+                    )
+                    if key in request.headers
+                }
+
+                await client.set_runtime_headers(
+                    {
+                        "Authorization": "Bearer runtime",
+                        "X-Runtime": "first",
+                    },
+                )
+                request = http_client.build_request(
+                    "POST",
+                    "https://example.com/mcp",
+                )
+                for hook in http_client.event_hooks["request"]:
+                    await hook(request)
+                second = {
+                    key: request.headers[key]
+                    for key in (
+                        "Authorization",
+                        "X-Static",
+                        "X-Runtime",
+                    )
+                    if key in request.headers
+                }
+
+                await client.set_runtime_headers(
+                    {
+                        "Authorization": "Bearer replacement",
+                    },
+                )
+                request = http_client.build_request(
+                    "POST",
+                    "https://example.com/mcp",
+                )
+                for hook in http_client.event_hooks["request"]:
+                    await hook(request)
+                third = {
+                    key: request.headers[key]
+                    for key in (
+                        "Authorization",
+                        "X-Static",
+                        "X-Runtime",
+                    )
+                    if key in request.headers
+                }
+
+                await client.set_runtime_headers({})
+                request = http_client.build_request(
+                    "POST",
+                    "https://example.com/mcp",
+                )
+                for hook in http_client.event_hooks["request"]:
+                    await hook(request)
+                cleared = {
+                    key: request.headers[key]
+                    for key in (
+                        "Authorization",
+                        "X-Static",
+                        "X-Runtime",
+                    )
+                    if key in request.headers
+                }
+
+        self.assertEqual(captured["url"], "https://example.com/mcp")
+        self.assertEqual(
+            first,
+            {
+                "Authorization": "Bearer static",
+                "X-Static": "static",
+            },
+        )
+        self.assertEqual(
+            second,
+            {
+                "Authorization": "Bearer runtime",
+                "X-Static": "static",
+                "X-Runtime": "first",
+            },
+        )
+        self.assertEqual(
+            third,
+            {
+                "Authorization": "Bearer replacement",
+                "X-Static": "static",
+            },
+        )
+        self.assertEqual(
+            cleared,
+            {
+                "Authorization": "Bearer static",
+                "X-Static": "static",
+            },
+        )
+        self.assertEqual(
+            {
+                "follow_redirects": http_client.follow_redirects,
+                "timeout": http_client.timeout.as_dict(),
+            },
+            {
+                "follow_redirects": False,
+                "timeout": {
+                    "connect": 30.0,
+                    "read": 30.0,
+                    "write": 30.0,
+                    "pool": 30.0,
+                },
+            },
+        )
+
+    async def test_streamable_http_preserves_mcp_default_fallback(
+        self,
+    ) -> None:
+        """An unconfigured client retains the MCP SDK HTTP defaults."""
+        captured: dict[str, httpx.AsyncClient] = {}
+
+        @asynccontextmanager
+        async def fake_streamable_http_client(
+            url: str,
+            *,
+            http_client: httpx.AsyncClient,
+        ) -> AsyncGenerator[tuple[object, object, object], None]:
+            del url
+            captured["http_client"] = http_client
+            yield object(), object(), object()
+
+        client = MCPClient(
+            name="runtime_headers",
+            is_stateful=False,
+            mcp_config=HttpMCPConfig(
+                url="https://example.com/mcp",
+                timeout=None,
+            ),
+        )
+
+        with patch(
+            "agentscope.mcp._mcp_client.streamable_http_client",
+            fake_streamable_http_client,
+        ):
+            async with client._create_http_client():
+                http_client = captured["http_client"]
+
+        self.assertEqual(
+            {
+                "follow_redirects": http_client.follow_redirects,
+                "timeout": http_client.timeout.as_dict(),
+            },
+            {
+                "follow_redirects": True,
+                "timeout": {
+                    "connect": 30.0,
+                    "read": 300.0,
+                    "write": 30.0,
+                    "pool": 30.0,
+                },
+            },
+        )
+
+    async def test_runtime_headers_stay_on_configured_origin(self) -> None:
+        """Cross-origin redirects never receive runtime credentials."""
+        received: list[dict[str, str | None]] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            received.append(
+                {
+                    "url": str(request.url),
+                    "authorization": request.headers.get("Authorization"),
+                    "runtime": request.headers.get("X-Runtime"),
+                },
+            )
+            if request.url.host == "example.com":
+                await client.set_runtime_headers({})
+                return httpx.Response(
+                    302,
+                    headers={"Location": "https://other.example/mcp"},
+                )
+            return httpx.Response(200)
+
+        client = MCPClient(
+            name="runtime_headers",
+            is_stateful=False,
+            mcp_config=HttpMCPConfig(url="https://example.com/mcp"),
+        )
+        await client.set_runtime_headers(
+            {
+                "Authorization": "Bearer runtime",
+                "X-Runtime": "runtime",
+            },
+        )
+
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            follow_redirects=True,
+            event_hooks={"request": [client._inject_runtime_headers]},
+        ) as http_client:
+            response = await http_client.get("https://example.com/mcp")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            received,
+            [
+                {
+                    "url": "https://example.com/mcp",
+                    "authorization": "Bearer runtime",
+                    "runtime": "runtime",
+                },
+                {
+                    "url": "https://other.example/mcp",
+                    "authorization": None,
+                    "runtime": None,
+                },
+            ],
+        )
+
+    async def test_stateless_streamable_http_uses_runtime_headers(
+        self,
+    ) -> None:
+        """A temporary HTTP client reads current runtime headers."""
+        captured: dict[str, httpx.AsyncClient] = {}
+
+        @asynccontextmanager
+        async def fake_streamable_http_client(
+            url: str,
+            *,
+            http_client: httpx.AsyncClient,
+        ) -> AsyncGenerator[tuple[object, object, object], None]:
+            del url
+            captured["http_client"] = http_client
+            yield object(), object(), object()
+
+        client = MCPClient(
+            name="runtime_headers",
+            is_stateful=False,
+            mcp_config=HttpMCPConfig(url="https://example.com/mcp"),
+        )
+        await client.set_runtime_headers(
+            {"Authorization": "Bearer runtime"},
+        )
+
+        with patch(
+            "agentscope.mcp._mcp_client.streamable_http_client",
+            fake_streamable_http_client,
+        ):
+            async with client._create_http_client():
+                http_client = captured["http_client"]
+                request = http_client.build_request(
+                    "POST",
+                    "https://example.com/mcp",
+                )
+                for hook in http_client.event_hooks["request"]:
+                    await hook(request)
+
+        self.assertEqual(
+            request.headers["Authorization"],
+            "Bearer runtime",
+        )
+
+    async def test_stateful_allows_runtime_headers_before_connect(
+        self,
+    ) -> None:
+        """A local stateful client accepts headers before connecting."""
+        client = MCPClient(
+            name="runtime_headers",
+            is_stateful=True,
+            mcp_config=HttpMCPConfig(url="https://example.com/mcp"),
+        )
+
+        await client.set_runtime_headers(
+            {"Authorization": "Bearer runtime"},
+        )
+
+        self.assertEqual(
+            {
+                "is_connected": client.is_connected,
+                "runtime_headers": client._runtime_headers,
+            },
+            {
+                "is_connected": False,
+                "runtime_headers": {
+                    "Authorization": "Bearer runtime",
+                },
+            },
+        )
+
+    async def test_runtime_headers_are_not_serialized(self) -> None:
+        """Live headers never become part of the persisted MCP spec."""
+        client = MCPClient(
+            name="runtime_headers",
+            is_stateful=False,
+            mcp_config=HttpMCPConfig(
+                url="https://example.com/mcp",
+                headers={"X-Static": "static"},
+            ),
+        )
+
+        await client.set_runtime_headers(
+            {"Authorization": "Bearer runtime"},
+        )
+
+        self.assertEqual(
+            client.model_dump(mode="json"),
+            {
+                "name": "runtime_headers",
+                "is_stateful": False,
+                "mcp_config": {
+                    "type": "http_mcp",
+                    "url": "https://example.com/mcp",
+                    "headers": {"X-Static": "static"},
+                    "timeout": 30.0,
+                },
+                "enable_tools": None,
+                "disable_tools": None,
+                "execution_timeout": None,
+            },
+        )
+
+    async def test_runtime_headers_reject_transport_headers(self) -> None:
+        """Callers cannot override headers owned by the MCP transport."""
+        client = MCPClient(
+            name="runtime_headers",
+            is_stateful=False,
+            mcp_config=HttpMCPConfig(url="https://example.com/mcp"),
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Mcp-Session-Id",
+        ):
+            await client.set_runtime_headers(
+                {"Mcp-Session-Id": "forbidden"},
+            )
+
+    async def test_runtime_headers_reject_sse(self) -> None:
+        """SSE headers remain fixed for the lifetime of the stream."""
+        for url in (
+            "https://example.com/sse",
+            "https://example.com/messages/",
+        ):
+            with self.subTest(url=url):
+                client = MCPClient(
+                    name="runtime_headers",
+                    is_stateful=True,
+                    mcp_config=HttpMCPConfig(url=url),
+                )
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "only Streamable HTTP",
+                ):
+                    await client.set_runtime_headers(
+                        {"Authorization": "Bearer runtime"},
+                    )
+
+    async def test_runtime_headers_reject_invalid_wire_values(self) -> None:
+        """Invalid names and values fail before an HTTP request is sent."""
+        client = MCPClient(
+            name="runtime_headers",
+            is_stateful=False,
+            mcp_config=HttpMCPConfig(url="https://example.com/mcp"),
+        )
+
+        for headers, invalid_name in (
+            ({"Bad Header": "sensitive-value"}, "Bad Header"),
+            ({"X-Unsafe": "sensitive\nvalue"}, "X-Unsafe"),
+            ({"X-Unicode": "sensitive-\u00e9"}, "X-Unicode"),
+        ):
+            with self.subTest(headers=list(headers)):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    invalid_name,
+                ) as raised:
+                    await client.set_runtime_headers(headers)
+                self.assertNotIn("sensitive", str(raised.exception))
+
+
+class GatewayRuntimeHeadersRouteTest(unittest.TestCase):
+    """The gateway updates its live client without replacing it."""
+
+    def setUp(self) -> None:
+        """Build an app with one registered stateful HTTP client."""
+        self.state = _State()
+        self.mcp = MCPClient(
+            name="remote",
+            is_stateful=True,
+            mcp_config=HttpMCPConfig(url="https://example.com/mcp"),
+        )
+        self.mcp._is_connected = True
+        self.state.clients[("agent", "session")] = {
+            "remote": self.mcp,
+        }
+        self.client = TestClient(_build_app(self.state))
+
+    def test_update_runtime_headers(self) -> None:
+        """PUT replaces live headers and returns no sensitive body."""
+        response = self.client.put(
+            "/mcps/remote/runtime-headers",
+            params={"agent_id": "agent", "session_id": "session"},
+            json={
+                "headers": {
+                    "Authorization": "Bearer runtime",
+                },
+            },
+        )
+
+        self.assertEqual(
+            {
+                "status_code": response.status_code,
+                "body": response.content,
+                "same_client": self.state.clients[("agent", "session")][
+                    "remote"
+                ]
+                is self.mcp,
+                "is_connected": self.mcp.is_connected,
+                "runtime_headers": self.mcp._runtime_headers,
+            },
+            {
+                "status_code": 204,
+                "body": b"",
+                "same_client": True,
+                "is_connected": True,
+                "runtime_headers": {
+                    "Authorization": "Bearer runtime",
+                },
+            },
+        )
+
+    def test_update_runtime_headers_rejects_unknown_client(self) -> None:
+        """The update route preserves the gateway's lookup contract."""
+        response = self.client.put(
+            "/mcps/missing/runtime-headers",
+            params={"agent_id": "agent", "session_id": "session"},
+            json={"headers": {"Authorization": "Bearer runtime"}},
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_update_runtime_headers_does_not_echo_values(self) -> None:
+        """Validation failures identify only the forbidden name."""
+        response = self.client.put(
+            "/mcps/remote/runtime-headers",
+            params={"agent_id": "agent", "session_id": "session"},
+            json={
+                "headers": {
+                    "Mcp-Session-Id": "sensitive-value",
+                },
+            },
+        )
+
+        self.assertEqual(
+            {
+                "status_code": response.status_code,
+                "body": response.json(),
+                "runtime_headers": self.mcp._runtime_headers,
+            },
+            {
+                "status_code": 400,
+                "body": {
+                    "detail": (
+                        "Runtime header 'Mcp-Session-Id' is owned by "
+                        "the transport."
+                    ),
+                },
+                "runtime_headers": {},
+            },
+        )
+        self.assertNotIn("sensitive-value", response.text)
+
+    def test_update_runtime_headers_holds_registry_lock(self) -> None:
+        """Header updates serialize with client registration changes."""
+        lock_states: list[bool] = []
+
+        async def capture_lock_state(
+            _client: MCPClient,
+            _headers: dict[str, str],
+        ) -> None:
+            lock_states.append(self.state.lock.locked())
+
+        with patch.object(
+            MCPClient,
+            "set_runtime_headers",
+            capture_lock_state,
+        ):
+            response = self.client.put(
+                "/mcps/remote/runtime-headers",
+                params={"agent_id": "agent", "session_id": "session"},
+                json={"headers": {"Authorization": "Bearer runtime"}},
+            )
+
+        self.assertEqual(
+            {
+                "status_code": response.status_code,
+                "lock_states": lock_states,
+            },
+            {
+                "status_code": 204,
+                "lock_states": [True],
+            },
+        )
+
+
+class GatewayMCPClientRuntimeHeadersTest(IsolatedAsyncioTestCase):
+    """The host-side proxy forwards runtime header updates."""
+
+    async def test_proxy_updates_connected_gateway_client(self) -> None:
+        """The proxy sends one scoped PUT without changing its spec."""
+        gateway = GatewayClient(
+            backend=object(),  # type: ignore[arg-type]
+            gateway_port=5600,
+        )
+        gateway.exec_request = AsyncMock(  # type: ignore[method-assign]
+            return_value=(204, b""),
+        )
+        client = gateway.make_client(
+            MCPClient(
+                name="remote",
+                is_stateful=False,
+                mcp_config=HttpMCPConfig(
+                    url="https://example.com/mcp",
+                ),
+            ).model_dump(mode="json"),
+            agent_id="agent",
+            session_id="session",
+            connected=True,
+        )
+
+        await client.set_runtime_headers(
+            {"Authorization": "Bearer runtime"},
+        )
+
+        gateway.exec_request.assert_awaited_once_with(
+            "PUT",
+            "/mcps/remote/runtime-headers",
+            params={"agent_id": "agent", "session_id": "session"},
+            body={
+                "headers": {
+                    "Authorization": "Bearer runtime",
+                },
+            },
+        )
+        self.assertEqual(
+            client.model_dump(mode="json")["mcp_config"]["headers"],
+            None,
+        )
+
+    async def test_proxy_rejects_update_before_connect(self) -> None:
+        """First-version updates require an existing gateway client."""
+        gateway = GatewayClient(
+            backend=object(),  # type: ignore[arg-type]
+            gateway_port=5600,
+        )
+        client = gateway.make_client(
+            MCPClient(
+                name="remote",
+                is_stateful=False,
+                mcp_config=HttpMCPConfig(
+                    url="https://example.com/mcp",
+                ),
+            ).model_dump(mode="json"),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "not connected"):
+            await client.set_runtime_headers(
+                {"Authorization": "Bearer runtime"},
+            )
+
+    async def test_proxy_maps_gateway_validation_error(self) -> None:
+        """Gateway validation failures match the local exception type."""
+        gateway = GatewayClient(
+            backend=object(),  # type: ignore[arg-type]
+            gateway_port=5600,
+        )
+        gateway.exec_request = AsyncMock(  # type: ignore[method-assign]
+            return_value=(
+                400,
+                b'{"detail":"Runtime header is invalid."}',
+            ),
+        )
+        client = gateway.make_client(
+            MCPClient(
+                name="remote",
+                is_stateful=False,
+                mcp_config=HttpMCPConfig(
+                    url="https://example.com/mcp",
+                ),
+            ).model_dump(mode="json"),
+            connected=True,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "HTTP 400: Runtime header is invalid",
+        ):
+            await client.set_runtime_headers(
+                {"Bad Header": "value"},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/mcp_runtime_headers_test.py
+++ b/tests/mcp_runtime_headers_test.py
@@ -17,24 +17,47 @@ from agentscope.workspace._mcp_gateway._mcp_gateway_app import (
     _build_app,
 )
 
+_WATCHED = ("Authorization", "X-Static", "X-Runtime", "Mcp-Session-Id")
+
 
 class MCPRuntimeHeadersTest(IsolatedAsyncioTestCase):
-    """Runtime headers are request-scoped, not serialized config."""
+    """Runtime headers are live client state, not serialized config."""
 
-    async def test_stateful_streamable_http_uses_runtime_headers(self) -> None:
-        """One live HTTP client sees each complete replacement map."""
-        captured: dict[str, Any] = {}
+    def setUp(self) -> None:
+        """Replace the transport with one exposing its HTTP client."""
+        self.seen: dict[str, Any] = {}
 
         @asynccontextmanager
-        async def fake_streamable_http_client(
+        async def fake_transport(
             url: str,
             *,
             http_client: httpx.AsyncClient,
         ) -> AsyncGenerator[tuple[object, object, object], None]:
-            captured["url"] = url
-            captured["http_client"] = http_client
+            self.seen.update(url=url, http_client=http_client)
             yield object(), object(), object()
 
+        patcher = patch(
+            "agentscope.mcp._mcp_client.streamable_http_client",
+            fake_transport,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _outgoing(self, **headers: str) -> dict[str, str]:
+        """The watched headers httpx would put on the next request."""
+        request = self.seen["http_client"].build_request(
+            "POST",
+            "https://example.com/mcp",
+            headers=headers or None,
+        )
+        return {
+            name: request.headers[name]
+            for name in _WATCHED
+            if name in request.headers
+        }
+
+    async def test_runtime_headers_replace_and_clear(self) -> None:
+        """Each call replaces the whole map; an empty one restores config."""
         client = MCPClient(
             name="runtime_headers",
             is_stateful=True,
@@ -47,304 +70,126 @@ class MCPRuntimeHeadersTest(IsolatedAsyncioTestCase):
             ),
         )
 
-        with patch(
-            "agentscope.mcp._mcp_client.streamable_http_client",
-            fake_streamable_http_client,
-        ):
-            async with client._create_http_client():
-                http_client = captured["http_client"]
-                request = http_client.build_request(
-                    "POST",
-                    "https://example.com/mcp",
-                )
-                for hook in http_client.event_hooks["request"]:
-                    await hook(request)
-                first = {
-                    key: request.headers[key]
-                    for key in (
-                        "Authorization",
-                        "X-Static",
-                        "X-Runtime",
-                    )
-                    if key in request.headers
-                }
+        async with client._create_http_client():
+            configured = self._outgoing()
 
-                await client.set_runtime_headers(
-                    {
-                        "Authorization": "Bearer runtime",
-                        "X-Runtime": "first",
-                    },
-                )
-                request = http_client.build_request(
-                    "POST",
-                    "https://example.com/mcp",
-                )
-                for hook in http_client.event_hooks["request"]:
-                    await hook(request)
-                second = {
-                    key: request.headers[key]
-                    for key in (
-                        "Authorization",
-                        "X-Static",
-                        "X-Runtime",
-                    )
-                    if key in request.headers
-                }
-
-                await client.set_runtime_headers(
-                    {
-                        "Authorization": "Bearer replacement",
-                    },
-                )
-                request = http_client.build_request(
-                    "POST",
-                    "https://example.com/mcp",
-                )
-                for hook in http_client.event_hooks["request"]:
-                    await hook(request)
-                third = {
-                    key: request.headers[key]
-                    for key in (
-                        "Authorization",
-                        "X-Static",
-                        "X-Runtime",
-                    )
-                    if key in request.headers
-                }
-
-                await client.set_runtime_headers({})
-                request = http_client.build_request(
-                    "POST",
-                    "https://example.com/mcp",
-                )
-                for hook in http_client.event_hooks["request"]:
-                    await hook(request)
-                cleared = {
-                    key: request.headers[key]
-                    for key in (
-                        "Authorization",
-                        "X-Static",
-                        "X-Runtime",
-                    )
-                    if key in request.headers
-                }
-
-        self.assertEqual(captured["url"], "https://example.com/mcp")
-        self.assertEqual(
-            first,
-            {
-                "Authorization": "Bearer static",
-                "X-Static": "static",
-            },
-        )
-        self.assertEqual(
-            second,
-            {
-                "Authorization": "Bearer runtime",
-                "X-Static": "static",
-                "X-Runtime": "first",
-            },
-        )
-        self.assertEqual(
-            third,
-            {
-                "Authorization": "Bearer replacement",
-                "X-Static": "static",
-            },
-        )
-        self.assertEqual(
-            cleared,
-            {
-                "Authorization": "Bearer static",
-                "X-Static": "static",
-            },
-        )
-        self.assertEqual(
-            {
-                "follow_redirects": http_client.follow_redirects,
-                "timeout": http_client.timeout.as_dict(),
-            },
-            {
-                "follow_redirects": False,
-                "timeout": {
-                    "connect": 30.0,
-                    "read": 30.0,
-                    "write": 30.0,
-                    "pool": 30.0,
-                },
-            },
-        )
-
-    async def test_streamable_http_preserves_mcp_default_fallback(
-        self,
-    ) -> None:
-        """An unconfigured client retains the MCP SDK HTTP defaults."""
-        captured: dict[str, httpx.AsyncClient] = {}
-
-        @asynccontextmanager
-        async def fake_streamable_http_client(
-            url: str,
-            *,
-            http_client: httpx.AsyncClient,
-        ) -> AsyncGenerator[tuple[object, object, object], None]:
-            del url
-            captured["http_client"] = http_client
-            yield object(), object(), object()
-
-        client = MCPClient(
-            name="runtime_headers",
-            is_stateful=False,
-            mcp_config=HttpMCPConfig(
-                url="https://example.com/mcp",
-                timeout=None,
-            ),
-        )
-
-        with patch(
-            "agentscope.mcp._mcp_client.streamable_http_client",
-            fake_streamable_http_client,
-        ):
-            async with client._create_http_client():
-                http_client = captured["http_client"]
-
-        self.assertEqual(
-            {
-                "follow_redirects": http_client.follow_redirects,
-                "timeout": http_client.timeout.as_dict(),
-            },
-            {
-                "follow_redirects": True,
-                "timeout": {
-                    "connect": 30.0,
-                    "read": 300.0,
-                    "write": 30.0,
-                    "pool": 30.0,
-                },
-            },
-        )
-
-    async def test_runtime_headers_stay_on_configured_origin(self) -> None:
-        """Cross-origin redirects never receive runtime credentials."""
-        received: list[dict[str, str | None]] = []
-
-        async def handler(request: httpx.Request) -> httpx.Response:
-            received.append(
-                {
-                    "url": str(request.url),
-                    "authorization": request.headers.get("Authorization"),
-                    "runtime": request.headers.get("X-Runtime"),
-                },
+            await client.set_runtime_headers(
+                {"Authorization": "Bearer runtime", "X-Runtime": "first"},
             )
-            if request.url.host == "example.com":
-                await client.set_runtime_headers({})
-                return httpx.Response(
-                    302,
-                    headers={"Location": "https://other.example/mcp"},
-                )
-            return httpx.Response(200)
+            overridden = self._outgoing()
 
-        client = MCPClient(
-            name="runtime_headers",
-            is_stateful=False,
-            mcp_config=HttpMCPConfig(url="https://example.com/mcp"),
-        )
-        await client.set_runtime_headers(
+            await client.set_runtime_headers(
+                {"Authorization": "Bearer replacement"},
+            )
+            replaced = self._outgoing()
+
+            await client.set_runtime_headers({})
+            cleared = self._outgoing()
+
+        self.assertDictEqual(
             {
-                "Authorization": "Bearer runtime",
-                "X-Runtime": "runtime",
-            },
-        )
-
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler),
-            follow_redirects=True,
-            event_hooks={"request": [client._inject_runtime_headers]},
-        ) as http_client:
-            response = await http_client.get("https://example.com/mcp")
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            received,
-            [
-                {
-                    "url": "https://example.com/mcp",
-                    "authorization": "Bearer runtime",
-                    "runtime": "runtime",
-                },
-                {
-                    "url": "https://other.example/mcp",
-                    "authorization": None,
-                    "runtime": None,
-                },
-            ],
-        )
-
-    async def test_stateless_streamable_http_uses_runtime_headers(
-        self,
-    ) -> None:
-        """A temporary HTTP client reads current runtime headers."""
-        captured: dict[str, httpx.AsyncClient] = {}
-
-        @asynccontextmanager
-        async def fake_streamable_http_client(
-            url: str,
-            *,
-            http_client: httpx.AsyncClient,
-        ) -> AsyncGenerator[tuple[object, object, object], None]:
-            del url
-            captured["http_client"] = http_client
-            yield object(), object(), object()
-
-        client = MCPClient(
-            name="runtime_headers",
-            is_stateful=False,
-            mcp_config=HttpMCPConfig(url="https://example.com/mcp"),
-        )
-        await client.set_runtime_headers(
-            {"Authorization": "Bearer runtime"},
-        )
-
-        with patch(
-            "agentscope.mcp._mcp_client.streamable_http_client",
-            fake_streamable_http_client,
-        ):
-            async with client._create_http_client():
-                http_client = captured["http_client"]
-                request = http_client.build_request(
-                    "POST",
-                    "https://example.com/mcp",
-                )
-                for hook in http_client.event_hooks["request"]:
-                    await hook(request)
-
-        self.assertEqual(
-            request.headers["Authorization"],
-            "Bearer runtime",
-        )
-
-    async def test_stateful_allows_runtime_headers_before_connect(
-        self,
-    ) -> None:
-        """A local stateful client accepts headers before connecting."""
-        client = MCPClient(
-            name="runtime_headers",
-            is_stateful=True,
-            mcp_config=HttpMCPConfig(url="https://example.com/mcp"),
-        )
-
-        await client.set_runtime_headers(
-            {"Authorization": "Bearer runtime"},
-        )
-
-        self.assertEqual(
-            {
-                "is_connected": client.is_connected,
-                "runtime_headers": client._runtime_headers,
+                "url": self.seen["url"],
+                "configured": configured,
+                "overridden": overridden,
+                "replaced": replaced,
+                "cleared": cleared,
             },
             {
-                "is_connected": False,
-                "runtime_headers": {
+                "url": "https://example.com/mcp",
+                "configured": {
+                    "Authorization": "Bearer static",
+                    "X-Static": "static",
+                },
+                "overridden": {
                     "Authorization": "Bearer runtime",
+                    "X-Static": "static",
+                    "X-Runtime": "first",
+                },
+                "replaced": {
+                    "Authorization": "Bearer replacement",
+                    "X-Static": "static",
+                },
+                "cleared": {
+                    "Authorization": "Bearer static",
+                    "X-Static": "static",
+                },
+            },
+        )
+
+    async def test_headers_set_before_the_client_exists_are_applied(
+        self,
+    ) -> None:
+        """A stateless client picks up headers set before it was built."""
+        client = MCPClient(
+            name="runtime_headers",
+            is_stateful=False,
+            mcp_config=HttpMCPConfig(url="https://example.com/mcp"),
+        )
+        await client.set_runtime_headers({"Authorization": "Bearer runtime"})
+
+        async with client._create_http_client():
+            outgoing = self._outgoing()
+
+        self.assertDictEqual(
+            outgoing,
+            {"Authorization": "Bearer runtime"},
+        )
+
+    async def test_transport_headers_win_over_runtime_headers(self) -> None:
+        """Per-request MCP headers outrank anything set on the client."""
+        client = MCPClient(
+            name="runtime_headers",
+            is_stateful=False,
+            mcp_config=HttpMCPConfig(url="https://example.com/mcp"),
+        )
+        await client.set_runtime_headers({"Mcp-Session-Id": "hijacked"})
+
+        async with client._create_http_client():
+            outgoing = self._outgoing(**{"mcp-session-id": "from-transport"})
+
+        self.assertDictEqual(
+            outgoing,
+            {"Mcp-Session-Id": "from-transport"},
+        )
+
+    async def test_streamable_http_client_keeps_mcp_defaults(self) -> None:
+        """Configured headers must not cost the SDK's HTTP defaults."""
+        defaults: dict[str, Any] = {}
+        for label, config in (
+            (
+                "configured",
+                HttpMCPConfig(
+                    url="https://example.com/mcp",
+                    headers={"X-Static": "static"},
+                ),
+            ),
+            (
+                "untimed",
+                HttpMCPConfig(url="https://example.com/mcp", timeout=None),
+            ),
+        ):
+            client = MCPClient(
+                name="runtime_headers",
+                is_stateful=False,
+                mcp_config=config,
+            )
+            async with client._create_http_client():
+                http_client = self.seen["http_client"]
+                defaults[label] = {
+                    "follow_redirects": http_client.follow_redirects,
+                    "read_timeout": http_client.timeout.read,
+                }
+
+        self.assertDictEqual(
+            defaults,
+            {
+                "configured": {
+                    "follow_redirects": True,
+                    "read_timeout": 30.0,
+                },
+                "untimed": {
+                    "follow_redirects": True,
+                    "read_timeout": 300.0,
                 },
             },
         )
@@ -359,12 +204,9 @@ class MCPRuntimeHeadersTest(IsolatedAsyncioTestCase):
                 headers={"X-Static": "static"},
             ),
         )
+        await client.set_runtime_headers({"Authorization": "Bearer runtime"})
 
-        await client.set_runtime_headers(
-            {"Authorization": "Bearer runtime"},
-        )
-
-        self.assertEqual(
+        self.assertDictEqual(
             client.model_dump(mode="json"),
             {
                 "name": "runtime_headers",
@@ -381,26 +223,10 @@ class MCPRuntimeHeadersTest(IsolatedAsyncioTestCase):
             },
         )
 
-    async def test_runtime_headers_reject_transport_headers(self) -> None:
-        """Callers cannot override headers owned by the MCP transport."""
-        client = MCPClient(
-            name="runtime_headers",
-            is_stateful=False,
-            mcp_config=HttpMCPConfig(url="https://example.com/mcp"),
-        )
-
-        with self.assertRaisesRegex(
-            ValueError,
-            "Mcp-Session-Id",
-        ):
-            await client.set_runtime_headers(
-                {"Mcp-Session-Id": "forbidden"},
-            )
-
     async def test_runtime_headers_reject_sse(self) -> None:
-        """SSE headers remain fixed for the lifetime of the stream."""
+        """SSE headers stay fixed for the lifetime of the stream."""
         for url in (
-            "https://example.com/sse",
+            "https://example.com/sse?key=secret",
             "https://example.com/messages/",
         ):
             with self.subTest(url=url):
@@ -409,13 +235,8 @@ class MCPRuntimeHeadersTest(IsolatedAsyncioTestCase):
                     is_stateful=True,
                     mcp_config=HttpMCPConfig(url=url),
                 )
-                with self.assertRaisesRegex(
-                    ValueError,
-                    "only Streamable HTTP",
-                ):
-                    await client.set_runtime_headers(
-                        {"Authorization": "Bearer runtime"},
-                    )
+                with self.assertRaisesRegex(ValueError, "Streamable HTTP"):
+                    await client.set_runtime_headers({"X-Runtime": "value"})
 
     async def test_runtime_headers_reject_invalid_wire_values(self) -> None:
         """Invalid names and values fail before an HTTP request is sent."""
@@ -425,16 +246,13 @@ class MCPRuntimeHeadersTest(IsolatedAsyncioTestCase):
             mcp_config=HttpMCPConfig(url="https://example.com/mcp"),
         )
 
-        for headers, invalid_name in (
+        for headers, name in (
             ({"Bad Header": "sensitive-value"}, "Bad Header"),
-            ({"X-Unsafe": "sensitive\nvalue"}, "X-Unsafe"),
-            ({"X-Unicode": "sensitive-\u00e9"}, "X-Unicode"),
+            ({"X-Unsafe": "sensitive\r\nInjected: 1"}, "X-Unsafe"),
+            ({"X-Unicode": "sensitive-é"}, "X-Unicode"),
         ):
             with self.subTest(headers=list(headers)):
-                with self.assertRaisesRegex(
-                    ValueError,
-                    invalid_name,
-                ) as raised:
+                with self.assertRaisesRegex(ValueError, name) as raised:
                     await client.set_runtime_headers(headers)
                 self.assertNotIn("sensitive", str(raised.exception))
 
@@ -451,24 +269,18 @@ class GatewayRuntimeHeadersRouteTest(unittest.TestCase):
             mcp_config=HttpMCPConfig(url="https://example.com/mcp"),
         )
         self.mcp._is_connected = True
-        self.state.clients[("agent", "session")] = {
-            "remote": self.mcp,
-        }
+        self.state.clients[("agent", "session")] = {"remote": self.mcp}
         self.client = TestClient(_build_app(self.state))
 
     def test_update_runtime_headers(self) -> None:
-        """PUT replaces live headers and returns no sensitive body."""
+        """PUT replaces live headers on the same client instance."""
         response = self.client.put(
             "/mcps/remote/runtime-headers",
             params={"agent_id": "agent", "session_id": "session"},
-            json={
-                "headers": {
-                    "Authorization": "Bearer runtime",
-                },
-            },
+            json={"headers": {"Authorization": "Bearer runtime"}},
         )
 
-        self.assertEqual(
+        self.assertDictEqual(
             {
                 "status_code": response.status_code,
                 "body": response.content,
@@ -484,9 +296,7 @@ class GatewayRuntimeHeadersRouteTest(unittest.TestCase):
                 "body": b"",
                 "same_client": True,
                 "is_connected": True,
-                "runtime_headers": {
-                    "Authorization": "Bearer runtime",
-                },
+                "runtime_headers": {"Authorization": "Bearer runtime"},
             },
         )
 
@@ -501,18 +311,14 @@ class GatewayRuntimeHeadersRouteTest(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_update_runtime_headers_does_not_echo_values(self) -> None:
-        """Validation failures identify only the forbidden name."""
+        """Validation failures identify only the offending name."""
         response = self.client.put(
             "/mcps/remote/runtime-headers",
             params={"agent_id": "agent", "session_id": "session"},
-            json={
-                "headers": {
-                    "Mcp-Session-Id": "sensitive-value",
-                },
-            },
+            json={"headers": {"Bad Header": "sensitive-value"}},
         )
 
-        self.assertEqual(
+        self.assertDictEqual(
             {
                 "status_code": response.status_code,
                 "body": response.json(),
@@ -520,52 +326,28 @@ class GatewayRuntimeHeadersRouteTest(unittest.TestCase):
             },
             {
                 "status_code": 400,
-                "body": {
-                    "detail": (
-                        "Runtime header 'Mcp-Session-Id' is owned by "
-                        "the transport."
-                    ),
-                },
+                "body": {"detail": "Runtime header 'Bad Header' is invalid."},
                 "runtime_headers": {},
-            },
-        )
-        self.assertNotIn("sensitive-value", response.text)
-
-    def test_update_runtime_headers_holds_registry_lock(self) -> None:
-        """Header updates serialize with client registration changes."""
-        lock_states: list[bool] = []
-
-        async def capture_lock_state(
-            _client: MCPClient,
-            _headers: dict[str, str],
-        ) -> None:
-            lock_states.append(self.state.lock.locked())
-
-        with patch.object(
-            MCPClient,
-            "set_runtime_headers",
-            capture_lock_state,
-        ):
-            response = self.client.put(
-                "/mcps/remote/runtime-headers",
-                params={"agent_id": "agent", "session_id": "session"},
-                json={"headers": {"Authorization": "Bearer runtime"}},
-            )
-
-        self.assertEqual(
-            {
-                "status_code": response.status_code,
-                "lock_states": lock_states,
-            },
-            {
-                "status_code": 204,
-                "lock_states": [True],
             },
         )
 
 
 class GatewayMCPClientRuntimeHeadersTest(IsolatedAsyncioTestCase):
     """The host-side proxy forwards runtime header updates."""
+
+    @staticmethod
+    def _proxy(gateway: GatewayClient, connected: bool) -> Any:
+        """A proxy for one stateless HTTP MCP on ``gateway``."""
+        return gateway.make_client(
+            MCPClient(
+                name="remote",
+                is_stateful=False,
+                mcp_config=HttpMCPConfig(url="https://example.com/mcp"),
+            ).model_dump(mode="json"),
+            agent_id="agent",
+            session_id="session",
+            connected=connected,
+        )
 
     async def test_proxy_updates_connected_gateway_client(self) -> None:
         """The proxy sends one scoped PUT without changing its spec."""
@@ -576,89 +358,83 @@ class GatewayMCPClientRuntimeHeadersTest(IsolatedAsyncioTestCase):
         gateway.exec_request = AsyncMock(  # type: ignore[method-assign]
             return_value=(204, b""),
         )
-        client = gateway.make_client(
-            MCPClient(
-                name="remote",
-                is_stateful=False,
-                mcp_config=HttpMCPConfig(
-                    url="https://example.com/mcp",
-                ),
-            ).model_dump(mode="json"),
-            agent_id="agent",
-            session_id="session",
-            connected=True,
-        )
+        client = self._proxy(gateway, connected=True)
 
-        await client.set_runtime_headers(
-            {"Authorization": "Bearer runtime"},
-        )
+        await client.set_runtime_headers({"Authorization": "Bearer runtime"})
 
         gateway.exec_request.assert_awaited_once_with(
             "PUT",
             "/mcps/remote/runtime-headers",
             params={"agent_id": "agent", "session_id": "session"},
-            body={
-                "headers": {
-                    "Authorization": "Bearer runtime",
-                },
-            },
+            body={"headers": {"Authorization": "Bearer runtime"}},
         )
-        self.assertEqual(
+        self.assertIsNone(
             client.model_dump(mode="json")["mcp_config"]["headers"],
-            None,
         )
 
-    async def test_proxy_rejects_update_before_connect(self) -> None:
-        """First-version updates require an existing gateway client."""
-        gateway = GatewayClient(
-            backend=object(),  # type: ignore[arg-type]
-            gateway_port=5600,
-        )
-        client = gateway.make_client(
-            MCPClient(
-                name="remote",
-                is_stateful=False,
-                mcp_config=HttpMCPConfig(
-                    url="https://example.com/mcp",
-                ),
-            ).model_dump(mode="json"),
-        )
-
-        with self.assertRaisesRegex(RuntimeError, "not connected"):
-            await client.set_runtime_headers(
-                {"Authorization": "Bearer runtime"},
-            )
-
-    async def test_proxy_maps_gateway_validation_error(self) -> None:
-        """Gateway validation failures match the local exception type."""
+    async def test_proxy_replays_runtime_headers_on_reconnect(self) -> None:
+        """``model_dump`` drops them, so ``connect`` must push them again."""
         gateway = GatewayClient(
             backend=object(),  # type: ignore[arg-type]
             gateway_port=5600,
         )
         gateway.exec_request = AsyncMock(  # type: ignore[method-assign]
-            return_value=(
-                400,
-                b'{"detail":"Runtime header is invalid."}',
-            ),
+            return_value=(204, b""),
         )
-        client = gateway.make_client(
-            MCPClient(
-                name="remote",
-                is_stateful=False,
-                mcp_config=HttpMCPConfig(
-                    url="https://example.com/mcp",
-                ),
-            ).model_dump(mode="json"),
-            connected=True,
+        client = self._proxy(gateway, connected=True)
+        await client.set_runtime_headers({"Authorization": "Bearer runtime"})
+        await client.close()
+
+        gateway.exec_request.reset_mock()
+        await client.connect()
+
+        self.assertListEqual(
+            [call.args[:2] for call in gateway.exec_request.await_args_list],
+            [
+                ("POST", "/mcps"),
+                ("PUT", "/mcps/remote/runtime-headers"),
+            ],
         )
 
-        with self.assertRaisesRegex(
-            ValueError,
-            "HTTP 400: Runtime header is invalid",
+    async def test_proxy_rejects_update_before_connect(self) -> None:
+        """Updates require an existing gateway-side client."""
+        gateway = GatewayClient(
+            backend=object(),  # type: ignore[arg-type]
+            gateway_port=5600,
+        )
+        client = self._proxy(gateway, connected=False)
+
+        with self.assertRaisesRegex(RuntimeError, "not connected"):
+            await client.set_runtime_headers({"X-Runtime": "value"})
+
+    async def test_proxy_reports_gateway_errors(self) -> None:
+        """400 matches the local exception type; 404 names the cause."""
+        for status, body, error, message in (
+            (
+                400,
+                b'{"detail":"Runtime header is invalid."}',
+                ValueError,
+                "HTTP 400: Runtime header is invalid",
+            ),
+            (
+                404,
+                b'{"detail":"Not Found"}',
+                RuntimeError,
+                "no runtime-headers route",
+            ),
         ):
-            await client.set_runtime_headers(
-                {"Bad Header": "value"},
-            )
+            with self.subTest(status=status):
+                gateway = GatewayClient(
+                    backend=object(),  # type: ignore[arg-type]
+                    gateway_port=5600,
+                )
+                gateway.exec_request = (  # type: ignore[method-assign]
+                    AsyncMock(return_value=(status, body))
+                )
+                client = self._proxy(gateway, connected=True)
+
+                with self.assertRaisesRegex(error, message):
+                    await client.set_runtime_headers({"X-Runtime": "value"})
 
 
 if __name__ == "__main__":

--- a/tests/mcp_runtime_headers_test.py
+++ b/tests/mcp_runtime_headers_test.py
@@ -238,6 +238,24 @@ class MCPRuntimeHeadersTest(IsolatedAsyncioTestCase):
                 with self.assertRaisesRegex(ValueError, "Streamable HTTP"):
                     await client.set_runtime_headers({"X-Runtime": "value"})
 
+    async def test_runtime_headers_reject_http_owned_names(self) -> None:
+        """httpx derives these with setdefault, so a value here would win."""
+        client = MCPClient(
+            name="runtime_headers",
+            is_stateful=False,
+            mcp_config=HttpMCPConfig(url="https://example.com/mcp"),
+        )
+
+        for name in (
+            "Host",
+            "Content-Length",
+            "Transfer-Encoding",
+            "connection",
+        ):
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(ValueError, "owned by the HTTP"):
+                    await client.set_runtime_headers({name: "hijacked"})
+
     async def test_runtime_headers_reject_invalid_wire_values(self) -> None:
         """Invalid names and values fail before an HTTP request is sent."""
         client = MCPClient(
@@ -297,6 +315,43 @@ class GatewayRuntimeHeadersRouteTest(unittest.TestCase):
                 "same_client": True,
                 "is_connected": True,
                 "runtime_headers": {"Authorization": "Bearer runtime"},
+            },
+        )
+
+    def test_registration_applies_headers_before_connect(self) -> None:
+        """The gateway's own handshake must use the rotated credential."""
+        at_connect: list[dict[str, str]] = []
+
+        async def capture(client: MCPClient) -> None:
+            at_connect.append(dict(client._runtime_headers))
+
+        with patch.object(MCPClient, "connect", capture), patch.object(
+            MCPClient,
+            "list_raw_tools",
+            AsyncMock(return_value=[]),
+        ):
+            response = self.client.post(
+                "/mcps",
+                params={"agent_id": "agent", "session_id": "session"},
+                json={
+                    "name": "fresh",
+                    "is_stateful": True,
+                    "mcp_config": {
+                        "type": "http_mcp",
+                        "url": "https://example.com/mcp",
+                    },
+                    "runtime_headers": {"Authorization": "Bearer runtime"},
+                },
+            )
+
+        self.assertDictEqual(
+            {
+                "status_code": response.status_code,
+                "headers_at_connect": at_connect,
+            },
+            {
+                "status_code": 200,
+                "headers_at_connect": [{"Authorization": "Bearer runtime"}],
             },
         )
 
@@ -368,12 +423,25 @@ class GatewayMCPClientRuntimeHeadersTest(IsolatedAsyncioTestCase):
             params={"agent_id": "agent", "session_id": "session"},
             body={"headers": {"Authorization": "Bearer runtime"}},
         )
-        self.assertIsNone(
-            client.model_dump(mode="json")["mcp_config"]["headers"],
+        self.assertDictEqual(
+            client.model_dump(mode="json"),
+            {
+                "name": "remote",
+                "is_stateful": False,
+                "mcp_config": {
+                    "type": "http_mcp",
+                    "url": "https://example.com/mcp",
+                    "headers": None,
+                    "timeout": 30.0,
+                },
+                "enable_tools": None,
+                "disable_tools": None,
+                "execution_timeout": None,
+            },
         )
 
-    async def test_proxy_replays_runtime_headers_on_reconnect(self) -> None:
-        """``model_dump`` drops them, so ``connect`` must push them again."""
+    async def test_proxy_registers_with_runtime_headers(self) -> None:
+        """The gateway connects during POST, so they must ride along."""
         gateway = GatewayClient(
             backend=object(),  # type: ignore[arg-type]
             gateway_port=5600,
@@ -388,12 +456,24 @@ class GatewayMCPClientRuntimeHeadersTest(IsolatedAsyncioTestCase):
         gateway.exec_request.reset_mock()
         await client.connect()
 
-        self.assertListEqual(
-            [call.args[:2] for call in gateway.exec_request.await_args_list],
-            [
-                ("POST", "/mcps"),
-                ("PUT", "/mcps/remote/runtime-headers"),
-            ],
+        gateway.exec_request.assert_awaited_once_with(
+            "POST",
+            "/mcps",
+            params={"agent_id": "agent", "session_id": "session"},
+            body={
+                "name": "remote",
+                "is_stateful": False,
+                "mcp_config": {
+                    "type": "http_mcp",
+                    "url": "https://example.com/mcp",
+                    "headers": None,
+                    "timeout": 30.0,
+                },
+                "enable_tools": None,
+                "disable_tools": None,
+                "execution_timeout": None,
+                "runtime_headers": {"Authorization": "Bearer runtime"},
+            },
         )
 
     async def test_proxy_rejects_update_before_connect(self) -> None:

--- a/tests/mcp_runtime_headers_test.py
+++ b/tests/mcp_runtime_headers_test.py
@@ -152,8 +152,8 @@ class MCPRuntimeHeadersTest(IsolatedAsyncioTestCase):
             {"Mcp-Session-Id": "from-transport"},
         )
 
-    async def test_streamable_http_client_keeps_mcp_defaults(self) -> None:
-        """Configured headers must not cost the SDK's HTTP defaults."""
+    async def test_owning_the_client_keeps_transport_defaults(self) -> None:
+        """Taking ownership must not change how the client is configured."""
         defaults: dict[str, Any] = {}
         for label, config in (
             (
@@ -184,7 +184,7 @@ class MCPRuntimeHeadersTest(IsolatedAsyncioTestCase):
             defaults,
             {
                 "configured": {
-                    "follow_redirects": True,
+                    "follow_redirects": False,
                     "read_timeout": 30.0,
                 },
                 "untimed": {


### PR DESCRIPTION
## AgentScope Version

2.0.7.post1

## Description

### Summary

Add support for updating MCP HTTP headers at runtime without rebuilding or re-registering the MCP client.

This mainly addresses Docker workspace scenarios, where the live MCP client runs inside the gateway process and cannot be updated by mutating the host-side client configuration.

### Changes

- Add `MCPClient.set_runtime_headers()` for Streamable HTTP clients.
- Apply runtime headers to each outgoing request through an HTTPX request hook.
- Support complete replacement and clearing of runtime headers.
- Allow local clients to set runtime headers before connecting.
- Add a gateway endpoint for updating the live MCP client: `PUT /mcps/{name}/runtime-headers`.
- Add `GatewayMCPClient.set_runtime_headers()` to forward updates to the gateway-side client.
- Keep runtime headers out of Pydantic serialization and workspace persistence.
- Prevent runtime headers from overriding HTTP- and MCP-managed headers.
- Validate header names and values before sending requests.
- Map gateway validation failures to `ValueError` for consistency with local clients.
- Replace private `_AsyncGeneratorContextManager` annotations with the public `AbstractAsyncContextManager` interface.

### Behavior

Runtime headers override static headers with the same name. Passing an empty dictionary clears all runtime overrides and restores the configured static headers.

The update affects subsequent outbound requests without reconnecting the MCP session. Requests already in progress may continue using the previous header snapshot.

### Limitations

- Runtime header updates currently support Streamable HTTP only.
- SSE transport is not supported because its headers are fixed when the stream is established.
- A `GatewayMCPClient` must be connected before its runtime headers can be updated.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review