### PR TITLE
fix(pipeline): honor structured output retry limit

### DIFF
--- a/src/agentscope/pipeline/_goal_pipeline.py
+++ b/src/agentscope/pipeline/_goal_pipeline.py
@@ -77,8 +77,9 @@ class GoalPipeline:
             max_iters (`int`, optional):
                 The maximum number of goal achievement attempts.
             max_retries (`int`, optional):
-                The maximum number of retries for the executor and verifier
-                agents to generate valid structured outputs. Defaults to `3`.
+                The maximum number of retries after the initial attempt for
+                the executor and verifier agents to generate valid structured
+                outputs. Defaults to `3`.
         """
         self.executor = executor
         self.verifier = verifier
@@ -88,6 +89,8 @@ class GoalPipeline:
         # Rounds already judged. On the instance rather than in
         # ``reply_stream``, so a HITL resume does not restart the budget.
         self._iters = 0
+        self._executor_retries = 0
+        self._verifier_retries = 0
         self._goal: None | list[TextBlock | DataBlock] = None
 
     async def reply_stream(
@@ -123,6 +126,8 @@ class GoalPipeline:
             executor_inputs = deepcopy(inputs)
             # A fresh run, so the iteration budget starts over.
             self._iters = 0
+            self._executor_retries = 0
+            self._verifier_retries = 0
 
             hint = (
                 "<system-reminder>When you finish the goal, you should "
@@ -205,6 +210,13 @@ class GoalPipeline:
                         break
 
                     if execution_report is None:
+                        if self._executor_retries >= self.max_retries:
+                            raise RuntimeError(
+                                "executor failed to generate valid structured "
+                                "output after "
+                                f"{self._executor_retries + 1} attempts.",
+                            )
+                        self._executor_retries += 1
                         # Update the instruction
                         executor_inputs = UserMsg(
                             name="system",
@@ -219,6 +231,7 @@ class GoalPipeline:
             if break_loop:
                 # The executor parked, so there is nothing to verify yet.
                 break
+            self._executor_retries = 0
 
             # Verifier
             final_msg = None
@@ -271,9 +284,14 @@ class GoalPipeline:
                 if break_loop:
                     # Escape the loop for hitl events
                     break
-                if final_msg is None:
-                    continue
-                if final_msg.structured_output is None:
+                if final_msg is None or final_msg.structured_output is None:
+                    if self._verifier_retries >= self.max_retries:
+                        raise RuntimeError(
+                            "verifier failed to generate valid structured "
+                            "output after "
+                            f"{self._verifier_retries + 1} attempts.",
+                        )
+                    self._verifier_retries += 1
                     # Update the instruction for valid verification result
                     # TODO: support multimodal verification instruction
                     final_msg = None
@@ -290,7 +308,10 @@ class GoalPipeline:
                             f"{self._goal}</system-reminder>"
                         ),
                     )
-                elif final_msg.structured_output.get("result") in (
+                    continue
+
+                self._verifier_retries = 0
+                if final_msg.structured_output.get("result") in (
                     "pass",
                     "impossible",
                 ):

--- a/tests/pipeline_goal_test.py
+++ b/tests/pipeline_goal_test.py
@@ -46,10 +46,12 @@ def _no_output(name: str) -> Msg:
     )
 
 
-def _confirm_request() -> RequireUserConfirmEvent:
+def _confirm_request(
+    reply_id: str = "executor-reply",
+) -> RequireUserConfirmEvent:
     """A tool call parked on a human."""
     return RequireUserConfirmEvent(
-        reply_id="executor-reply",
+        reply_id=reply_id,
         tool_calls=[
             ToolCallBlock(id="call-1", name="write_file", input="{}"),
         ],
@@ -63,10 +65,16 @@ class StubAgent:
     reminders the pipeline built reached the right agent.
     """
 
-    def __init__(self, name: str, script: list[list[Any]]) -> None:
+    def __init__(
+        self,
+        name: str,
+        script: list[list[Any]],
+        max_calls: int | None = None,
+    ) -> None:
         """Initialize the stub with one script entry per call."""
         self.name = name
         self.script = script
+        self.max_calls = max_calls
         self.state = SimpleNamespace(reply_id=f"{name}-reply")
         self.received: list[Any] = []
 
@@ -79,6 +87,8 @@ class StubAgent:
     ) -> AsyncGenerator[Any, None]:
         """Yield the next batch, holding the final message back unless it
         was asked for, the way ``Agent.reply_stream`` does."""
+        if self.max_calls is not None and len(self.received) >= self.max_calls:
+            raise AssertionError(f"{self.name} exceeded its call limit")
         self.received.append(inputs)
         batch = self.script[min(len(self.received) - 1, len(self.script) - 1)]
         for chunk in batch:
@@ -157,6 +167,132 @@ class GoalPipelineTest(IsolatedAsyncioTestCase):
         self.assertEqual(len(executor.received), 1)
         self.assertEqual(len(verifier.received), 1)
 
+    async def test_executor_stops_after_structured_output_retries(
+        self,
+    ) -> None:
+        """An executor cannot retry a missing report indefinitely."""
+        executor = StubAgent(
+            "executor",
+            [[_no_output("executor")]],
+            max_calls=2,
+        )
+        verifier = StubAgent("verifier", [[_verdict("pass")]])
+        pipe = GoalPipeline(executor, verifier, max_retries=1)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "executor failed to generate valid structured output "
+            "after 2 attempts",
+        ):
+            await self._run(pipe, self.query)
+
+        self.assertEqual(len(executor.received), 2)
+        self.assertListEqual(verifier.received, [])
+
+    async def test_verifier_stops_after_structured_output_retries(
+        self,
+    ) -> None:
+        """A verifier cannot retry a missing verdict indefinitely."""
+        executor = StubAgent("executor", [[_report()]])
+        verifier = StubAgent(
+            "verifier",
+            [[_no_output("verifier")]],
+            max_calls=2,
+        )
+        pipe = GoalPipeline(executor, verifier, max_retries=1)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "verifier failed to generate valid structured output "
+            "after 2 attempts",
+        ):
+            await self._run(pipe, self.query)
+
+        self.assertEqual(len(executor.received), 1)
+        self.assertEqual(len(verifier.received), 2)
+
+    async def test_verifier_counts_a_missing_final_message_as_retry(
+        self,
+    ) -> None:
+        """An empty verifier stream consumes the same retry budget."""
+        executor = StubAgent("executor", [[_report()]])
+        verifier = StubAgent("verifier", [[]], max_calls=2)
+        pipe = GoalPipeline(executor, verifier, max_retries=1)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "verifier failed to generate valid structured output "
+            "after 2 attempts",
+        ):
+            await self._run(pipe, self.query)
+
+        self.assertEqual(len(executor.received), 1)
+        self.assertEqual(len(verifier.received), 2)
+
+    async def test_executor_retry_budget_survives_hitl_resume(self) -> None:
+        """Parking does not reset the executor's consumed retry budget."""
+        request = _confirm_request()
+        executor = StubAgent(
+            "executor",
+            [
+                [_no_output("executor")],
+                [request],
+                [_no_output("executor")],
+            ],
+            max_calls=3,
+        )
+        verifier = StubAgent("verifier", [[_verdict("pass")]])
+        pipe = GoalPipeline(executor, verifier, max_retries=1)
+
+        await self._run(pipe, self.query)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "executor failed to generate valid structured output "
+            "after 2 attempts",
+        ):
+            await self._run(
+                pipe,
+                UserConfirmResultEvent(
+                    reply_id="executor-reply",
+                    confirm_results=[],
+                ),
+            )
+
+        self.assertEqual(len(executor.received), 3)
+        self.assertListEqual(verifier.received, [])
+
+    async def test_verifier_retry_budget_survives_hitl_resume(self) -> None:
+        """Parking does not reset the verifier's consumed retry budget."""
+        request = _confirm_request("verifier-reply")
+        executor = StubAgent("executor", [[_report()]])
+        verifier = StubAgent(
+            "verifier",
+            [
+                [_no_output("verifier")],
+                [request],
+                [_no_output("verifier")],
+            ],
+            max_calls=3,
+        )
+        pipe = GoalPipeline(executor, verifier, max_retries=1)
+
+        await self._run(pipe, self.query)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "verifier failed to generate valid structured output "
+            "after 2 attempts",
+        ):
+            await self._run(
+                pipe,
+                UserConfirmResultEvent(
+                    reply_id="verifier-reply",
+                    confirm_results=[],
+                ),
+            )
+
+        self.assertEqual(len(executor.received), 1)
+        self.assertEqual(len(verifier.received), 3)
+
     async def test_reprompts_a_verifier_that_skips_the_tool(self) -> None:
         """A final message with no verdict is not a refusal: the verifier
         is reminded rather than the executor being sent back."""
@@ -165,7 +301,7 @@ class GoalPipelineTest(IsolatedAsyncioTestCase):
             "verifier",
             [[_no_output("verifier")], [_verdict("pass")]],
         )
-        pipe = GoalPipeline(executor, verifier)
+        pipe = GoalPipeline(executor, verifier, max_retries=1)
 
         await self._run(pipe, self.query)
 
@@ -185,7 +321,7 @@ class GoalPipelineTest(IsolatedAsyncioTestCase):
             [[_no_output("executor")], [_report()]],
         )
         verifier = StubAgent("verifier", [[_verdict("pass")]])
-        pipe = GoalPipeline(executor, verifier)
+        pipe = GoalPipeline(executor, verifier, max_retries=1)
 
         await self._run(pipe, self.query)
 


### PR DESCRIPTION
## AgentScope Version

`2.0.7.post1` (`main` at `10eaaac269101e25ad9f808353c45e305c6d7231`)

## Description

Fixes #2497.

`GoalPipeline.max_retries` was documented and stored but never applied to the executor or verifier structured-output retry loops. An agent that repeatedly completed without structured output could therefore be called indefinitely, independently of `max_iters`.

This PR:

- bounds executor and verifier structured-output retries to the initial attempt plus `max_retries`;
- preserves consumed retry counts across HITL/external-execution parking without charging the park itself;
- resets each budget on a fresh task or after that agent produces valid structured output;
- treats a verifier stream with no completed final message as an invalid attempt;
- raises a role-specific `RuntimeError` when the retry budget is exhausted;
- adds regression coverage for normal exhaustion, empty verifier streams, final-allowed-attempt success, and executor/verifier HITL resume lifecycles.

`max_iters`, the public API, and the existing executor-verifier behavior for `pass`, `fail`, and `impossible` remain unchanged.

### Testing

- `python -m pytest tests/pipeline_goal_test.py -q` — 15 passed
- `pre-commit run --files src/agentscope/pipeline/_goal_pipeline.py tests/pipeline_goal_test.py` — all hooks passed

The full test suite was also attempted locally, but collection requires optional development dependencies (`fakeredis`, `moto`, `mem0`, and `redis`) that are not installed in this environment.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation has been updated, or is not required because this restores the documented behavior
- [x] Code is ready for review