### PR TITLE
fix(workspace): recover expired OpenSandbox sandboxes

### DIFF
--- a/src/agentscope/app/workspace_manager/_opensandbox_workspace_manager.py
+++ b/src/agentscope/app/workspace_manager/_opensandbox_workspace_manager.py
@@ -23,8 +23,8 @@ Differences from the Docker manager:
   ``workspace_id``.
 * Idle workspaces are evicted by a background sweeper task started in
   :meth:`__aenter__` and cancelled in :meth:`__aexit__`.
-* Cached workspaces are checked against the OpenSandbox control plane before
-  reuse. Paused sandboxes are reattached; expired sandboxes are recreated.
+* Cached workspaces renew their sandbox lease on access. A renewal 404
+  evicts the stale connection so the sandbox can be recreated.
 * ``close_all`` fans calls out with :func:`asyncio.gather` because
   ``sandbox.pause()`` is a remote round-trip per sandbox.
 """
@@ -104,7 +104,8 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
                 command timeout.
             timeout_seconds (`int`, defaults to `DEFAULT_TIMEOUT`):
                 Sandbox expiration lease and create/connect/resume timeout.
-                Open workspaces renew the finite lease in the background.
+                Defaults to 1800 seconds and renews on cache access, not
+                in the background. Set it longer than the longest turn.
             gateway_port (`int`, defaults to `DEFAULT_GATEWAY_PORT`):
                 TCP port the in-sandbox gateway listens on.
             env (`dict[str, str] | None`, optional):
@@ -199,64 +200,6 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
         await ws.initialize()
         return ws
 
-    async def _reuse_cached(
-        self,
-        workspace_id: str,
-    ) -> OpenSandboxWorkspace | None:
-        """Return a live cached workspace or evict its stale connection.
-
-        Remote lifecycle calls run outside :attr:`_lock` so one slow control
-        plane does not block unrelated workspace ids. Cache identity is
-        rechecked under the lock before a result is reused or evicted.
-
-        Args:
-            workspace_id (`str`):
-                Cache key to inspect.
-
-        Returns:
-            `OpenSandboxWorkspace | None`:
-                The renewed cached workspace, or ``None`` when the caller
-                must build a replacement.
-        """
-        while True:
-            async with self._lock:
-                cached = self._cache.get(workspace_id)
-            if cached is None:
-                return None
-            ws, _ = cached
-            # pylint: disable-next=protected-access
-            lifecycle = await ws._refresh_remote_lifecycle()
-
-            async with self._lock:
-                current = self._cache.get(workspace_id)
-                if current is None or current[0] is not ws:
-                    continue
-                if lifecycle == "running":
-                    self._cache[workspace_id] = (ws, time.monotonic())
-                    return ws
-                self._cache.pop(workspace_id)
-
-            if lifecycle == "reattach":
-                logger.info(
-                    "OpenSandbox workspace %r is paused; reattaching "
-                    "sandbox %r",
-                    workspace_id,
-                    ws.sandbox_id,
-                )
-            else:
-                logger.warning(
-                    "OpenSandbox workspace %r lost sandbox %r; recreating "
-                    "it. Ephemeral workspace data may have been lost.",
-                    workspace_id,
-                    ws.sandbox_id,
-                )
-            # Do not pause a sandbox that may already be paused or gone. Drop
-            # the SDK transport locally, then let normal initialization resume
-            # the matching paused sandbox or create a fresh one when absent.
-            # pylint: disable-next=protected-access
-            await ws._discard_local_connection()
-            return None
-
     async def get_workspace(
         self,
         user_id: str,
@@ -266,11 +209,12 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
     ) -> OpenSandboxWorkspace:
         """Return an initialized workspace, reattaching on cache miss.
 
-        Cached workspaces are checked and renewed before reuse. A paused
-        sandbox is reattached, while an expired or deleted sandbox is replaced
-        under the same ``workspace_id``. On a cache miss, normal initialization
-        finds an existing sandbox by metadata, connects or resumes it depending
-        on state, or creates a fresh sandbox otherwise.
+        Cached workspaces renew their lease before reuse. A renewal 404
+        triggers replacement under the same ``workspace_id``; other renewal
+        failures are logged without rejecting the cached workspace. On a
+        cache miss, initialization connects or resumes an existing sandbox
+        found by metadata, or creates a fresh one otherwise. Recreation
+        cannot recover ephemeral data lost with the previous sandbox.
 
         Idle eviction is not performed here; the background sweeper
         started by :meth:`__aenter__` handles that.
@@ -297,34 +241,37 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
         """
         del session_id  # accepted for interface parity; not used here
 
-        if not workspace_id:
-            workspace_id = await self.assign_workspace_id(
-                user_id=user_id,
-                agent_id=agent_id,
-                session_id="",
-            )
-        assert workspace_id is not None
+        resolved_id: str = workspace_id or await self.assign_workspace_id(
+            user_id=user_id,
+            agent_id=agent_id,
+            session_id="",
+        )
 
-        ws = await self._reuse_cached(workspace_id)
-        if ws is not None:
-            return ws
-
-        # Cache miss: build under the lock to prevent two concurrent
-        # get_workspace(workspace_id=X) calls from creating two
-        # workspaces (and thus two sandboxes) for the same id.
+        # Serialize reuse and recovery so concurrent requests cannot create
+        # two replacement sandboxes for the same workspace id.
         async with self._lock:
-            cached = self._cache.get(workspace_id)
+            cached = self._cache.get(resolved_id)
             if cached is not None:
                 ws, _ = cached
-                self._cache[workspace_id] = (ws, time.monotonic())
-                return ws
+                # pylint: disable-next=protected-access
+                if await ws._renew_once():
+                    self._cache[resolved_id] = (ws, time.monotonic())
+                    return ws
+                self._cache.pop(resolved_id)
+                logger.warning(
+                    "OpenSandbox workspace %r lost sandbox %r; recreating "
+                    "it. Ephemeral workspace data may have been lost.",
+                    resolved_id,
+                    ws.sandbox_id,
+                )
+                await self._safe_close(ws)
 
             ws = await self._build_and_start(
-                workspace_id=workspace_id,
+                workspace_id=resolved_id,
                 user_id=user_id,
                 agent_id=agent_id,
             )
-            self._cache[workspace_id] = (ws, time.monotonic())
+            self._cache[resolved_id] = (ws, time.monotonic())
             return ws
 
     async def close(self, workspace_id: str) -> None:

--- a/src/agentscope/app/workspace_manager/_opensandbox_workspace_manager.py
+++ b/src/agentscope/app/workspace_manager/_opensandbox_workspace_manager.py
@@ -23,6 +23,8 @@ Differences from the Docker manager:
   ``workspace_id``.
 * Idle workspaces are evicted by a background sweeper task started in
   :meth:`__aenter__` and cancelled in :meth:`__aexit__`.
+* Cached workspaces are checked against the OpenSandbox control plane before
+  reuse. Paused sandboxes are reattached; expired sandboxes are recreated.
 * ``close_all`` fans calls out with :func:`asyncio.gather` because
   ``sandbox.pause()`` is a remote round-trip per sandbox.
 """
@@ -101,7 +103,8 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
                 SDK HTTP streaming layer is not shorter than bootstrap
                 command timeout.
             timeout_seconds (`int`, defaults to `DEFAULT_TIMEOUT`):
-                Sandbox keep-alive / resume timeout.
+                Sandbox expiration lease and create/connect/resume timeout.
+                Open workspaces renew the finite lease in the background.
             gateway_port (`int`, defaults to `DEFAULT_GATEWAY_PORT`):
                 TCP port the in-sandbox gateway listens on.
             env (`dict[str, str] | None`, optional):
@@ -196,6 +199,64 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
         await ws.initialize()
         return ws
 
+    async def _reuse_cached(
+        self,
+        workspace_id: str,
+    ) -> OpenSandboxWorkspace | None:
+        """Return a live cached workspace or evict its stale connection.
+
+        Remote lifecycle calls run outside :attr:`_lock` so one slow control
+        plane does not block unrelated workspace ids. Cache identity is
+        rechecked under the lock before a result is reused or evicted.
+
+        Args:
+            workspace_id (`str`):
+                Cache key to inspect.
+
+        Returns:
+            `OpenSandboxWorkspace | None`:
+                The renewed cached workspace, or ``None`` when the caller
+                must build a replacement.
+        """
+        while True:
+            async with self._lock:
+                cached = self._cache.get(workspace_id)
+            if cached is None:
+                return None
+            ws, _ = cached
+            # pylint: disable-next=protected-access
+            lifecycle = await ws._refresh_remote_lifecycle()
+
+            async with self._lock:
+                current = self._cache.get(workspace_id)
+                if current is None or current[0] is not ws:
+                    continue
+                if lifecycle == "running":
+                    self._cache[workspace_id] = (ws, time.monotonic())
+                    return ws
+                self._cache.pop(workspace_id)
+
+            if lifecycle == "reattach":
+                logger.info(
+                    "OpenSandbox workspace %r is paused; reattaching "
+                    "sandbox %r",
+                    workspace_id,
+                    ws.sandbox_id,
+                )
+            else:
+                logger.warning(
+                    "OpenSandbox workspace %r lost sandbox %r; recreating "
+                    "it. Ephemeral workspace data may have been lost.",
+                    workspace_id,
+                    ws.sandbox_id,
+                )
+            # Do not pause a sandbox that may already be paused or gone. Drop
+            # the SDK transport locally, then let normal initialization resume
+            # the matching paused sandbox or create a fresh one when absent.
+            # pylint: disable-next=protected-access
+            await ws._discard_local_connection()
+            return None
+
     async def get_workspace(
         self,
         user_id: str,
@@ -205,11 +266,11 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
     ) -> OpenSandboxWorkspace:
         """Return an initialized workspace, reattaching on cache miss.
 
-        On miss, the manager constructs ``OpenSandboxWorkspace`` with
-        the requested ``workspace_id`` and relies on its ``initialize``
-        method to find an existing sandbox by metadata, connect or
-        resume it depending on state, or create a fresh sandbox
-        otherwise.
+        Cached workspaces are checked and renewed before reuse. A paused
+        sandbox is reattached, while an expired or deleted sandbox is replaced
+        under the same ``workspace_id``. On a cache miss, normal initialization
+        finds an existing sandbox by metadata, connects or resumes it depending
+        on state, or creates a fresh sandbox otherwise.
 
         Idle eviction is not performed here; the background sweeper
         started by :meth:`__aenter__` handles that.
@@ -242,13 +303,11 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
                 agent_id=agent_id,
                 session_id="",
             )
+        assert workspace_id is not None
 
-        async with self._lock:
-            cached = self._cache.get(workspace_id)
-            if cached is not None:
-                ws, _ = cached
-                self._cache[workspace_id] = (ws, time.monotonic())
-                return ws
+        ws = await self._reuse_cached(workspace_id)
+        if ws is not None:
+            return ws
 
         # Cache miss: build under the lock to prevent two concurrent
         # get_workspace(workspace_id=X) calls from creating two

--- a/src/agentscope/app/workspace_manager/_opensandbox_workspace_manager.py
+++ b/src/agentscope/app/workspace_manager/_opensandbox_workspace_manager.py
@@ -32,6 +32,7 @@ Differences from the Docker manager:
 import asyncio
 import time
 from typing import Any, Literal, Self
+from weakref import WeakValueDictionary
 
 from ..._logging import logger
 from ...mcp import MCPClient
@@ -158,8 +159,28 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
 
         # workspace_id -> (workspace, last_access_monotonic)
         self._cache: dict[str, tuple[OpenSandboxWorkspace, float]] = {}
+        # Keep only locks referenced by active operations. Idle cached
+        # workspaces do not need a permanent lock entry, and a fresh lookup
+        # will create one before the next operation.
+        self._workspace_locks: WeakValueDictionary[
+            str,
+            asyncio.Lock,
+        ] = WeakValueDictionary()
         self._lock = asyncio.Lock()
         self._sweep_task: asyncio.Task | None = None
+
+    async def _get_workspace_lock(self, workspace_id: str) -> asyncio.Lock:
+        """Return the serialization lock for one workspace id.
+
+        The manager-wide lock only protects the weak lock registry. Callers
+        must release it before waiting for the returned workspace lock.
+        """
+        async with self._lock:
+            workspace_lock = self._workspace_locks.get(workspace_id)
+            if workspace_lock is None:
+                workspace_lock = asyncio.Lock()
+                self._workspace_locks[workspace_id] = workspace_lock
+            return workspace_lock
 
     async def _build_and_start(
         self,
@@ -247,17 +268,22 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
             session_id="",
         )
 
-        # Serialize reuse and recovery so concurrent requests cannot create
-        # two replacement sandboxes for the same workspace id.
-        async with self._lock:
-            cached = self._cache.get(resolved_id)
+        # Serialize reuse and recovery per workspace id. Remote operations
+        # must not hold the manager-wide cache lock, otherwise one slow
+        # sandbox blocks unrelated workspaces.
+        workspace_lock = await self._get_workspace_lock(resolved_id)
+        async with workspace_lock:
+            async with self._lock:
+                cached = self._cache.get(resolved_id)
             if cached is not None:
                 ws, _ = cached
                 # pylint: disable-next=protected-access
                 if await ws._renew_once():
-                    self._cache[resolved_id] = (ws, time.monotonic())
+                    async with self._lock:
+                        self._cache[resolved_id] = (ws, time.monotonic())
                     return ws
-                self._cache.pop(resolved_id)
+                async with self._lock:
+                    self._cache.pop(resolved_id, None)
                 logger.warning(
                     "OpenSandbox workspace %r lost sandbox %r; recreating "
                     "it. Ephemeral workspace data may have been lost.",
@@ -271,17 +297,20 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
                 user_id=user_id,
                 agent_id=agent_id,
             )
-            self._cache[resolved_id] = (ws, time.monotonic())
+            async with self._lock:
+                self._cache[resolved_id] = (ws, time.monotonic())
             return ws
 
     async def close(self, workspace_id: str) -> None:
         """Close (= pause the sandbox) and evict a single workspace."""
-        async with self._lock:
-            entry = self._cache.pop(workspace_id, None)
-        if entry is None:
-            return
-        ws, _ = entry
-        await self._safe_close(ws)
+        workspace_lock = await self._get_workspace_lock(workspace_id)
+        async with workspace_lock:
+            async with self._lock:
+                entry = self._cache.pop(workspace_id, None)
+            if entry is None:
+                return
+            ws, _ = entry
+            await self._safe_close(ws)
 
     async def close_all(self) -> None:
         """Close every cached workspace in parallel.
@@ -290,12 +319,11 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
         it sequentially on shutdown would produce unnecessary latency.
         """
         async with self._lock:
-            entries = list(self._cache.values())
-            self._cache.clear()
-        if not entries:
+            workspace_ids = set(self._cache) | set(self._workspace_locks)
+        if not workspace_ids:
             return
         await asyncio.gather(
-            *(self._safe_close(ws) for ws, _ in entries),
+            *(self.close(workspace_id) for workspace_id in workspace_ids),
             return_exceptions=True,
         )
 
@@ -335,20 +363,35 @@ class OpenSandboxWorkspaceManager(WorkspaceManagerBase):
 
     async def _sweep_once(self) -> None:
         """One sweeper tick: evict expired entries and close them."""
-        now = time.monotonic()
+        cutoff = time.monotonic() - self._ttl
         async with self._lock:
             expired_ids = [
-                wid
-                for wid, (_, ts) in self._cache.items()
-                if now - ts > self._ttl
+                wid for wid, (_, ts) in self._cache.items() if ts < cutoff
             ]
-            evicted = [self._cache.pop(wid)[0] for wid in expired_ids]
-        if not evicted:
+        if not expired_ids:
             return
         await asyncio.gather(
-            *(self._safe_close(ws) for ws in evicted),
+            *(
+                self._close_if_expired(workspace_id, cutoff)
+                for workspace_id in expired_ids
+            ),
             return_exceptions=True,
         )
+
+    async def _close_if_expired(
+        self,
+        workspace_id: str,
+        cutoff: float,
+    ) -> None:
+        """Close a candidate only if it is still idle after serialization."""
+        workspace_lock = await self._get_workspace_lock(workspace_id)
+        async with workspace_lock:
+            async with self._lock:
+                entry = self._cache.get(workspace_id)
+                if entry is None or entry[1] >= cutoff:
+                    return
+                ws, _ = self._cache.pop(workspace_id)
+            await self._safe_close(ws)
 
     @staticmethod
     async def _safe_close(ws: OpenSandboxWorkspace) -> None:

--- a/src/agentscope/workspace/_opensandbox/_constants.py
+++ b/src/agentscope/workspace/_opensandbox/_constants.py
@@ -15,8 +15,9 @@ base class, not here.
 #: and ripgrep during bootstrap.
 DEFAULT_IMAGE = "python:3.11-slim"
 
-#: Default keep-alive timeout in seconds for newly-created sandboxes.
-DEFAULT_TIMEOUT = 300
+#: Default sandbox lease in seconds. Configure a longer lease for turns
+#: that can exceed 30 minutes; there is no background lease renewal.
+DEFAULT_TIMEOUT = 1800
 
 #: Per-command timeout for first-time bootstrap shell commands.
 BOOTSTRAP_COMMAND_TIMEOUT = 600.0

--- a/src/agentscope/workspace/_opensandbox/_opensandbox_workspace.py
+++ b/src/agentscope/workspace/_opensandbox/_opensandbox_workspace.py
@@ -32,6 +32,11 @@ if TYPE_CHECKING:
         SandboxInfo,
     )
 
+    from .._gateway_client import GatewayClient
+
+
+_RemoteLifecycleState = Literal["running", "reattach", "missing"]
+
 
 class OpenSandboxWorkspace(SandboxedWorkspaceBase):
     """Workspace backed by an OpenSandbox sandbox.
@@ -138,6 +143,9 @@ class OpenSandboxWorkspace(SandboxedWorkspaceBase):
 
         self._sandbox: Sandbox | None = None
         self._backend: OpenSandboxBackend | None = None
+        self._gateway: GatewayClient | None
+        self._renew_task: asyncio.Task | None = None
+        self._lease_lost = False
 
     @property
     def sandbox_id(self) -> str | None:
@@ -164,6 +172,20 @@ class OpenSandboxWorkspace(SandboxedWorkspaceBase):
         await self._wait_until_running()
 
         self._backend = OpenSandboxBackend(self._sandbox, SANDBOX_WORKDIR)
+        if not await self._renew_once():
+            raise RuntimeError(
+                "OpenSandbox sandbox disappeared during initialization "
+                f"(workspace_id={self.workspace_id!r})",
+            )
+        self._start_renewal()
+
+    async def initialize(self) -> None:
+        """Initialize the workspace and clean up partial failures."""
+        try:
+            await super().initialize()
+        except Exception:
+            await self.close()
+            raise
 
     async def _teardown_backend(self) -> None:
         """Pause the sandbox (keep filesystem) and drop the handle.
@@ -172,6 +194,7 @@ class OpenSandboxWorkspace(SandboxedWorkspaceBase):
         :meth:`initialize` can reattach via metadata lookup and
         resume. Errors are swallowed.
         """
+        await self._stop_renewal()
         if self._sandbox is not None:
             try:
                 await self._sandbox.pause()
@@ -185,6 +208,127 @@ class OpenSandboxWorkspace(SandboxedWorkspaceBase):
                     exc,
                 )
             self._sandbox = None
+        self._lease_lost = False
+
+    @property
+    def _renew_interval(self) -> float:
+        """Return a conservative interval for refreshing the lease."""
+        return max(1.0, min(60.0, self.timeout_seconds / 3.0))
+
+    def _start_renewal(self) -> None:
+        """Start the sandbox lease-renewal loop once."""
+        if self._renew_task is None or self._renew_task.done():
+            self._renew_task = asyncio.create_task(self._renew_loop())
+
+    async def _stop_renewal(self) -> None:
+        """Cancel and await the sandbox lease-renewal loop."""
+        task = self._renew_task
+        self._renew_task = None
+        if task is None:
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def _renew_loop(self) -> None:
+        """Keep the finite sandbox lease alive while this workspace is open."""
+        while True:
+            try:
+                await asyncio.sleep(self._renew_interval)
+            except asyncio.CancelledError:
+                return
+            try:
+                if not await self._renew_once():
+                    logger.warning(
+                        "OpenSandboxWorkspace: sandbox lease was lost for "
+                        "workspace_id=%r; waiting for manager recovery",
+                        self.workspace_id,
+                    )
+                    return
+            except Exception as exc:  # noqa: BLE001
+                # A transient control-plane failure must not cause a second
+                # sandbox to be created. Retry on the next renewal tick; the
+                # manager performs an authoritative check on cache access.
+                logger.warning(
+                    "OpenSandboxWorkspace: lease renewal failed for "
+                    "workspace_id=%r (will retry): %s",
+                    self.workspace_id,
+                    exc,
+                )
+
+    async def _renew_once(self) -> bool:
+        """Renew the current lease, returning ``False`` after a 404."""
+        from opensandbox.exceptions import SandboxApiException
+
+        if self._sandbox is None:
+            self._lease_lost = True
+            return False
+        try:
+            await self._sandbox.renew(
+                timedelta(seconds=self.timeout_seconds),
+            )
+        except SandboxApiException as exc:
+            if exc.status_code == 404:
+                self._lease_lost = True
+                return False
+            raise
+        self._lease_lost = False
+        return True
+
+    async def _refresh_remote_lifecycle(self) -> _RemoteLifecycleState:
+        """Check the remote state and refresh a running sandbox lease.
+
+        Returns:
+            `_RemoteLifecycleState`:
+                ``"running"`` when the current handle is reusable,
+                ``"reattach"`` when the sandbox is paused, or ``"missing"``
+                when it was deleted or entered a terminal state.
+        """
+        from opensandbox.exceptions import SandboxApiException
+
+        if self._sandbox is None or self._lease_lost:
+            return "missing"
+        try:
+            info = await self._sandbox.get_info()
+        except SandboxApiException as exc:
+            if exc.status_code == 404:
+                self._lease_lost = True
+                return "missing"
+            raise
+
+        state = info.status.state.lower()
+        if state == "running":
+            return "running" if await self._renew_once() else "missing"
+        if state == "paused":
+            return "reattach"
+        if state in {"stopping", "terminated", "failed"}:
+            self._lease_lost = True
+            return "missing"
+        raise RuntimeError(
+            f"OpenSandbox sandbox {self._sandbox.id!r} is transitioning "
+            f"(state={state!r}); retry later",
+        )
+
+    async def _discard_local_connection(self) -> None:
+        """Drop stale local handles without changing remote lifecycle state."""
+        await self._stop_renewal()
+        if self._gateway is not None:
+            try:
+                await self._gateway.aclose()
+            except Exception:  # noqa: BLE001
+                pass
+            self._gateway = None
+        self._mcp_instances.clear()
+        self._mcp_last_used.clear()
+
+        sandbox = self._sandbox
+        self._sandbox = None
+        if sandbox is not None:
+            await sandbox.close()
+        self._backend = None
+        self.is_alive = False
 
     async def get_instructions(self) -> str:
         """Return the system-prompt fragment for this workspace.

--- a/src/agentscope/workspace/_opensandbox/_opensandbox_workspace.py
+++ b/src/agentscope/workspace/_opensandbox/_opensandbox_workspace.py
@@ -32,11 +32,6 @@ if TYPE_CHECKING:
         SandboxInfo,
     )
 
-    from .._gateway_client import GatewayClient
-
-
-_RemoteLifecycleState = Literal["running", "reattach", "missing"]
-
 
 class OpenSandboxWorkspace(SandboxedWorkspaceBase):
     """Workspace backed by an OpenSandbox sandbox.
@@ -94,7 +89,10 @@ class OpenSandboxWorkspace(SandboxedWorkspaceBase):
                 SDK HTTP request timeout. ``None`` leaves the SDK
                 default in effect.
             timeout_seconds (`int`, defaults to `DEFAULT_TIMEOUT`):
-                Sandbox keep-alive and create/connect/resume timeout.
+                Sandbox expiration lease and create/connect/resume timeout.
+                Defaults to 1800 seconds. The manager renews the lease on
+                cache access, not in the background; configure a longer
+                lease for turns that can exceed this duration.
             gateway_port (`int`, defaults to `DEFAULT_GATEWAY_PORT`):
                 TCP port the in-sandbox gateway listens on.
             env (`dict[str, str] | None`, optional):
@@ -143,9 +141,6 @@ class OpenSandboxWorkspace(SandboxedWorkspaceBase):
 
         self._sandbox: Sandbox | None = None
         self._backend: OpenSandboxBackend | None = None
-        self._gateway: GatewayClient | None
-        self._renew_task: asyncio.Task | None = None
-        self._lease_lost = False
 
     @property
     def sandbox_id(self) -> str | None:
@@ -167,23 +162,24 @@ class OpenSandboxWorkspace(SandboxedWorkspaceBase):
         existing = await self._find_existing_sandbox()
         if existing is not None:
             self._sandbox = await self._attach_existing_sandbox(existing)
+            # SDK connect/resume timeouts only bound readiness checks;
+            # reusing an existing sandbox also needs a fresh lease.
+            if not await self._renew_once():
+                raise RuntimeError(
+                    "OpenSandbox sandbox disappeared during initialization "
+                    f"(workspace_id={self.workspace_id!r})",
+                )
         else:
             self._sandbox = await self._create_sandbox()
         await self._wait_until_running()
 
         self._backend = OpenSandboxBackend(self._sandbox, SANDBOX_WORKDIR)
-        if not await self._renew_once():
-            raise RuntimeError(
-                "OpenSandbox sandbox disappeared during initialization "
-                f"(workspace_id={self.workspace_id!r})",
-            )
-        self._start_renewal()
 
     async def initialize(self) -> None:
         """Initialize the workspace and clean up partial failures."""
         try:
             await super().initialize()
-        except Exception:
+        except (Exception, asyncio.CancelledError):
             await self.close()
             raise
 
@@ -194,7 +190,6 @@ class OpenSandboxWorkspace(SandboxedWorkspaceBase):
         :meth:`initialize` can reattach via metadata lookup and
         resume. Errors are swallowed.
         """
-        await self._stop_renewal()
         if self._sandbox is not None:
             try:
                 await self._sandbox.pause()
@@ -208,127 +203,35 @@ class OpenSandboxWorkspace(SandboxedWorkspaceBase):
                     exc,
                 )
             self._sandbox = None
-        self._lease_lost = False
-
-    @property
-    def _renew_interval(self) -> float:
-        """Return a conservative interval for refreshing the lease."""
-        return max(1.0, min(60.0, self.timeout_seconds / 3.0))
-
-    def _start_renewal(self) -> None:
-        """Start the sandbox lease-renewal loop once."""
-        if self._renew_task is None or self._renew_task.done():
-            self._renew_task = asyncio.create_task(self._renew_loop())
-
-    async def _stop_renewal(self) -> None:
-        """Cancel and await the sandbox lease-renewal loop."""
-        task = self._renew_task
-        self._renew_task = None
-        if task is None:
-            return
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
-
-    async def _renew_loop(self) -> None:
-        """Keep the finite sandbox lease alive while this workspace is open."""
-        while True:
-            try:
-                await asyncio.sleep(self._renew_interval)
-            except asyncio.CancelledError:
-                return
-            try:
-                if not await self._renew_once():
-                    logger.warning(
-                        "OpenSandboxWorkspace: sandbox lease was lost for "
-                        "workspace_id=%r; waiting for manager recovery",
-                        self.workspace_id,
-                    )
-                    return
-            except Exception as exc:  # noqa: BLE001
-                # A transient control-plane failure must not cause a second
-                # sandbox to be created. Retry on the next renewal tick; the
-                # manager performs an authoritative check on cache access.
-                logger.warning(
-                    "OpenSandboxWorkspace: lease renewal failed for "
-                    "workspace_id=%r (will retry): %s",
-                    self.workspace_id,
-                    exc,
-                )
 
     async def _renew_once(self) -> bool:
-        """Renew the current lease, returning ``False`` after a 404."""
+        """Try to renew the lease without making availability depend on it.
+
+        Returns:
+            `bool`:
+                ``False`` only when the local sandbox handle is absent or
+                renewal returns 404. Other renewal failures are logged and
+                return ``True`` so callers can still try the existing
+                connection; this is not a guarantee of sandbox health.
+        """
         from opensandbox.exceptions import SandboxApiException
 
         if self._sandbox is None:
-            self._lease_lost = True
             return False
         try:
             await self._sandbox.renew(
                 timedelta(seconds=self.timeout_seconds),
             )
-        except SandboxApiException as exc:
-            if exc.status_code == 404:
-                self._lease_lost = True
+        except Exception as exc:
+            if isinstance(exc, SandboxApiException) and exc.status_code == 404:
                 return False
-            raise
-        self._lease_lost = False
+            logger.warning(
+                "OpenSandboxWorkspace: lease renewal failed for "
+                "workspace_id=%r; keeping the existing connection: %s",
+                self.workspace_id,
+                exc,
+            )
         return True
-
-    async def _refresh_remote_lifecycle(self) -> _RemoteLifecycleState:
-        """Check the remote state and refresh a running sandbox lease.
-
-        Returns:
-            `_RemoteLifecycleState`:
-                ``"running"`` when the current handle is reusable,
-                ``"reattach"`` when the sandbox is paused, or ``"missing"``
-                when it was deleted or entered a terminal state.
-        """
-        from opensandbox.exceptions import SandboxApiException
-
-        if self._sandbox is None or self._lease_lost:
-            return "missing"
-        try:
-            info = await self._sandbox.get_info()
-        except SandboxApiException as exc:
-            if exc.status_code == 404:
-                self._lease_lost = True
-                return "missing"
-            raise
-
-        state = info.status.state.lower()
-        if state == "running":
-            return "running" if await self._renew_once() else "missing"
-        if state == "paused":
-            return "reattach"
-        if state in {"stopping", "terminated", "failed"}:
-            self._lease_lost = True
-            return "missing"
-        raise RuntimeError(
-            f"OpenSandbox sandbox {self._sandbox.id!r} is transitioning "
-            f"(state={state!r}); retry later",
-        )
-
-    async def _discard_local_connection(self) -> None:
-        """Drop stale local handles without changing remote lifecycle state."""
-        await self._stop_renewal()
-        if self._gateway is not None:
-            try:
-                await self._gateway.aclose()
-            except Exception:  # noqa: BLE001
-                pass
-            self._gateway = None
-        self._mcp_instances.clear()
-        self._mcp_last_used.clear()
-
-        sandbox = self._sandbox
-        self._sandbox = None
-        if sandbox is not None:
-            await sandbox.close()
-        self._backend = None
-        self.is_alive = False
 
     async def get_instructions(self) -> str:
         """Return the system-prompt fragment for this workspace.

--- a/tests/workspace_manager_opensandbox_test.py
+++ b/tests/workspace_manager_opensandbox_test.py
@@ -1,0 +1,377 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Unit tests for OpenSandbox workspace lease and cache recovery."""
+
+import asyncio
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.async_case import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+from opensandbox.exceptions import SandboxApiException
+
+from agentscope.app.workspace_manager import OpenSandboxWorkspaceManager
+from agentscope.workspace import OpenSandboxWorkspace
+
+
+class _FakeSandbox:
+    """OpenSandbox SDK double for lifecycle calls."""
+
+    def __init__(self, state: str = "Running") -> None:
+        """Initialize a running sandbox double.
+
+        Args:
+            state (`str`, defaults to `"Running"`):
+                Lifecycle state returned by :meth:`get_info`.
+        """
+        self.id = "sandbox-1"
+        self.state = state
+        self.info_error: Exception | None = None
+        self.renew_error: Exception | None = None
+        self.renewed: list[timedelta] = []
+        self.closed = False
+
+    async def get_info(self) -> SimpleNamespace:
+        """Return the configured lifecycle state."""
+        if self.info_error is not None:
+            raise self.info_error
+        return SimpleNamespace(status=SimpleNamespace(state=self.state))
+
+    async def renew(self, timeout: timedelta) -> None:
+        """Record a lease renewal.
+
+        Args:
+            timeout (`timedelta`):
+                Requested new lease duration.
+        """
+        if self.renew_error is not None:
+            raise self.renew_error
+        self.renewed.append(timeout)
+
+    async def close(self) -> None:
+        """Record local SDK transport cleanup."""
+        self.closed = True
+
+
+class TestOpenSandboxWorkspaceLease(IsolatedAsyncioTestCase):
+    """Workspace-level renewal and lifecycle checks."""
+
+    async def test_running_sandbox_is_renewed(self) -> None:
+        """A running cached sandbox receives a fresh finite lease."""
+        workspace = OpenSandboxWorkspace(
+            workspace_id="wid",
+            timeout_seconds=90,
+        )
+        sandbox = _FakeSandbox()
+        workspace._sandbox = sandbox
+
+        state = await workspace._refresh_remote_lifecycle()
+
+        self.assertEqual(
+            {
+                "state": state,
+                "renewed": sandbox.renewed,
+                "lease_lost": workspace._lease_lost,
+            },
+            {
+                "state": "running",
+                "renewed": [timedelta(seconds=90)],
+                "lease_lost": False,
+            },
+        )
+
+    async def test_paused_sandbox_requests_reattach(self) -> None:
+        """A paused sandbox is not treated as missing or renewed."""
+        workspace = OpenSandboxWorkspace(workspace_id="wid")
+        sandbox = _FakeSandbox(state="Paused")
+        workspace._sandbox = sandbox
+
+        state = await workspace._refresh_remote_lifecycle()
+
+        self.assertEqual(
+            {"state": state, "renewed": sandbox.renewed},
+            {"state": "reattach", "renewed": []},
+        )
+
+    async def test_missing_sandbox_marks_lease_lost(self) -> None:
+        """A lifecycle 404 makes the cached handle replaceable."""
+        workspace = OpenSandboxWorkspace(workspace_id="wid")
+        sandbox = _FakeSandbox()
+        sandbox.info_error = SandboxApiException(status_code=404)
+        workspace._sandbox = sandbox
+
+        state = await workspace._refresh_remote_lifecycle()
+
+        self.assertEqual(
+            {"state": state, "lease_lost": workspace._lease_lost},
+            {"state": "missing", "lease_lost": True},
+        )
+
+    async def test_transient_control_plane_error_is_not_missing(self) -> None:
+        """A non-404 API failure propagates without poisoning the lease."""
+        workspace = OpenSandboxWorkspace(workspace_id="wid")
+        sandbox = _FakeSandbox()
+        sandbox.info_error = SandboxApiException(status_code=503)
+        workspace._sandbox = sandbox
+
+        with self.assertRaises(SandboxApiException):
+            await workspace._refresh_remote_lifecycle()
+
+        self.assertFalse(workspace._lease_lost)
+
+    async def test_discard_stops_renewal_and_closes_local_transport(
+        self,
+    ) -> None:
+        """Recovery drops stale local resources without pausing the remote."""
+        workspace = OpenSandboxWorkspace(workspace_id="wid")
+        sandbox = _FakeSandbox()
+        workspace._sandbox = sandbox
+        workspace.is_alive = True
+        workspace._start_renewal()
+        renew_task = workspace._renew_task
+
+        await workspace._discard_local_connection()
+
+        self.assertEqual(
+            {
+                "sandbox_closed": sandbox.closed,
+                "sandbox": workspace._sandbox,
+                "backend": workspace._backend,
+                "is_alive": workspace.is_alive,
+                "renew_task": workspace._renew_task,
+                "task_done": renew_task.done(),
+            },
+            {
+                "sandbox_closed": True,
+                "sandbox": None,
+                "backend": None,
+                "is_alive": False,
+                "renew_task": None,
+                "task_done": True,
+            },
+        )
+
+    async def test_provision_starts_renewal_before_bootstrap(self) -> None:
+        """The lease loop starts as soon as the backend is provisioned."""
+        workspace = OpenSandboxWorkspace(
+            workspace_id="wid",
+            timeout_seconds=90,
+        )
+        sandbox = _FakeSandbox()
+        workspace._find_existing_sandbox = AsyncMock(return_value=None)
+        workspace._create_sandbox = AsyncMock(return_value=sandbox)
+        workspace._wait_until_running = AsyncMock()
+
+        await workspace._provision_backend()
+        renew_task = workspace._renew_task
+        await workspace._stop_renewal()
+
+        self.assertEqual(
+            {
+                "renewed": sandbox.renewed,
+                "task_created": renew_task is not None,
+                "task_done": renew_task.done(),
+            },
+            {
+                "renewed": [timedelta(seconds=90)],
+                "task_created": True,
+                "task_done": True,
+            },
+        )
+
+    async def test_initialize_failure_closes_partial_workspace(self) -> None:
+        """A bootstrap failure cannot leave a renewal task behind."""
+        workspace = OpenSandboxWorkspace(workspace_id="wid")
+        workspace.close = AsyncMock()
+
+        with patch(
+            "agentscope.workspace._sandboxed_base."
+            "SandboxedWorkspaceBase.initialize",
+            AsyncMock(side_effect=RuntimeError("bootstrap failed")),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "bootstrap failed"):
+                await workspace.initialize()
+
+        workspace.close.assert_awaited_once()
+
+
+class _FakeWorkspace:
+    """Workspace double used by manager recovery tests."""
+
+    created: list["_FakeWorkspace"] = []
+
+    def __init__(self, **kwargs: object) -> None:
+        """Record forwarded manager configuration.
+
+        Args:
+            **kwargs (`object`):
+                Workspace constructor arguments.
+        """
+        self.kwargs = kwargs
+        self.workspace_id = str(kwargs["workspace_id"])
+        self.sandbox_id = f"sandbox-{len(self.created) + 1}"
+        self.lifecycle = "running"
+        self.refresh_error: Exception | None = None
+        self.initialized = False
+        self.discarded = False
+        self.closed = False
+        self.refresh_count = 0
+        self.created.append(self)
+
+    async def initialize(self) -> None:
+        """Mark full workspace initialization."""
+        await asyncio.sleep(0)
+        self.initialized = True
+
+    async def _refresh_remote_lifecycle(self) -> str:
+        """Return the configured lifecycle result."""
+        await asyncio.sleep(0)
+        self.refresh_count += 1
+        if self.refresh_error is not None:
+            raise self.refresh_error
+        return self.lifecycle
+
+    async def _discard_local_connection(self) -> None:
+        """Record recovery cleanup without remote pause."""
+        self.discarded = True
+
+    async def close(self) -> None:
+        """Record ordinary manager eviction."""
+        self.closed = True
+
+
+class TestOpenSandboxWorkspaceManagerRecovery(IsolatedAsyncioTestCase):
+    """Cache reuse and automatic replacement behavior."""
+
+    async def asyncSetUp(self) -> None:
+        """Patch the concrete workspace built by the manager."""
+        _FakeWorkspace.created.clear()
+        self.workspace_patch = patch(
+            "agentscope.app.workspace_manager."
+            "_opensandbox_workspace_manager.OpenSandboxWorkspace",
+            _FakeWorkspace,
+        )
+        self.workspace_patch.start()
+
+    async def asyncTearDown(self) -> None:
+        """Undo the workspace patch."""
+        self.workspace_patch.stop()
+
+    async def test_running_cache_entry_is_reused_and_refreshed(self) -> None:
+        """A live cache hit keeps object identity and renews its lease."""
+        manager = OpenSandboxWorkspaceManager()
+
+        first = await manager.get_workspace("u", "a", "s1", "wid")
+        second = await manager.get_workspace("u", "a", "s2", "wid")
+
+        self.assertEqual(
+            {
+                "same": first is second,
+                "created": len(_FakeWorkspace.created),
+                "refresh_count": first.refresh_count,
+            },
+            {"same": True, "created": 1, "refresh_count": 1},
+        )
+
+    async def test_missing_cache_entry_is_recreated_with_warning(self) -> None:
+        """A destroyed sandbox is replaced under the same workspace id."""
+        manager = OpenSandboxWorkspaceManager()
+        first = await manager.get_workspace("u", "a", "s1", "wid")
+        first.lifecycle = "missing"
+
+        with patch(
+            "agentscope.app.workspace_manager."
+            "_opensandbox_workspace_manager.logger.warning",
+        ) as warning:
+            second = await manager.get_workspace("u", "a", "s2", "wid")
+
+        self.assertEqual(
+            {
+                "replaced": first is not second,
+                "discarded": first.discarded,
+                "created": len(_FakeWorkspace.created),
+                "workspace_id": second.workspace_id,
+            },
+            {
+                "replaced": True,
+                "discarded": True,
+                "created": 2,
+                "workspace_id": "wid",
+            },
+        )
+        warning.assert_called_once()
+
+    async def test_paused_cache_entry_is_reattached(self) -> None:
+        """A paused sandbox follows normal metadata-based initialization."""
+        manager = OpenSandboxWorkspaceManager()
+        first = await manager.get_workspace("u", "a", "s1", "wid")
+        first.lifecycle = "reattach"
+
+        second = await manager.get_workspace("u", "a", "s2", "wid")
+
+        self.assertEqual(
+            {
+                "replaced": first is not second,
+                "discarded": first.discarded,
+                "created": len(_FakeWorkspace.created),
+                "workspace_id": second.workspace_id,
+            },
+            {
+                "replaced": True,
+                "discarded": True,
+                "created": 2,
+                "workspace_id": "wid",
+            },
+        )
+
+    async def test_transient_error_keeps_cached_workspace(self) -> None:
+        """A control-plane outage does not trigger duplicate creation."""
+        manager = OpenSandboxWorkspaceManager()
+        workspace = await manager.get_workspace("u", "a", "s1", "wid")
+        workspace.refresh_error = RuntimeError("control plane unavailable")
+
+        with self.assertRaisesRegex(RuntimeError, "control plane unavailable"):
+            await manager.get_workspace("u", "a", "s2", "wid")
+
+        self.assertEqual(
+            {
+                "cached": manager._cache["wid"][0] is workspace,
+                "discarded": workspace.discarded,
+                "created": len(_FakeWorkspace.created),
+            },
+            {"cached": True, "discarded": False, "created": 1},
+        )
+
+    async def test_concurrent_expiration_creates_one_replacement(self) -> None:
+        """Concurrent cache hits share a single recovery build."""
+        manager = OpenSandboxWorkspaceManager()
+        first = await manager.get_workspace("u", "a", "s0", "wid")
+        first.lifecycle = "missing"
+
+        results = await asyncio.gather(
+            *(
+                manager.get_workspace("u", "a", f"s{i}", "wid")
+                for i in range(8)
+            ),
+        )
+
+        self.assertEqual(
+            {
+                "created": len(_FakeWorkspace.created),
+                "discarded": first.discarded,
+                "one_replacement": all(item is results[0] for item in results),
+                "cached_replacement": manager._cache["wid"][0] is results[0],
+            },
+            {
+                "created": 2,
+                "discarded": True,
+                "one_replacement": True,
+                "cached_replacement": True,
+            },
+        )
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/tests/workspace_manager_opensandbox_test.py
+++ b/tests/workspace_manager_opensandbox_test.py
@@ -1,283 +1,91 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=protected-access
-"""Unit tests for OpenSandbox workspace lease and cache recovery."""
+"""Unit tests for OpenSandbox workspace cache renewal and recovery."""
 
 import asyncio
 from datetime import timedelta
+from importlib.util import find_spec
 from types import SimpleNamespace
+from typing import Any
+import unittest
 from unittest.async_case import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, patch
-
-from opensandbox.exceptions import SandboxApiException
 
 from agentscope.app.workspace_manager import OpenSandboxWorkspaceManager
 from agentscope.workspace import OpenSandboxWorkspace
 
 
-class _FakeSandbox:
-    """OpenSandbox SDK double for lifecycle calls."""
-
-    def __init__(self, state: str = "Running") -> None:
-        """Initialize a running sandbox double.
-
-        Args:
-            state (`str`, defaults to `"Running"`):
-                Lifecycle state returned by :meth:`get_info`.
-        """
-        self.id = "sandbox-1"
-        self.state = state
-        self.info_error: Exception | None = None
-        self.renew_error: Exception | None = None
-        self.renewed: list[timedelta] = []
-        self.closed = False
-
-    async def get_info(self) -> SimpleNamespace:
-        """Return the configured lifecycle state."""
-        if self.info_error is not None:
-            raise self.info_error
-        return SimpleNamespace(status=SimpleNamespace(state=self.state))
-
-    async def renew(self, timeout: timedelta) -> None:
-        """Record a lease renewal.
-
-        Args:
-            timeout (`timedelta`):
-                Requested new lease duration.
-        """
-        if self.renew_error is not None:
-            raise self.renew_error
-        self.renewed.append(timeout)
-
-    async def close(self) -> None:
-        """Record local SDK transport cleanup."""
-        self.closed = True
-
-
-class TestOpenSandboxWorkspaceLease(IsolatedAsyncioTestCase):
-    """Workspace-level renewal and lifecycle checks."""
-
-    async def test_running_sandbox_is_renewed(self) -> None:
-        """A running cached sandbox receives a fresh finite lease."""
-        workspace = OpenSandboxWorkspace(
-            workspace_id="wid",
-            timeout_seconds=90,
-        )
-        sandbox = _FakeSandbox()
-        workspace._sandbox = sandbox
-
-        state = await workspace._refresh_remote_lifecycle()
-
-        self.assertEqual(
-            {
-                "state": state,
-                "renewed": sandbox.renewed,
-                "lease_lost": workspace._lease_lost,
-            },
-            {
-                "state": "running",
-                "renewed": [timedelta(seconds=90)],
-                "lease_lost": False,
-            },
-        )
-
-    async def test_paused_sandbox_requests_reattach(self) -> None:
-        """A paused sandbox is not treated as missing or renewed."""
-        workspace = OpenSandboxWorkspace(workspace_id="wid")
-        sandbox = _FakeSandbox(state="Paused")
-        workspace._sandbox = sandbox
-
-        state = await workspace._refresh_remote_lifecycle()
-
-        self.assertEqual(
-            {"state": state, "renewed": sandbox.renewed},
-            {"state": "reattach", "renewed": []},
-        )
-
-    async def test_missing_sandbox_marks_lease_lost(self) -> None:
-        """A lifecycle 404 makes the cached handle replaceable."""
-        workspace = OpenSandboxWorkspace(workspace_id="wid")
-        sandbox = _FakeSandbox()
-        sandbox.info_error = SandboxApiException(status_code=404)
-        workspace._sandbox = sandbox
-
-        state = await workspace._refresh_remote_lifecycle()
-
-        self.assertEqual(
-            {"state": state, "lease_lost": workspace._lease_lost},
-            {"state": "missing", "lease_lost": True},
-        )
-
-    async def test_transient_control_plane_error_is_not_missing(self) -> None:
-        """A non-404 API failure propagates without poisoning the lease."""
-        workspace = OpenSandboxWorkspace(workspace_id="wid")
-        sandbox = _FakeSandbox()
-        sandbox.info_error = SandboxApiException(status_code=503)
-        workspace._sandbox = sandbox
-
-        with self.assertRaises(SandboxApiException):
-            await workspace._refresh_remote_lifecycle()
-
-        self.assertFalse(workspace._lease_lost)
-
-    async def test_discard_stops_renewal_and_closes_local_transport(
-        self,
-    ) -> None:
-        """Recovery drops stale local resources without pausing the remote."""
-        workspace = OpenSandboxWorkspace(workspace_id="wid")
-        sandbox = _FakeSandbox()
-        workspace._sandbox = sandbox
-        workspace.is_alive = True
-        workspace._start_renewal()
-        renew_task = workspace._renew_task
-
-        await workspace._discard_local_connection()
-
-        self.assertEqual(
-            {
-                "sandbox_closed": sandbox.closed,
-                "sandbox": workspace._sandbox,
-                "backend": workspace._backend,
-                "is_alive": workspace.is_alive,
-                "renew_task": workspace._renew_task,
-                "task_done": renew_task.done(),
-            },
-            {
-                "sandbox_closed": True,
-                "sandbox": None,
-                "backend": None,
-                "is_alive": False,
-                "renew_task": None,
-                "task_done": True,
-            },
-        )
-
-    async def test_provision_starts_renewal_before_bootstrap(self) -> None:
-        """The lease loop starts as soon as the backend is provisioned."""
-        workspace = OpenSandboxWorkspace(
-            workspace_id="wid",
-            timeout_seconds=90,
-        )
-        sandbox = _FakeSandbox()
-        workspace._find_existing_sandbox = AsyncMock(return_value=None)
-        workspace._create_sandbox = AsyncMock(return_value=sandbox)
-        workspace._wait_until_running = AsyncMock()
-
-        await workspace._provision_backend()
-        renew_task = workspace._renew_task
-        await workspace._stop_renewal()
-
-        self.assertEqual(
-            {
-                "renewed": sandbox.renewed,
-                "task_created": renew_task is not None,
-                "task_done": renew_task.done(),
-            },
-            {
-                "renewed": [timedelta(seconds=90)],
-                "task_created": True,
-                "task_done": True,
-            },
-        )
-
-    async def test_initialize_failure_closes_partial_workspace(self) -> None:
-        """A bootstrap failure cannot leave a renewal task behind."""
-        workspace = OpenSandboxWorkspace(workspace_id="wid")
-        workspace.close = AsyncMock()
-
-        with patch(
-            "agentscope.workspace._sandboxed_base."
-            "SandboxedWorkspaceBase.initialize",
-            AsyncMock(side_effect=RuntimeError("bootstrap failed")),
-        ):
-            with self.assertRaisesRegex(RuntimeError, "bootstrap failed"):
-                await workspace.initialize()
-
-        workspace.close.assert_awaited_once()
-
-
-class _FakeWorkspace:
-    """Workspace double used by manager recovery tests."""
-
-    created: list["_FakeWorkspace"] = []
-
-    def __init__(self, **kwargs: object) -> None:
-        """Record forwarded manager configuration.
-
-        Args:
-            **kwargs (`object`):
-                Workspace constructor arguments.
-        """
-        self.kwargs = kwargs
-        self.workspace_id = str(kwargs["workspace_id"])
-        self.sandbox_id = f"sandbox-{len(self.created) + 1}"
-        self.lifecycle = "running"
-        self.refresh_error: Exception | None = None
-        self.initialized = False
-        self.discarded = False
-        self.closed = False
-        self.refresh_count = 0
-        self.created.append(self)
-
-    async def initialize(self) -> None:
-        """Mark full workspace initialization."""
-        await asyncio.sleep(0)
-        self.initialized = True
-
-    async def _refresh_remote_lifecycle(self) -> str:
-        """Return the configured lifecycle result."""
-        await asyncio.sleep(0)
-        self.refresh_count += 1
-        if self.refresh_error is not None:
-            raise self.refresh_error
-        return self.lifecycle
-
-    async def _discard_local_connection(self) -> None:
-        """Record recovery cleanup without remote pause."""
-        self.discarded = True
-
-    async def close(self) -> None:
-        """Record ordinary manager eviction."""
-        self.closed = True
-
-
+@unittest.skipUnless(find_spec("opensandbox"), "opensandbox is not installed")
 class TestOpenSandboxWorkspaceManagerRecovery(IsolatedAsyncioTestCase):
-    """Cache reuse and automatic replacement behavior."""
+    """Exercise real renewal and cleanup with mocked SDK connections."""
 
     async def asyncSetUp(self) -> None:
-        """Patch the concrete workspace built by the manager."""
-        _FakeWorkspace.created.clear()
+        """Replace sandbox provisioning with local workspace objects."""
+        self.workspaces: list[OpenSandboxWorkspace] = []
         self.workspace_patch = patch(
             "agentscope.app.workspace_manager."
             "_opensandbox_workspace_manager.OpenSandboxWorkspace",
-            _FakeWorkspace,
+            side_effect=self._make_workspace,
         )
         self.workspace_patch.start()
+        self.addCleanup(self.workspace_patch.stop)
 
-    async def asyncTearDown(self) -> None:
-        """Undo the workspace patch."""
-        self.workspace_patch.stop()
+    def _make_workspace(self, **kwargs: Any) -> OpenSandboxWorkspace:
+        """Construct a workspace without making any remote requests."""
 
-    async def test_running_cache_entry_is_reused_and_refreshed(self) -> None:
-        """A live cache hit keeps object identity and renews its lease."""
-        manager = OpenSandboxWorkspaceManager()
+        async def initialize() -> None:
+            """Yield so concurrent requests can race during provisioning."""
+            await asyncio.sleep(0)
 
-        first = await manager.get_workspace("u", "a", "s1", "wid")
-        second = await manager.get_workspace("u", "a", "s2", "wid")
-
-        self.assertEqual(
-            {
-                "same": first is second,
-                "created": len(_FakeWorkspace.created),
-                "refresh_count": first.refresh_count,
-            },
-            {"same": True, "created": 1, "refresh_count": 1},
+        workspace = OpenSandboxWorkspace(**kwargs)
+        workspace._sandbox = SimpleNamespace(
+            id=f"sandbox-{len(self.workspaces) + 1}",
+            renew=AsyncMock(),
+            get_info=AsyncMock(),
+            pause=AsyncMock(),
+            close=AsyncMock(),
         )
+        workspace._gateway = SimpleNamespace(aclose=AsyncMock())
+        workspace.initialize = AsyncMock(side_effect=initialize)
+        workspace.is_alive = True
+        self.workspaces.append(workspace)
+        return workspace
 
-    async def test_missing_cache_entry_is_recreated_with_warning(self) -> None:
-        """A destroyed sandbox is replaced under the same workspace id."""
+    async def test_cache_hit_renews_once_and_updates_access_time(self) -> None:
+        """Reuse the same object with one renewal and no state pre-check."""
+        for timeout in (None, 90):
+            with self.subTest(timeout=timeout):
+                manager = (
+                    OpenSandboxWorkspaceManager()
+                    if timeout is None
+                    else OpenSandboxWorkspaceManager(timeout_seconds=timeout)
+                )
+                first = await manager.get_workspace("u", "a", "s1", "wid")
+                sandbox = first._sandbox
+                sandbox.renew.assert_not_awaited()
+                manager._cache["wid"] = (first, 0.0)
+
+                second = await manager.get_workspace("u", "a", "s2", "wid")
+
+                self.assertIs(first, second)
+                self.assertEqual(first.timeout_seconds, timeout or 1800)
+                sandbox.renew.assert_awaited_once_with(
+                    timedelta(seconds=timeout or 1800),
+                )
+                sandbox.get_info.assert_not_awaited()
+                self.assertGreater(manager._cache["wid"][1], 0.0)
+
+    async def test_404_recreates_workspace_and_closes_old_resources(
+        self,
+    ) -> None:
+        """A missing sandbox is replaced under the same workspace id."""
+        from opensandbox.exceptions import SandboxApiException
+
         manager = OpenSandboxWorkspaceManager()
         first = await manager.get_workspace("u", "a", "s1", "wid")
-        first.lifecycle = "missing"
+        sandbox, gateway = first._sandbox, first._gateway
+        sandbox.renew.side_effect = SandboxApiException(status_code=404)
+        sandbox.pause.side_effect = SandboxApiException(status_code=404)
 
         with patch(
             "agentscope.app.workspace_manager."
@@ -285,68 +93,97 @@ class TestOpenSandboxWorkspaceManagerRecovery(IsolatedAsyncioTestCase):
         ) as warning:
             second = await manager.get_workspace("u", "a", "s2", "wid")
 
-        self.assertEqual(
-            {
-                "replaced": first is not second,
-                "discarded": first.discarded,
-                "created": len(_FakeWorkspace.created),
-                "workspace_id": second.workspace_id,
-            },
-            {
-                "replaced": True,
-                "discarded": True,
-                "created": 2,
-                "workspace_id": "wid",
-            },
+        self.assertIsNot(first, second)
+        self.assertEqual(second.workspace_id, "wid")
+        self.assertEqual(len(self.workspaces), 2)
+        self.assertIs(manager._cache["wid"][0], second)
+        warning.assert_any_call(
+            "OpenSandbox workspace %r lost sandbox %r; recreating "
+            "it. Ephemeral workspace data may have been lost.",
+            "wid",
+            sandbox.id,
         )
-        warning.assert_called_once()
+        gateway.aclose.assert_awaited_once()
+        sandbox.close.assert_awaited_once()
+        self.assertIsNone(first._sandbox)
+        self.assertIsNone(first._backend)
+        self.assertIsNone(first._gateway)
+        self.assertFalse(first.is_alive)
 
-    async def test_paused_cache_entry_is_reattached(self) -> None:
-        """A paused sandbox follows normal metadata-based initialization."""
+    async def test_missing_local_handle_is_replaced(self) -> None:
+        """A cached workspace without a sandbox handle is not reusable."""
         manager = OpenSandboxWorkspaceManager()
         first = await manager.get_workspace("u", "a", "s1", "wid")
-        first.lifecycle = "reattach"
+        first._sandbox = None
 
         second = await manager.get_workspace("u", "a", "s2", "wid")
 
-        self.assertEqual(
-            {
-                "replaced": first is not second,
-                "discarded": first.discarded,
-                "created": len(_FakeWorkspace.created),
-                "workspace_id": second.workspace_id,
-            },
-            {
-                "replaced": True,
-                "discarded": True,
-                "created": 2,
-                "workspace_id": "wid",
-            },
-        )
+        self.assertIsNot(first, second)
+        self.assertEqual(len(self.workspaces), 2)
+        self.assertFalse(first.is_alive)
 
-    async def test_transient_error_keeps_cached_workspace(self) -> None:
-        """A control-plane outage does not trigger duplicate creation."""
+    async def test_missing_workspace_id_is_resolved_before_caching(
+        self,
+    ) -> None:
+        """An assigned id is used consistently for construction and reuse."""
         manager = OpenSandboxWorkspaceManager()
-        workspace = await manager.get_workspace("u", "a", "s1", "wid")
-        workspace.refresh_error = RuntimeError("control plane unavailable")
+        manager.assign_workspace_id = AsyncMock(return_value="assigned-id")
 
-        with self.assertRaisesRegex(RuntimeError, "control plane unavailable"):
-            await manager.get_workspace("u", "a", "s2", "wid")
+        first = await manager.get_workspace("u", "a", "s1")
+        second = await manager.get_workspace("u", "a", "s2", "assigned-id")
 
-        self.assertEqual(
-            {
-                "cached": manager._cache["wid"][0] is workspace,
-                "discarded": workspace.discarded,
-                "created": len(_FakeWorkspace.created),
-            },
-            {"cached": True, "discarded": False, "created": 1},
+        self.assertIs(first, second)
+        self.assertEqual(first.workspace_id, "assigned-id")
+        self.assertIs(manager._cache["assigned-id"][0], first)
+        manager.assign_workspace_id.assert_awaited_once_with(
+            user_id="u",
+            agent_id="a",
+            session_id="",
         )
+
+    async def test_renewal_errors_keep_cached_workspace(self) -> None:
+        """API and network failures do not reject or replace a cache hit."""
+        from opensandbox.exceptions import SandboxApiException
+
+        for error in (
+            SandboxApiException(status_code=503),
+            SandboxApiException(status_code=401),
+            TimeoutError("control plane unavailable"),
+        ):
+            with self.subTest(error=error):
+                manager = OpenSandboxWorkspaceManager()
+                first = await manager.get_workspace("u", "a", "s1", "wid")
+                sandbox = first._sandbox
+                sandbox.renew.side_effect = error
+                manager._cache["wid"] = (first, 0.0)
+                created = len(self.workspaces)
+
+                with patch(
+                    "agentscope.workspace._opensandbox."
+                    "_opensandbox_workspace.logger.warning",
+                ) as warning:
+                    second = await manager.get_workspace("u", "a", "s2", "wid")
+
+                self.assertIs(first, second)
+                self.assertEqual(len(self.workspaces), created)
+                self.assertGreater(manager._cache["wid"][1], 0.0)
+                sandbox.close.assert_not_awaited()
+                sandbox.get_info.assert_not_awaited()
+                warning.assert_called_once()
 
     async def test_concurrent_expiration_creates_one_replacement(self) -> None:
-        """Concurrent cache hits share a single recovery build."""
+        """Concurrent cache hits share exactly one recovery build."""
+        from opensandbox.exceptions import SandboxApiException
+
+        async def expired(*_: object) -> None:
+            """Let other requests run before the remote 404 arrives."""
+            await asyncio.sleep(0)
+            raise SandboxApiException(status_code=404)
+
         manager = OpenSandboxWorkspaceManager()
         first = await manager.get_workspace("u", "a", "s0", "wid")
-        first.lifecycle = "missing"
+        sandbox = first._sandbox
+        sandbox.renew.side_effect = expired
 
         results = await asyncio.gather(
             *(
@@ -355,23 +192,68 @@ class TestOpenSandboxWorkspaceManagerRecovery(IsolatedAsyncioTestCase):
             ),
         )
 
-        self.assertEqual(
-            {
-                "created": len(_FakeWorkspace.created),
-                "discarded": first.discarded,
-                "one_replacement": all(item is results[0] for item in results),
-                "cached_replacement": manager._cache["wid"][0] is results[0],
-            },
-            {
-                "created": 2,
-                "discarded": True,
-                "one_replacement": True,
-                "cached_replacement": True,
-            },
-        )
+        self.assertEqual(len(self.workspaces), 2)
+        self.assertTrue(all(item is results[0] for item in results))
+        self.assertIs(manager._cache["wid"][0], results[0])
+        sandbox.close.assert_awaited_once()
+        sandbox.renew.assert_awaited_once()
+
+    async def test_cancelled_renewal_propagates_without_eviction(self) -> None:
+        """Cancellation is not mistaken for a failed lease renewal."""
+        manager = OpenSandboxWorkspaceManager()
+        workspace = await manager.get_workspace("u", "a", "s1", "wid")
+        workspace._sandbox.renew.side_effect = asyncio.CancelledError()
+
+        with self.assertRaises(asyncio.CancelledError):
+            await manager.get_workspace("u", "a", "s2", "wid")
+
+        self.assertIs(manager._cache["wid"][0], workspace)
+        self.assertFalse(manager._lock.locked())
+        workspace._sandbox.close.assert_not_awaited()
+
+    async def test_failed_replacement_is_not_cached(self) -> None:
+        """Initialization failure propagates and leaves no stale entry."""
+        manager = OpenSandboxWorkspaceManager()
+        first = await manager.get_workspace("u", "a", "s1", "wid")
+        first._sandbox = None
+        with patch.object(
+            manager,
+            "_build_and_start",
+            AsyncMock(side_effect=RuntimeError("bootstrap failed")),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "bootstrap failed"):
+                await manager.get_workspace("u", "a", "s2", "wid")
+        self.assertNotIn("wid", manager._cache)
+
+    async def test_idle_sweep_closes_without_renewing(self) -> None:
+        """The sweeper evicts idle workspaces without renewing their lease."""
+        manager = OpenSandboxWorkspaceManager()
+        workspace = await manager.get_workspace("u", "a", "s1", "wid")
+        sandbox = workspace._sandbox
+        manager._cache["wid"] = (workspace, 0.0)
+
+        await manager._sweep_once()
+
+        self.assertNotIn("wid", manager._cache)
+        sandbox.renew.assert_not_awaited()
+        sandbox.pause.assert_awaited_once()
+        sandbox.close.assert_awaited_once()
+
+    async def test_close_all_preserves_existing_cleanup(self) -> None:
+        """Closing all cached workspaces releases each connection."""
+        manager = OpenSandboxWorkspaceManager()
+        first = await manager.get_workspace("u", "a", "s1", "wid1")
+        second = await manager.get_workspace("u", "a", "s2", "wid2")
+        sandboxes = [first._sandbox, second._sandbox]
+
+        await manager.close_all()
+
+        self.assertFalse(manager._cache)
+        for sandbox in sandboxes:
+            sandbox.pause.assert_awaited_once()
+            sandbox.close.assert_awaited_once()
+            sandbox.renew.assert_not_awaited()
 
 
 if __name__ == "__main__":
-    import unittest
-
     unittest.main()

--- a/tests/workspace_manager_opensandbox_test.py
+++ b/tests/workspace_manager_opensandbox_test.py
@@ -5,6 +5,7 @@
 import asyncio
 from datetime import timedelta
 from importlib.util import find_spec
+import time
 from types import SimpleNamespace
 from typing import Any
 import unittest
@@ -230,7 +231,10 @@ class TestOpenSandboxWorkspaceManagerRecovery(IsolatedAsyncioTestCase):
         manager = OpenSandboxWorkspaceManager()
         workspace = await manager.get_workspace("u", "a", "s1", "wid")
         sandbox = workspace._sandbox
-        manager._cache["wid"] = (workspace, 0.0)
+        manager._cache["wid"] = (
+            workspace,
+            time.monotonic() - manager._ttl - 1.0,
+        )
 
         await manager._sweep_once()
 

--- a/tests/workspace_manager_opensandbox_test.py
+++ b/tests/workspace_manager_opensandbox_test.py
@@ -76,6 +76,39 @@ class TestOpenSandboxWorkspaceManagerRecovery(IsolatedAsyncioTestCase):
                 sandbox.get_info.assert_not_awaited()
                 self.assertGreater(manager._cache["wid"][1], 0.0)
 
+    async def test_slow_renewal_does_not_block_other_workspace(self) -> None:
+        """A remote renewal only serializes access to its own workspace."""
+        manager = OpenSandboxWorkspaceManager()
+        workspace_a = await manager.get_workspace("u", "a", "s1", "wid-a")
+        workspace_b = await manager.get_workspace("u", "a", "s2", "wid-b")
+        renewal_started = asyncio.Event()
+        release_renewal = asyncio.Event()
+
+        async def block_renewal(*_: object) -> None:
+            renewal_started.set()
+            await release_renewal.wait()
+
+        workspace_a._sandbox.renew.side_effect = block_renewal
+        task_a = asyncio.create_task(
+            manager.get_workspace("u", "a", "s3", "wid-a"),
+        )
+        await renewal_started.wait()
+        task_b = asyncio.create_task(
+            manager.get_workspace("u", "a", "s4", "wid-b"),
+        )
+
+        try:
+            completed, _ = await asyncio.wait({task_b}, timeout=1.0)
+        finally:
+            release_renewal.set()
+            result_a, result_b = await asyncio.gather(task_a, task_b)
+
+        self.assertIn(task_b, completed)
+        self.assertIs(result_a, workspace_a)
+        self.assertIs(result_b, workspace_b)
+        workspace_a._sandbox.renew.assert_awaited_once()
+        workspace_b._sandbox.renew.assert_awaited_once()
+
     async def test_404_recreates_workspace_and_closes_old_resources(
         self,
     ) -> None:
@@ -203,6 +236,7 @@ class TestOpenSandboxWorkspaceManagerRecovery(IsolatedAsyncioTestCase):
         """Cancellation is not mistaken for a failed lease renewal."""
         manager = OpenSandboxWorkspaceManager()
         workspace = await manager.get_workspace("u", "a", "s1", "wid")
+        workspace_lock = await manager._get_workspace_lock("wid")
         workspace._sandbox.renew.side_effect = asyncio.CancelledError()
 
         with self.assertRaises(asyncio.CancelledError):
@@ -210,6 +244,7 @@ class TestOpenSandboxWorkspaceManagerRecovery(IsolatedAsyncioTestCase):
 
         self.assertIs(manager._cache["wid"][0], workspace)
         self.assertFalse(manager._lock.locked())
+        self.assertFalse(workspace_lock.locked())
         workspace._sandbox.close.assert_not_awaited()
 
     async def test_failed_replacement_is_not_cached(self) -> None:
@@ -240,6 +275,82 @@ class TestOpenSandboxWorkspaceManagerRecovery(IsolatedAsyncioTestCase):
 
         self.assertNotIn("wid", manager._cache)
         sandbox.renew.assert_not_awaited()
+        sandbox.pause.assert_awaited_once()
+        sandbox.close.assert_awaited_once()
+
+    async def test_sweep_keeps_workspace_refreshed_after_snapshot(
+        self,
+    ) -> None:
+        """A stale sweep candidate is rechecked after waiting for renewal."""
+        manager = OpenSandboxWorkspaceManager(ttl=1.0)
+        workspace = await manager.get_workspace("u", "a", "s1", "wid")
+        sandbox = workspace._sandbox
+        manager._cache["wid"] = (
+            workspace,
+            time.monotonic() - manager._ttl - 1.0,
+        )
+        renewal_started = asyncio.Event()
+        release_renewal = asyncio.Event()
+        candidate_selected = asyncio.Event()
+
+        async def block_renewal(*_: object) -> None:
+            renewal_started.set()
+            await release_renewal.wait()
+
+        original_close_if_expired = manager._close_if_expired
+
+        async def observe_candidate(workspace_id: str, cutoff: float) -> None:
+            candidate_selected.set()
+            await original_close_if_expired(workspace_id, cutoff)
+
+        sandbox.renew.side_effect = block_renewal
+        renewal_task = asyncio.create_task(
+            manager.get_workspace("u", "a", "s2", "wid"),
+        )
+        await renewal_started.wait()
+        with patch.object(
+            manager,
+            "_close_if_expired",
+            new=observe_candidate,
+        ):
+            sweep_task = asyncio.create_task(manager._sweep_once())
+            await candidate_selected.wait()
+            release_renewal.set()
+            renewed, _ = await asyncio.gather(renewal_task, sweep_task)
+
+        self.assertIs(renewed, workspace)
+        self.assertIs(manager._cache["wid"][0], workspace)
+        sandbox.pause.assert_not_awaited()
+        sandbox.close.assert_not_awaited()
+
+    async def test_close_all_waits_for_active_workspace_operation(
+        self,
+    ) -> None:
+        """Shutdown includes workspaces active when its snapshot is taken."""
+        manager = OpenSandboxWorkspaceManager()
+        workspace = await manager.get_workspace("u", "a", "s1", "wid")
+        sandbox = workspace._sandbox
+        renewal_started = asyncio.Event()
+        release_renewal = asyncio.Event()
+
+        async def block_renewal(*_: object) -> None:
+            renewal_started.set()
+            await release_renewal.wait()
+
+        sandbox.renew.side_effect = block_renewal
+        renewal_task = asyncio.create_task(
+            manager.get_workspace("u", "a", "s2", "wid"),
+        )
+        await renewal_started.wait()
+        close_task = asyncio.create_task(manager.close_all())
+        await asyncio.sleep(0)
+
+        self.assertFalse(close_task.done())
+        release_renewal.set()
+        renewed, _ = await asyncio.gather(renewal_task, close_task)
+
+        self.assertIs(renewed, workspace)
+        self.assertFalse(manager._cache)
         sandbox.pause.assert_awaited_once()
         sandbox.close.assert_awaited_once()
 

--- a/tests/workspace_opensandbox_test.py
+++ b/tests/workspace_opensandbox_test.py
@@ -1,16 +1,22 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access
 """Test cases for OpenSandboxWorkspace.
 
-The whole module is skipped when the ``OPENSANDBOX_DOMAIN`` environment
-variable is not set, because every test requires a live OpenSandbox
-service.
+Lease unit tests use mocked SDK connections. Only integration tests
+require the ``OPENSANDBOX_DOMAIN`` environment variable.
 """
+import asyncio
+from datetime import timedelta
+from importlib.util import find_spec
 import os
+from types import SimpleNamespace
 import unittest
 from unittest.async_case import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
 
 from agentscope.mcp import MCPClient, StdioMCPConfig
 from agentscope.workspace import OpenSandboxWorkspace
+from agentscope.workspace._opensandbox._constants import DEFAULT_TIMEOUT
 
 
 # ── OpenSandbox availability check ─────────────────────────────────
@@ -20,7 +26,157 @@ _API_KEY = os.getenv("OPENSANDBOX_API_KEY", "")
 _SKIP_REASON = "OPENSANDBOX_DOMAIN environment variable is not set"
 
 
-# ── lifecycle tests ────────────────────────────────────────────────
+# ── lease unit tests ──────────────────────────────────────────────
+
+
+@unittest.skipUnless(find_spec("opensandbox"), "opensandbox is not installed")
+class TestOpenSandboxWorkspaceLease(IsolatedAsyncioTestCase):
+    """Test demand-driven leases without an OpenSandbox server."""
+
+    async def asyncSetUp(self) -> None:
+        """Prepare a real workspace with an isolated SDK double."""
+        self.workspace = OpenSandboxWorkspace(workspace_id="wid")
+        self.sandbox = SimpleNamespace(
+            id="sandbox-1",
+            renew=AsyncMock(),
+            get_info=AsyncMock(),
+            pause=AsyncMock(),
+            close=AsyncMock(),
+        )
+        self.workspace._sandbox = self.sandbox
+        self.addAsyncCleanup(self.workspace.close)
+
+    async def test_default_and_custom_lease_are_forwarded_on_creation(
+        self,
+    ) -> None:
+        """Sandbox creation receives the default or explicit lease."""
+        self.assertEqual(DEFAULT_TIMEOUT, 1800)
+        self.assertEqual(self.workspace.timeout_seconds, 1800)
+        for timeout in (1800, 90):
+            with self.subTest(timeout=timeout):
+                self.workspace.timeout_seconds = timeout
+                with patch(
+                    "opensandbox.Sandbox.create",
+                    AsyncMock(return_value=self.sandbox),
+                ) as create:
+                    await self.workspace._create_sandbox()
+                self.assertEqual(
+                    create.call_args.kwargs["timeout"],
+                    timedelta(seconds=timeout),
+                )
+
+    async def test_renewal_uses_configured_lease_without_precheck(
+        self,
+    ) -> None:
+        """One access needs one renewal and no get_info request."""
+        self.workspace.timeout_seconds = 90
+
+        self.assertTrue(await self.workspace._renew_once())
+
+        self.sandbox.renew.assert_awaited_once_with(timedelta(seconds=90))
+        self.sandbox.get_info.assert_not_awaited()
+
+    async def test_404_and_missing_handle_are_not_reusable(self) -> None:
+        """Only confirmed disappearance requests replacement."""
+        from opensandbox.exceptions import SandboxApiException
+
+        self.sandbox.renew.side_effect = SandboxApiException(status_code=404)
+        self.assertFalse(await self.workspace._renew_once())
+
+        self.workspace._sandbox = None
+        self.assertFalse(await self.workspace._renew_once())
+        self.sandbox.renew.assert_awaited_once()
+
+    async def test_new_sandbox_does_not_start_background_renewal(self) -> None:
+        """A newly created sandbox already has its configured lease."""
+        self.workspace._find_existing_sandbox = AsyncMock(return_value=None)
+        self.workspace._create_sandbox = AsyncMock(return_value=self.sandbox)
+        self.workspace._wait_until_running = AsyncMock()
+
+        with patch(
+            "agentscope.workspace._opensandbox."
+            "_opensandbox_workspace.asyncio.create_task",
+        ) as create_task:
+            await self.workspace._provision_backend()
+            create_task.assert_not_called()
+
+        self.sandbox.renew.assert_not_awaited()
+        self.assertIsNotNone(self.workspace._backend)
+
+    async def test_connect_and_resume_renew_existing_lease(self) -> None:
+        """Reattachment explicitly renews; SDK readiness timeouts do not."""
+        self.workspace._wait_until_running = AsyncMock()
+        for state, operation in (("Running", "connect"), ("Paused", "resume")):
+            with self.subTest(state=state):
+                self.sandbox.renew.reset_mock()
+                self.workspace._find_existing_sandbox = AsyncMock(
+                    return_value=SimpleNamespace(
+                        id=self.sandbox.id,
+                        status=SimpleNamespace(state=state),
+                    ),
+                )
+                with patch(
+                    f"opensandbox.Sandbox.{operation}",
+                    AsyncMock(return_value=self.sandbox),
+                ) as attach:
+                    await self.workspace._provision_backend()
+
+                attach.assert_awaited_once()
+                self.sandbox.renew.assert_awaited_once_with(
+                    timedelta(seconds=1800),
+                )
+                self.sandbox.get_info.assert_not_awaited()
+
+    async def test_reattachment_404_cleans_partial_workspace(self) -> None:
+        """A sandbox disappearing during reattachment fails with cleanup."""
+        from opensandbox.exceptions import SandboxApiException
+
+        self.workspace._find_existing_sandbox = AsyncMock(
+            return_value=SimpleNamespace(id=self.sandbox.id),
+        )
+        self.workspace._attach_existing_sandbox = AsyncMock(
+            return_value=self.sandbox,
+        )
+        self.sandbox.renew.side_effect = SandboxApiException(status_code=404)
+
+        with self.assertRaisesRegex(RuntimeError, "disappeared"):
+            await self.workspace.initialize()
+
+        self.sandbox.close.assert_awaited_once()
+        self.assertIsNone(self.workspace._sandbox)
+        self.assertFalse(self.workspace.is_alive)
+
+    async def test_initialize_failure_or_cancellation_cleans_resources(
+        self,
+    ) -> None:
+        """Cleanup must preserve initialization errors and cancellation."""
+        for error in (
+            RuntimeError("bootstrap failed"),
+            asyncio.CancelledError(),
+        ):
+            with self.subTest(error=type(error).__name__):
+                self.sandbox.close.reset_mock()
+                self.workspace._sandbox = self.sandbox
+                gateway = SimpleNamespace(aclose=AsyncMock())
+                self.workspace._gateway = gateway
+
+                with patch(
+                    "agentscope.workspace._sandboxed_base."
+                    "SandboxedWorkspaceBase.initialize",
+                    AsyncMock(side_effect=error),
+                ):
+                    with self.assertRaises(type(error)):
+                        await self.workspace.initialize()
+
+                gateway.aclose.assert_awaited_once()
+                self.sandbox.close.assert_awaited_once()
+                self.assertIsNone(self.workspace._gateway)
+                self.assertIsNone(self.workspace._backend)
+                self.assertIsNone(self.workspace._sandbox)
+                self.assertFalse(self.workspace.is_alive)
+
+
+# ── lifecycle integration tests ───────────────────────────────────
 
 
 @unittest.skipUnless(_DOMAIN, _SKIP_REASON)


### PR DESCRIPTION
## AgentScope Version

2.0.7.post1

## Description

Fixes #2483.

OpenSandbox workspaces could remain cached after their remote sandbox had expired. Subsequent requests would reuse the stale local workspace and fail instead of recovering automatically.

This PR:

- renews the sandbox lease while a workspace is active;
- checks the remote sandbox state before reusing a cached workspace;
- reuses and renews running sandboxes;
- reattaches paused sandboxes;
- recreates expired, deleted, or terminal sandboxes under the same workspace ID;
- avoids duplicate sandbox creation during concurrent recovery;
- cleans up partially initialized workspaces on failure;
- adds unit tests covering lease renewal, expiration recovery, paused sandboxes, transient errors, cleanup, and concurrent requests.
