### PR TITLE
fix: repair agent-facing prompt template text defects

### DIFF
--- a/src/agentscope/middleware/_longterm_memory/_agentic_memory/_middleware.py
+++ b/src/agentscope/middleware/_longterm_memory/_agentic_memory/_middleware.py
@@ -324,13 +324,13 @@ information that will be useful in future conversations.
 When looking for past context:
 1. Search topic files in your memory directory:
 ```
-Grep with pattern="<search>" path="{memory_dir}" glob="*.md"</search>
+Grep with pattern="<search>" path="{memory_dir}" glob="*.md"
 # or Bash command:
 grep -rn "<search term>" {memory_dir} --include="*.md"
 ```
 Use narrow search terms (error messages, file paths, function names) rather \
 than broad keywords.
-"""  # noqa:
+"""
 
 DEFAULT_RETRIEVAL_INSTRUCTIONS = (
     "You are selecting memory files that will be useful as context for "

--- a/src/agentscope/pipeline/_goal_pipeline.py
+++ b/src/agentscope/pipeline/_goal_pipeline.py
@@ -36,7 +36,7 @@ class _VerificationResult(BaseModel):
 
     result: Literal["pass", "fail", "impossible"] = Field(
         description=(
-            "The verfication result, which can be 'pass', 'fail', or "
+            "The verification result, which can be 'pass', 'fail', or "
             "'impossible'. 'impossible' means the given goal is impossible to "
             "achieve, and the executor should stop trying."
         ),

--- a/src/agentscope/workspace/_utils.py
+++ b/src/agentscope/workspace/_utils.py
@@ -74,6 +74,7 @@ personal environment, but treat credentials as if they could leak.
 project:
 ```shell
 uv venv && uv pip install ...
+```
 - Never install packages into a shared or global environment — each project \
 must manage its own dependencies to avoid conflicts.</workspace>"""
 


### PR DESCRIPTION
Fixes #2510

Four small text defects that reach the LLM/agent:

1. `DEFAULT_WORKSPACE_INSTRUCTIONS` (workspace/_utils.py) opened a \`\`\`shell fence it never closed — the final instruction bullet and the closing `</workspace>` tag rendered inside the code block in every LocalWorkspace system prompt.
2. The agentic-memory retrieval instructions (middleware/_longterm_memory/_agentic_memory/_middleware.py) had a dangling `</search>` close tag with no opener.
3. `GoalPipeline` verifier field description (pipeline/_goal_pipeline.py) misspelled 'verification' as 'verfication' — shipped to the LLM as a structured-output schema description.
4. Dropped the malformed trailing `# noqa:` (no codes) on the retrieval-instructions string; ruff emits an 'Invalid noqa directive' warning for it.

### Checklist
- [x] An issue has been created for this PR (#2510)
- [x] Commit message follows conventional format
- [x] Strings only; no behavioral code paths changed