### PR TITLE
feat(rag): add RAGFlowKnowledge knowledge-layer backend

### DIFF
--- a/examples/rag/README.md
+++ b/examples/rag/README.md
@@ -6,6 +6,7 @@ Two library-mode walk-throughs of `agentscope.rag` — no FastAPI service, no ma
 | --- | --- |
 | [`index_and_search.py`](./index_and_search.py) | The minimal pipeline: parse → chunk → embed → insert, then `KnowledgeBase.search`. Start here. |
 | [`integrate_with_agent.py`](./integrate_with_agent.py) | Attaches the same `KnowledgeBase` to an `Agent` via `RAGMiddleware`, in both `static` (auto-inject) and `agentic` (tool-driven) modes. |
+| [`ragflow_knowledge.py`](./ragflow_knowledge.py) | Uses `RAGFlowKnowledge` — a knowledge-layer integration that delegates parsing/chunking/indexing/retrieval to a RAGFlow server instead of running the pipeline locally. |
 
 Both examples use an in-memory Qdrant store (`location=":memory:"`) and the DashScope `text-embedding-v4` model, so no external services are required. The sections below show how to swap in Milvus Lite, MongoDB, or Elasticsearch instead; those backends need additional setup.
 
@@ -225,6 +226,58 @@ store = ElasticsearchStore(
 - For service mode, construct
   `CollectionPerKbManager(storage=storage, vector_store=store)` and pass it
   to `create_app(knowledge_base_manager=...)`.
+
+### RAGFlow (managed pipeline)
+
+[RAGFlow](https://ragflow.io/) is a managed, end-to-end RAG pipeline: it
+owns document parsing, chunking, indexing, and retrieval on the server
+side.  Instead of being forced underneath `VectorStoreBase`, it is exposed
+as `RAGFlowKnowledge` — a knowledge-layer handle with the same interface
+as `KnowledgeBase` (`search`, `insert_document`, `delete_document`,
+`list_documents`).
+
+Install the optional extra:
+
+```bash
+uv pip install "agentscope[vdb-ragflow]"
+# Or from source (repo root)
+uv pip install -e ".[vdb-ragflow]"
+```
+
+**Prerequisites**
+
+- A reachable RAGFlow instance (e.g. via Docker Compose) with a dataset
+  already created in the RAGFlow console.  RAGFlow's dataset is the
+  knowledge base — note its id and set its embedding model / parsing
+  strategy in the console (RAGFlow, not AgentScope, runs those steps).
+- An API key and base URL available in the environment (do not hard-code
+  credentials).
+
+```bash
+export RAGFLOW_API_KEY="ragflow-xxxxx"
+export RAGFLOW_BASE_URL="http://localhost:9380"
+export RAGFLOW_DATASET_ID="kb-xxxxx"
+```
+
+Then run the example — no parser, chunker, embedding model, or vector
+store is needed on your side:
+
+```bash
+python examples/rag/ragflow_knowledge.py
+```
+
+**Notes**
+
+- `insert_document` uploads raw document bytes; RAGFlow parses, chunks,
+  and indexes them server-side.  This deliberately differs from
+  `KnowledgeBase.insert_document`, which takes pre-embedded `Chunk`
+  objects because AgentScope runs the pipeline locally.
+- Retrieval tuning (`top_k`, `similarity_threshold`,
+  `vector_similarity_weight`, optional rerank) is configured on
+  `RAGFlowConfig`.
+- RAGFlow scores like a hybrid of vector + keyword similarity rather than
+  a plain cosine distance, so `score_threshold` behaves a little
+  differently from the pure vector backends.
 
 ### Choosing a vector backend
 

--- a/examples/rag/README.md
+++ b/examples/rag/README.md
@@ -1,6 +1,6 @@
 # RAG Examples
 
-Two library-mode walk-throughs of `agentscope.rag` — no FastAPI service, no manager, no message bus. Each script wires the building blocks (parser, chunker, embedding model, vector store, `KnowledgeBase` handle) by hand so the data flow is visible end-to-end.
+Library-mode walk-throughs of `agentscope.rag` — no FastAPI service, no manager, no message bus. The first two scripts wire the building blocks (parser, chunker, embedding model, vector store, `KnowledgeBase` handle) by hand so the data flow is visible end-to-end; the third delegates the whole pipeline to a RAGFlow server via `RAGFlowKnowledge`.
 
 | Script | What it shows |
 | --- | --- |
@@ -232,11 +232,13 @@ store = ElasticsearchStore(
 [RAGFlow](https://ragflow.io/) is a managed, end-to-end RAG pipeline: it
 owns document parsing, chunking, indexing, and retrieval on the server
 side.  Instead of being forced underneath `VectorStoreBase`, it is exposed
-as `RAGFlowKnowledge` — a knowledge-layer handle with the same interface
-as `KnowledgeBase` (`search`, `insert_document`, `delete_document`,
-`list_documents`).
+as `RAGFlowKnowledge` — a knowledge-layer handle that exposes the same
+operations as `KnowledgeBase` (`search`, `insert_document`,
+`delete_document`, `list_documents`, `list_chunks`).
 
-Install the optional extra:
+Install the optional extra (kept opt-in — it is **not** part of
+`agentscope[full]`, because `ragflow-sdk` does not yet support
+Python 3.13+):
 
 ```bash
 uv pip install "agentscope[vdb-ragflow]"
@@ -272,6 +274,14 @@ python examples/rag/ragflow_knowledge.py
   and indexes them server-side.  This deliberately differs from
   `KnowledgeBase.insert_document`, which takes pre-embedded `Chunk`
   objects because AgentScope runs the pipeline locally.
+- RAGFlow indexing is **asynchronous** — `insert_document` returns once
+  the upload is accepted, but a document becomes searchable only after
+  RAGFlow finishes parsing it.  The example polls the document's parse
+  status before searching (see `wait_until_indexed`).
+- Because the two handles expose *operations with the same names but
+  different signatures*, a caller cannot transparently swap a
+  `RAGFlowKnowledge` in for a `KnowledgeBase` without adapting the
+  `insert_document` / `search` calls.
 - Retrieval tuning (`top_k`, `similarity_threshold`,
   `vector_similarity_weight`, optional rerank) is configured on
   `RAGFlowConfig`.

--- a/examples/rag/ragflow_knowledge.py
+++ b/examples/rag/ragflow_knowledge.py
@@ -8,10 +8,11 @@ bring your own parser, chunker, embedding model, or vector store:
 RAGFlow parses, chunks, indexes, and retrieves on the server side using
 the model and parsing strategy configured on its dataset.
 
-This example shows the four operations on the shared knowledge
-interface — :meth:`insert_document`, :meth:`search`,
-:meth:`list_documents`, :meth:`delete_document` — against a RAGFlow
-dataset you have already created in the RAGFlow console.
+This example walks through the knowledge operations — :meth:`insert_document`,
+:meth:`search`, :meth:`list_documents`, :meth:`delete_document` — against a
+RAGFlow dataset you have already created in the RAGFlow console.  Note that
+``insert_document`` uploads and requests server-side *indexing* asynchronously,
+so the example polls the document's parse status before searching.
 
 Run with::
 
@@ -25,6 +26,49 @@ import os
 
 from agentscope.message import TextBlock
 from agentscope.rag import RAGFlowConfig, RAGFlowKnowledge
+
+
+# RAGFlow document parse states that mean "finished" (or can never finish).
+_TERMINAL_RUN = {"DONE", "FAIL", "CANCEL"}
+
+
+async def wait_until_indexed(
+    knowledge: RAGFlowKnowledge,
+    document_id: str,
+    timeout_sec: float = 120.0,
+    poll_interval_sec: float = 3.0,
+) -> None:
+    """Poll a just-uploaded RAGFlow document until RAGFlow has parsed it.
+
+    RAGFlow indexing is asynchronous: ``insert_document`` returns as soon as
+    the upload is accepted.  ``search`` only sees a document once RAGFlow has
+    finished parsing/chunking it, so callers that want to search right away
+    should wait for the parse to complete.
+
+    Args:
+        knowledge (`RAGFlowKnowledge`): The handle used to poll.
+        document_id (`str`): The document to wait on.
+        timeout_sec (`float`): Give up after this many seconds.
+        poll_interval_sec (`float`): Seconds between polls.
+    """
+    elapsed = 0.0
+    while elapsed < timeout_sec:
+        for summary in await knowledge.list_documents():
+            if summary.document_id != document_id:
+                continue
+            run = summary.metadata.get("run", "")
+            if str(run).upper() in _TERMINAL_RUN:
+                return
+            # ``progress`` reaches 1.0 (100%) on completion.
+            progress = summary.metadata.get("parse_progress", 0.0)
+            if float(progress) >= 1.0:
+                return
+        await asyncio.sleep(poll_interval_sec)
+        elapsed += poll_interval_sec
+    print(
+        f"  WARNING: document {document_id!r} not indexed within "
+        f"{timeout_sec}s; search results may be incomplete.",
+    )
 
 
 async def search_and_print(
@@ -80,14 +124,16 @@ async def main() -> None:
         ),
     )
 
-    # RAGFlow parses/chunks/indexes the uploaded bytes on the server.
-    # The returned document id is yours to keep for delete_document.
+    # RAGFlow parses/chunks/indexes the uploaded bytes on the server,
+    # *asynchronously*.  The returned document id is yours to keep for
+    # delete_document.
     document_id = await knowledge.insert_document(
         b"# Cats\n\nCats are small carnivorous mammals. They are popular "
         b"as pets for their playful and affectionate nature.\n",
         filename="cats.md",
     )
-    print(f"Uploaded document_id={document_id}")
+    print(f"Uploaded document_id={document_id}; waiting for indexing ...")
+    await wait_until_indexed(knowledge, document_id)
 
     await search_and_print(knowledge, "What are cats known for?")
 

--- a/examples/rag/ragflow_knowledge.py
+++ b/examples/rag/ragflow_knowledge.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""RAGFlow-backed knowledge — no parse/chunk/embed pipeline on your side.
+
+:class:`~agentscope.rag.RAGFlowKnowledge` is the knowledge-layer
+integration for [RAGFlow](https://ragflow.io/), a managed end-to-end RAG
+pipeline.  Unlike :class:`~agentscope.rag.KnowledgeBase`, you do **not**
+bring your own parser, chunker, embedding model, or vector store:
+RAGFlow parses, chunks, indexes, and retrieves on the server side using
+the model and parsing strategy configured on its dataset.
+
+This example shows the four operations on the shared knowledge
+interface — :meth:`insert_document`, :meth:`search`,
+:meth:`list_documents`, :meth:`delete_document` — against a RAGFlow
+dataset you have already created in the RAGFlow console.
+
+Run with::
+
+    RAGFLOW_API_KEY=ragflow-xxxxx \\
+    RAGFLOW_BASE_URL=http://localhost:9380 \\
+    RAGFLOW_DATASET_ID=kb-xxxxx \\
+    python examples/rag/ragflow_knowledge.py
+"""
+import asyncio
+import os
+
+from agentscope.message import TextBlock
+from agentscope.rag import RAGFlowConfig, RAGFlowKnowledge
+
+
+async def search_and_print(
+    knowledge: RAGFlowKnowledge,
+    query: str,
+    top_k: int = 3,
+) -> None:
+    """Run a search via the :class:`RAGFlowKnowledge` handle and print hits."""
+    results = await knowledge.search([query], top_k=top_k)
+
+    print(f"\nQuery: {query!r}")
+    if not results:
+        print("  (no hits)")
+        return
+    for rank, result in enumerate(results, start=1):
+        snippet = (
+            result.chunk.content.text
+            if isinstance(result.chunk.content, TextBlock)
+            else "<non-text chunk>"
+        )
+        snippet = snippet.replace("\n", " ").strip()
+        if len(snippet) > 120:
+            snippet = snippet[:117] + "..."
+        print(
+            f"  [{rank}] score={result.score:.4f} "
+            f"source={result.chunk.source} "
+            f"document_id={result.document_id}\n"
+            f"      {snippet}",
+        )
+
+
+async def main() -> None:
+    """The main entry point of the example."""
+    api_key = os.environ.get("RAGFLOW_API_KEY")
+    base_url = os.environ.get("RAGFLOW_BASE_URL", "http://localhost:9380")
+    dataset_id = os.environ.get("RAGFLOW_DATASET_ID")
+    if not api_key or not dataset_id:
+        raise RuntimeError(
+            "Set RAGFLOW_API_KEY and RAGFLOW_DATASET_ID before running "
+            "this example (RAGFLOW_BASE_URL defaults to "
+            "http://localhost:9380).",
+        )
+
+    knowledge = RAGFlowKnowledge(
+        name="demo-kb",
+        description="A toy RAGFlow corpus on cats.",
+        config=RAGFlowConfig(
+            api_key=api_key,
+            base_url=base_url,
+            dataset_id=dataset_id,
+            top_k=10,
+            similarity_threshold=0.2,
+        ),
+    )
+
+    # RAGFlow parses/chunks/indexes the uploaded bytes on the server.
+    # The returned document id is yours to keep for delete_document.
+    document_id = await knowledge.insert_document(
+        b"# Cats\n\nCats are small carnivorous mammals. They are popular "
+        b"as pets for their playful and affectionate nature.\n",
+        filename="cats.md",
+    )
+    print(f"Uploaded document_id={document_id}")
+
+    await search_and_print(knowledge, "What are cats known for?")
+
+    print("\nDocuments in the dataset:")
+    for summary in await knowledge.list_documents():
+        print(
+            f"  - {summary.source!r} "
+            f"(id={summary.document_id}, chunks={summary.chunk_count})",
+        )
+
+    # Uncomment to remove the uploaded document.
+    # await knowledge.delete_document(document_id)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,11 @@ vdb-milvus = [
 ]
 vdb-mongodb = ["pymongo>=4.7"]
 vdb-elasticsearch = ["elasticsearch[async]>=8.12"]
+# RAGFlow is a managed end-to-end RAG pipeline (parsing, chunking,
+# indexing, retrieval).  It is integrated at the knowledge layer as
+# `RAGFlowKnowledge` rather than underneath VectorStoreBase, so it ships
+# as its own extra.
+vdb-ragflow = ["ragflow-sdk>=0.17.0"]
 # ------------ RAG ------------
 # Document parsers; pick a vector store via the vdb-* extras.
 rag = [
@@ -148,6 +153,7 @@ k8s = ["agentscope[workspace-k8s]"]
 milvuslite = ["agentscope[vdb-milvus]"]
 mongodb = ["agentscope[vdb-mongodb]"]
 elasticsearch = ["agentscope[vdb-elasticsearch]"]
+ragflow = ["agentscope[vdb-ragflow]"]
 mem0 = ["agentscope[memory-mem0]"]
 reme = ["agentscope[memory-reme]"]
 # ------------ Full ------------
@@ -165,6 +171,7 @@ full = [
     "agentscope[vdb-milvus]",
     "agentscope[vdb-mongodb]",
     "agentscope[vdb-elasticsearch]",
+    "agentscope[vdb-ragflow]",
     "agentscope[memory]",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,10 @@ vdb-elasticsearch = ["elasticsearch[async]>=8.12"]
 # RAGFlow is a managed end-to-end RAG pipeline (parsing, chunking,
 # indexing, retrieval).  It is integrated at the knowledge layer as
 # `RAGFlowKnowledge` rather than underneath VectorStoreBase, so it ships
-# as its own extra.
+# as its own extra.  Do not add it to the `full` metapackage: the
+# `ragflow-sdk` ships a ``Requires-Python: <3.13`` upper bound while
+# AgentScope supports 3.13+, so a `full` dependency would break
+# ``pip install agentscope[full]`` there.
 vdb-ragflow = ["ragflow-sdk>=0.17.0"]
 # ------------ RAG ------------
 # Document parsers; pick a vector store via the vdb-* extras.
@@ -171,7 +174,6 @@ full = [
     "agentscope[vdb-milvus]",
     "agentscope[vdb-mongodb]",
     "agentscope[vdb-elasticsearch]",
-    "agentscope[vdb-ragflow]",
     "agentscope[memory]",
 ]
 

--- a/src/agentscope/rag/__init__.py
+++ b/src/agentscope/rag/__init__.py
@@ -26,6 +26,7 @@ from ._vdb import (
     MongoDBStore,
 )
 from ._knowledge import KnowledgeBase
+from ._ragflow import RAGFlowConfig, RAGFlowKnowledge
 
 __all__ = [
     "ApproxTokenChunker",
@@ -48,4 +49,6 @@ __all__ = [
     "QdrantStore",
     "KnowledgeBase",
     "MongoDBStore",
+    "RAGFlowConfig",
+    "RAGFlowKnowledge",
 ]

--- a/src/agentscope/rag/_ragflow.py
+++ b/src/agentscope/rag/_ragflow.py
@@ -9,19 +9,23 @@ pipeline.  Forcing RAGFlow underneath :class:`VectorStoreBase` would
 require bypassing its core strengths (its built-in document processing
 and indexing pipeline), so it is exposed instead as a knowledge-layer
 handle that sits *alongside* :class:`~agentscope.rag.KnowledgeBase`
-and implements the same application-level interface.
+rather than beneath :class:`~agentscope.rag.VectorStoreBase`.
 
-:class:`RAGFlowKnowledge` therefore mirrors the public surface of
+:class:`RAGFlowKnowledge` exposes the same *purpose-built operations* as
 :class:`~agentscope.rag.KnowledgeBase` — :meth:`search`,
 :meth:`insert_document`, :meth:`delete_document`, :meth:`list_documents`,
-:meth:`list_chunks` — so code written against one knowledge backend
-keeps working with the other, while delegating the heavy lifting to the
-RAGFlow service.
+:meth:`list_chunks` — so callers consult and manage a knowledge base
+through the same method names while the heavy lifting is delegated to the
+RAGFlow service.  The method signatures are *not* fully interchangeable:
+``search`` accepts only text queries (RAGFlow embeds them server-side, so
+no embedding model or ``DataBlock`` inputs are involved), and
+``insert_document`` takes raw document bytes rather than pre-embedded
+``Chunk`` objects.
 
-The one deliberate divergence from :class:`~agentscope.rag.KnowledgeBase`
-is how a document is added.  ``KnowledgeBase.insert_document`` takes
-pre-embedded ``Chunk`` objects because AgentScope runs the parsing and
-chunking locally.  RAGFlow runs those steps on the server, so
+The deliberate divergence in how a document is added follows from
+the same root cause.  ``KnowledgeBase.insert_document`` takes pre-embedded
+``Chunk`` objects because AgentScope runs the parsing and chunking
+locally.  RAGFlow runs those steps on the server, so
 :meth:`RAGFlowKnowledge.insert_document` accepts raw document bytes plus a
 filename and lets RAGFlow parse, chunk, and index them.
 
@@ -33,11 +37,11 @@ filename and lets RAGFlow parse, chunk, and index them.
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any
+from collections import defaultdict
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
-from .._utils._common import _generate_id
 from ._document import Chunk
 from ._vdb import DocumentSummary, VectorSearchResult
 from ..message import TextBlock
@@ -258,14 +262,17 @@ class RAGFlowKnowledge:
         Each query is sent to RAGFlow's ``retrieve`` endpoint, which
         combines vector similarity and (optionally) keyword matching and
         returns chunks already ranked by the server.  Hits across all
-        queries are deduplicated by ``(document_id, chunk_index)`` keeping
-        the best similarity score, optionally filtered by
-        ``score_threshold``, and truncated to ``top_k`` — the same
-        normalisation applied by :class:`~agentscope.rag.KnowledgeBase`.
+        queries are deduplicated by the RAGFlow chunk id (kept in
+        ``chunk.metadata["ragflow_chunk_id"]``) inside the same
+        ``document_id``, keeping the best similarity score, optionally
+        filtered by ``score_threshold``, and truncated to ``top_k``.
 
         Unlike :class:`~agentscope.rag.KnowledgeBase`, no embedding model
         is needed: RAGFlow embeds the query server-side with the model
-        configured on the dataset.
+        configured on the dataset.  RAGFlow reports neither the 0-based
+        index nor the total chunk count of a chunk *within* its source
+        document, so ``Chunk.chunk_index`` is a per-document ordinal of
+        the retrieved hits and ``Chunk.total_chunks`` is ``0``.
 
         Args:
             queries (`list[str | TextBlock]`):
@@ -319,10 +326,17 @@ class RAGFlowKnowledge:
             ),
         )
 
-        best: dict[tuple[str, int], VectorSearchResult] = {}
+        # The same underlying chunk can surface from more than one query
+        # (and / or under repeated chunks when RAGFlow splits a document),
+        # so it is deduplicated by its stable ``ragflow_chunk_id``.  The
+        # best (highest-similarity) representation of each chunk is kept.
+        best: dict[tuple[str, str], VectorSearchResult] = {}
+        # Per-document 0-based ordinal, so ``Chunk.chunk_index`` stays a
+        # meaningful index within its source document rather than a rank.
+        document_offsets: dict[str, int] = defaultdict(int)
         for query_results in results_per_query:
-            for index, chunk in enumerate(query_results):
-                score = self._extract_score(chunk)
+            for chunk in query_results:
+                score = chunk.similarity
                 threshold = (
                     self._config.similarity_threshold
                     if score_threshold is None
@@ -330,12 +344,25 @@ class RAGFlowKnowledge:
                 )
                 if threshold is not None and score < threshold:
                     continue
-                document_id = (
-                    getattr(chunk, "dataset_id", None)
-                    or self._config.dataset_id
+                document_id = chunk.document_id
+                # RAGFlow always identifies the source document of a hit;
+                # without it the chunk cannot be cited or deleted, so drop it.
+                if not document_id:
+                    continue
+                chunk_data = chunk.id
+                # ``document_offsets`` keeps a running 0, 1, 2, ... ordinal
+                # per document so ``chunk_index`` is a position within its
+                # document rather than a retrieval rank.
+                chunk_index = document_offsets[document_id]
+                document_offsets[document_id] += 1
+                agent_chunk = Chunk(
+                    content=TextBlock(text=str(chunk.content)),
+                    source=chunk.document_name,
+                    chunk_index=chunk_index,
+                    total_chunks=0,  # RAGFlow does not report a total
+                    metadata={"ragflow_chunk_id": chunk_data},
                 )
-                agent_chunk = self._to_agentscope_chunk(chunk, index)
-                key = (document_id, agent_chunk.chunk_index)
+                key = (document_id, chunk_data)
                 if key not in best or score > best[key].score:
                     best[key] = VectorSearchResult(
                         score=score,
@@ -350,74 +377,11 @@ class RAGFlowKnowledge:
         )
         return merged[:top_k] if top_k > 0 else merged
 
-    @staticmethod
-    def _extract_score(chunk: Any) -> float:
-        """Extract the similarity score from an SDK ``Chunk``.
-
-        RAGFlow exposes the score under a ``similarity`` attribute on the
-        returned chunk objects; the exact attribute may vary across SDK
-        versions, so a small set of candidates is tried and ``0.0`` is
-        returned when none is present.
-
-        Args:
-            chunk (`Any`):
-                A ``ragflow_sdk.Chunk`` returned by ``retrieve``.
-
-        Returns:
-            `float`: The similarity score, or ``0.0`` if unavailable.
-        """
-        for attr in ("similarity", "score"):
-            value = getattr(chunk, attr, None)
-            if value is not None:
-                try:
-                    return float(value)
-                except (TypeError, ValueError):
-                    break
-        return 0.0
-
-    @staticmethod
-    def _to_agentscope_chunk(chunk: Any, index: int) -> Chunk:
-        """Wrap an SDK ``Chunk`` into an :class:`~agentscope.rag.Chunk`.
-
-        RAGFlow's chunks have no dense ``chunk_index`` / ``total_chunks``
-        sequence of their own, so a stable index (the retrieval ordering
-        position) is used for the chunk index.  Document and source names
-        are taken from the SDK chunk fields when available.
-
-        Args:
-            chunk (`Any`):
-                A ``ragflow_sdk.Chunk`` returned by ``retrieve``.
-            index (`int`):
-                The 0-based position of the chunk within this query's
-                results — used as the chunk index for dedup.
-
-        Returns:
-            `Chunk`: The AgentScope chunk.
-        """
-        content = getattr(chunk, "content", None) or ""
-        source = getattr(chunk, "document_name", None) or ""
-        metadata: dict[str, Any] = {}
-        chunk_id = getattr(chunk, "id", None)
-        if chunk_id:
-            metadata["ragflow_chunk_id"] = chunk_id
-        return Chunk(
-            content=TextBlock(text=str(content)),
-            source=source,
-            chunk_index=index,
-            total_chunks=0,
-            metadata=metadata,
-        )
-
     # ------------------------------------------------------------------
     # Document management
     # ------------------------------------------------------------------
 
-    async def insert_document(
-        self,
-        blob: bytes,
-        filename: str,
-        document_id: str | None = None,
-    ) -> str:
+    async def insert_document(self, blob: bytes, filename: str) -> str:
         """Upload a raw document to the bound RAGFlow dataset.
 
         RAGFlow parses, chunks, and indexes the document on the server
@@ -425,20 +389,24 @@ class RAGFlowKnowledge:
         :meth:`~agentscope.rag.KnowledgeBase.insert_document` — this takes
         raw file bytes rather than pre-embedded ``Chunk`` objects.
 
+        .. note:: Indexing is **asynchronous**.  This method uploads the
+            document and asks RAGFlow to parse it (via
+            ``async_parse_documents``), then returns immediately; the
+            document becomes searchable only after RAGFlow finishes
+            parsing, which may lag behind this call.  Poll
+            :meth:`list_documents` (e.g. on ``parse_progress`` / ``run``)
+            to wait for readiness before searching.
+
         Args:
             blob (`bytes`):
                 The raw bytes of the document (PDF, DOCX, TXT, ...).
             filename (`str`):
                 The display filename RAGFlow stores the document under.
                 RAGFlow infers the parser from its extension.
-            document_id (`str | None`, optional):
-                An optional caller-supplied RAGFlow document id.  RAGFlow
-                assigns its own id on upload, so when ``None``, the id of
-                the newly created document is resolved and returned.
 
         Returns:
             `str`:
-                The RAGFlow document id of the uploaded document.
+                The RAGFlow document id assigned to the uploaded document.
         """
         dataset = await self._get_dataset()
         documents = await asyncio.to_thread(
@@ -451,7 +419,11 @@ class RAGFlowKnowledge:
                 f"{filename!r} to dataset {self._config.dataset_id!r}.",
             )
         document = documents[0]
-        return getattr(document, "id", None) or document_id or _generate_id()
+        await asyncio.to_thread(
+            dataset.async_parse_documents,
+            [document.id],
+        )
+        return document.id
 
     async def delete_document(self, document_id: str) -> None:
         """Remove one document from the bound RAGFlow dataset.
@@ -483,22 +455,15 @@ class RAGFlowKnowledge:
         )
         summaries: list[DocumentSummary] = []
         for document in documents:
-            document_id = getattr(document, "id", None) or ""
-            if not document_id:
-                continue
             summaries.append(
                 DocumentSummary(
-                    document_id=document_id,
-                    source=getattr(document, "name", "") or "",
-                    chunk_count=int(getattr(document, "chunk_count", 0) or 0),
+                    document_id=document.id,
+                    source=document.name,
+                    chunk_count=document.chunk_count,
                     metadata={
-                        "parse_progress": getattr(
-                            document,
-                            "progress",
-                            None,
-                        ),
-                        "run": getattr(document, "run", None),
-                        "size": getattr(document, "size", None),
+                        "parse_progress": document.progress,
+                        "run": document.run,
+                        "size": document.size,
                     },
                 ),
             )
@@ -513,9 +478,11 @@ class RAGFlowKnowledge:
     ) -> list[Chunk]:
         """List one document's chunks as indexed by RAGFlow.
 
-        RAGFlow numbers chunks per document from 1; AgentScope numbers
-        them from 0, so the returned :attr:`Chunk.chunk_index` is rebased
-        accordingly to stay consistent with the rest of the RAG module.
+        RAGFlow does not expose a dense ``chunk_index``/``total_chunks``
+        sequence, so ``chunk_index`` is the 0-based ordinal of the chunk
+        within the pages returned so far and ``total_chunks`` is ``0``.
+        The RAGFlow chunk id is preserved in
+        ``metadata["ragflow_chunk_id"]``.
 
         Args:
             document_id (`str`):
@@ -530,7 +497,7 @@ class RAGFlowKnowledge:
                 At most ``limit`` chunks.
         """
         document = await self._get_document(document_id)
-        # RAGFlow pages from 1 and numbers chunks from 1.
+        # RAGFlow pages from 1.
         page = offset // limit + 1 if limit > 0 else 1
         chunk_data = await asyncio.to_thread(
             document.list_chunks,
@@ -540,17 +507,13 @@ class RAGFlowKnowledge:
         chunks: list[Chunk] = []
         base_index = (page - 1) * limit
         for index, chunk in enumerate(chunk_data):
-            content = getattr(chunk, "content", None) or ""
-            chunk_id = getattr(chunk, "id", None)
             chunks.append(
                 Chunk(
-                    content=TextBlock(text=str(content)),
-                    source=getattr(chunk, "document_name", None) or "",
+                    content=TextBlock(text=str(chunk.content)),
+                    source=chunk.document_name,
                     chunk_index=base_index + index,
                     total_chunks=0,
-                    metadata=(
-                        {"ragflow_chunk_id": chunk_id} if chunk_id else {}
-                    ),
+                    metadata={"ragflow_chunk_id": chunk.id},
                 ),
             )
         return chunks

--- a/src/agentscope/rag/_ragflow.py
+++ b/src/agentscope/rag/_ragflow.py
@@ -1,0 +1,556 @@
+# -*- coding: utf-8 -*-
+"""RAGFlow-backed knowledge base handle.
+
+RAGFlow is a managed, end-to-end RAG pipeline: it owns document
+parsing, chunking, indexing, and retrieval all on the server side.
+That makes it fundamentally different from a vector database, where
+AgentScope is responsible for the whole parse -> chunk -> embed
+pipeline.  Forcing RAGFlow underneath :class:`VectorStoreBase` would
+require bypassing its core strengths (its built-in document processing
+and indexing pipeline), so it is exposed instead as a knowledge-layer
+handle that sits *alongside* :class:`~agentscope.rag.KnowledgeBase`
+and implements the same application-level interface.
+
+:class:`RAGFlowKnowledge` therefore mirrors the public surface of
+:class:`~agentscope.rag.KnowledgeBase` — :meth:`search`,
+:meth:`insert_document`, :meth:`delete_document`, :meth:`list_documents`,
+:meth:`list_chunks` — so code written against one knowledge backend
+keeps working with the other, while delegating the heavy lifting to the
+RAGFlow service.
+
+The one deliberate divergence from :class:`~agentscope.rag.KnowledgeBase`
+is how a document is added.  ``KnowledgeBase.insert_document`` takes
+pre-embedded ``Chunk`` objects because AgentScope runs the parsing and
+chunking locally.  RAGFlow runs those steps on the server, so
+:meth:`RAGFlowKnowledge.insert_document` accepts raw document bytes plus a
+filename and lets RAGFlow parse, chunk, and index them.
+
+.. note:: The ``ragflow-sdk`` package is required.  Install it with
+    ``pip install "agentscope[vdb-ragflow]"``.  It is imported lazily so
+    importing :mod:`agentscope` stays lightweight.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel
+
+from .._utils._common import _generate_id
+from ._document import Chunk
+from ._vdb import DocumentSummary, VectorSearchResult
+from ..message import TextBlock
+
+if TYPE_CHECKING:
+    from ragflow_sdk import RAGFlow, Dataset, Document
+
+
+class RAGFlowConfig(BaseModel):
+    """Connection and retrieval tuning for a RAGFlow knowledge base.
+
+    Carries everything needed to talk to one RAGFlow dataset (RAGFlow's
+    name for a knowledge base) and to tune how :meth:`RAGFlowKnowledge.search`
+    retrieves chunks from it.
+    """
+
+    api_key: str
+    """The RAGFlow API key."""
+
+    base_url: str
+    """The RAGFlow service base URL, e.g. ``"http://localhost:9380"``."""
+
+    dataset_id: str
+    """The RAGFlow dataset (knowledge base) id to bind against."""
+
+    top_k: int = 10
+    """Server-side top-k: the number of candidates RAGFlow considers for
+    vector cosine computation before reranking/filtering."""
+
+    similarity_threshold: float = 0.2
+    """Server-side minimum similarity score a chunk must reach to be
+    returned."""
+
+    vector_similarity_weight: float = 0.3
+    """Relative weight of vector cosine similarity versus term (keyword)
+    similarity when combining the two.  ``x`` is the weight of the vector
+    score, ``1 - x`` the weight of the term score."""
+
+    enable_rerank: bool = False
+    """Whether to rerank the candidates with a RAGFlow rerank model.  When
+    ``True``, :attr:`rerank_id` must point at a configured rerank model."""
+
+    rerank_id: str | None = None
+    """The id of the rerank model to use when :attr:`enable_rerank` is
+    ``True``."""
+
+    keyword: bool = False
+    """Whether to additionally match chunks by keyword (in addition to the
+    vector similarity search)."""
+
+
+class RAGFlowKnowledge:
+    """Runtime handle for one RAGFlow knowledge base.
+
+    Binds a RAGFlow dataset together with retrieval tuning so callers
+    can retrieve / add / delete / list documents without repeating the
+    wiring.  Cheap to construct (no I/O); the RAGFlow client is created
+    lazily on the first network call.
+
+    .. code-block:: python
+
+        kb = RAGFlowKnowledge(
+            name="company-handbook",
+            description="Internal HR and onboarding documents.",
+            config=RAGFlowConfig(
+                api_key="ragflow-xxxxx",
+                base_url="http://localhost:9380",
+                dataset_id="kb-xxxxx",
+            ),
+        )
+        await kb.insert_document(
+            b"...raw pdf bytes...",
+            filename="handbook.pdf",
+        )
+        results = await kb.search(["What is the PTO policy?"])
+    """
+
+    name: str
+    """Agent-oriented knowledge base name — used by tool descriptions
+    and frontend rendering, mirroring
+    :class:`~agentscope.rag.KnowledgeBase`."""
+
+    description: str
+    """Agent-oriented knowledge base description — what this knowledge
+    base contains and when to retrieve from it."""
+
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        config: RAGFlowConfig,
+    ) -> None:
+        """Initialize the runtime handle.
+
+        Args:
+            name (`str`):
+                Agent-oriented knowledge base name.  Surfaced to the
+                LLM (via tool descriptions) and to the front-end.
+            description (`str`):
+                Agent-oriented description.  Should answer "what is in
+                this knowledge base and when should I search it?" — the
+                LLM uses it to decide whether to call the search tool
+                in agentic mode.
+            config (`RAGFlowConfig`):
+                Connection details (API key, base URL, dataset id) and
+                retrieval tuning.
+        """
+        self.name = name
+        self.description = description
+        self._config = config
+        self._client: "RAGFlow | None" = None
+
+    # ------------------------------------------------------------------
+    # Read-only accessors
+    # ------------------------------------------------------------------
+
+    @property
+    def config(self) -> RAGFlowConfig:
+        """The bound :class:`RAGFlowConfig`."""
+        return self._config
+
+    @property
+    def api_key(self) -> str:
+        """The RAGFlow API key."""
+        return self._config.api_key
+
+    @property
+    def base_url(self) -> str:
+        """The RAGFlow service base URL."""
+        return self._config.base_url
+
+    @property
+    def dataset_id(self) -> str:
+        """The bound RAGFlow dataset (knowledge base) id."""
+        return self._config.dataset_id
+
+    # ------------------------------------------------------------------
+    # Client
+    # ------------------------------------------------------------------
+
+    def get_client(self) -> "RAGFlow":
+        """Lazily create and cache the RAGFlow client.
+
+        The ``ragflow-sdk`` package is imported here (not at module top
+        level) so ``import agentscope`` stays lightweight.
+
+        Returns:
+            `ragflow_sdk.RAGFlow`:
+                The shared synchronous RAGFlow client.
+        """
+        if self._client is None:
+            from ragflow_sdk import RAGFlow
+
+            self._client = RAGFlow(
+                api_key=self._config.api_key,
+                base_url=self._config.base_url,
+            )
+        return self._client
+
+    async def _get_dataset(self) -> "Dataset":
+        """Resolve the bound RAGFlow dataset.
+
+        Returns:
+            `ragflow_sdk.Dataset`:
+                The dataset object matching :attr:`dataset_id`.
+        """
+        client = self.get_client()
+        datasets = await asyncio.to_thread(
+            client.list_datasets,
+            id=self._config.dataset_id,
+        )
+        if not datasets:
+            raise RuntimeError(
+                f"RAGFlow dataset {self._config.dataset_id!r} not found "
+                f"at {self._config.base_url!r}.",
+            )
+        return datasets[0]
+
+    async def _get_document(self, document_id: str) -> "Document":
+        """Resolve a single document inside the bound dataset.
+
+        Args:
+            document_id (`str`):
+                The RAGFlow document id.
+
+        Returns:
+            `ragflow_sdk.Document`:
+                The document object.
+
+        Raises:
+            `RuntimeError`:
+                If the document does not exist in the dataset.
+        """
+        dataset = await self._get_dataset()
+        documents = await asyncio.to_thread(
+            dataset.list_documents,
+            id=document_id,
+        )
+        if not documents:
+            raise RuntimeError(
+                f"RAGFlow document {document_id!r} not found in dataset "
+                f"{self._config.dataset_id!r}.",
+            )
+        return documents[0]
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        queries: list[str | TextBlock],
+        top_k: int = 5,
+        score_threshold: float | None = None,
+    ) -> list[VectorSearchResult]:
+        """Search the knowledge base with one or more queries.
+
+        Each query is sent to RAGFlow's ``retrieve`` endpoint, which
+        combines vector similarity and (optionally) keyword matching and
+        returns chunks already ranked by the server.  Hits across all
+        queries are deduplicated by ``(document_id, chunk_index)`` keeping
+        the best similarity score, optionally filtered by
+        ``score_threshold``, and truncated to ``top_k`` — the same
+        normalisation applied by :class:`~agentscope.rag.KnowledgeBase`.
+
+        Unlike :class:`~agentscope.rag.KnowledgeBase`, no embedding model
+        is needed: RAGFlow embeds the query server-side with the model
+        configured on the dataset.
+
+        Args:
+            queries (`list[str | TextBlock]`):
+                Query inputs, each a plain ``str`` or a :class:`TextBlock`.
+            top_k (`int`, defaults to ``5``):
+                Maximum number of results returned across all queries
+                (after dedup).  This is the *client-side* cap and is
+                independent of :attr:`RAGFlowConfig.top_k`, which controls
+                how many candidates RAGFlow considers server-side.
+            score_threshold (`float | None`, optional):
+                Minimum similarity score for a hit to be retained.
+                ``None`` falls back to the server-side
+                :attr:`RAGFlowConfig.similarity_threshold`.
+
+        Returns:
+            `list[VectorSearchResult]`:
+                At most ``top_k`` deduplicated hits ordered by descending
+                similarity score.  Empty when there are no queries.
+        """
+        if not queries:
+            return []
+
+        query_texts = [
+            query.text if isinstance(query, TextBlock) else query
+            for query in queries
+        ]
+
+        client = self.get_client()
+        page_size = max(top_k, 1)
+
+        results_per_query = await asyncio.gather(
+            *(
+                asyncio.to_thread(
+                    client.retrieve,
+                    question=text,
+                    dataset_ids=[self._config.dataset_id],
+                    similarity_threshold=self._config.similarity_threshold,
+                    vector_similarity_weight=(
+                        self._config.vector_similarity_weight
+                    ),
+                    top_k=self._config.top_k,
+                    rerank_id=(
+                        self._config.rerank_id
+                        if self._config.enable_rerank
+                        else None
+                    ),
+                    keyword=self._config.keyword,
+                    page_size=page_size,
+                )
+                for text in query_texts
+            ),
+        )
+
+        best: dict[tuple[str, int], VectorSearchResult] = {}
+        for query_results in results_per_query:
+            for index, chunk in enumerate(query_results):
+                score = self._extract_score(chunk)
+                threshold = (
+                    self._config.similarity_threshold
+                    if score_threshold is None
+                    else score_threshold
+                )
+                if threshold is not None and score < threshold:
+                    continue
+                document_id = (
+                    getattr(chunk, "dataset_id", None)
+                    or self._config.dataset_id
+                )
+                agent_chunk = self._to_agentscope_chunk(chunk, index)
+                key = (document_id, agent_chunk.chunk_index)
+                if key not in best or score > best[key].score:
+                    best[key] = VectorSearchResult(
+                        score=score,
+                        document_id=document_id,
+                        chunk=agent_chunk,
+                    )
+
+        merged = sorted(
+            best.values(),
+            key=lambda result: result.score,
+            reverse=True,
+        )
+        return merged[:top_k] if top_k > 0 else merged
+
+    @staticmethod
+    def _extract_score(chunk: Any) -> float:
+        """Extract the similarity score from an SDK ``Chunk``.
+
+        RAGFlow exposes the score under a ``similarity`` attribute on the
+        returned chunk objects; the exact attribute may vary across SDK
+        versions, so a small set of candidates is tried and ``0.0`` is
+        returned when none is present.
+
+        Args:
+            chunk (`Any`):
+                A ``ragflow_sdk.Chunk`` returned by ``retrieve``.
+
+        Returns:
+            `float`: The similarity score, or ``0.0`` if unavailable.
+        """
+        for attr in ("similarity", "score"):
+            value = getattr(chunk, attr, None)
+            if value is not None:
+                try:
+                    return float(value)
+                except (TypeError, ValueError):
+                    break
+        return 0.0
+
+    @staticmethod
+    def _to_agentscope_chunk(chunk: Any, index: int) -> Chunk:
+        """Wrap an SDK ``Chunk`` into an :class:`~agentscope.rag.Chunk`.
+
+        RAGFlow's chunks have no dense ``chunk_index`` / ``total_chunks``
+        sequence of their own, so a stable index (the retrieval ordering
+        position) is used for the chunk index.  Document and source names
+        are taken from the SDK chunk fields when available.
+
+        Args:
+            chunk (`Any`):
+                A ``ragflow_sdk.Chunk`` returned by ``retrieve``.
+            index (`int`):
+                The 0-based position of the chunk within this query's
+                results — used as the chunk index for dedup.
+
+        Returns:
+            `Chunk`: The AgentScope chunk.
+        """
+        content = getattr(chunk, "content", None) or ""
+        source = getattr(chunk, "document_name", None) or ""
+        metadata: dict[str, Any] = {}
+        chunk_id = getattr(chunk, "id", None)
+        if chunk_id:
+            metadata["ragflow_chunk_id"] = chunk_id
+        return Chunk(
+            content=TextBlock(text=str(content)),
+            source=source,
+            chunk_index=index,
+            total_chunks=0,
+            metadata=metadata,
+        )
+
+    # ------------------------------------------------------------------
+    # Document management
+    # ------------------------------------------------------------------
+
+    async def insert_document(
+        self,
+        blob: bytes,
+        filename: str,
+        document_id: str | None = None,
+    ) -> str:
+        """Upload a raw document to the bound RAGFlow dataset.
+
+        RAGFlow parses, chunks, and indexes the document on the server
+        side, so — unlike
+        :meth:`~agentscope.rag.KnowledgeBase.insert_document` — this takes
+        raw file bytes rather than pre-embedded ``Chunk`` objects.
+
+        Args:
+            blob (`bytes`):
+                The raw bytes of the document (PDF, DOCX, TXT, ...).
+            filename (`str`):
+                The display filename RAGFlow stores the document under.
+                RAGFlow infers the parser from its extension.
+            document_id (`str | None`, optional):
+                An optional caller-supplied RAGFlow document id.  RAGFlow
+                assigns its own id on upload, so when ``None``, the id of
+                the newly created document is resolved and returned.
+
+        Returns:
+            `str`:
+                The RAGFlow document id of the uploaded document.
+        """
+        dataset = await self._get_dataset()
+        documents = await asyncio.to_thread(
+            dataset.upload_documents,
+            [{"display_name": filename, "blob": blob}],
+        )
+        if not documents:
+            raise RuntimeError(
+                f"RAGFlow did not return a document after uploading "
+                f"{filename!r} to dataset {self._config.dataset_id!r}.",
+            )
+        document = documents[0]
+        return getattr(document, "id", None) or document_id or _generate_id()
+
+    async def delete_document(self, document_id: str) -> None:
+        """Remove one document from the bound RAGFlow dataset.
+
+        Args:
+            document_id (`str`):
+                The RAGFlow document id to delete.
+        """
+        dataset = await self._get_dataset()
+        await asyncio.to_thread(
+            dataset.delete_documents,
+            ids=[document_id],
+        )
+
+    async def list_documents(self) -> list[DocumentSummary]:
+        """List all documents in the bound RAGFlow dataset.
+
+        Returns:
+            `list[DocumentSummary]`:
+                One summary per document in the dataset, in server-defined
+                order.
+        """
+        dataset = await self._get_dataset()
+        documents = await asyncio.to_thread(
+            dataset.list_documents,
+            id=None,
+            page=1,
+            page_size=30,
+        )
+        summaries: list[DocumentSummary] = []
+        for document in documents:
+            document_id = getattr(document, "id", None) or ""
+            if not document_id:
+                continue
+            summaries.append(
+                DocumentSummary(
+                    document_id=document_id,
+                    source=getattr(document, "name", "") or "",
+                    chunk_count=int(getattr(document, "chunk_count", 0) or 0),
+                    metadata={
+                        "parse_progress": getattr(
+                            document,
+                            "progress",
+                            None,
+                        ),
+                        "run": getattr(document, "run", None),
+                        "size": getattr(document, "size", None),
+                    },
+                ),
+            )
+        return summaries
+
+    async def list_chunks(
+        self,
+        document_id: str,
+        *,
+        offset: int = 0,
+        limit: int = 30,
+    ) -> list[Chunk]:
+        """List one document's chunks as indexed by RAGFlow.
+
+        RAGFlow numbers chunks per document from 1; AgentScope numbers
+        them from 0, so the returned :attr:`Chunk.chunk_index` is rebased
+        accordingly to stay consistent with the rest of the RAG module.
+
+        Args:
+            document_id (`str`):
+                The RAGFlow document id whose chunks should be listed.
+            offset (`int`, defaults to ``0``):
+                Number of leading chunks to skip.
+            limit (`int`, defaults to ``30``):
+                Maximum number of chunks to return.
+
+        Returns:
+            `list[Chunk]`:
+                At most ``limit`` chunks.
+        """
+        document = await self._get_document(document_id)
+        # RAGFlow pages from 1 and numbers chunks from 1.
+        page = offset // limit + 1 if limit > 0 else 1
+        chunk_data = await asyncio.to_thread(
+            document.list_chunks,
+            page=page,
+            page_size=limit,
+        )
+        chunks: list[Chunk] = []
+        base_index = (page - 1) * limit
+        for index, chunk in enumerate(chunk_data):
+            content = getattr(chunk, "content", None) or ""
+            chunk_id = getattr(chunk, "id", None)
+            chunks.append(
+                Chunk(
+                    content=TextBlock(text=str(content)),
+                    source=getattr(chunk, "document_name", None) or "",
+                    chunk_index=base_index + index,
+                    total_chunks=0,
+                    metadata=(
+                        {"ragflow_chunk_id": chunk_id} if chunk_id else {}
+                    ),
+                ),
+            )
+        return chunks

--- a/tests/rag_ragflow_test.py
+++ b/tests/rag_ragflow_test.py
@@ -1,0 +1,282 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Unit tests for the RAGFlowKnowledge class.
+
+The ``ragflow-sdk`` package is an optional dependency, so these tests
+skip cleanly when it is not installed (matching the pattern used by the
+other vector-store backend tests).  When it *is* installed, the SDK
+client is mocked so the tests exercise AgentScope's mapping / dedup /
+threshold logic without needing a live RAGFlow server.
+"""
+import unittest
+from importlib.util import find_spec
+from unittest.mock import MagicMock
+
+from agentscope.rag import (
+    DocumentSummary,
+    RAGFlowConfig,
+    RAGFlowKnowledge,
+    VectorSearchResult,
+)
+
+
+_RAGFLOW_SDK_AVAILABLE = find_spec("ragflow_sdk") is not None
+
+
+def _sdk_chunk(
+    content: str,
+    index: int,
+    doc_name: str = "handbook.txt",
+    chunk_id: str | None = None,
+    similarity: float = 0.8,
+    dataset_id: str = "kb-1",
+) -> MagicMock:
+    """Build a stand-in for a ``ragflow_sdk.Chunk``."""
+    chunk = MagicMock()
+    chunk.content = content
+    chunk.document_name = doc_name
+    chunk.similarity = similarity
+    chunk.dataset_id = dataset_id
+    chunk.id = chunk_id or f"chunk-{index}"
+    return chunk
+
+
+def _sdk_document(
+    document_id: str,
+    name: str,
+    chunk_count: int = 3,
+    progress: float = 100.0,
+    run: str = "DONE",
+) -> MagicMock:
+    """Build a stand-in for a ``ragflow_sdk.Document``."""
+    doc = MagicMock()
+    doc.id = document_id
+    doc.name = name
+    doc.chunk_count = chunk_count
+    doc.progress = progress
+    doc.run = run
+    doc.size = 1024
+    return doc
+
+
+@unittest.skipUnless(
+    _RAGFLOW_SDK_AVAILABLE,
+    "ragflow-sdk is required for RAGFlowKnowledge tests",
+)
+class RAGFlowKnowledgeTest(unittest.IsolatedAsyncioTestCase):
+    """The test cases for the RAGFlowKnowledge class."""
+
+    def setUp(self) -> None:
+        """Build a RAGFlowKnowledge wired to a mocked RAGFlow client."""
+        self.config = RAGFlowConfig(
+            api_key="ragflow-test-key",
+            base_url="http://localhost:9380",
+            dataset_id="kb-1",
+            top_k=10,
+            similarity_threshold=0.2,
+        )
+        self.kb = RAGFlowKnowledge(
+            name="company-handbook",
+            description="Internal HR docs.",
+            config=self.config,
+        )
+
+        # Mock the SDK client and its dataset lookup.
+        self.mock_client = MagicMock()
+        self.mock_dataset = MagicMock()
+        self.mock_dataset.id = "kb-1"
+        self.kb._client = self.mock_client
+        self.mock_client.list_datasets.return_value = [self.mock_dataset]
+
+    # ------------------------------------------------------------------
+    # Construction / accessors
+    # ------------------------------------------------------------------
+
+    def test_accessors(self) -> None:
+        """Read-only accessors surface the bound config."""
+        self.assertEqual(self.kb.name, "company-handbook")
+        self.assertEqual(self.kb.description, "Internal HR docs.")
+        self.assertEqual(self.kb.dataset_id, "kb-1")
+        self.assertEqual(self.kb.api_key, "ragflow-test-key")
+        self.assertEqual(self.kb.base_url, "http://localhost:9380")
+        self.assertEqual(self.kb.config, self.config)
+
+    def test_client_is_lazily_created(self) -> None:
+        """The SDK client is created only on first use."""
+        self.kb._client = None
+        self.kb.get_client()
+        self.assertIsNotNone(self.kb.get_client())
+        # The same cached instance is reused.
+        self.assertIs(self.kb.get_client(), self.kb._client)
+
+    async def test_missing_dataset_raises(self) -> None:
+        """A doc op against a missing dataset raises RuntimeError."""
+        self.mock_client.list_datasets.return_value = []
+        with self.assertRaises(RuntimeError):
+            await self.kb.list_documents()
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    async def test_search_returns_vectorsresults(self) -> None:
+        """Search maps SDK chunks to VectorSearchResult entries."""
+        hits = [
+            _sdk_chunk(
+                "PTO is 4 weeks.",
+                0,
+                doc_name="handbook.txt",
+                similarity=0.9,
+            ),
+            _sdk_chunk(
+                "Sick leave is 10 days.",
+                1,
+                doc_name="sick.txt",
+                similarity=0.7,
+            ),
+        ]
+        self.mock_client.retrieve.return_value = hits
+
+        results = await self.kb.search(["What is PTO?"], top_k=5)
+
+        self.assertEqual(len(results), 2)
+        self.assertIsInstance(results[0], VectorSearchResult)
+        # Ordered by descending similarity.
+        self.assertAlmostEqual(results[0].score, 0.9)
+        self.assertAlmostEqual(results[1].score, 0.7)
+        self.assertEqual(results[0].document_id, "kb-1")
+        self.assertEqual(results[0].chunk.content.text, "PTO is 4 weeks.")
+        self.assertEqual(
+            results[0].chunk.metadata["ragflow_chunk_id"],
+            "chunk-0",
+        )
+
+    async def test_search_dedups_by_document_and_chunk(self) -> None:
+        """Cross-query hits dedup by (document_id, chunk_index)."""
+        q1 = [_sdk_chunk("A", 1, doc_name="handbook.txt", similarity=0.6)]
+        q2 = [_sdk_chunk("A", 1, doc_name="handbook.txt", similarity=0.8)]
+        self.mock_client.retrieve.side_effect = [q1, q2]
+
+        results = await self.kb.search(["q1", "q2"], top_k=5)
+
+        self.assertEqual(len(results), 1)
+        self.assertAlmostEqual(results[0].score, 0.8)
+
+    async def test_search_applies_score_threshold(self) -> None:
+        """A client-side score_threshold filters weak hits."""
+        hits = [
+            _sdk_chunk("best", 0, similarity=0.9),
+            _sdk_chunk("weak", 1, similarity=0.1),
+        ]
+        self.mock_client.retrieve.return_value = hits
+
+        results = await self.kb.search(
+            ["query"],
+            top_k=5,
+            score_threshold=0.5,
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].chunk.content.text, "best")
+
+    async def test_search_empty_queries(self) -> None:
+        """No queries returns an empty list without calling RAGFlow."""
+        results = await self.kb.search([])
+        self.assertEqual(results, [])
+        self.mock_client.retrieve.assert_not_called()
+
+    async def test_search_passes_retrieval_tuning(self) -> None:
+        """Retrieval parameters are forwarded to the SDK retrieve call."""
+        config = RAGFlowConfig(
+            api_key="k",
+            base_url="http://localhost:9380",
+            dataset_id="kb-1",
+            top_k=42,
+            similarity_threshold=0.3,
+            vector_similarity_weight=0.5,
+            enable_rerank=True,
+            rerank_id="rerank-1",
+            keyword=True,
+        )
+        kb = RAGFlowKnowledge(
+            name="n",
+            description="d",
+            config=config,
+        )
+        kb._client = self.mock_client
+
+        await kb.search(["hello"], top_k=5)
+
+        self.mock_client.retrieve.assert_called_once()
+        kwargs = self.mock_client.retrieve.call_args.kwargs
+        self.assertEqual(kwargs["dataset_ids"], ["kb-1"])
+        self.assertEqual(kwargs["top_k"], 42)
+        self.assertEqual(kwargs["similarity_threshold"], 0.3)
+        self.assertEqual(kwargs["vector_similarity_weight"], 0.5)
+        self.assertEqual(kwargs["rerank_id"], "rerank-1")
+        self.assertEqual(kwargs["keyword"], True)
+
+    # ------------------------------------------------------------------
+    # Document management
+    # ------------------------------------------------------------------
+
+    async def test_insert_document_uploads_and_returns_id(self) -> None:
+        """insert_document uploads raw bytes and returns the document id."""
+        created = _sdk_document("doc-abc", "handbook.pdf")
+        self.mock_dataset.upload_documents.return_value = [created]
+
+        document_id = await self.kb.insert_document(
+            b"%PDF-1.4",
+            "handbook.pdf",
+        )
+
+        self.assertEqual(document_id, "doc-abc")
+        self.mock_dataset.upload_documents.assert_called_once()
+        payload = self.mock_dataset.upload_documents.call_args.args[0][0]
+        self.assertEqual(payload["display_name"], "handbook.pdf")
+        self.assertEqual(payload["blob"], b"%PDF-1.4")
+
+    async def test_delete_document(self) -> None:
+        """delete_document forwards the id to the dataset."""
+        await self.kb.delete_document("doc-abc")
+        self.mock_dataset.delete_documents.assert_called_once_with(
+            ids=["doc-abc"],
+        )
+
+    async def test_list_documents_maps_to_summaries(self) -> None:
+        """list_documents maps SDK documents to DocumentSummary objects."""
+        self.mock_dataset.list_documents.return_value = [
+            _sdk_document("doc-1", "handbook.pdf", chunk_count=5),
+            _sdk_document("doc-2", "sick.txt", chunk_count=2),
+        ]
+
+        summaries = await self.kb.list_documents()
+
+        self.assertEqual(len(summaries), 2)
+        self.assertIsInstance(summaries[0], DocumentSummary)
+        self.assertEqual(summaries[0].document_id, "doc-1")
+        self.assertEqual(summaries[0].source, "handbook.pdf")
+        self.assertEqual(summaries[0].chunk_count, 5)
+        self.assertEqual(summaries[1].document_id, "doc-2")
+
+    async def test_list_chunks_maps_to_agentscope_chunks(self) -> None:
+        """list_chunks maps SDK chunk paging onto AgentScope chunks."""
+        doc = _sdk_document("doc-1", "handbook.txt")
+        self.mock_dataset.list_documents.return_value = [doc]
+        doc.list_chunks.return_value = [
+            _sdk_chunk("c0", 0, doc_name="handbook.txt"),
+            _sdk_chunk("c1", 1, doc_name="handbook.txt"),
+        ]
+
+        chunks = await self.kb.list_chunks("doc-1", offset=0, limit=2)
+
+        self.assertEqual(len(chunks), 2)
+        self.assertEqual(chunks[0].content.text, "c0")
+        self.assertEqual(chunks[1].content.text, "c1")
+        # Rebased to a 0-based chunk index.
+        self.assertEqual(chunks[0].chunk_index, 0)
+        self.assertEqual(chunks[1].chunk_index, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/rag_ragflow_test.py
+++ b/tests/rag_ragflow_test.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=protected-access
-"""Unit tests for the RAGFlowKnowledge class.
+"""Unit tests for the ``RAGFlowKnowledge`` class.
 
-The ``ragflow-sdk`` package is an optional dependency, so these tests
-skip cleanly when it is not installed (matching the pattern used by the
-other vector-store backend tests).  When it *is* installed, the SDK
-client is mocked so the tests exercise AgentScope's mapping / dedup /
-threshold logic without needing a live RAGFlow server.
+The RAGFlow SDK client is fully mocked here — none of the SDK is imported
+at runtime (AgentScope imports it lazily inside ``get_client()``) — so the
+tests run in CI even though ``ragflow-sdk`` is an optional extra.  They
+exercise AgentScope's mapping / dedup / threshold logic without needing a
+live RAGFlow server.
 """
 import unittest
 from importlib.util import find_spec
@@ -23,21 +23,44 @@ from agentscope.rag import (
 _RAGFLOW_SDK_AVAILABLE = find_spec("ragflow_sdk") is not None
 
 
+def _dump_result(result: VectorSearchResult) -> dict:
+    """Reduce a search hit to its deterministic, semantic fields.
+
+    ``VectorSearchResult``/``Chunk``/``TextBlock`` are pydantic models whose
+    ``model_dump()`` carries dynamic ``id`` timestamps, so comparisons use a
+    compact projection instead of the raw dump.
+    """
+    return {
+        "score": result.score,
+        "document_id": result.document_id,
+        "source": result.chunk.source,
+        "content": result.chunk.content.text,
+        "chunk_index": result.chunk.chunk_index,
+        "ragflow_chunk_id": result.chunk.metadata["ragflow_chunk_id"],
+    }
+
+
 def _sdk_chunk(
     content: str,
-    index: int,
+    document_id: str,
     doc_name: str = "handbook.txt",
-    chunk_id: str | None = None,
+    chunk_id: str = "chunk-doc0",
     similarity: float = 0.8,
     dataset_id: str = "kb-1",
 ) -> MagicMock:
-    """Build a stand-in for a ``ragflow_sdk.Chunk``."""
+    """Build a stand-in for a ``ragflow_sdk.Chunk``.
+
+    Mirrors the real SDK ``Chunk``: ``similarity``, ``document_id``,
+    ``document_name``, ``id``, ``dataset_id`` and ``content`` are always
+    initialised.
+    """
     chunk = MagicMock()
     chunk.content = content
     chunk.document_name = doc_name
     chunk.similarity = similarity
+    chunk.document_id = document_id
     chunk.dataset_id = dataset_id
-    chunk.id = chunk_id or f"chunk-{index}"
+    chunk.id = chunk_id
     return chunk
 
 
@@ -59,10 +82,6 @@ def _sdk_document(
     return doc
 
 
-@unittest.skipUnless(
-    _RAGFLOW_SDK_AVAILABLE,
-    "ragflow-sdk is required for RAGFlowKnowledge tests",
-)
 class RAGFlowKnowledgeTest(unittest.IsolatedAsyncioTestCase):
     """The test cases for the RAGFlowKnowledge class."""
 
@@ -101,6 +120,10 @@ class RAGFlowKnowledgeTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.kb.base_url, "http://localhost:9380")
         self.assertEqual(self.kb.config, self.config)
 
+    @unittest.skipUnless(
+        _RAGFLOW_SDK_AVAILABLE,
+        "ragflow-sdk is required to instantiate the real client",
+    )
     def test_client_is_lazily_created(self) -> None:
         """The SDK client is created only on first use."""
         self.kb._client = None
@@ -119,19 +142,21 @@ class RAGFlowKnowledgeTest(unittest.IsolatedAsyncioTestCase):
     # Search
     # ------------------------------------------------------------------
 
-    async def test_search_returns_vectorsresults(self) -> None:
-        """Search maps SDK chunks to VectorSearchResult entries."""
+    async def test_search_returns_hits_across_documents(self) -> None:
+        """Search maps SDK chunks to entries carrying their true doc ids."""
         hits = [
             _sdk_chunk(
                 "PTO is 4 weeks.",
-                0,
+                document_id="doc-handbook",
                 doc_name="handbook.txt",
+                chunk_id="chunk-pto",
                 similarity=0.9,
             ),
             _sdk_chunk(
                 "Sick leave is 10 days.",
-                1,
+                document_id="doc-sick",
                 doc_name="sick.txt",
+                chunk_id="chunk-sick",
                 similarity=0.7,
             ),
         ]
@@ -139,34 +164,86 @@ class RAGFlowKnowledgeTest(unittest.IsolatedAsyncioTestCase):
 
         results = await self.kb.search(["What is PTO?"], top_k=5)
 
-        self.assertEqual(len(results), 2)
-        self.assertIsInstance(results[0], VectorSearchResult)
-        # Ordered by descending similarity.
-        self.assertAlmostEqual(results[0].score, 0.9)
-        self.assertAlmostEqual(results[1].score, 0.7)
-        self.assertEqual(results[0].document_id, "kb-1")
-        self.assertEqual(results[0].chunk.content.text, "PTO is 4 weeks.")
-        self.assertEqual(
-            results[0].chunk.metadata["ragflow_chunk_id"],
-            "chunk-0",
+        dumped = [_dump_result(result) for result in results]
+        self.assertListEqual(
+            dumped,
+            [
+                {
+                    "score": 0.9,
+                    "document_id": "doc-handbook",
+                    "source": "handbook.txt",
+                    "content": "PTO is 4 weeks.",
+                    "chunk_index": 0,
+                    "ragflow_chunk_id": "chunk-pto",
+                },
+                {
+                    "score": 0.7,
+                    "document_id": "doc-sick",
+                    "source": "sick.txt",
+                    "content": "Sick leave is 10 days.",
+                    "chunk_index": 0,
+                    "ragflow_chunk_id": "chunk-sick",
+                },
+            ],
         )
+        # Results never carry the dataset id *as* the document id.
+        self.assertNotIn(self.kb.dataset_id, [r.document_id for r in results])
 
-    async def test_search_dedups_by_document_and_chunk(self) -> None:
-        """Cross-query hits dedup by (document_id, chunk_index)."""
-        q1 = [_sdk_chunk("A", 1, doc_name="handbook.txt", similarity=0.6)]
-        q2 = [_sdk_chunk("A", 1, doc_name="handbook.txt", similarity=0.8)]
+    async def test_search_dedups_by_chunk_id_within_a_document(self) -> None:
+        """The same RAGFlow chunk is not duplicated across queries."""
+        q1 = [
+            _sdk_chunk(
+                "A",
+                document_id="doc-x",
+                chunk_id="chunk-a",
+                similarity=0.6,
+            ),
+        ]
+        q2 = [
+            _sdk_chunk(
+                "A",
+                document_id="doc-x",
+                chunk_id="chunk-a",
+                similarity=0.8,
+            ),
+            _sdk_chunk(
+                "A different chunk",
+                document_id="doc-x",
+                chunk_id="chunk-b",
+                similarity=0.5,
+            ),
+        ]
         self.mock_client.retrieve.side_effect = [q1, q2]
 
         results = await self.kb.search(["q1", "q2"], top_k=5)
 
-        self.assertEqual(len(results), 1)
+        # q1's chunk (score 0.6) is superseded by q2's same chunk (0.8);
+        # chunk-b is a distinct chunk, so it is kept too.
+        self.assertListEqual(
+            [r.document_id for r in results],
+            ["doc-x", "doc-x"],
+        )
+        self.assertEqual(
+            [r.chunk.metadata["ragflow_chunk_id"] for r in results],
+            ["chunk-a", "chunk-b"],
+        )
         self.assertAlmostEqual(results[0].score, 0.8)
 
     async def test_search_applies_score_threshold(self) -> None:
         """A client-side score_threshold filters weak hits."""
         hits = [
-            _sdk_chunk("best", 0, similarity=0.9),
-            _sdk_chunk("weak", 1, similarity=0.1),
+            _sdk_chunk(
+                "best",
+                document_id="doc-x",
+                chunk_id="chunk-best",
+                similarity=0.9,
+            ),
+            _sdk_chunk(
+                "weak",
+                document_id="doc-x",
+                chunk_id="chunk-weak",
+                similarity=0.1,
+            ),
         ]
         self.mock_client.retrieve.return_value = hits
 
@@ -178,6 +255,29 @@ class RAGFlowKnowledgeTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].chunk.content.text, "best")
+
+    async def test_search_ignores_hits_without_a_document(self) -> None:
+        """Chunks RAGFlow cannot attach to a document are dropped."""
+        hits = [
+            _sdk_chunk(
+                "orphan",
+                document_id="",
+                chunk_id="chunk-orphan",
+                similarity=0.9,
+            ),
+            _sdk_chunk(
+                "real",
+                document_id="doc-x",
+                chunk_id="chunk-real",
+                similarity=0.6,
+            ),
+        ]
+        self.mock_client.retrieve.return_value = hits
+
+        results = await self.kb.search(["query"])
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].document_id, "doc-x")
 
     async def test_search_empty_queries(self) -> None:
         """No queries returns an empty list without calling RAGFlow."""
@@ -220,10 +320,11 @@ class RAGFlowKnowledgeTest(unittest.IsolatedAsyncioTestCase):
     # Document management
     # ------------------------------------------------------------------
 
-    async def test_insert_document_uploads_and_returns_id(self) -> None:
-        """insert_document uploads raw bytes and returns the document id."""
-        created = _sdk_document("doc-abc", "handbook.pdf")
-        self.mock_dataset.upload_documents.return_value = [created]
+    async def test_insert_document_uploads_and_triggers_parse(self) -> None:
+        """insert_document uploads raw bytes and requests async parsing."""
+        self.mock_dataset.upload_documents.return_value = [
+            _sdk_document("doc-abc", "handbook.pdf"),
+        ]
 
         document_id = await self.kb.insert_document(
             b"%PDF-1.4",
@@ -231,10 +332,13 @@ class RAGFlowKnowledgeTest(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(document_id, "doc-abc")
-        self.mock_dataset.upload_documents.assert_called_once()
-        payload = self.mock_dataset.upload_documents.call_args.args[0][0]
-        self.assertEqual(payload["display_name"], "handbook.pdf")
-        self.assertEqual(payload["blob"], b"%PDF-1.4")
+        self.mock_dataset.upload_documents.assert_called_once_with(
+            [{"display_name": "handbook.pdf", "blob": b"%PDF-1.4"}],
+        )
+        # RAGFlow indexes asynchronously; the doc id is submitted for parse.
+        self.mock_dataset.async_parse_documents.assert_called_once_with(
+            ["doc-abc"],
+        )
 
     async def test_delete_document(self) -> None:
         """delete_document forwards the id to the dataset."""
@@ -246,26 +350,61 @@ class RAGFlowKnowledgeTest(unittest.IsolatedAsyncioTestCase):
     async def test_list_documents_maps_to_summaries(self) -> None:
         """list_documents maps SDK documents to DocumentSummary objects."""
         self.mock_dataset.list_documents.return_value = [
-            _sdk_document("doc-1", "handbook.pdf", chunk_count=5),
-            _sdk_document("doc-2", "sick.txt", chunk_count=2),
+            _sdk_document(
+                "doc-1",
+                "handbook.pdf",
+                chunk_count=5,
+                progress=80.0,
+            ),
+            _sdk_document("doc-2", "sick.txt", chunk_count=2, run="DONE"),
         ]
 
         summaries = await self.kb.list_documents()
 
-        self.assertEqual(len(summaries), 2)
         self.assertIsInstance(summaries[0], DocumentSummary)
-        self.assertEqual(summaries[0].document_id, "doc-1")
-        self.assertEqual(summaries[0].source, "handbook.pdf")
-        self.assertEqual(summaries[0].chunk_count, 5)
-        self.assertEqual(summaries[1].document_id, "doc-2")
+        self.assertEqual(
+            [s.model_dump() for s in summaries],
+            [
+                {
+                    "document_id": "doc-1",
+                    "source": "handbook.pdf",
+                    "chunk_count": 5,
+                    "metadata": {
+                        "parse_progress": 80.0,
+                        "run": "DONE",  # default run from helper
+                        "size": 1024,  # default size from helper
+                    },
+                },
+                {
+                    "document_id": "doc-2",
+                    "source": "sick.txt",
+                    "chunk_count": 2,
+                    "metadata": {
+                        "parse_progress": 100.0,
+                        "run": "DONE",
+                        "size": 1024,
+                    },
+                },
+            ],
+        )
 
     async def test_list_chunks_maps_to_agentscope_chunks(self) -> None:
-        """list_chunks maps SDK chunk paging onto AgentScope chunks."""
+        """list_chunks maps SDK chunk data onto AgentScope chunks."""
         doc = _sdk_document("doc-1", "handbook.txt")
         self.mock_dataset.list_documents.return_value = [doc]
         doc.list_chunks.return_value = [
-            _sdk_chunk("c0", 0, doc_name="handbook.txt"),
-            _sdk_chunk("c1", 1, doc_name="handbook.txt"),
+            _sdk_chunk(
+                "c0",
+                document_id="doc-1",
+                doc_name="handbook.txt",
+                chunk_id="ragflow-chunk-0",
+            ),
+            _sdk_chunk(
+                "c1",
+                document_id="doc-1",
+                doc_name="handbook.txt",
+                chunk_id="ragflow-chunk-1",
+            ),
         ]
 
         chunks = await self.kb.list_chunks("doc-1", offset=0, limit=2)
@@ -273,9 +412,12 @@ class RAGFlowKnowledgeTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(chunks), 2)
         self.assertEqual(chunks[0].content.text, "c0")
         self.assertEqual(chunks[1].content.text, "c1")
-        # Rebased to a 0-based chunk index.
         self.assertEqual(chunks[0].chunk_index, 0)
         self.assertEqual(chunks[1].chunk_index, 1)
+        self.assertEqual(
+            chunks[0].metadata["ragflow_chunk_id"],
+            "ragflow-chunk-0",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Support RAGFlow as a managed, end-to-end RAG pipeline at the knowledge layer, sitting alongside KnowledgeBase rather than underneath VectorStoreBase. RAGFlow owns document parsing, chunking, indexing, and retrieval on the server side, so RAGFlowKnowledge accepts raw document bytes and delegates the heavy lifting to RAGFlow.

Mirrors the KnowledgeBase interface (search, insert_document, delete_document, list_documents, list_chunks) for consistency across knowledge backends. The ragflow-sdk dependency is lazily imported and ships behind a new vdb-ragflow extra.

Refs #2481

## PR Title Format

Please ensure your PR title follows the Conventional Commits format:
- Format: `<type>(<scope>): <description>`
- Example: `feat(memory): add redis cache support`
- Allowed types: `feat`, `fix`, `docs`, `ci`, `refactor`, `test`, `chore`, `perf`, `style`, `build`, `revert`
- Description should start with a lowercase letter

## AgentScope Version

[The version of AgentScope you are working on, e.g. `import agentscope; print(agentscope.__version__)`]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [ ]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [ ]  Code is ready for review