### PR TITLE
fix(tool): resolve the real command name in the bash removal check

### DIFF
--- a/src/agentscope/tool/_builtin/_bash.py
+++ b/src/agentscope/tool/_builtin/_bash.py
@@ -22,6 +22,15 @@ from .._response import ToolChunk
 from ._backend import BackendBase
 
 
+# Commands that remove files. Compared against the *resolved* command
+# name, so ``/bin/rm`` and ``\rm`` are recognized too.
+_REMOVAL_COMMANDS = frozenset({"rm", "rmdir"})
+
+# Commands that execute the command passed to them as an argument, so the
+# removal command can appear after one of these instead of first.
+_COMMAND_WRAPPERS = frozenset({"sudo", "env", "command"})
+
+
 class Bash(ToolBase):
     """The bash tool."""
 
@@ -604,25 +613,72 @@ easier to review tool calls and give permission.
 
         # Check each subcommand for rm/rmdir
         for subcmd in subcommands:
-            subcmd_tokens = subcmd.strip().split()
-            if not subcmd_tokens:
-                continue
-            base = subcmd_tokens[0]
-            if base not in ("rm", "rmdir"):
+            argument_tokens = self._removal_argument_tokens(
+                subcmd.strip().split(),
+            )
+            if argument_tokens is None:
                 continue
 
             # Collect non-flag arguments as potential paths
-            i = 1
-            while i < len(subcmd_tokens):
-                tok = subcmd_tokens[i]
+            for tok in argument_tokens:
                 # Skip flags
                 if tok.startswith("-"):
-                    i += 1
                     continue
                 path = tok.strip("'\"")
                 if await self._is_dangerous_removal_path(path):
                     return path
-                i += 1
+
+        return None
+
+    @staticmethod
+    def _removal_argument_tokens(
+        subcmd_tokens: list[str],
+    ) -> list[str] | None:
+        """Return a removal command's argument tokens, or ``None``.
+
+        Comparing ``subcmd_tokens[0]`` against ``rm`` misses spellings
+        that bash runs as the very same command: an absolute or relative
+        path (``/bin/rm``), a backslash suppressing alias expansion
+        (``\\rm``), leading environment assignments (``FOO=1 rm``), and
+        wrappers that exec their argument (``sudo rm``, ``env rm``).
+
+        Args:
+            subcmd_tokens (`list[str]`):
+                Whitespace-split tokens of a single subcommand.
+
+        Returns:
+            `list[str] | None`:
+                The tokens following the removal command, or ``None`` when
+                this subcommand does not invoke one.
+        """
+        index = 0
+        after_wrapper = False
+        while index < len(subcmd_tokens):
+            token = subcmd_tokens[index]
+
+            # A leading ``NAME=value`` pair is part of the environment
+            # prefix, not the command itself.
+            name, separator, _ = token.partition("=")
+            if separator and name.isidentifier():
+                index += 1
+                continue
+
+            # Flags belonging to a wrapper (``env -i rm ...``) precede the
+            # wrapped command.
+            if after_wrapper and token.startswith("-"):
+                index += 1
+                continue
+
+            command_name = os.path.basename(
+                token.strip("'\"").lstrip("\\"),
+            )
+            if command_name in _COMMAND_WRAPPERS:
+                after_wrapper = True
+                index += 1
+                continue
+            if command_name in _REMOVAL_COMMANDS:
+                return subcmd_tokens[index + 1 :]
+            return None
 
         return None
 

--- a/tests/builtin_bash_test.py
+++ b/tests/builtin_bash_test.py
@@ -599,6 +599,56 @@ class BashToolDangerousRemovalTest(IsolatedAsyncioTestCase):
                     or "dangerous pattern" in decision.message,
                 )
 
+    async def test_indirect_rm_spellings_are_not_bypassed(self) -> None:
+        """Test that non-literal spellings of rm still reach the check.
+
+        Splitting the flags (``-r -f``) keeps the command clear of the
+        ``rm -rf`` dangerous-pattern substring, so the dangerous-removal
+        check is the only thing standing between these commands and a
+        permission rule.
+        """
+
+        test_cases = [
+            "/bin/rm -r -f /",
+            "/usr/bin/rm -r -f /etc",
+            "\\rm -r -f /",
+            "env rm -r -f /",
+            "env -i rm -r -f /",
+            "command rm -r -f /",
+            "FOO=1 rm -r -f /",
+            "sudo /bin/rm -r -f /",
+            "/bin/rm -r -f ~",
+        ]
+        for cmd in test_cases:
+            with self.subTest(cmd=cmd):
+                decision = await self.bash_tool.check_permissions(
+                    {"command": cmd},
+                    self.context,
+                )
+                self.assertEqual(decision.behavior, PermissionBehavior.ASK)
+                self.assertTrue(decision.bypass_immune)
+                self.assertIn("Dangerous removal operation", decision.message)
+
+    async def test_rm_lookalikes_are_not_removal_commands(self) -> None:
+        """Test that commands merely mentioning rm are left alone."""
+
+        test_cases = [
+            "echo rm",
+            "ls /bin/rm",
+            "grep -r rm /tmp/project",
+        ]
+        for cmd in test_cases:
+            with self.subTest(cmd=cmd):
+                decision = await self.bash_tool.check_permissions(
+                    {"command": cmd},
+                    self.context,
+                )
+                if decision.behavior == PermissionBehavior.ASK:
+                    self.assertNotIn(
+                        "Dangerous removal operation",
+                        decision.message,
+                    )
+
     async def asyncTearDown(self) -> None:
         """Clean up test fixtures."""
         self.bash_tool = None


### PR DESCRIPTION
Fixes #2500

## Summary

Resolve the real command name in `_check_dangerous_removal_path()` so every spelling bash runs as
`rm` / `rmdir` reaches the bypass-immune removal check.

## Root cause

The helper decided whether a subcommand was a removal command by comparing the first
whitespace-separated token literally:

```python
subcmd_tokens = subcmd.strip().split()
base = subcmd_tokens[0]
if base not in ("rm", "rmdir"):
    continue
```

Bash runs several other spellings as the very same command, and none of them matched: an absolute or
relative path (`/bin/rm`), a backslash suppressing alias expansion (`\rm`), a leading environment
assignment (`FOO=1 rm`), and wrappers that exec their argument (`env rm`, `command rm`).

Writing the flags separately (`-r -f`) also keeps the command clear of the `"rm -rf"` substring in
`DANGEROUS_COMMANDS`, so step 2 did not catch these either. `check_permissions()` therefore returned
`PASSTHROUGH` with `bypass_immune=False`, letting a user-configured Bash allow rule auto-approve a
command that removes a critical system path — and dropping the "cannot be auto-allowed by permission
rules" guarantee that the `rm -r -f /` form still has.

## Changes

- `src/agentscope/tool/_builtin/_bash.py`: add `_removal_argument_tokens()`, which resolves the
  command name (basename, alias-suppressing backslash removed) and steps over leading `NAME=value`
  assignments and `sudo` / `env` / `command` wrappers before comparing it. The argument scan is
  unchanged apart from now iterating over the tokens the helper returns.
- `tests/builtin_bash_test.py`: regression coverage for the indirect spellings, plus a guard that
  lookalikes such as `echo rm`, `ls /bin/rm` and `grep -r rm ...` are still not treated as removals.

## Verification

Before / after for the reported vectors (`PermissionMode.DEFAULT`, repro script in #2500):

| command | before | after |
|---|---|---|
| `/bin/rm -r -f /` | passthrough, `bypass_immune=False` | ask, `bypass_immune=True` |
| `/usr/bin/rm -r -f /etc` | passthrough, `bypass_immune=False` | ask, `bypass_immune=True` |
| `\rm -r -f /` | passthrough, `bypass_immune=False` | ask, `bypass_immune=True` |
| `env rm -r -f /` | passthrough, `bypass_immune=False` | ask, `bypass_immune=True` |
| `env -i rm -r -f /` | passthrough, `bypass_immune=False` | ask, `bypass_immune=True` |
| `command rm -r -f /` | passthrough, `bypass_immune=False` | ask, `bypass_immune=True` |
| `FOO=1 rm -r -f /` | passthrough, `bypass_immune=False` | ask, `bypass_immune=True` |
| `sudo /bin/rm -r -f /` | passthrough, `bypass_immune=False` | ask, `bypass_immune=True` |
| `/bin/rm -r -f ~` | passthrough, `bypass_immune=False` | ask, `bypass_immune=True` |

`rm -rf /`, `rm -r -f /`, `rmdir /` and `sudo rm -rf /` are unchanged, and the existing
`test_safe_rm_commands_pass` cases still pass.

- New tests fail on `main` without the source change (9 subtest failures, all
  `PASSTHROUGH != ASK`) and pass with it.
- `pytest tests/builtin_bash_test.py` — 31 passed, 56 subtests passed.
- `pytest` over `builtin_bash_test.py` and every `permission_*_test.py` — 195 passed, 344 subtests
  passed.
- `pytest tests` — 2161 passed, 12 failed, 124 skipped. The 12 failures reproduce identically on
  unmodified `main` in this environment (`builtin_grep_test.py` needs a `rg` binary,
  `test_e2e_api.py` needs external services), so they are unrelated to this change.
- `pre-commit run --files src/agentscope/tool/_builtin/_bash.py tests/builtin_bash_test.py` — mypy,
  black, flake8, pylint and pyroma all pass.

Run on macOS with Python 3.12.13.

## Compatibility and risk

Low. The change only widens which subcommands reach an existing check, so its effect is to turn some
`PASSTHROUGH` decisions into the ASK that the equivalent literal `rm` spelling already produced. No
public API, signature or configuration change. A command that merely mentions `rm` as an argument is
unaffected, which the added lookalike test pins down.
