### PR TITLE
fix(middleware): isolate concurrent retrieval tasks per session

### DIFF
--- a/src/agentscope/middleware/_longterm_memory/_agentic_memory/_middleware.py
+++ b/src/agentscope/middleware/_longterm_memory/_agentic_memory/_middleware.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, AsyncGenerator, Callable
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable
 
 from pydantic import BaseModel, Field
 
@@ -476,11 +476,12 @@ class AgenticMemoryMiddleware(MiddlewareBase):
         self._parameters = parameters or self.Parameters()
         self._backend = backend or LocalBackend()
 
-        self._cached_input: str | None = None
-        # The in-flight asynchronous retrieval task started in ``on_reply``
-        # and consumed in ``on_reasoning``. Kept on the instance so the
-        # reasoning hook can poll for completion across iterations.
-        self._retrieval_task: asyncio.Task | None = None
+        # In-flight background retrieval per session (started in ``on_reply``,
+        # consumed/injected in ``on_reasoning``, cleaned up in ``on_reply``'s
+        # finally). Keyed by ``session_id`` so one middleware shared across
+        # agents keeps each session's retrieval isolated — a concurrent reply
+        # in another session never clobbers this one's task.
+        self._retrieval_tasks: dict[Any, asyncio.Task] = {}
 
     @staticmethod
     def _truncate_if_needed(content: str, max_length: int) -> str:
@@ -565,14 +566,25 @@ class AgenticMemoryMiddleware(MiddlewareBase):
 
         return f"{current_prompt}\n\n{content}"
 
+    @staticmethod
+    def _session_id_of(agent: "Agent") -> str | None:
+        """Read the ``session_id`` live from the agent.
+
+        The retrieval task is keyed by ``session_id``, read from
+        ``agent.state.session_id`` at hook time and threaded through per
+        call — **never** stored on the middleware — so a single instance
+        shared across agents keeps each session's retrieval isolated.
+        """
+        return getattr(getattr(agent, "state", None), "session_id", None)
+
     async def on_reply(
         self,
         agent: "Agent",
         input_kwargs: dict,
         next_handler: Callable[..., AsyncGenerator],
     ) -> AsyncGenerator:
-        """Cache the user input and kick off an asynchronous retrieval task
-        that runs concurrently with the agent reply.
+        """Kick off an asynchronous retrieval task that runs concurrently
+        with the agent reply.
 
         Args:
             agent (`Agent`):
@@ -586,6 +598,7 @@ class AgenticMemoryMiddleware(MiddlewareBase):
             `Any`:
                 Items yielded by ``next_handler``.
         """
+        session_id = self._session_id_of(agent)
 
         if self._parameters.retrieval_async:
             inputs = input_kwargs.get("inputs")
@@ -598,8 +611,9 @@ class AgenticMemoryMiddleware(MiddlewareBase):
             elif isinstance(inputs, Msg):
                 msgs = [inputs]
 
+            cached_input = None
             if msgs is not None:
-                self._cached_input = "\n".join(
+                cached_input = "\n".join(
                     [
                         f"{_.name}: " + _.get_text_content()
                         for _ in msgs
@@ -607,30 +621,35 @@ class AgenticMemoryMiddleware(MiddlewareBase):
                     ],
                 )
 
+            # Discard any stale task left for this session (a previous turn
+            # that never reached its finally is unexpected, but never leak
+            # one).
+            stale = self._retrieval_tasks.pop(session_id, None)
+            if stale is not None and not stale.done():
+                stale.cancel()
+
             # Start an asynchronous retrieval task that uses an LLM to decide
             # which memory files are relevant to the current user input. The
             # result is consumed by ``on_reasoning``.
-            if self._cached_input:
-                self._retrieval_task = asyncio.create_task(
-                    self._retrieve_relevant_files(agent, self._cached_input),
+            if cached_input:
+                self._retrieval_tasks[session_id] = asyncio.create_task(
+                    self._retrieve_relevant_files(agent, cached_input),
                 )
 
         try:
             async for _ in next_handler(**input_kwargs):
                 yield _
         finally:
-            # Ensure the retrieval task does not outlive the reply.
-            if (
-                self._retrieval_task is not None
-                and not self._retrieval_task.done()
-            ):
-                self._retrieval_task.cancel()
+            # Consume this session's retrieval task so it does not outlive
+            # the reply; tasks of other in-flight sessions are untouched.
+            task = self._retrieval_tasks.pop(session_id, None)
+            if task is not None:
+                if not task.done():
+                    task.cancel()
                 try:
-                    await self._retrieval_task
+                    await task
                 except (asyncio.CancelledError, Exception):  # noqa: BLE001
                     pass
-            self._retrieval_task = None
-            self._cached_input = None
 
     async def on_reasoning(
         self,
@@ -653,11 +672,13 @@ class AgenticMemoryMiddleware(MiddlewareBase):
             `Any`:
                 Items yielded by ``next_handler``.
         """
-        # Poll the in-flight retrieval task; if it has finished, consume its
-        # result and inject it into the agent context exactly once.
-        if self._retrieval_task is not None and self._retrieval_task.done():
-            task = self._retrieval_task
-            self._retrieval_task = None
+        # Poll this session's in-flight retrieval task; if it has finished,
+        # consume its result and inject it into the agent context exactly
+        # once. Tasks of other in-flight sessions are left untouched.
+        session_id = self._session_id_of(agent)
+        task = self._retrieval_tasks.get(session_id)
+        if task is not None and task.done():
+            self._retrieval_tasks.pop(session_id, None)
             try:
                 retrieval_result = task.result()
             except (asyncio.CancelledError, Exception):

--- a/src/agentscope/middleware/_longterm_memory/_agentic_memory/_middleware.py
+++ b/src/agentscope/middleware/_longterm_memory/_agentic_memory/_middleware.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable
+from typing import TYPE_CHECKING, AsyncGenerator, Callable
 
 from pydantic import BaseModel, Field
 
@@ -476,12 +476,9 @@ class AgenticMemoryMiddleware(MiddlewareBase):
         self._parameters = parameters or self.Parameters()
         self._backend = backend or LocalBackend()
 
-        # In-flight background retrieval per session (started in ``on_reply``,
-        # consumed/injected in ``on_reasoning``, cleaned up in ``on_reply``'s
-        # finally). Keyed by ``session_id`` so one middleware shared across
-        # agents keeps each session's retrieval isolated — a concurrent reply
-        # in another session never clobbers this one's task.
-        self._retrieval_tasks: dict[Any, asyncio.Task] = {}
+        # In-flight retrieval per session, so a shared instance never
+        # clobbers another session's task.
+        self._retrieval_tasks: dict[str, asyncio.Task] = {}
 
     @staticmethod
     def _truncate_if_needed(content: str, max_length: int) -> str:
@@ -566,17 +563,6 @@ class AgenticMemoryMiddleware(MiddlewareBase):
 
         return f"{current_prompt}\n\n{content}"
 
-    @staticmethod
-    def _session_id_of(agent: "Agent") -> str | None:
-        """Read the ``session_id`` live from the agent.
-
-        The retrieval task is keyed by ``session_id``, read from
-        ``agent.state.session_id`` at hook time and threaded through per
-        call — **never** stored on the middleware — so a single instance
-        shared across agents keeps each session's retrieval isolated.
-        """
-        return getattr(getattr(agent, "state", None), "session_id", None)
-
     async def on_reply(
         self,
         agent: "Agent",
@@ -598,7 +584,7 @@ class AgenticMemoryMiddleware(MiddlewareBase):
             `Any`:
                 Items yielded by ``next_handler``.
         """
-        session_id = self._session_id_of(agent)
+        session_id = agent.state.session_id
 
         if self._parameters.retrieval_async:
             inputs = input_kwargs.get("inputs")
@@ -675,7 +661,7 @@ class AgenticMemoryMiddleware(MiddlewareBase):
         # Poll this session's in-flight retrieval task; if it has finished,
         # consume its result and inject it into the agent context exactly
         # once. Tasks of other in-flight sessions are left untouched.
-        session_id = self._session_id_of(agent)
+        session_id = agent.state.session_id
         task = self._retrieval_tasks.get(session_id)
         if task is not None and task.done():
             self._retrieval_tasks.pop(session_id, None)

--- a/tests/middleware_filesystem_memory_test.py
+++ b/tests/middleware_filesystem_memory_test.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=protected-access,unused-argument
 """Unit tests for AgenticMemoryMiddleware with real Agent execution."""
 import asyncio
 import os
@@ -7,6 +6,7 @@ import shutil
 import tempfile
 from typing import Any, AsyncGenerator, Type
 from unittest.async_case import IsolatedAsyncioTestCase
+from unittest.mock import patch
 
 from pydantic import BaseModel
 from utils import AnyString, AnyValue, MockModel
@@ -799,19 +799,8 @@ class AgenticMemoryMiddlewareTest(IsolatedAsyncioTestCase):
         }
         session_of = {id(agent_a): session_a, id(agent_b): session_b}
 
-        async def fake_retrieve(agent: Agent, query: str) -> str:
-            """Block on ``release`` so the task lifetime is deterministic.
-
-            Args:
-                agent (`Agent`):
-                    The agent whose session owns the retrieval.
-                query (`str`):
-                    The cached user input (unused).
-
-            Returns:
-                `str`:
-                    A per-session sentinel hint.
-            """
+        async def fake_retrieve(agent: Agent, _query: str) -> str:
+            """Block on ``release`` so the task lifetime is deterministic."""
             session = session_of[id(agent)]
             started[session].set()
             try:
@@ -821,12 +810,10 @@ class AgenticMemoryMiddlewareTest(IsolatedAsyncioTestCase):
                 raise
             return hints[session]
 
-        middleware._retrieve_relevant_files = fake_retrieve
-
         async def drive_on_reply(agent: Agent) -> None:
             """Drive ``on_reply`` with a handler blocked on the gate."""
 
-            async def next_handler(**kwargs: Any) -> AsyncGenerator:
+            async def next_handler(**_kwargs: Any) -> AsyncGenerator:
                 await gate[session_of[id(agent)]].wait()
                 yield "event"
 
@@ -837,50 +824,45 @@ class AgenticMemoryMiddlewareTest(IsolatedAsyncioTestCase):
             ):
                 pass
 
-        reply_a = asyncio.create_task(drive_on_reply(agent_a))
-        await started[session_a].wait()
-        reply_b = asyncio.create_task(drive_on_reply(agent_b))
-        await started[session_b].wait()
+        with patch.object(
+            middleware,
+            "_retrieve_relevant_files",
+            fake_retrieve,
+        ):
+            reply_a = asyncio.create_task(drive_on_reply(agent_a))
+            await started[session_a].wait()
+            reply_b = asyncio.create_task(drive_on_reply(agent_b))
+            await started[session_b].wait()
 
-        # Session A finishes its reply while session B's retrieval is still
-        # in flight: A's cleanup must cancel only A's own task.
-        gate[session_a].set()
-        await reply_a
-        task_b = middleware._retrieval_tasks.get(session_b)
-        b_task_alive_after_a_exit = task_b is not None and not task_b.done()
-        a_entry_left_after_a_exit = session_a in middleware._retrieval_tasks
+            # Session A finishes its reply while session B's retrieval is
+            # still in flight: A's cleanup must cancel only A's own task.
+            gate[session_a].set()
+            await reply_a
 
-        # Session B's retrieval completes and is consumed by its own
-        # reasoning hook — not cancelled by A's cleanup.
-        release.set()
-        await task_b
+            # Session B's retrieval completes and is consumed by its own
+            # reasoning hook — not cancelled by A's cleanup.
+            release.set()
+            await asyncio.sleep(0)
 
-        async def passthrough(**kwargs: Any) -> AsyncGenerator:
-            yield "reasoning-event"
+            async def passthrough(**_kwargs: Any) -> AsyncGenerator:
+                """Forward reasoning items unchanged."""
+                yield "reasoning-event"
 
-        async for _ in middleware.on_reasoning(agent_b, {}, passthrough):
-            pass
+            async for _ in middleware.on_reasoning(agent_b, {}, passthrough):
+                pass
 
-        gate[session_b].set()
-        await reply_b
+            gate[session_b].set()
+            await reply_b
 
         self.assertDictEqual(
             {
                 "a_retrieval_cancelled": cancelled[session_a],
                 "b_retrieval_cancelled": cancelled[session_b],
-                "b_task_alive_after_a_exit": b_task_alive_after_a_exit,
-                "a_entry_left_after_a_exit": a_entry_left_after_a_exit,
                 "b_hints": _hint_texts(agent_b),
-                "tasks_left_after_both_replies": len(
-                    middleware._retrieval_tasks,
-                ),
             },
             {
                 "a_retrieval_cancelled": True,
                 "b_retrieval_cancelled": False,
-                "b_task_alive_after_a_exit": True,
-                "a_entry_left_after_a_exit": False,
                 "b_hints": ["hint for session b"],
-                "tasks_left_after_both_replies": 0,
             },
         )

--- a/tests/middleware_filesystem_memory_test.py
+++ b/tests/middleware_filesystem_memory_test.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access,unused-argument
 """Unit tests for AgenticMemoryMiddleware with real Agent execution."""
+import asyncio
 import os
 import shutil
 import tempfile
-from typing import Any, Type
+from typing import Any, AsyncGenerator, Type
 from unittest.async_case import IsolatedAsyncioTestCase
 
 from pydantic import BaseModel
@@ -772,5 +774,113 @@ class AgenticMemoryMiddlewareTest(IsolatedAsyncioTestCase):
                 },
                 "hints": [],
                 "structured_call_count": 0,
+            },
+        )
+
+    async def test_concurrent_replies_isolate_retrieval_per_session(
+        self,
+    ) -> None:
+        """A reply finishing in one session must not cancel another
+        session's in-flight retrieval task."""
+        middleware = AgenticMemoryMiddleware(workdir=self.temp_dir)
+        agent_a = self._make_agent(_RecordingMockModel(), middleware)
+        agent_b = self._make_agent(_RecordingMockModel(), middleware)
+        session_a = agent_a.state.session_id
+        session_b = agent_b.state.session_id
+        self.assertNotEqual(session_a, session_b)
+
+        started = {session_a: asyncio.Event(), session_b: asyncio.Event()}
+        gate = {session_a: asyncio.Event(), session_b: asyncio.Event()}
+        release = asyncio.Event()
+        cancelled = {session_a: False, session_b: False}
+        hints = {
+            session_a: "hint for session a",
+            session_b: "hint for session b",
+        }
+        session_of = {id(agent_a): session_a, id(agent_b): session_b}
+
+        async def fake_retrieve(agent: Agent, query: str) -> str:
+            """Block on ``release`` so the task lifetime is deterministic.
+
+            Args:
+                agent (`Agent`):
+                    The agent whose session owns the retrieval.
+                query (`str`):
+                    The cached user input (unused).
+
+            Returns:
+                `str`:
+                    A per-session sentinel hint.
+            """
+            session = session_of[id(agent)]
+            started[session].set()
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                cancelled[session] = True
+                raise
+            return hints[session]
+
+        middleware._retrieve_relevant_files = fake_retrieve
+
+        async def drive_on_reply(agent: Agent) -> None:
+            """Drive ``on_reply`` with a handler blocked on the gate."""
+
+            async def next_handler(**kwargs: Any) -> AsyncGenerator:
+                await gate[session_of[id(agent)]].wait()
+                yield "event"
+
+            async for _ in middleware.on_reply(
+                agent,
+                {"inputs": UserMsg("user", "hello")},
+                next_handler,
+            ):
+                pass
+
+        reply_a = asyncio.create_task(drive_on_reply(agent_a))
+        await started[session_a].wait()
+        reply_b = asyncio.create_task(drive_on_reply(agent_b))
+        await started[session_b].wait()
+
+        # Session A finishes its reply while session B's retrieval is still
+        # in flight: A's cleanup must cancel only A's own task.
+        gate[session_a].set()
+        await reply_a
+        task_b = middleware._retrieval_tasks.get(session_b)
+        b_task_alive_after_a_exit = task_b is not None and not task_b.done()
+        a_entry_left_after_a_exit = session_a in middleware._retrieval_tasks
+
+        # Session B's retrieval completes and is consumed by its own
+        # reasoning hook — not cancelled by A's cleanup.
+        release.set()
+        await task_b
+
+        async def passthrough(**kwargs: Any) -> AsyncGenerator:
+            yield "reasoning-event"
+
+        async for _ in middleware.on_reasoning(agent_b, {}, passthrough):
+            pass
+
+        gate[session_b].set()
+        await reply_b
+
+        self.assertDictEqual(
+            {
+                "a_retrieval_cancelled": cancelled[session_a],
+                "b_retrieval_cancelled": cancelled[session_b],
+                "b_task_alive_after_a_exit": b_task_alive_after_a_exit,
+                "a_entry_left_after_a_exit": a_entry_left_after_a_exit,
+                "b_hints": _hint_texts(agent_b),
+                "tasks_left_after_both_replies": len(
+                    middleware._retrieval_tasks,
+                ),
+            },
+            {
+                "a_retrieval_cancelled": True,
+                "b_retrieval_cancelled": False,
+                "b_task_alive_after_a_exit": True,
+                "a_entry_left_after_a_exit": False,
+                "b_hints": ["hint for session b"],
+                "tasks_left_after_both_replies": 0,
             },
         )


### PR DESCRIPTION
Fixes #2274

## AgentScope Version

2.0.7.post1 (main @ e90f1c75)

## Description

**Problem.** `AgenticMemoryMiddleware` kept its in-flight retrieval task in a single instance-level `_retrieval_task` slot. When one middleware instance is shared by multiple agents/sessions, a later reply overwrites the earlier session's task, and the earlier reply's `on_reply` `finally` block then cancels the **later** session's retrieval instead of its own (see the hook-level reproduction in #2274).

**Changes** (mirrors the per-session isolation pattern already used by `ReMeMiddleware`):
- Replace the single `_retrieval_task` slot with `_retrieval_tasks: dict[str, Task]`, keyed by `agent.state.session_id` read live at hook time.
- `on_reply` discards any stale task left for its own session before starting a new one, and its `finally` consumes/cancels **only** this session's task; tasks of other in-flight sessions are untouched.
- `on_reasoning` consumes the matching session's task only.
- `_cached_input` (the other piece of per-reply state previously kept on the instance) is now a local variable in `on_reply`.

**Scope.** This isolates replies from *different* sessions sharing one middleware instance. Two concurrent replies within the *same* session (e.g. agents restored from one chat session, `app/_service/_chat.py:982`) can still clobber each other's task; per-reply keying would be needed for that and is left as future work.

No public API, configuration, or default behavior changed.

**Tests.** Regression test `test_concurrent_replies_isolate_retrieval_per_session`: two agents sharing one middleware instance, retrieval stubbed to block on an event so the interleaving is deterministic. Asserts behavior only: session A finishing its reply cancels only A's own task, session B's retrieval is not cancelled, and B's `on_reasoning` afterwards injects B's own hint.

## Checklist

- [x]  An issue has been created for this PR
- [x]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [x]  Code is ready for review

Local checks: `pytest` on the middleware suites — all pass; `black --line-length=79`, `flake8 --extend-ignore=E203`, `mypy`, `pylint` clean on the changed files.
