### PR TITLE
fix(webui): keep channel toggle inside card

### DIFF
--- a/examples/web_ui/frontend/src/pages/channel/index.tsx
+++ b/examples/web_ui/frontend/src/pages/channel/index.tsx
@@ -60,19 +60,19 @@ function ChannelCard({
 			onClick={onOpen}
 			className="cursor-pointer items-start shadow-panel transition hover:border-ring/40"
 		>
-			<ItemHeader>
-				<div className="flex min-w-0 items-center gap-3">
+			<ItemHeader className="min-w-0">
+				<div className="flex min-w-0 flex-1 items-center gap-3">
 					<ItemMedia>
 						<TypeAvatar type={type} className="size-9 rounded-lg" />
 					</ItemMedia>
-					<div className="min-w-0">
-						<ItemTitle className="truncate">{name}</ItemTitle>
-						<span className="font-mono text-[11px] text-muted-foreground">
+					<div className="min-w-0 flex-1">
+						<ItemTitle className="max-w-full truncate">{name}</ItemTitle>
+						<span className="block truncate font-mono text-[11px] text-muted-foreground">
 							{typeName}
 						</span>
 					</div>
 				</div>
-				<ItemActions>
+				<ItemActions className="shrink-0">
 					<Switch
 						checked={channel.enabled}
 						onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
# PR Title

`fix(webui): keep channel toggle inside card`

## AgentScope Version

`2.0.7.post1`

## Description

While performing the DingTalk knowledge-base E2E test, I noticed that the channel enable/disable switch overflowed the channel card.

This PR adjusts the channel card header layout so that long channel information is truncated when necessary and the switch remains inside the card.

## Testing

- `pnpm --filter frontend lint`
- `pnpm --filter frontend build`
- `pnpm exec prettier --check frontend/src/pages/channel/index.tsx`
- Manually verified the channel card layout in the Web UI.

### Screenshot

#### Before

<img width="664" height="472" alt="5285c07b4f561f2397dd90c35db5c5db" src="https://github.com/user-attachments/assets/394e662c-3c79-4651-972c-7c5b87a382ec" />


#### After

<img width="736" height="448" alt="7b62a144bb3f8b54983899387b66dd64" src="https://github.com/user-attachments/assets/7452c173-f8fa-42e7-b472-8e99ca15a764" />

## Checklist

- [ ] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [x] Code is ready for review
