### PR TITLE
fix(state): preserve LRU cache under concurrent hits

### DIFF
--- a/src/agentscope/state/_state.py
+++ b/src/agentscope/state/_state.py
@@ -62,27 +62,19 @@ class ToolContext(BaseModel):
                 except Exception:
                     updated_at = None
 
-                current_idx = next(
-                    (
-                        idx
-                        for idx, cached_entry in enumerate(
-                            self.read_file_cache,
-                        )
-                        if cached_entry is entry
-                    ),
-                    None,
-                )
-                if current_idx is None:
+                # Concurrent calls may have reordered or dropped the entry
+                # while awaiting, so locate it again by the object itself.
+                if entry not in self.read_file_cache:
                     return None
 
-                if updated_at == entry.updated_at:
-                    self.read_file_cache.pop(current_idx)
-                    self.read_file_cache.append(entry)
-                    return entry
+                self.read_file_cache.remove(entry)
+                if updated_at != entry.updated_at:
+                    # Cache is outdated, or the file no longer exists
+                    return None
 
-                # Cache is outdated or the file no longer exists
-                self.read_file_cache.pop(current_idx)
-                return None
+                # Move the entry to the most recent position
+                self.read_file_cache.append(entry)
+                return entry
         return None
 
     async def cache_file(self, file_path: str, lines: list[str]) -> None:

--- a/src/agentscope/state/_state.py
+++ b/src/agentscope/state/_state.py
@@ -54,23 +54,35 @@ class ToolContext(BaseModel):
         """
 
         # Find the cache entry
-        for idx, entry in enumerate(self.read_file_cache):
+        for entry in self.read_file_cache:
             if entry.file_path == file_path:
                 # Check if cache is still valid
                 try:
                     updated_at = await aiofiles.os.path.getmtime(file_path)
-                    if updated_at == entry.updated_at:
-                        self.read_file_cache.pop(idx)
-                        self.read_file_cache.append(entry)
-                        return entry
-                    else:
-                        # Cache is outdated, remove it
-                        self.read_file_cache.remove(entry)
-                        return None
                 except Exception:
-                    # File might not exist anymore
-                    self.read_file_cache.remove(entry)
+                    updated_at = None
+
+                current_idx = next(
+                    (
+                        idx
+                        for idx, cached_entry in enumerate(
+                            self.read_file_cache,
+                        )
+                        if cached_entry is entry
+                    ),
+                    None,
+                )
+                if current_idx is None:
                     return None
+
+                if updated_at == entry.updated_at:
+                    self.read_file_cache.pop(current_idx)
+                    self.read_file_cache.append(entry)
+                    return entry
+
+                # Cache is outdated or the file no longer exists
+                self.read_file_cache.pop(current_idx)
+                return None
         return None
 
     async def cache_file(self, file_path: str, lines: list[str]) -> None:

--- a/tests/builtin_file_cache_test.py
+++ b/tests/builtin_file_cache_test.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 """File cache test case for Read/Write/Edit tools."""
+import asyncio
 import os
 import tempfile
 from unittest.async_case import IsolatedAsyncioTestCase
+from unittest.mock import patch
 
-from agentscope.state import AgentState
+from agentscope.state import AgentState, ToolContext
 from agentscope.tool import Read, Write, Edit
 
 
@@ -279,6 +281,53 @@ class FileCacheTest(IsolatedAsyncioTestCase):
         self.assertNotIn(files[1], cached_paths)
         self.assertIn(files[2], cached_paths)
         self.assertIn(files[3], cached_paths)
+
+    async def test_concurrent_cache_hits_preserve_lru_entries(self) -> None:
+        """Concurrent hits must not duplicate or evict cache entries."""
+        context = ToolContext(
+            read_file_cache=[
+                {
+                    "lines": ["a"],
+                    "updated_at": 1.0,
+                    "bytes": 1.0,
+                    "file_path": "a",
+                },
+                {
+                    "lines": ["b"],
+                    "updated_at": 1.0,
+                    "bytes": 1.0,
+                    "file_path": "b",
+                },
+            ],
+        )
+        both_started = asyncio.Event()
+        calls = 0
+
+        async def synchronized_getmtime(_: str) -> float:
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                both_started.set()
+            await both_started.wait()
+            return 1.0
+
+        with patch(
+            "agentscope.state._state.aiofiles.os.path.getmtime",
+            side_effect=synchronized_getmtime,
+        ):
+            results = await asyncio.gather(
+                context.get_cache("a"),
+                context.get_cache("a"),
+            )
+
+        self.assertEqual(
+            [entry.file_path for entry in results if entry],
+            ["a", "a"],
+        )
+        self.assertEqual(
+            [entry.file_path for entry in context.read_file_cache],
+            ["b", "a"],
+        )
 
     async def test_cache_without_state(self) -> None:
         """Test tools work without state (fallback mode)."""

--- a/tests/builtin_file_cache_test.py
+++ b/tests/builtin_file_cache_test.py
@@ -7,6 +7,7 @@ from unittest.async_case import IsolatedAsyncioTestCase
 from unittest.mock import patch
 
 from agentscope.state import AgentState, ToolContext
+from agentscope.state._state import ReadCacheEntry
 from agentscope.tool import Read, Write, Edit
 
 
@@ -315,18 +316,46 @@ class FileCacheTest(IsolatedAsyncioTestCase):
             "agentscope.state._state.aiofiles.os.path.getmtime",
             side_effect=synchronized_getmtime,
         ):
-            results = await asyncio.gather(
-                context.get_cache("a"),
-                context.get_cache("a"),
+            results = list(
+                await asyncio.gather(
+                    context.get_cache("a"),
+                    context.get_cache("a"),
+                ),
             )
 
-        self.assertEqual(
-            [entry.file_path for entry in results if entry],
-            ["a", "a"],
+        self.assertListEqual(
+            results,
+            [
+                ReadCacheEntry(
+                    lines=["a"],
+                    updated_at=1.0,
+                    bytes=1.0,
+                    file_path="a",
+                ),
+                ReadCacheEntry(
+                    lines=["a"],
+                    updated_at=1.0,
+                    bytes=1.0,
+                    file_path="a",
+                ),
+            ],
         )
-        self.assertEqual(
-            [entry.file_path for entry in context.read_file_cache],
-            ["b", "a"],
+        self.assertListEqual(
+            context.read_file_cache,
+            [
+                ReadCacheEntry(
+                    lines=["b"],
+                    updated_at=1.0,
+                    bytes=1.0,
+                    file_path="b",
+                ),
+                ReadCacheEntry(
+                    lines=["a"],
+                    updated_at=1.0,
+                    bytes=1.0,
+                    file_path="a",
+                ),
+            ],
         )
 
     async def test_cache_without_state(self) -> None:


### PR DESCRIPTION
## AgentScope Version

2.0.7.post1

## Description

Fixes #2455.

`ToolContext.get_cache()` kept a cache-list index across an asynchronous
`getmtime()` call. Concurrent hits could reorder the list while another
coroutine was suspended, causing the stale index to remove an unrelated entry
and duplicate the requested entry.

This change re-finds the original cache entry by identity after the filesystem
check before updating its LRU position. If that entry was replaced or removed
while the check was in progress, the lookup returns `None` without modifying
the current cache entry.

## Tests

```bash
python -m pytest \
  tests/builtin_file_cache_test.py::FileCacheTest::test_concurrent_cache_hits_preserve_lru_entries \
  -q
# 1 passed

python -m pytest tests/builtin_file_cache_test.py -q
# 17 passed

python -m pytest tests/compress_context_test.py -k read_cache -q
# 3 passed, 10 deselected

pre-commit run --files \
  src/agentscope/state/_state.py \
  tests/builtin_file_cache_test.py

git diff --check upstream/main..HEAD
```

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated
- [x] Code is ready for review
