### PR TITLE
fix(model): preserve Anthropic streaming content blocks

### DIFF
--- a/src/agentscope/model/_anthropic/_model.py
+++ b/src/agentscope/model/_anthropic/_model.py
@@ -412,8 +412,8 @@ class AnthropicChatModel(ChatModelBase):
 
         usage = None
         response_id: str = _generate_id()
-        text_id: str = _generate_id()
-        thinking_id: str = _generate_id()
+        # Keep text and thinking blocks distinct, including their signatures.
+        block_id_mapping: dict[int, str] = {}
         # The mapping from index to tool call id
         tool_call_mapping: dict = OrderedDict()
 
@@ -453,7 +453,10 @@ class AnthropicChatModel(ChatModelBase):
                         )
 
                 elif event.type == "content_block_start":
-                    if event.content_block.type == "tool_use":
+                    if event.content_block.type in ("text", "thinking"):
+                        block_id_mapping[event.index] = _generate_id()
+
+                    elif event.content_block.type == "tool_use":
                         tool_block = event.content_block
                         # Record the id and name
                         tool_call_mapping[event.index] = (
@@ -484,13 +487,16 @@ class AnthropicChatModel(ChatModelBase):
 
                     # Text block
                     if delta.type == "text_delta":
-                        delta_res.append_text(delta.text, block_id=text_id)
+                        delta_res.append_text(
+                            delta.text,
+                            block_id=block_id_mapping[block_index],
+                        )
 
                     # Thinking block
                     elif delta.type == "thinking_delta":
                         delta_res.append_thinking(
                             delta.thinking,
-                            block_id=thinking_id,
+                            block_id=block_id_mapping[block_index],
                         )
 
                     # Special handling for Anthropic API that requires
@@ -498,7 +504,7 @@ class AnthropicChatModel(ChatModelBase):
                     elif delta.type == "signature_delta":
                         delta_res.append_thinking(
                             "",
-                            block_id=thinking_id,
+                            block_id=block_id_mapping[block_index],
                             signature=delta.signature,
                         )
 

--- a/tests/model_anthropic_test.py
+++ b/tests/model_anthropic_test.py
@@ -12,9 +12,16 @@ import unittest
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock
 
+from anthropic import types as anthropic_types
+
 from utils import AnyString
 
-from agentscope.message import TextBlock, ToolCallBlock, ThinkingBlock
+from agentscope.message import (
+    AssistantMsg,
+    TextBlock,
+    ToolCallBlock,
+    ThinkingBlock,
+)
 from agentscope.model import AnthropicChatModel
 from agentscope.credential import AnthropicCredential
 from agentscope.tool import ToolChoice
@@ -82,6 +89,93 @@ def _make_event(event_type: str, **kwargs: Any) -> MagicMock:
     for key, val in kwargs.items():
         setattr(event, key, val)
     return event
+
+
+def _completion_events(completion: anthropic_types.Message) -> list:
+    """Split a completion into SDK events with multiple deltas per block."""
+    events: list = [
+        anthropic_types.RawMessageStartEvent(
+            type="message_start",
+            message=completion.model_copy(
+                update={
+                    "content": [],
+                    "stop_reason": None,
+                    "usage": completion.usage.model_copy(
+                        update={"output_tokens": 0},
+                    ),
+                },
+            ),
+        ),
+    ]
+    for index, block in enumerate(completion.content):
+        start = block.model_dump()
+        deltas = []
+        if block.type in ("text", "thinking"):
+            value = start[block.type]
+            start[block.type] = ""
+            if value:
+                midpoint = len(value) // 2
+                deltas.extend(
+                    {"type": f"{block.type}_delta", block.type: part}
+                    for part in (value[:midpoint], value[midpoint:])
+                )
+            if block.type == "thinking":
+                start["signature"] = ""
+                deltas.append(
+                    {"type": "signature_delta", "signature": block.signature},
+                )
+        elif block.type == "tool_use":
+            start["input"] = {}
+            deltas.append(
+                {
+                    "type": "input_json_delta",
+                    "partial_json": json.dumps(block.input),
+                },
+            )
+
+        events.append(
+            anthropic_types.RawContentBlockStartEvent.model_validate(
+                {
+                    "type": "content_block_start",
+                    "index": index,
+                    "content_block": start,
+                },
+            ),
+        )
+        events.extend(
+            anthropic_types.RawContentBlockDeltaEvent.model_validate(
+                {
+                    "type": "content_block_delta",
+                    "index": index,
+                    "delta": delta,
+                },
+            )
+            for delta in deltas
+        )
+        events.append(
+            anthropic_types.RawContentBlockStopEvent(
+                type="content_block_stop",
+                index=index,
+            ),
+        )
+    events.extend(
+        [
+            anthropic_types.RawMessageDeltaEvent.model_validate(
+                {
+                    "type": "message_delta",
+                    "delta": {
+                        "stop_reason": completion.stop_reason,
+                        "stop_sequence": None,
+                    },
+                    "usage": {
+                        "output_tokens": completion.usage.output_tokens,
+                    },
+                },
+            ),
+            anthropic_types.RawMessageStopEvent(type="message_stop"),
+        ],
+    )
+    return events
 
 
 class _MockAsyncEventStream:
@@ -821,6 +915,103 @@ class TestAnthropicStream(IsolatedAsyncioTestCase):
                 ),
             ],
         )
+
+    async def test_stream_preserves_content_blocks(self) -> None:
+        """Streaming preserves block boundaries and the replayed message."""
+        thinking_a = {
+            "type": "thinking",
+            "thinking": "First thought.",
+            "signature": "sig_A",
+        }
+        thinking_b = {
+            "type": "thinking",
+            "thinking": "Second thought.",
+            "signature": "sig_B",
+        }
+        tool = {
+            "type": "tool_use",
+            "id": "toolu_1",
+            "name": "get_weather",
+            "input": {"city": "Beijing"},
+        }
+        cases = {
+            "multiple_thinking": [thinking_a, thinking_b, tool],
+            "signature_only": [
+                {**thinking_a, "thinking": ""},
+                {**thinking_b, "thinking": ""},
+                tool,
+            ],
+            "text_around_tool": [
+                {"type": "text", "text": "Before the tool."},
+                tool,
+                {"type": "text", "text": "After the tool."},
+            ],
+            "thinking_around_redacted": [
+                thinking_a,
+                {"type": "redacted_thinking", "data": "encrypted_data"},
+                thinking_b,
+                tool,
+            ],
+        }
+        non_stream_model = _make_model(stream=False)
+        non_stream_model.client = self.mock_client
+
+        for name, content in cases.items():
+            with self.subTest(name=name):
+                completion = anthropic_types.Message.model_validate(
+                    {
+                        "id": "msg-blocks",
+                        "type": "message",
+                        "role": "assistant",
+                        "model": self.model.model,
+                        "content": content,
+                        "stop_reason": "tool_use",
+                        "stop_sequence": None,
+                        "usage": {"input_tokens": 10, "output_tokens": 20},
+                    },
+                )
+                stream = _MockAsyncEventStream(_completion_events(completion))
+                self.mock_client.messages.create = AsyncMock(
+                    side_effect=[stream, completion],
+                )
+
+                responses = [r async for r in await self.model([])]
+                final = responses[-1]
+                non_stream = await non_stream_model([])
+
+                self.assertTrue(stream.exited)
+                self.assertTrue(final.is_last)
+                self.assertEqual(final.id, completion.id)
+                self.assertEqual(
+                    len({block.id for block in final.content}),
+                    len(content),
+                )
+                # Compare the accumulated blocks before formatting, so a
+                # formatter cannot hide a missing or accidentally split block.
+                normalized = []
+                for response in (final, non_stream):
+                    normalized.append(
+                        [
+                            block.model_dump(
+                                exclude={"created_at", "finished_at"}
+                                | (
+                                    set()
+                                    if block.type == "tool_call"
+                                    else {"id"}
+                                ),
+                            )
+                            for block in response.content
+                        ],
+                    )
+                self.assertEqual(normalized[0], normalized[1])
+
+                replay = await self.model.formatter.format(
+                    [AssistantMsg(name="assistant", content=final.content)],
+                )
+                self.assertEqual(
+                    replay,
+                    [{"role": "assistant", "content": content}],
+                )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## AgentScope Version

2.0.7.post1

## Description

Fixes #2494.

Anthropic streaming responses currently share one ID for all thinking blocks and one ID for all text blocks. This merges separate blocks, overwrites earlier thinking signatures, and changes their order relative to tool calls.

This PR assigns separate block IDs by `event.index`, preserving each block's content, signature, and position while continuing to accumulate deltas within the same block.

Regression tests cover:

- Multiple thinking blocks with separate signatures.
- Thinking blocks containing only signatures.
- Text blocks before and after a tool call.
- Thinking blocks separated by redacted thinking.
- Multiple deltas within one block.

The tests compare streaming and non-streaming results and verify the assistant message formatted for the next request.

## Validation

- Related model, response aggregation, and Anthropic formatter tests: **80 passed, 10 subtests passed**.
- `pre-commit run --all-files`: **passed**.
- The full test suite did not pass locally. Remaining failures include Redis/Lua, DingTalk, and MCP tests; Redis-backed tests reported missing Lua `EVAL` support.

## Checklist

- [x] An issue has been created for this PR.
- [x] I have read CONTRIBUTING.md.
- [x] Docstrings follow the project style.
- [x] Documentation impact reviewed; no public API or configuration changes.
- [x] Code is ready for review.