### PR TITLE
fix(channel): show a channel that is starting as connecting, not stopped

### DIFF
--- a/src/agentscope/app/_service/_channel.py
+++ b/src/agentscope/app/_service/_channel.py
@@ -160,6 +160,9 @@ class ChannelService:
         reporting can leave its last entry behind indefinitely while a
         successor keeps the namespace alive.
 
+        With no report at all, the enabled flag decides: an enabled
+        channel is starting, a disabled one is stopped.
+
         Args:
             channel_id (`str`): The channel to report on.
         """
@@ -180,7 +183,17 @@ class ChannelService:
                 return beat.status
             if best is None or best.state == "stopped":
                 best = beat.status
-        return best or ChannelStatus(state="stopped")
+        if best is not None:
+            return best
+
+        # Nobody has reported yet. For an enabled channel that means it
+        # has not been picked up *yet* — a freshly created one is on its
+        # way — and calling that "stopped" sends the operator looking
+        # for something to start that is already starting.
+        record = await self._storage.get_channel(channel_id)
+        if record is not None and record.enabled:
+            return ChannelStatus(state="connecting")
+        return ChannelStatus(state="stopped")
 
     async def list_seen_chat_ids(self, channel_id: str) -> list[str]:
         """Chat_ids passively recorded from inbound messages.

--- a/tests/channel_clients_test.py
+++ b/tests/channel_clients_test.py
@@ -278,9 +278,13 @@ class ChannelDeliveryTest(IsolatedAsyncioTestCase):
 class ChannelStatusTest(IsolatedAsyncioTestCase):
     """Status is read from the heartbeat, not from local instances."""
 
-    def _service(self, bus: InMemoryMessageBus) -> ChannelService:
+    def _service(
+        self,
+        bus: InMemoryMessageBus,
+        enabled: bool = True,
+    ) -> ChannelService:
         return ChannelService(
-            storage=_Storage(_record()),
+            storage=_Storage(_record(enabled=enabled)),
             message_bus=bus,
             type_registry=ChannelTypeRegistry([_FakeChannel]),
         )
@@ -303,11 +307,25 @@ class ChannelStatusTest(IsolatedAsyncioTestCase):
             ttl_secs=LIVENESS_TTL_SECS,
         )
 
-    async def test_no_heartbeat_reads_as_stopped(self) -> None:
-        """Nothing is holding the channel, so nothing reports it."""
+    async def test_an_enabled_channel_with_no_report_is_connecting(
+        self,
+    ) -> None:
+        """A channel just created has not been picked up yet. Calling
+        that stopped sends the operator looking for something to start
+        that is already starting."""
         bus = InMemoryMessageBus()
         self.assertEqual(
             await self._service(bus).get_status("chan-1"),
+            ChannelStatus(state="connecting"),
+        )
+
+    async def test_a_disabled_channel_with_no_report_is_stopped(
+        self,
+    ) -> None:
+        """Nothing is holding it, and nothing is meant to."""
+        bus = InMemoryMessageBus()
+        self.assertEqual(
+            await self._service(bus, enabled=False).get_status("chan-1"),
             ChannelStatus(state="stopped"),
         )
 
@@ -339,8 +357,11 @@ class ChannelStatusTest(IsolatedAsyncioTestCase):
             ChannelStatus(state="connecting"),
         )
 
-    async def test_only_stale_reports_read_as_stopped(self) -> None:
-        """Every holder went away; nothing fresh is left to believe."""
+    async def test_only_stale_reports_fall_back_to_the_enabled_flag(
+        self,
+    ) -> None:
+        """Every holder went away; nothing fresh is left to believe, so
+        this reads like never having been reported at all."""
         bus = InMemoryMessageBus()
         await self._beat(
             bus,
@@ -351,6 +372,10 @@ class ChannelStatusTest(IsolatedAsyncioTestCase):
 
         self.assertEqual(
             await self._service(bus).get_status("chan-1"),
+            ChannelStatus(state="connecting"),
+        )
+        self.assertEqual(
+            await self._service(bus, enabled=False).get_status("chan-1"),
             ChannelStatus(state="stopped"),
         )
 


### PR DESCRIPTION
## AgentScope Version

`main` @ `180b409b8`

## Description

### Background

Creating a channel shows it as closed for a moment, then connecting, then connected — so the first thing the operator sees about a channel that is on its way up is that it is down.

A channel's status comes from the heartbeat its holder writes into `channel_liveness`. A freshly created one has no holder yet: the record has to be persisted and notified, and a dispatcher has to reconcile and start it, before any heartbeat exists. `ChannelService.get_status` treated "no report" as `stopped`.

That conflates two different things. `stopped` reads as an instruction — the channel is not running, go start it — but there is nowhere to go, and it is already starting.

### Changes

With no fresh report, let the enabled flag decide: an enabled channel has simply not been picked up yet, so report `connecting`; only a disabled one is `stopped`. Stale-only reports fall into the same path, since a channel whose holders all went away is in the same position as one that never had any.

The frontend already renders an absent status as `connecting` (`channel-status.tsx`: `status?.state ?? 'connecting'`), so this only makes the response agree with what the UI does while waiting for it. No frontend change.

### A consequence worth naming

An enabled channel in a deployment with no channel worker running now reads as `connecting` forever rather than `stopped`. That is the more accurate of the two — nothing stopped it, nothing has picked it up — but it does mean a missing worker shows as a channel that never finishes connecting rather than one that is off.

### Testing

- `tests/channel_clients_test.py`: the two tests that asserted the old fallback now state the new contract, split by the enabled flag, plus the disabled counterpart for each.
- `pytest tests/` — same 12 pre-existing failures as `main` (`builtin_grep_test.py`, `test_e2e_api.py::TestPerAgentMCPAPI`), nothing new.
- `pre-commit run --all-files` passes.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated
- [x] Code is ready for review