### PR TITLE
fix(xai): include reasoning tokens in output usage

### DIFF
--- a/src/agentscope/model/_xai/_model.py
+++ b/src/agentscope/model/_xai/_model.py
@@ -381,7 +381,7 @@ class XAIChatModel(ChatModelBase):
             u = last_response.usage
             trailing.usage = ChatUsage(
                 input_tokens=u.prompt_tokens,
-                output_tokens=u.completion_tokens,
+                output_tokens=u.completion_tokens + u.reasoning_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
                 cache_input_tokens=getattr(
                     u,
@@ -433,7 +433,7 @@ class XAIChatModel(ChatModelBase):
             u = response.usage
             usage = ChatUsage(
                 input_tokens=u.prompt_tokens,
-                output_tokens=u.completion_tokens,
+                output_tokens=u.completion_tokens + u.reasoning_tokens,
                 time=(datetime.now() - start_datetime).total_seconds(),
                 cache_input_tokens=getattr(
                     u,

--- a/tests/model_xai_test.py
+++ b/tests/model_xai_test.py
@@ -307,6 +307,37 @@ class TestXAINonStream(IsolatedAsyncioTestCase):
             ),
         )
 
+    @patch("xai_sdk.AsyncClient")
+    async def test_usage_includes_reasoning_tokens(
+        self,
+        mock_client_cls: MagicMock,
+    ) -> None:
+        """Reasoning tokens are included in normalized output usage."""
+        response = _mock_completion(text="Answer")
+        response.usage = MagicMock()
+        response.usage.prompt_tokens = 100
+        response.usage.completion_tokens = 20
+        response.usage.reasoning_tokens = 30
+        response.usage.cached_prompt_text_tokens = 10
+        mock_chat = _MockChatStream(sample_response=response)
+        mock_client_cls.return_value.chat.create.return_value = mock_chat
+        mock_client_cls.return_value.close = AsyncMock()
+
+        result = await self.model([])
+
+        self.assertEqual(
+            dict(result.usage),
+            {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "time": result.usage.time,
+                "cache_creation_input_tokens": 0,
+                "cache_input_tokens": 10,
+                "type": "chat",
+                "metadata": None,
+            },
+        )
+
 
 # ---------------------------------------------------------------------------
 # Streaming tests
@@ -327,6 +358,7 @@ class TestXAIStream(IsolatedAsyncioTestCase):
         final_response.usage = MagicMock()
         final_response.usage.prompt_tokens = 10
         final_response.usage.completion_tokens = 5
+        final_response.usage.reasoning_tokens = 0
         final_response.usage.cached_prompt_text_tokens = 0
 
         stream_items = [
@@ -388,6 +420,7 @@ class TestXAIStream(IsolatedAsyncioTestCase):
         final_response.usage = MagicMock()
         final_response.usage.prompt_tokens = 10
         final_response.usage.completion_tokens = 5
+        final_response.usage.reasoning_tokens = 7
         final_response.usage.cached_prompt_text_tokens = 0
 
         stream_items = [
@@ -441,6 +474,18 @@ class TestXAIStream(IsolatedAsyncioTestCase):
                 ),
             ],
         )
+        self.assertEqual(
+            dict(responses[-1].usage),
+            {
+                "input_tokens": 10,
+                "output_tokens": 12,
+                "time": responses[-1].usage.time,
+                "cache_creation_input_tokens": 0,
+                "cache_input_tokens": 0,
+                "type": "chat",
+                "metadata": None,
+            },
+        )
 
     @patch("xai_sdk.AsyncClient")
     async def test_stream_tool_calls_in_final(
@@ -460,6 +505,7 @@ class TestXAIStream(IsolatedAsyncioTestCase):
         final_response.usage = MagicMock()
         final_response.usage.prompt_tokens = 10
         final_response.usage.completion_tokens = 5
+        final_response.usage.reasoning_tokens = 0
         final_response.usage.cached_prompt_text_tokens = 0
 
         stream_items = [


### PR DESCRIPTION
## AgentScope Version

2.0.7.post1

## Description

The xAI SDK reports `completion_tokens` and `reasoning_tokens` separately, but `XAIChatModel` previously used only `completion_tokens` for normalized `output_tokens`. This caused reasoning usage to be omitted from cost and budget accounting.

This PR includes `reasoning_tokens` in `output_tokens` for both streaming and non-streaming responses and adds regression tests for both paths.

**How to test:**

```bash
pytest tests/model_xai_test.py
```

## Checklist

- [ ] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation has been updated (N/A — no user-facing documentation changes are needed)
- [x] Code is ready for review