### PR TITLE
docs(middleware): fix reply budget example class name

### DIFF
--- a/src/agentscope/middleware/_budget.py
+++ b/src/agentscope/middleware/_budget.py
@@ -45,12 +45,12 @@ class ReplyBudgetControlMiddleware(MiddlewareBase):
 
     Example::
 
-        from agentscope.middleware import BudgetControlMiddleware
+        from agentscope.middleware import ReplyBudgetControlMiddleware
 
         agent = Agent(
             ...,
             middlewares=[
-                BudgetControlMiddleware(
+                ReplyBudgetControlMiddleware(
                     token_budget=10000,
                     input_token_weight=1.0,
                     output_token_weight=2.0,


### PR DESCRIPTION
## AgentScope Version

2.0.7.post1

## Description

The public docstring example for ReplyBudgetControlMiddleware imports and instantiates BudgetControlMiddleware, which is not exported by agentscope.middleware.

This PR updates both references to the actual public class name, ReplyBudgetControlMiddleware, so users can copy the example without hitting an import error.

## Testing

- pre-commit run --files src/agentscope/middleware/_budget.py
- imported and instantiated ReplyBudgetControlMiddleware in the local development environment

## Checklist

- [ ] An issue has been created for this PR (not created; this is a two-line documentation correction)
- [x] I have read the CONTRIBUTING.md
- [x] Docstrings are in Google style
- [x] Related documentation has been updated where applicable (no separate docs change is needed)
- [x] Code is ready for review