### PR TITLE
fix(gemini): preserve tool call thought signatures

### DIFF
--- a/src/agentscope/formatter/_gemini_formatter.py
+++ b/src/agentscope/formatter/_gemini_formatter.py
@@ -202,21 +202,29 @@ class GeminiChatFormatter(_GeminiFormatterBase):
                         parts.append(formatted)
 
                 elif isinstance(block, ToolCallBlock):
-                    parts.append(
-                        {
-                            "function_call": {
-                                "id": block.id,
-                                "name": block.name,
-                                # Use the repair helper so a truncated input
-                                # (from interrupted streaming or context
-                                # compression) degrades to {} instead of
-                                # raising JSONDecodeError.
-                                "args": _json_loads_with_repair(
-                                    block.input or "{}",
-                                ),
-                            },
+                    function_call_part: dict[str, Any] = {
+                        "function_call": {
+                            "id": block.id,
+                            "name": block.name,
+                            # Use the repair helper so a truncated input
+                            # (from interrupted streaming or context
+                            # compression) degrades to {} instead of raising
+                            # JSONDecodeError.
+                            "args": _json_loads_with_repair(
+                                block.input or "{}",
+                            ),
                         },
+                    }
+                    thought_signature = getattr(
+                        block,
+                        "thought_signature",
+                        None,
                     )
+                    if thought_signature:
+                        function_call_part[
+                            "thought_signature"
+                        ] = base64.b64decode(thought_signature)
+                    parts.append(function_call_part)
 
                 elif isinstance(block, ToolResultBlock):
                     if parts:

--- a/src/agentscope/message/_block.py
+++ b/src/agentscope/message/_block.py
@@ -136,9 +136,14 @@ class ToolCallState(StrEnum):
 
 
 class ToolCallBlock(BaseModel):
-    """The tool call block."""
+    """The tool call block.
 
-    model_config = ConfigDict(use_enum_values=True)
+    Allows extra provider-specific fields (e.g. Gemini's
+    ``thought_signature``) via ``extra="allow"`` so model implementations can
+    preserve metadata that must be returned with conversation history.
+    """
+
+    model_config = ConfigDict(use_enum_values=True, extra="allow")
 
     type: Literal["tool_call"] = "tool_call"
     """The type of the tool call block, which is always 'tool_call'."""

--- a/src/agentscope/model/_gemini/_model.py
+++ b/src/agentscope/model/_gemini/_model.py
@@ -394,10 +394,12 @@ class GeminiChatModel(ChatModelBase):
 
                     # Tool call
                     if part.function_call:
+                        thought_signature: str | None = None
                         if part.thought_signature:
-                            call_id = base64.b64encode(
+                            thought_signature = base64.b64encode(
                                 part.thought_signature,
                             ).decode("utf-8")
+                            call_id = thought_signature
                         else:
                             call_id = part.function_call.id or _generate_id()
 
@@ -408,6 +410,7 @@ class GeminiChatModel(ChatModelBase):
                                 part.function_call.args or {},
                                 ensure_ascii=False,
                             ),
+                            thought_signature=thought_signature,
                         )
 
             usage = self._extract_usage(chunk.usage_metadata, start_datetime)
@@ -451,19 +454,22 @@ class GeminiChatModel(ChatModelBase):
 
                 if part.function_call:
                     keyword_args = part.function_call.args or {}
+                    thought_signature: str | None = None
                     if part.thought_signature:
-                        call_id = base64.b64encode(
+                        thought_signature = base64.b64encode(
                             part.thought_signature,
                         ).decode("utf-8")
+                        call_id = thought_signature
                     else:
                         call_id = part.function_call.id or _generate_id()
-                    content_blocks.append(
-                        ToolCallBlock(
-                            id=call_id,
-                            name=part.function_call.name,
-                            input=json.dumps(keyword_args, ensure_ascii=False),
-                        ),
+                    tool_call = ToolCallBlock(
+                        id=call_id,
+                        name=part.function_call.name,
+                        input=json.dumps(keyword_args, ensure_ascii=False),
                     )
+                    if thought_signature:
+                        tool_call.thought_signature = thought_signature
+                    content_blocks.append(tool_call)
 
         usage = self._extract_usage(response.usage_metadata, start_datetime)
 

--- a/src/agentscope/model/_gemini/_model.py
+++ b/src/agentscope/model/_gemini/_model.py
@@ -399,9 +399,11 @@ class GeminiChatModel(ChatModelBase):
                             thought_signature = base64.b64encode(
                                 part.thought_signature,
                             ).decode("utf-8")
-                            call_id = thought_signature
-                        else:
-                            call_id = part.function_call.id or _generate_id()
+                        call_id = (
+                            part.function_call.id
+                            or thought_signature
+                            or _generate_id()
+                        )
 
                         delta_res.append_tool_call(
                             block_id=call_id,
@@ -459,9 +461,11 @@ class GeminiChatModel(ChatModelBase):
                         thought_signature = base64.b64encode(
                             part.thought_signature,
                         ).decode("utf-8")
-                        call_id = thought_signature
-                    else:
-                        call_id = part.function_call.id or _generate_id()
+                    call_id = (
+                        part.function_call.id
+                        or thought_signature
+                        or _generate_id()
+                    )
                     tool_call = ToolCallBlock(
                         id=call_id,
                         name=part.function_call.name,

--- a/src/agentscope/model/_gemini/_model.py
+++ b/src/agentscope/model/_gemini/_model.py
@@ -399,11 +399,7 @@ class GeminiChatModel(ChatModelBase):
                             thought_signature = base64.b64encode(
                                 part.thought_signature,
                             ).decode("utf-8")
-                        call_id = (
-                            part.function_call.id
-                            or thought_signature
-                            or _generate_id()
-                        )
+                        call_id = part.function_call.id or _generate_id()
 
                         delta_res.append_tool_call(
                             block_id=call_id,
@@ -461,19 +457,22 @@ class GeminiChatModel(ChatModelBase):
                         thought_signature = base64.b64encode(
                             part.thought_signature,
                         ).decode("utf-8")
-                    call_id = (
-                        part.function_call.id
-                        or thought_signature
-                        or _generate_id()
+                    call_id = part.function_call.id or _generate_id()
+                    content_blocks.append(
+                        ToolCallBlock(
+                            id=call_id,
+                            name=part.function_call.name,
+                            input=json.dumps(
+                                keyword_args,
+                                ensure_ascii=False,
+                            ),
+                            **(
+                                {"thought_signature": thought_signature}
+                                if thought_signature
+                                else {}
+                            ),
+                        ),
                     )
-                    tool_call = ToolCallBlock(
-                        id=call_id,
-                        name=part.function_call.name,
-                        input=json.dumps(keyword_args, ensure_ascii=False),
-                    )
-                    if thought_signature:
-                        tool_call.thought_signature = thought_signature
-                    content_blocks.append(tool_call)
 
         usage = self._extract_usage(response.usage_metadata, start_datetime)
 

--- a/src/agentscope/model/_utils.py
+++ b/src/agentscope/model/_utils.py
@@ -89,8 +89,13 @@ class _AccToolCallBlock(ToolCallBlock):
         self.input.append(block.input)
         # Most providers carry ``name`` on the opening delta only, but some
         # send an empty one first and fill the name in afterwards.
-        if not self.name and block.name:
+        if not getattr(self, "name", "") and block.name:
             self.name = block.name
+        # Provider-specific extras (e.g. Gemini's ``thought_signature``)
+        # may arrive on a later delta of the block.
+        for key, value in (block.model_extra or {}).items():
+            if value is not None:
+                setattr(self, key, value)
 
     def build(self) -> ToolCallBlock:
         """Join the fragments into a plain ``ToolCallBlock``."""

--- a/tests/model_base_test.py
+++ b/tests/model_base_test.py
@@ -1074,7 +1074,63 @@ class ChatModelBaseCallTest(IsolatedAsyncioTestCase):
         )
 
     # ------------------------------------------------------------------
-    # 14) stream usage carried by a trailing usage-only chunk
+    # 14) stream tool-call metadata carried by a later delta
+    # ------------------------------------------------------------------
+    async def test_stream_tool_call_metadata_on_later_delta(self) -> None:
+        """Provider metadata on a later tool-call delta must survive."""
+        deltas = [
+            ChatResponse(
+                content=[
+                    ToolCallBlock(
+                        id="tool-1",
+                        name="search",
+                        input='{"query":',
+                    ),
+                ],
+                is_last=False,
+                id="chunk-1",
+            ),
+            ChatResponse(
+                content=[
+                    ToolCallBlock(
+                        id="tool-1",
+                        name="",
+                        input='"hello"}',
+                        thought_signature="sig-abc",
+                    ),
+                ],
+                is_last=False,
+                id="chunk-2",
+            ),
+        ]
+        self.model.set_responses([deltas])
+
+        gen = await self.model(messages=self.messages)
+        last_chunk = None
+        async for chunk in gen:
+            last_chunk = chunk
+
+        self.assertDictEqual(
+            _dump(last_chunk),
+            _expected(
+                content=[
+                    {
+                        "type": "tool_call",
+                        "id": "tool-1",
+                        "name": "search",
+                        "input": '{"query":"hello"}',
+                        "state": "pending",
+                        "suggested_rules": [],
+                        "thought_signature": "sig-abc",
+                    },
+                ],
+                is_last=True,
+                finished_reason=FinishedReason.COMPLETED,
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # 15) stream usage carried by a trailing usage-only chunk
     # ------------------------------------------------------------------
     async def test_stream_usage_absorbed_into_accumulated(self) -> None:
         """OpenAI-compatible APIs emit a trailing usage-only chunk with

--- a/tests/model_gemini_test.py
+++ b/tests/model_gemini_test.py
@@ -21,6 +21,7 @@ from agentscope.message import (
     Msg,
     TextBlock,
     ToolCallBlock,
+    ToolResultBlock,
     ThinkingBlock,
 )
 from agentscope.model import GeminiChatModel
@@ -240,7 +241,7 @@ class TestGeminiNonStream(IsolatedAsyncioTestCase):
                 function_call={
                     "name": "get_weather",
                     "args": {"city": "Tokyo"},
-                    "id": None,
+                    "id": "gemini-call-1",
                 },
                 thought_signature=signature,
             ),
@@ -252,14 +253,21 @@ class TestGeminiNonStream(IsolatedAsyncioTestCase):
         result = await self.model([])
         history_msg = AssistantMsg(
             name="assistant",
-            content=result.content,
+            content=[
+                *result.content,
+                ToolResultBlock(
+                    id=result.content[0].id,
+                    name="get_weather",
+                    output="sunny",
+                ),
+            ],
         )
         restored_msg = Msg.model_validate(history_msg.model_dump())
         formatted = await GeminiChatFormatter().format(
             [restored_msg],
         )
 
-        self.assertEqual(result.content[0].id, signature_b64)
+        self.assertEqual(result.content[0].id, "gemini-call-1")
         self.assertEqual(
             getattr(result.content[0], "thought_signature", None),
             signature_b64,
@@ -268,12 +276,42 @@ class TestGeminiNonStream(IsolatedAsyncioTestCase):
             formatted[0]["parts"][0],
             {
                 "function_call": {
-                    "id": signature_b64,
+                    "id": "gemini-call-1",
                     "name": "get_weather",
                     "args": {"city": "Tokyo"},
                 },
                 "thought_signature": signature,
             },
+        )
+        self.assertEqual(
+            formatted[1]["parts"][0]["function_response"]["id"],
+            "gemini-call-1",
+        )
+
+    async def test_thought_signature_remains_the_id_fallback(self) -> None:
+        """A signature remains the fallback when Gemini omits a call id."""
+        signature = b"signature-without-call-id"
+        signature_b64 = base64.b64encode(signature).decode("utf-8")
+        parts = [
+            _make_part(
+                function_call={
+                    "name": "get_weather",
+                    "args": {"city": "Tokyo"},
+                    "id": None,
+                },
+                thought_signature=signature,
+            ),
+        ]
+        self.mock_client.aio.models.generate_content = AsyncMock(
+            return_value=_mock_completion(parts),
+        )
+
+        result = await self.model([])
+
+        self.assertEqual(result.content[0].id, signature_b64)
+        self.assertEqual(
+            getattr(result.content[0], "thought_signature", None),
+            signature_b64,
         )
 
     async def test_thinking_response(self) -> None:
@@ -613,7 +651,7 @@ class TestGeminiStream(IsolatedAsyncioTestCase):
                         function_call={
                             "name": "search",
                             "args": {"q": "test"},
-                            "id": None,
+                            "id": "gemini-stream-call-1",
                         },
                         thought_signature=signature,
                     ),
@@ -636,14 +674,50 @@ class TestGeminiStream(IsolatedAsyncioTestCase):
             ],
         )
 
-        self.assertEqual(final_block.id, signature_b64)
+        self.assertEqual(final_block.id, "gemini-stream-call-1")
         self.assertEqual(
             getattr(final_block, "thought_signature", None),
             signature_b64,
         )
         self.assertEqual(
+            formatted[0]["parts"][0]["function_call"]["id"],
+            "gemini-stream-call-1",
+        )
+        self.assertEqual(
             formatted[0]["parts"][0]["thought_signature"],
             signature,
+        )
+
+    async def test_stream_signature_remains_the_id_fallback(self) -> None:
+        """Streaming keeps the signature fallback for an id-less call."""
+        signature = b"stream-signature-without-call-id"
+        signature_b64 = base64.b64encode(signature).decode("utf-8")
+        chunks = [
+            _make_stream_chunk(
+                [
+                    _make_part(
+                        function_call={
+                            "name": "search",
+                            "args": {"q": "test"},
+                            "id": None,
+                        },
+                        thought_signature=signature,
+                    ),
+                ],
+            ),
+        ]
+        self.mock_client.aio.models.generate_content_stream = AsyncMock(
+            return_value=_MockAsyncStream(chunks),
+        )
+
+        gen = await self.model([])
+        responses = [response async for response in gen]
+        final_block = responses[-1].content[0]
+
+        self.assertEqual(final_block.id, signature_b64)
+        self.assertEqual(
+            getattr(final_block, "thought_signature", None),
+            signature_b64,
         )
 
 

--- a/tests/model_gemini_test.py
+++ b/tests/model_gemini_test.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 from typing import Any
 import unittest
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from utils import AnyString
 
@@ -267,29 +267,61 @@ class TestGeminiNonStream(IsolatedAsyncioTestCase):
             [restored_msg],
         )
 
-        self.assertEqual(result.content[0].id, "gemini-call-1")
         self.assertEqual(
-            getattr(result.content[0], "thought_signature", None),
-            signature_b64,
+            result.content,
+            [
+                ToolCallBlock.model_construct(
+                    id="gemini-call-1",
+                    created_at=A,
+                    name="get_weather",
+                    input=json.dumps(
+                        {"city": "Tokyo"},
+                        ensure_ascii=False,
+                    ),
+                    thought_signature=signature_b64,
+                ),
+            ],
         )
         self.assertEqual(
-            formatted[0]["parts"][0],
-            {
-                "function_call": {
-                    "id": "gemini-call-1",
-                    "name": "get_weather",
-                    "args": {"city": "Tokyo"},
+            formatted,
+            [
+                {
+                    "role": "model",
+                    "parts": [
+                        {
+                            "function_call": {
+                                "id": "gemini-call-1",
+                                "name": "get_weather",
+                                "args": {"city": "Tokyo"},
+                            },
+                            "thought_signature": signature,
+                        },
+                    ],
                 },
-                "thought_signature": signature,
-            },
-        )
-        self.assertEqual(
-            formatted[1]["parts"][0]["function_response"]["id"],
-            "gemini-call-1",
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "function_response": {
+                                "id": "gemini-call-1",
+                                "name": "get_weather",
+                                "response": {"output": "sunny"},
+                            },
+                        },
+                    ],
+                },
+            ],
         )
 
-    async def test_thought_signature_remains_the_id_fallback(self) -> None:
-        """A signature remains the fallback when Gemini omits a call id."""
+    @patch(
+        "agentscope.model._gemini._model._generate_id",
+        return_value="generated-call-id",
+    )
+    async def test_thought_signature_with_generated_id_round_trip(
+        self,
+        _mock_generate_id: MagicMock,
+    ) -> None:
+        """An id-less call keeps its signature and gets a generated id."""
         signature = b"signature-without-call-id"
         signature_b64 = base64.b64encode(signature).decode("utf-8")
         parts = [
@@ -307,11 +339,65 @@ class TestGeminiNonStream(IsolatedAsyncioTestCase):
         )
 
         result = await self.model([])
+        call_id = "generated-call-id"
+        history_msg = AssistantMsg(
+            name="assistant",
+            content=[
+                *result.content,
+                ToolResultBlock(
+                    id=call_id,
+                    name="get_weather",
+                    output="sunny",
+                ),
+            ],
+        )
+        restored_msg = Msg.model_validate(history_msg.model_dump())
+        formatted = await GeminiChatFormatter().format([restored_msg])
 
-        self.assertEqual(result.content[0].id, signature_b64)
         self.assertEqual(
-            getattr(result.content[0], "thought_signature", None),
-            signature_b64,
+            result.content,
+            [
+                ToolCallBlock.model_construct(
+                    id=call_id,
+                    created_at=A,
+                    name="get_weather",
+                    input=json.dumps(
+                        {"city": "Tokyo"},
+                        ensure_ascii=False,
+                    ),
+                    thought_signature=signature_b64,
+                ),
+            ],
+        )
+        self.assertEqual(
+            formatted,
+            [
+                {
+                    "role": "model",
+                    "parts": [
+                        {
+                            "function_call": {
+                                "id": call_id,
+                                "name": "get_weather",
+                                "args": {"city": "Tokyo"},
+                            },
+                            "thought_signature": signature,
+                        },
+                    ],
+                },
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "function_response": {
+                                "id": call_id,
+                                "name": "get_weather",
+                                "response": {"output": "sunny"},
+                            },
+                        },
+                    ],
+                },
+            ],
         )
 
     async def test_thinking_response(self) -> None:
@@ -664,7 +750,6 @@ class TestGeminiStream(IsolatedAsyncioTestCase):
 
         gen = await self.model([])
         responses = [response async for response in gen]
-        final_block = responses[-1].content[0]
         formatted = await GeminiChatFormatter().format(
             [
                 AssistantMsg(
@@ -674,22 +759,49 @@ class TestGeminiStream(IsolatedAsyncioTestCase):
             ],
         )
 
-        self.assertEqual(final_block.id, "gemini-stream-call-1")
         self.assertEqual(
-            getattr(final_block, "thought_signature", None),
-            signature_b64,
+            responses[-1].content,
+            [
+                ToolCallBlock.model_construct(
+                    id="gemini-stream-call-1",
+                    created_at=A,
+                    name="search",
+                    input=json.dumps(
+                        {"q": "test"},
+                        ensure_ascii=False,
+                    ),
+                    thought_signature=signature_b64,
+                ),
+            ],
         )
         self.assertEqual(
-            formatted[0]["parts"][0]["function_call"]["id"],
-            "gemini-stream-call-1",
-        )
-        self.assertEqual(
-            formatted[0]["parts"][0]["thought_signature"],
-            signature,
+            formatted,
+            [
+                {
+                    "role": "model",
+                    "parts": [
+                        {
+                            "function_call": {
+                                "id": "gemini-stream-call-1",
+                                "name": "search",
+                                "args": {"q": "test"},
+                            },
+                            "thought_signature": signature,
+                        },
+                    ],
+                },
+            ],
         )
 
-    async def test_stream_signature_remains_the_id_fallback(self) -> None:
-        """Streaming keeps the signature fallback for an id-less call."""
+    @patch(
+        "agentscope.model._gemini._model._generate_id",
+        return_value="generated-call-id",
+    )
+    async def test_stream_signature_with_generated_id_round_trip(
+        self,
+        _mock_generate_id: MagicMock,
+    ) -> None:
+        """An id-less streamed call keeps its signature when formatted."""
         signature = b"stream-signature-without-call-id"
         signature_b64 = base64.b64encode(signature).decode("utf-8")
         chunks = [
@@ -712,12 +824,48 @@ class TestGeminiStream(IsolatedAsyncioTestCase):
 
         gen = await self.model([])
         responses = [response async for response in gen]
-        final_block = responses[-1].content[0]
+        call_id = "generated-call-id"
+        formatted = await GeminiChatFormatter().format(
+            [
+                AssistantMsg(
+                    name="assistant",
+                    content=responses[-1].content,
+                ),
+            ],
+        )
 
-        self.assertEqual(final_block.id, signature_b64)
         self.assertEqual(
-            getattr(final_block, "thought_signature", None),
-            signature_b64,
+            responses[-1].content,
+            [
+                ToolCallBlock.model_construct(
+                    id=call_id,
+                    created_at=A,
+                    name="search",
+                    input=json.dumps(
+                        {"q": "test"},
+                        ensure_ascii=False,
+                    ),
+                    thought_signature=signature_b64,
+                ),
+            ],
+        )
+        self.assertEqual(
+            formatted,
+            [
+                {
+                    "role": "model",
+                    "parts": [
+                        {
+                            "function_call": {
+                                "id": call_id,
+                                "name": "search",
+                                "args": {"q": "test"},
+                            },
+                            "thought_signature": signature,
+                        },
+                    ],
+                },
+            ],
         )
 
 

--- a/tests/model_gemini_test.py
+++ b/tests/model_gemini_test.py
@@ -5,6 +5,7 @@
 Tests cover both non-streaming and streaming modes.
 Gemini uses google.genai client with async iterator streaming.
 """
+import base64
 import json
 from types import SimpleNamespace
 from typing import Any
@@ -14,7 +15,14 @@ from unittest.mock import AsyncMock, MagicMock
 
 from utils import AnyString
 
-from agentscope.message import TextBlock, ToolCallBlock, ThinkingBlock
+from agentscope.formatter import GeminiChatFormatter
+from agentscope.message import (
+    AssistantMsg,
+    Msg,
+    TextBlock,
+    ToolCallBlock,
+    ThinkingBlock,
+)
 from agentscope.model import GeminiChatModel
 from agentscope.model._gemini._model import _sanitize_schema_for_gemini
 from agentscope._utils._common import _flatten_json_schema
@@ -222,6 +230,51 @@ class TestGeminiNonStream(IsolatedAsyncioTestCase):
         )
         self.assertIsInstance(result.content[0].id, str)
         self.assertTrue(result.content[0].id)
+
+    async def test_tool_call_thought_signature_round_trip(self) -> None:
+        """Gemini thought signatures survive parsing and formatting."""
+        signature = bytes(range(32))
+        signature_b64 = base64.b64encode(signature).decode("utf-8")
+        parts = [
+            _make_part(
+                function_call={
+                    "name": "get_weather",
+                    "args": {"city": "Tokyo"},
+                    "id": None,
+                },
+                thought_signature=signature,
+            ),
+        ]
+        self.mock_client.aio.models.generate_content = AsyncMock(
+            return_value=_mock_completion(parts),
+        )
+
+        result = await self.model([])
+        history_msg = AssistantMsg(
+            name="assistant",
+            content=result.content,
+        )
+        restored_msg = Msg.model_validate(history_msg.model_dump())
+        formatted = await GeminiChatFormatter().format(
+            [restored_msg],
+        )
+
+        self.assertEqual(result.content[0].id, signature_b64)
+        self.assertEqual(
+            getattr(result.content[0], "thought_signature", None),
+            signature_b64,
+        )
+        self.assertEqual(
+            formatted[0]["parts"][0],
+            {
+                "function_call": {
+                    "id": signature_b64,
+                    "name": "get_weather",
+                    "args": {"city": "Tokyo"},
+                },
+                "thought_signature": signature,
+            },
+        )
 
     async def test_thinking_response(self) -> None:
         """Non-stream response with reasoning creates ThinkingBlock."""
@@ -547,6 +600,50 @@ class TestGeminiStream(IsolatedAsyncioTestCase):
                 json.dumps({"q": "a"}, ensure_ascii=False),
                 json.dumps({"q": "b"}, ensure_ascii=False),
             ],
+        )
+
+    async def test_stream_tool_call_thought_signature_round_trip(self) -> None:
+        """Streaming keeps the signature on the accumulated tool call."""
+        signature = b"streaming-thought-signature"
+        signature_b64 = base64.b64encode(signature).decode("utf-8")
+        chunks = [
+            _make_stream_chunk(
+                [
+                    _make_part(
+                        function_call={
+                            "name": "search",
+                            "args": {"q": "test"},
+                            "id": None,
+                        },
+                        thought_signature=signature,
+                    ),
+                ],
+            ),
+        ]
+        self.mock_client.aio.models.generate_content_stream = AsyncMock(
+            return_value=_MockAsyncStream(chunks),
+        )
+
+        gen = await self.model([])
+        responses = [response async for response in gen]
+        final_block = responses[-1].content[0]
+        formatted = await GeminiChatFormatter().format(
+            [
+                AssistantMsg(
+                    name="assistant",
+                    content=responses[-1].content,
+                ),
+            ],
+        )
+
+        self.assertEqual(final_block.id, signature_b64)
+        self.assertEqual(
+            getattr(final_block, "thought_signature", None),
+            signature_b64,
+        )
+        self.assertEqual(
+            formatted[0]["parts"][0]["thought_signature"],
+            signature,
         )
 
 


### PR DESCRIPTION
Fixes #2462

## AgentScope Version

2.0.7.post1 (main @ e90f1c7)

## Description

Gemini 3 requires the opaque `thought_signature` from a function-call response to be returned with that same history part on the next request. The model parser retained the signature in the tool-call ID, but the message-formatting path dropped the signature metadata, causing the next tool-call round to fail with HTTP 400.

This change preserves the base64-encoded signature as provider-specific `ToolCallBlock` metadata and restores it as raw bytes when formatting Gemini history. Both streaming and non-streaming responses use the same round trip, and streamed provider metadata is retained even when it arrives on a later delta.

When Gemini provides a function-call ID, that ID is preserved independently from the signature and reused for the matching function response. When Gemini omits the ID, AgentScope generates one while keeping the signature as separate metadata. Existing persisted blocks without separate signature metadata are not heuristically migrated because an arbitrary ID may also look like Base64.

## Verification

- Reproduced the missing `thought_signature` on the original base revision.
- Verified mocked Gemini responses through parsing, message serialization/restoration, history formatting, function-response ID mapping, generated IDs, and later-delta signature accumulation for streaming and non-streaming paths.
- `.venv/bin/python -m pytest tests/model_gemini_test.py tests/model_base_test.py tests/formatter_gemini_test.py tests/model_response_test.py tests/message_test.py -q` — 83 passed.
- `.venv/bin/pre-commit run --files src/agentscope/message/_block.py src/agentscope/model/_gemini/_model.py src/agentscope/model/_utils.py src/agentscope/formatter/_gemini_formatter.py tests/model_gemini_test.py tests/model_base_test.py` — all hooks passed.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the CONTRIBUTING.md
- [x] Docstrings are in Google style
- [x] Related documentation has been updated (not applicable: no public API or setup behavior changed)
- [x] Code is ready for review
