### PR TITLE
ci(monitor): stop watching review events that can never access secrets

### DIFF
--- a/.github/workflows/github-monitor.yml
+++ b/.github/workflows/github-monitor.yml
@@ -19,10 +19,8 @@ on:
     # synchronize is silent (stored only) — see SILENT_REALTIME_EVENTS in scripts/config.py.
     # It's needed for the daily "PRs with new commits to re-review" section.
     types: [opened, closed, reopened, synchronize, review_requested]
-  pull_request_review:
-    types: [submitted]
-  pull_request_review_comment:
-    types: [created]
+  # pull_request_review(_comment) can't be watched here: GitHub withholds secrets
+  # from the runs they trigger on fork PRs, so the job always fails at checkout.
   discussion:
     types: [created, answered]
   discussion_comment:


### PR DESCRIPTION
## Problem

The `GitHub Monitor / notify` check fails on every PR that gets reviewed. It is not flaky — over the last 100 runs of the workflow:

| trigger | success | failure / action_required |
|---|---|---|
| `pull_request_target` | 35 | 1 |
| `issues` / `issue_comment` / `discussion` | 35 | 0 |
| `pull_request_review` | **0** | **18** |
| `pull_request_review_comment` | **0** | **8 + 3 pending approval** |

Every one of them dies on the very first step:

```
Checkout storage repo (notification scripts)
##[error]Input required and not supplied: token
```

## Cause

`pull_request_review` and `pull_request_review_comment` are fork-triggered events. With the exception of `GITHUB_TOKEN`, GitHub does not pass secrets to a workflow run triggered from a forked repository, so `secrets.STORAGE_REPO_TOKEN` resolves to an empty string and `actions/checkout` rejects it. The three `action_required` runs are the same story from the other side — the fork-PR approval gate. `pull_request_target` works precisely because it is the one PR trigger designed to run in the base-repo context with secrets.

Since virtually all PRs here come from forks, these two triggers can never succeed.

## Fix

Drop them from the trigger list. The remaining triggers (`issues`, `issue_comment`, `pull_request_target`, `discussion`, `discussion_comment`) all run in a context that has secrets and are unaffected.

Trade-off: PR reviews and inline review comments are no longer relayed to Dingtalk or recorded for the daily summary. That is a real loss, but it is what the workflow already delivers in practice today — a red check and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)