### PR TITLE
fix(web-ui): keep running MCP tool calls visible

### DIFF
--- a/examples/web_ui/frontend/src/components/chat/ASMessageBubble.tsx
+++ b/examples/web_ui/frontend/src/components/chat/ASMessageBubble.tsx
@@ -740,7 +740,7 @@ export function ASBlock({ block, ...props }: ASBlockProps) {
 						<div
 							className={cn(
 								'group w-full flex gap-2 items-center text-sm text-muted-foreground cursor-pointer hover:text-primary',
-								hasRunningCall && 'motion-safe:animate-pulse',
+								hasRunningCall && 'shimmer',
 							)}
 						>
 							<span>{title}</span>

--- a/examples/web_ui/frontend/src/components/chat/ASMessageBubble.tsx
+++ b/examples/web_ui/frontend/src/components/chat/ASMessageBubble.tsx
@@ -731,14 +731,16 @@ export function ASBlock({ block, ...props }: ASBlockProps) {
 		}
 		case 'tool_call_group': {
 			const { title, insertions, deletions } = summarizeToolGroup(block.calls, t);
-			const allFinished = block.calls.some((c) => !c.result || c.result.state === 'running');
+			const hasRunningCall = block.calls.some(
+				(c) => !c.result || c.result.state === 'running',
+			);
 			return (
 				<Collapsible defaultOpen={false}>
 					<CollapsibleTrigger asChild>
 						<div
 							className={cn(
 								'group w-full flex gap-2 items-center text-sm text-muted-foreground cursor-pointer hover:text-primary',
-								allFinished && 'shimmer',
+								hasRunningCall && 'motion-safe:animate-pulse',
 							)}
 						>
 							<span>{title}</span>

--- a/examples/web_ui/frontend/src/components/chat/tool-renderers/_shared.tsx
+++ b/examples/web_ui/frontend/src/components/chat/tool-renderers/_shared.tsx
@@ -74,17 +74,13 @@ export function ToolCallRow({
 	body?: ReactNode;
 }) {
 	const expandable = body != null && body !== false;
-	// Shimmer the header text. The shadcn ``shimmer`` util is a text-clip effect,
-	// so it has to sit on the elements that *directly* hold the text — the
-	// header's own leaf spans — not on a wrapper (a wrapper only makes descendant
-	// text transparent). We target the direct span children of this flex row
-	// instead of wrapping ``header``, which also keeps their ``gap-x-2`` spacing.
+	const isRunning = !pair.result || pair.result.state === 'running';
 	const row = (
 		<div
 			className={cn(
 				'group flex flex-row gap-x-2 items-center w-full',
 				expandable && 'cursor-pointer',
-				!pair.result || pair.result.state === 'running' ? 'shimmer' : '',
+				isRunning && 'motion-safe:animate-pulse',
 			)}
 		>
 			{header}

--- a/examples/web_ui/frontend/src/components/chat/tool-renderers/_shared.tsx
+++ b/examples/web_ui/frontend/src/components/chat/tool-renderers/_shared.tsx
@@ -74,13 +74,18 @@ export function ToolCallRow({
 	body?: ReactNode;
 }) {
 	const expandable = body != null && body !== false;
+	// Shimmer the header text. The shadcn ``shimmer`` util is a text-clip effect,
+	// so it has to sit on the elements that *directly* hold the text — the
+	// header's own leaf spans — not on a wrapper (a wrapper only makes descendant
+	// text transparent). We target the direct span children of this flex row
+	// instead of wrapping ``header``, which also keeps their ``gap-x-2`` spacing.
 	const isRunning = !pair.result || pair.result.state === 'running';
 	const row = (
 		<div
 			className={cn(
 				'group flex flex-row gap-x-2 items-center w-full',
 				expandable && 'cursor-pointer',
-				isRunning && 'motion-safe:animate-pulse',
+				isRunning && 'shimmer',
 			)}
 		>
 			{header}

--- a/examples/web_ui/frontend/src/index.css
+++ b/examples/web_ui/frontend/src/index.css
@@ -8,6 +8,16 @@
 
 @plugin '@tailwindcss/typography';
 
+/* Shimmer relies on relative color syntax. Older browsers drop its gradient
+   while keeping the text fill transparent, so fall back to visible text. */
+@supports not (color: oklch(from red l c h)) {
+	.shimmer {
+		--shimmer-image: none;
+		--shimmer-text-fill: currentColor;
+		animation: none;
+	}
+}
+
 html,
 body,
 #root {


### PR DESCRIPTION
## AgentScope Version

2.0.8

## Description

Fixes #2475

The `shimmer` utility uses CSS relative color syntax while making the text fill transparent. Browsers that do not support relative colors can therefore drop the gradient and leave running-state labels blank.

This PR:

- keeps the existing shimmer effect in browsers that support relative colors
- adds an `@supports` fallback that disables the unsupported gradient and animation and restores `currentColor` in older browsers
- preserves the existing running predicate: no result yet, or `result.state === 'running'`
- keeps completed, errored, denied, and interrupted calls static

Verification:

- `pre-commit run --all-files`
- `pytest -q --disable-warnings tests --ignore=tests/test_e2e_docker_mcp.py --ignore=tests/workspace_docker_test.py` (`2150 passed, 127 skipped`; the excluded Docker integration files were blocked locally by an external Docker image build EOF/hang)
- `pnpm exec prettier --check .`
- `pnpm --filter frontend exec eslint . --quiet`
- frontend and backend TypeScript compilation, plus the frontend production build
- inspected the generated CSS to confirm the modern shimmer rule is retained and the fallback is emitted after it with all three overrides

### Runtime verification

The screenshot below shows two MCP tool calls in progress. The MCP group and both tool rows remain readable, and each running tool keeps its loading indicator. The final revision retains shimmer on supporting browsers and uses visible static text as the compatibility fallback.

![Two MCP tool calls displaying readable running state and loading indicators](https://github.com/user-attachments/assets/5a7df225-9ece-4dce-b780-8192036c7eec)

No public API, docstring, or documentation changes are required.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style (not applicable; no Python changes)
- [x] Related documentation has been updated (not applicable; UI compatibility fix)
- [x] Code is ready for review
