### PR TITLE
fix(agent): repair interrupted tool call arguments

### DIFF
--- a/src/agentscope/model/_base.py
+++ b/src/agentscope/model/_base.py
@@ -34,6 +34,28 @@ _TOOL_CHOICE_LITERAL_MODES = {"auto", "none", "required"}
 _MULTIMODAL_DATA_BLOCK_TOKEN_ESTIMATE = 2000
 
 
+def _repair_tool_call_arguments(response: ChatResponse) -> ChatResponse:
+    """Repair incomplete tool arguments in a final model response."""
+    for block in response.content:
+        if not isinstance(block, ToolCallBlock):
+            continue
+
+        try:
+            parsed = json.loads(block.input)
+            if isinstance(parsed, dict):
+                continue
+        except json.JSONDecodeError:
+            pass
+
+        try:
+            parsed = _json_loads_with_repair(block.input)
+        except ToolJSONDecodeError:
+            continue
+        block.input = json.dumps(parsed, ensure_ascii=False)
+
+    return response
+
+
 class ChatModelBase:
     """The base class for chat models."""
 
@@ -255,7 +277,7 @@ class ChatModelBase:
         # Consume the model calling result
         # =====================================================================
         if isinstance(res, ChatResponse):
-            return res
+            return _repair_tool_call_arguments(res)
 
         async def _stream() -> AsyncGenerator[ChatResponse, None]:
             """The wrapper around model calling."""
@@ -279,13 +301,14 @@ class ChatModelBase:
                             continue
                     else:
                         yield_acc_res = False
+                        _repair_tool_call_arguments(chunk)
                     yield chunk
             except asyncio.CancelledError:
                 acc_res.finished_reason = FinishedReason.INTERRUPTED
                 yield_acc_res = True
 
             if yield_acc_res:
-                yield acc_res.build()
+                yield _repair_tool_call_arguments(acc_res.build())
 
         return _stream()
 

--- a/tests/agent_interrupt_test.py
+++ b/tests/agent_interrupt_test.py
@@ -12,6 +12,7 @@
   loop.
 """
 import asyncio
+import json
 from typing import Any, AsyncGenerator
 from unittest.async_case import IsolatedAsyncioTestCase
 
@@ -309,6 +310,53 @@ class AgentInterruptCancelTest(IsolatedAsyncioTestCase):
             injection_config=InjectionConfig(inject_runtime_state=False),
         )
         return agent, model
+
+    async def test_interrupted_partial_tool_input_is_repaired(self) -> None:
+        """Partially streamed tool arguments remain valid in history."""
+        agent, model = self._make_agent([])
+        model.set_responses(
+            [
+                [
+                    ChatResponse(
+                        content=[
+                            ToolCallBlock(
+                                id="tc-partial",
+                                name="write",
+                                input=(
+                                    '{"file_path": "/tmp/test.py", '
+                                    '"content": "unfinished'
+                                ),
+                            ),
+                        ],
+                        is_last=False,
+                    ),
+                    asyncio.CancelledError(),
+                ],
+            ],
+        )
+
+        events = []
+        async for event in agent.reply_stream(
+            UserMsg(name="user", content="Write a file"),
+        ):
+            events.append(event)
+
+        _assert_interrupted_end(
+            self,
+            events,
+            reply_id=agent.state.reply_id,
+            session_id=agent.state.session_id,
+        )
+        tool_call = agent.state.context[-1].content[0]
+        self.assertIsInstance(tool_call, ToolCallBlock)
+        assert isinstance(tool_call, ToolCallBlock)
+        self.assertDictEqual(
+            json.loads(tool_call.input),
+            {
+                "file_path": "/tmp/test.py",
+                "content": "unfinished",
+            },
+        )
 
     async def test_sequential_tool_cancelled_mid_execution(self) -> None:
         """Sequential batch: model emits one slow sequential tool call,

--- a/tests/model_base_test.py
+++ b/tests/model_base_test.py
@@ -3,6 +3,7 @@
 retry / accumulation / interrupt wrapper around ``_call_api``."""
 import asyncio
 import base64
+import json
 from typing import Any
 from unittest.async_case import IsolatedAsyncioTestCase
 
@@ -163,6 +164,52 @@ class ChatModelBaseCallTest(IsolatedAsyncioTestCase):
                 is_last=True,
             ),
         )
+
+    async def test_non_stream_repairs_partial_tool_input(self) -> None:
+        """Repair incomplete tool arguments in a non-stream response."""
+        response = ChatResponse(
+            content=[
+                ToolCallBlock(
+                    id="tool-1",
+                    name="get_weather",
+                    input='{"city":"Beijing"',
+                ),
+            ],
+            is_last=True,
+        )
+        self.model.set_responses([response])
+
+        result = await self.model(messages=self.messages)
+
+        self.assertIsInstance(result, ChatResponse)
+        assert isinstance(result, ChatResponse)
+        tool_call = result.content[0]
+        self.assertIsInstance(tool_call, ToolCallBlock)
+        assert isinstance(tool_call, ToolCallBlock)
+        self.assertDictEqual(json.loads(tool_call.input), {"city": "Beijing"})
+
+    async def test_non_stream_preserves_unrepairable_tool_input(self) -> None:
+        """Keep invalid input when it cannot be repaired into an object."""
+        response = ChatResponse(
+            content=[
+                ToolCallBlock(
+                    id="tool-1",
+                    name="get_weather",
+                    input="not json",
+                ),
+            ],
+            is_last=True,
+        )
+        self.model.set_responses([response])
+
+        result = await self.model(messages=self.messages)
+
+        self.assertIsInstance(result, ChatResponse)
+        assert isinstance(result, ChatResponse)
+        tool_call = result.content[0]
+        self.assertIsInstance(tool_call, ToolCallBlock)
+        assert isinstance(tool_call, ToolCallBlock)
+        self.assertEqual(tool_call.input, "not json")
 
     # ------------------------------------------------------------------
     # 2) non-stream CancelledError raised from inside _call_api
@@ -508,9 +555,8 @@ class ChatModelBaseCallTest(IsolatedAsyncioTestCase):
                     ],
                     is_last=False,
                 ),
-                # accumulated final — thinking / text preserved,
-                # tool_call.input concatenated to the partial JSON
-                # received before the cancellation (no closing "}")
+                # accumulated final — thinking / text preserved and the
+                # partial tool input repaired before it is returned
                 _expected(
                     content=[
                         {
@@ -527,7 +573,7 @@ class ChatModelBaseCallTest(IsolatedAsyncioTestCase):
                             "type": "tool_call",
                             "id": "tool-1",
                             "name": "get_weather",
-                            "input": '{"city":"Beijing"',
+                            "input": '{"city": "Beijing"}',
                             "state": "pending",
                             "suggested_rules": [],
                         },
@@ -652,6 +698,32 @@ class ChatModelBaseCallTest(IsolatedAsyncioTestCase):
                 ),
             ],
         )
+
+    async def test_stream_repairs_model_provided_final_chunk(self) -> None:
+        """Repair a partial tool call in a provider's final chunk."""
+        deltas = [
+            ChatResponse(
+                content=[
+                    ToolCallBlock(
+                        id="tool-1",
+                        name="get_weather",
+                        input='{"city":"Beijing"',
+                    ),
+                ],
+                is_last=True,
+                id="chunk-final",
+            ),
+        ]
+        self.model.set_responses([deltas])
+
+        gen = await self.model(messages=self.messages)
+        collected = [chunk async for chunk in gen]
+
+        self.assertEqual(len(collected), 1)
+        tool_call = collected[0].content[0]
+        self.assertIsInstance(tool_call, ToolCallBlock)
+        assert isinstance(tool_call, ToolCallBlock)
+        self.assertDictEqual(json.loads(tool_call.input), {"city": "Beijing"})
 
     # ------------------------------------------------------------------
     # 9) stream mixed block types — normal completion (happy path)


### PR DESCRIPTION
## AgentScope Version

`2.0.7.post1`

## Description

Fixes https://github.com/agentscope-ai/agentscope/issues/2469.

When a streaming model call is interrupted while generating tool-call arguments, the partial JSON could be persisted and replayed on later turns. Strict OpenAI-compatible backends such as vLLM then rejected the request with HTTP 400.

## What Changed

- Adds a helper that validates and repairs tool-call arguments as a JSON object string.
- Repairs partial tool-call arguments during interruption cleanup.
- Adds defensive repair in `OpenAIChatFormatter` for existing sessions containing malformed tool-call arguments.
- Adds regression tests for interrupted streams and malformed historical tool calls.

### Testing

```bash
PYTHONPATH=src .venv/bin/pytest -q \
  tests/agent_interrupt_test.py \
  tests/formatter_openai_chat_test.py \
  tests/model_base_test.py \
  tests/formatter_anthropic_test.py \
  tests/formatter_gemini_test.py \
  tests/formatter_ollama_test.py
```

Result: `80 passed`.

`black`, `flake8`, `mypy`, and `pylint` also pass for the changed files.

## Checklist

- [x] An issue has been created for this PR (#2469)
- [ ] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation has been updated (not applicable for this bug fix)
- [x] Code is ready for review
