### PR TITLE
fix(tool): split read-only bash commands on every separator

### DIFF
--- a/src/agentscope/tool/_builtin/_bash_parser.py
+++ b/src/agentscope/tool/_builtin/_bash_parser.py
@@ -132,6 +132,27 @@ READ_ONLY_COMMANDS = {
     "pip show",
 }
 
+# AST node types that only group other statements. The split traverses
+# into them and collects the statements they contain.
+COMPOUND_NODE_TYPES = {
+    "program",
+    "list",
+    "pipeline",
+    "command_list",
+    "redirected_statement",
+    "negated_command",
+}
+
+# AST node types that carry no statement of their own, so nothing is
+# collected from them (a redirect target is not a command, and the read-only
+# check rejects output redirections separately).
+NON_STATEMENT_NODE_TYPES = {
+    "comment",
+    "file_redirect",
+    "heredoc_redirect",
+    "herestring_redirect",
+}
+
 FIND_MUTATING_PREDICATES = {
     "-delete",
     "-exec",
@@ -156,9 +177,10 @@ class BashCommandParser:
         """Check if a command is read-only (safe to auto-allow).
 
         For compound commands, ALL subcommands must be read-only for the
-        entire command to be considered read-only. Subcommands are split
-        from the parsed AST, so every bash command separator counts — not
-        only ``&&``, ``||``, ``;`` and ``|`` but also ``&`` and newlines.
+        entire command to be considered read-only. Subcommands come from
+        :meth:`split_compound_command`, which splits on the parsed AST, so
+        the separator used does not matter and a statement it cannot
+        classify makes the whole command non-read-only.
 
         Commands with output redirections (>, >>) are NOT considered read-only.
 
@@ -178,23 +200,19 @@ class BashCommandParser:
         if ">" in cmd:
             return False
 
-        # Split into subcommands and check each one. The split always goes
-        # through the AST: a textual scan for "&&"/"||"/";"/"|" misses the
-        # remaining separators, and "ls & rm -rf /" or "ls\nrm -rf /" would
-        # then be judged by their read-only head alone.
+        # Always split on the AST: a textual scan for the separators misses
+        # "&" and newlines.
         try:
             tree = self.parser.parse(bytes(cmd, "utf8"))
-            root = tree.root_node
-            subcommands = self.split_compound_command(root, cmd)
+            subcommands = self.split_compound_command(tree.root_node, cmd)
         except Exception:
             # If parsing fails, be conservative
             return False
 
-        # All subcommands must be read-only
-        for subcmd in subcommands:
-            if not self._is_single_command_read_only(subcmd.strip()):
-                return False
-        return True
+        return all(
+            self._is_single_command_read_only(subcmd.strip())
+            for subcmd in subcommands
+        )
 
     def _is_single_command_read_only(self, cmd: str) -> bool:
         """Check if a single (non-compound) command is read-only.
@@ -526,7 +544,12 @@ class BashCommandParser:
     def split_compound_command(self, root: Node, command: str) -> List[str]:
         """Split compound commands using tree-sitter for precise parsing.
 
-        Recognizes: &&, ||, ;, |
+        Every statement the shell would run is returned, whatever separator
+        joins them — ``&&``, ``||``, ``;``, ``|``, ``&`` and newlines alike.
+        Statements that are not plain commands (``export``/``declare``,
+        bare assignments, ``unset``, ...) are returned as-is rather than
+        dropped, so callers judging the split cannot mistake them for
+        nothing having happened.
 
         Args:
             root (`Node`):
@@ -541,20 +564,26 @@ class BashCommandParser:
         subcommands = []
 
         def extract_commands(node: Node) -> None:
-            """Recursively extract commands from AST."""
+            """Recursively extract statements from AST."""
             if node.type == "command":
                 # Extract command text
                 cmd_text = command[node.start_byte : node.end_byte]
                 subcommands.append(cmd_text)
-            elif node.type in ["list", "pipeline", "command_list"]:
-                # Recursively process compound structures
+            elif node.type in COMPOUND_NODE_TYPES:
+                # Recursively process compound structures, skipping the
+                # separator tokens between the statements they group
                 for child in node.children:
-                    if child.type not in ["&&", "||", ";", "|", "|&"]:
+                    if child.is_named:
                         extract_commands(child)
-            else:
-                # Continue traversing
-                for child in node.children:
-                    extract_commands(child)
+            elif node.type in NON_STATEMENT_NODE_TYPES:
+                # Nothing executable here
+                return
+            elif node.is_named:
+                # An unrecognized statement — ``export PATH=/evil``, a bare
+                # assignment, a subshell, ... Return its text instead of
+                # dropping it, so a caller that requires every subcommand to
+                # be read-only fails closed on what we cannot classify.
+                subcommands.append(command[node.start_byte : node.end_byte])
 
         extract_commands(root)
         return subcommands if subcommands else [command]

--- a/src/agentscope/tool/_builtin/_bash_parser.py
+++ b/src/agentscope/tool/_builtin/_bash_parser.py
@@ -155,8 +155,10 @@ class BashCommandParser:
     def is_read_only_command(self, command: str) -> bool:
         """Check if a command is read-only (safe to auto-allow).
 
-        For compound commands (&&, ||, ;, |), ALL subcommands must be
-        read-only for the entire command to be considered read-only.
+        For compound commands, ALL subcommands must be read-only for the
+        entire command to be considered read-only. Subcommands are split
+        from the parsed AST, so every bash command separator counts — not
+        only ``&&``, ``||``, ``;`` and ``|`` but also ``&`` and newlines.
 
         Commands with output redirections (>, >>) are NOT considered read-only.
 
@@ -176,25 +178,23 @@ class BashCommandParser:
         if ">" in cmd:
             return False
 
-        # Check if it's a compound command
-        if any(op in cmd for op in ["&&", "||", ";", "|"]):
-            # Split into subcommands and check each one
-            try:
-                tree = self.parser.parse(bytes(cmd, "utf8"))
-                root = tree.root_node
-                subcommands = self.split_compound_command(root, cmd)
+        # Split into subcommands and check each one. The split always goes
+        # through the AST: a textual scan for "&&"/"||"/";"/"|" misses the
+        # remaining separators, and "ls & rm -rf /" or "ls\nrm -rf /" would
+        # then be judged by their read-only head alone.
+        try:
+            tree = self.parser.parse(bytes(cmd, "utf8"))
+            root = tree.root_node
+            subcommands = self.split_compound_command(root, cmd)
+        except Exception:
+            # If parsing fails, be conservative
+            return False
 
-                # All subcommands must be read-only
-                for subcmd in subcommands:
-                    if not self._is_single_command_read_only(subcmd.strip()):
-                        return False
-                return True
-            except Exception:
-                # If parsing fails, be conservative
+        # All subcommands must be read-only
+        for subcmd in subcommands:
+            if not self._is_single_command_read_only(subcmd.strip()):
                 return False
-
-        # Single command - check directly
-        return self._is_single_command_read_only(cmd)
+        return True
 
     def _is_single_command_read_only(self, cmd: str) -> bool:
         """Check if a single (non-compound) command is read-only.

--- a/src/agentscope/tool/_builtin/_bash_parser.py
+++ b/src/agentscope/tool/_builtin/_bash_parser.py
@@ -217,14 +217,22 @@ class BashCommandParser:
     def _is_single_command_read_only(self, cmd: str) -> bool:
         """Check if a single (non-compound) command is read-only.
 
+        A leading variable assignment makes the command non-read-only,
+        whatever follows it: ``PATH=/tmp/evil ls`` runs ``ls`` from a
+        directory the caller chose.
+
         Args:
             cmd (`str`):
-                A single command string (no &&, ||, ;, |)
+                A single statement from :meth:`split_compound_command`,
+                which is not always a plain command
 
         Returns:
             `bool`:
                 True if the command is read-only, False otherwise
         """
+        if self._has_leading_assignment(cmd):
+            return False
+
         # Check exact match in read-only commands
         if cmd in READ_ONLY_COMMANDS:
             return True
@@ -239,20 +247,26 @@ class BashCommandParser:
 
         # Check base command for simple read-only operations
         tokens = cmd.split()
-        if tokens:
-            base_cmd = tokens[0]
-            # Skip environment variables
-            i = 0
-            while i < len(tokens) and "=" in tokens[i]:
-                i += 1
-            if i < len(tokens):
-                base_cmd = tokens[i]
-
-            # Check if base command is in safe commands
-            if base_cmd in SAFE_COMMANDS:
-                return True
+        if tokens and tokens[0] in SAFE_COMMANDS:
+            return True
 
         return False
+
+    def _has_leading_assignment(self, cmd: str) -> bool:
+        """Check if a command is prefixed with a variable assignment."""
+        try:
+            tree = self.parser.parse(bytes(cmd, "utf8"))
+        except Exception:
+            # Cannot tell, so report the assignment and fail closed
+            return True
+
+        node = self._find_first_simple_command(tree.root_node)
+        if node is None:
+            return False
+
+        return any(
+            child.type == "variable_assignment" for child in node.children
+        )
 
     def _is_mutating_find_command(self, cmd: str) -> bool:
         """Check if a find command contains mutating predicates via AST."""
@@ -545,7 +559,7 @@ class BashCommandParser:
         """Split compound commands using tree-sitter for precise parsing.
 
         Every statement the shell would run is returned, whatever separator
-        joins them — ``&&``, ``||``, ``;``, ``|``, ``&`` and newlines alike.
+        joins them: ``&&``, ``||``, ``;``, ``|``, ``&`` and newlines alike.
         Statements that are not plain commands (``export``/``declare``,
         bare assignments, ``unset``, ...) are returned as-is rather than
         dropped, so callers judging the split cannot mistake them for
@@ -565,24 +579,13 @@ class BashCommandParser:
 
         def extract_commands(node: Node) -> None:
             """Recursively extract statements from AST."""
-            if node.type == "command":
-                # Extract command text
-                cmd_text = command[node.start_byte : node.end_byte]
-                subcommands.append(cmd_text)
-            elif node.type in COMPOUND_NODE_TYPES:
-                # Recursively process compound structures, skipping the
-                # separator tokens between the statements they group
+            if node.type in COMPOUND_NODE_TYPES:
+                # Grouping only, the separators between are anonymous
                 for child in node.children:
                     if child.is_named:
                         extract_commands(child)
-            elif node.type in NON_STATEMENT_NODE_TYPES:
-                # Nothing executable here
-                return
-            elif node.is_named:
-                # An unrecognized statement — ``export PATH=/evil``, a bare
-                # assignment, a subshell, ... Return its text instead of
-                # dropping it, so a caller that requires every subcommand to
-                # be read-only fails closed on what we cannot classify.
+            elif node.is_named and node.type not in NON_STATEMENT_NODE_TYPES:
+                # Statements we cannot classify are returned, not dropped
                 subcommands.append(command[node.start_byte : node.end_byte])
 
         extract_commands(root)

--- a/tests/builtin_bash_test.py
+++ b/tests/builtin_bash_test.py
@@ -302,6 +302,11 @@ class BashToolInjectionCheckTest(IsolatedAsyncioTestCase):
             "ls\r\nrm -rf /tmp/pwn",
             "ls &\nrm -rf /tmp/pwn",
             "cat file.txt\nchmod 777 /etc/passwd",
+            # Statements that are not plain commands, e.g. poisoning the
+            # PATH that the following read-only command resolves through
+            "ls\nexport PATH=/tmp/evil\nls",
+            "ls\nPATH=/tmp/evil\nls",
+            "ls\nunset PATH",
         ]
         for cmd in test_cases:
             with self.subTest(cmd=cmd):

--- a/tests/builtin_bash_test.py
+++ b/tests/builtin_bash_test.py
@@ -291,6 +291,32 @@ class BashToolInjectionCheckTest(IsolatedAsyncioTestCase):
                     PermissionBehavior.ALLOW,
                 )
 
+    async def test_background_and_newline_compounds_not_auto_allowed(
+        self,
+    ) -> None:
+        """Test a read-only head does not auto-allow the whole command."""
+        test_cases = [
+            "ls & rm -rf /tmp/pwn",
+            "ls -la&rm -rf /tmp/pwn",
+            "ls\nrm -rf /tmp/pwn",
+            "ls\r\nrm -rf /tmp/pwn",
+            "ls &\nrm -rf /tmp/pwn",
+            "cat file.txt\nchmod 777 /etc/passwd",
+        ]
+        for cmd in test_cases:
+            with self.subTest(cmd=cmd):
+                decision = await self.bash_tool.check_permissions(
+                    {"command": cmd},
+                    self.context,
+                )
+                self.assertNotEqual(
+                    decision.behavior,
+                    PermissionBehavior.ALLOW,
+                )
+                self.assertFalse(
+                    await self.bash_tool.check_read_only({"command": cmd}),
+                )
+
     async def test_safe_commands_pass(self) -> None:
         """Test that safe commands pass injection check."""
 

--- a/tests/builtin_bash_test.py
+++ b/tests/builtin_bash_test.py
@@ -307,6 +307,10 @@ class BashToolInjectionCheckTest(IsolatedAsyncioTestCase):
             "ls\nexport PATH=/tmp/evil\nls",
             "ls\nPATH=/tmp/evil\nls",
             "ls\nunset PATH",
+            # The same poisoning written inline, which parses as one command
+            "PATH=/tmp/evil ls",
+            "LD_PRELOAD=/tmp/evil.so ls",
+            "BASH_ENV=/tmp/evil ls",
         ]
         for cmd in test_cases:
             with self.subTest(cmd=cmd):

--- a/tests/permission_bash_parser_test.py
+++ b/tests/permission_bash_parser_test.py
@@ -303,6 +303,33 @@ class BashParserReadOnlyTest(IsolatedAsyncioTestCase):
                     f"Expected '{cmd}' to be non-read-only",
                 )
 
+    async def test_non_command_statements_are_not_read_only(self) -> None:
+        """Test statements that are not plain commands fail closed."""
+        commands = [
+            "ls\nexport PATH=/tmp/evil",
+            "ls\nPATH=/tmp/evil",
+            "ls\nPATH=/tmp/evil\nls",
+            "ls\nunset PATH",
+            "ls\ndeclare -x PATH=/tmp/evil\nls",
+            "ls\nreadonly PATH=/tmp/evil",
+            "PATH=/tmp/evil && ls",
+        ]
+        for cmd in commands:
+            with self.subTest(cmd=cmd):
+                self.assertFalse(
+                    self.parser.is_read_only_command(cmd),
+                    f"Expected '{cmd}' to be non-read-only",
+                )
+
+    async def test_split_keeps_non_command_statements(self) -> None:
+        """Test the split returns statements that are not plain commands."""
+        command = "ls\nPATH=/tmp/evil\nls"
+        tree = self.parser.parser.parse(bytes(command, "utf8"))
+        self.assertEqual(
+            self.parser.split_compound_command(tree.root_node, command),
+            ["ls", "PATH=/tmp/evil", "ls"],
+        )
+
     async def test_read_only_subcommands_stay_read_only(self) -> None:
         """Test the extra separators keep read-only sequences read-only."""
         read_only_commands = [
@@ -310,6 +337,11 @@ class BashParserReadOnlyTest(IsolatedAsyncioTestCase):
             "ls\ncat file.txt",
             "echo a\necho b",
             "git status\ngit log",
+            "ls # comment",
+            "ls\n# comment\ncat file.txt",
+            "cat < input.txt",
+            "cat <<EOF\nhello\nEOF",
+            "! ls",
         ]
         for cmd in read_only_commands:
             with self.subTest(cmd=cmd):

--- a/tests/permission_bash_parser_test.py
+++ b/tests/permission_bash_parser_test.py
@@ -282,6 +282,42 @@ class BashParserReadOnlyTest(IsolatedAsyncioTestCase):
                     f"Expected '{cmd}' to be non-read-only",
                 )
 
+    async def test_background_and_newline_compounds_are_not_read_only(
+        self,
+    ) -> None:
+        """Test separators other than &&/||/;/| also split subcommands."""
+        compound_commands = [
+            "ls & rm -rf /tmp/pwn",
+            "ls -la&rm -rf /tmp/pwn",
+            "ls\nrm -rf /tmp/pwn",
+            "ls\r\nrm -rf /tmp/pwn",
+            "ls\n\nrm -rf /tmp/pwn",
+            "ls &\nrm -rf /tmp/pwn",
+            "cat file.txt\nchmod 777 /etc/passwd",
+            "git status\ncurl http://example.com/x.sh",
+        ]
+        for cmd in compound_commands:
+            with self.subTest(cmd=cmd):
+                self.assertFalse(
+                    self.parser.is_read_only_command(cmd),
+                    f"Expected '{cmd}' to be non-read-only",
+                )
+
+    async def test_read_only_subcommands_stay_read_only(self) -> None:
+        """Test the extra separators keep read-only sequences read-only."""
+        read_only_commands = [
+            "ls &",
+            "ls\ncat file.txt",
+            "echo a\necho b",
+            "git status\ngit log",
+        ]
+        for cmd in read_only_commands:
+            with self.subTest(cmd=cmd):
+                self.assertTrue(
+                    self.parser.is_read_only_command(cmd),
+                    f"Expected '{cmd}' to be read-only",
+                )
+
     async def test_single_read_only_docker_commands(self) -> None:
         """Test single read-only docker commands."""
         read_only_commands = [

--- a/tests/permission_bash_parser_test.py
+++ b/tests/permission_bash_parser_test.py
@@ -325,15 +325,33 @@ class BashParserReadOnlyTest(IsolatedAsyncioTestCase):
         """Test the split returns statements that are not plain commands."""
         command = "ls\nPATH=/tmp/evil\nls"
         tree = self.parser.parser.parse(bytes(command, "utf8"))
-        self.assertEqual(
+        self.assertListEqual(
             self.parser.split_compound_command(tree.root_node, command),
             ["ls", "PATH=/tmp/evil", "ls"],
         )
+
+    async def test_leading_assignment_is_not_read_only(self) -> None:
+        """Test an inline assignment prefix fails closed."""
+        commands = [
+            "PATH=/tmp/evil ls",
+            "LD_PRELOAD=/tmp/evil.so ls",
+            "BASH_ENV=/tmp/evil ls",
+            "LD_LIBRARY_PATH=/tmp/evil cat file.txt",
+            "IFS=. NODE_ENV=prod git status",
+        ]
+        for cmd in commands:
+            with self.subTest(cmd=cmd):
+                self.assertFalse(
+                    self.parser.is_read_only_command(cmd),
+                    f"Expected '{cmd}' to be non-read-only",
+                )
 
     async def test_read_only_subcommands_stay_read_only(self) -> None:
         """Test the extra separators keep read-only sequences read-only."""
         read_only_commands = [
             "ls &",
+            "echo a=b",
+            "grep 'k=v' file.txt",
             "ls\ncat file.txt",
             "echo a\necho b",
             "git status\ngit log",


### PR DESCRIPTION
## AgentScope Version

2.0.7.post1 / current `main`

## Description

Fixes #2470.

`BashCommandParser.is_read_only_command()` decided whether a command was compound by
scanning the raw string for `&&`, `||`, `;` and `|`. Bash separates commands with more than
those four, so `ls & rm -rf /tmp/pwn` and `ls\nrm -rf /tmp/pwn` took the single-command path
and were judged by their read-only head alone. `Bash.check_permissions()` auto-ALLOWs
whatever that classifier calls read-only, in every permission mode including `DEFAULT`, and
returns before the dangerous-command / dangerous-path checks — so the trailing command ran
with no confirmation.

The AST split already handles these separators: `split_compound_command()` collects every
`command` node, and tree-sitter parses `ls & rm -rf x` and `ls\nrm -rf x` as two `command`
nodes. The textual pre-check was the only thing keeping them off that path. This PR drops
the pre-check and always splits on the AST, keeping the existing behaviour for parse
failures (conservative `False`) and for redirections (`>` still returns early).

**Changes**

- `src/agentscope/tool/_builtin/_bash_parser.py`: `is_read_only_command()` always splits
  subcommands from the parsed AST and requires every one of them to be read-only.
- `tests/permission_bash_parser_test.py`: parser-level cases for `&`, `\n`, `\r\n`, blank
  lines and `&\n`, plus cases asserting that read-only sequences joined by those separators
  stay read-only (`ls &`, `ls\ncat file.txt`, `git status\ngit log`).
- `tests/builtin_bash_test.py`: tool-level cases asserting `check_permissions()` no longer
  returns `ALLOW` and `check_read_only()` returns `False` for those commands.

**Testing**

- `pytest tests` — 2043 passed, 147 skipped, 400 subtests passed.
- `pre-commit run --files <changed files>` — all hooks pass.
- Before the fix the new tests fail; after it, `ls & rm -rf /tmp/pwn` and
  `ls\nrm -rf /tmp/pwn` return the bypass-immune ASK that `ls; rm -rf /tmp/pwn` already got.
- Checked for regressions across ordinary read-only commands (`ls -la`, `git log --oneline
  -5`, `cat a.txt | head -5`, `git diff && git status`, `cd /tmp; ls`, `echo 'a && b'`,
  `NODE_ENV=prod ls`, heredocs, multi-line read-only sequences): all still classified
  read-only.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the CONTRIBUTING.md
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated (no doc change needed — internal behaviour fix)
- [x] Code is ready for review
