### PR TITLE
fix: correct misleading docstring in src/agentscope/__init__.py

### DIFF
--- a/src/agentscope/__init__.py
+++ b/src/agentscope/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""The agentscope serialization module"""
+"""The agentscope package."""
 import warnings
 
 from ._logging import (


### PR DESCRIPTION
## Summary

Fix misleading docstring in `src/agentscope/__init__.py`.

The package's main `__init__.py` had a docstring claiming it was "the agentscope serialization module", but the file only exports:

- `logger`, `setup_logger` (from `.\_logging`)
- `set_id_factory`, `set_timestamp_factory` (from `.\_utils._common`)
- `__version__`

There is no serialization functionality in this file (or anywhere in the package - I checked the entire `src/agentscope/` tree for any `*serial*` modules and found none).

## Why this matters

The misleading docstring appears in Sphinx-generated API documentation and editor tooltips, so it actively misleads users browsing the package reference. Correcting it to a neutral description is a no-risk doc fix.

## Change

```diff
- The agentscope serialization module
+ The agentscope package.
```

Single line, doc-only, no behavior change.

## Context

This was spotted while deep-reading the AgentScope source code as part of an 8-week focused study of the framework. The line clearly looks like a copy-paste leftover from a planned serialization module that was never added (or was renamed/removed) - but the docstring survived.
