### PR TITLE
fix(app): drain wakeup backlog completely on startup

### DIFF
--- a/src/agentscope/app/_manager/_wakeup_dispatcher.py
+++ b/src/agentscope/app/_manager/_wakeup_dispatcher.py
@@ -61,6 +61,10 @@ _RESUME_INPUT_ADAPTER: TypeAdapter = TypeAdapter(
 # to avoid a hot re-enqueue loop while the lock is held.
 _RESUME_RETRY_BACKOFF_SECS = 0.1
 
+# Keep each queue operation bounded while allowing startup to consume a
+# backlog over multiple calls.
+_WAKEUP_DRAIN_BATCH_SIZE = 64
+
 
 class WakeupDispatcher:
     """One asyncio task per process, draining the shared trigger queue.
@@ -127,7 +131,9 @@ class WakeupDispatcher:
             name="wakeup-dispatcher",
         )
         await ready.wait()
-        await self._drain_and_dispatch()
+        while True:
+            if not await self._drain_and_dispatch():
+                break
         return self
 
     async def __aexit__(self, *exc: object) -> None:
@@ -175,17 +181,23 @@ class WakeupDispatcher:
                 "WakeupDispatcher loop crashed; subscription ended.",
             )
 
-    async def _drain_and_dispatch(self) -> None:
-        """Read up to a batch of trigger entries and dispatch each."""
+    async def _drain_and_dispatch(self) -> bool:
+        """Read a batch of trigger entries and dispatch each.
+
+        Returns:
+            `bool`:
+                Whether the queue returned a full batch and may still have
+                more entries to drain.
+        """
         try:
             raw_entries = await self._bus.queue_drain(
                 MessageBusKeys.wakeup_queue(),
-                max_count=64,
+                max_count=_WAKEUP_DRAIN_BATCH_SIZE,
             )
             entries = [payload for _, payload in raw_entries]
         except Exception:  # pylint: disable=broad-except
             logger.exception("WakeupDispatcher: dequeue_wakeups failed.")
-            return
+            return False
 
         for payload in entries:
             try:
@@ -207,6 +219,8 @@ class WakeupDispatcher:
                 kind=kind,
                 raw_input=payload.get("input"),
             )
+
+        return len(raw_entries) == _WAKEUP_DRAIN_BATCH_SIZE
 
     async def _dispatch_one(
         self,

--- a/tests/service_wakeup_dispatcher_test.py
+++ b/tests/service_wakeup_dispatcher_test.py
@@ -302,6 +302,34 @@ class TestWakeupDispatcherDispatch(IsolatedAsyncioTestCase):
             ],
         )
 
+    async def test_initial_drain_consumes_backlog_beyond_batch_size(
+        self,
+    ) -> None:
+        """Startup drains every pending entry without a new signal."""
+        bus = _FakeBus()
+        chat = _FakeChatService()
+        queue_key = MessageBusKeys.wakeup_queue()
+        for index in range(65):
+            await bus.queue_push(
+                queue_key,
+                {
+                    "user_id": "u",
+                    "session_id": f"pre-{index}",
+                    "agent_id": "a",
+                },
+            )
+
+        async with WakeupDispatcher(
+            message_bus=bus,
+            storage=_FakeStorage(),
+            chat_service=chat,
+            chat_run_registry=ChatRunRegistry(),
+        ):
+            await _yield_a_few_times()
+
+        self.assertEqual(len(chat.calls), 65)
+        self.assertEqual(bus.queues[queue_key], [])
+
     async def test_active_session_not_spawned_while_locked(self) -> None:
         """While the target session holds its run lock, no chat run is
         spawned for it."""


### PR DESCRIPTION
Fixes #2514

## Summary

`WakeupDispatcher` previously performed only one queue drain when starting. Because each drain is capped at 64 entries, a durable backlog larger than 64 could leave entries stranded indefinitely when no new wakeup signal was published after startup.

## Changes

- Keep the queue operation bounded at 64 entries.
- Make the startup recovery path continue draining while it receives a full batch.
- Leave the normal signal-driven path unchanged: each signal still performs one bounded drain.
- Add a regression test with 65 pre-existing wakeup entries and no new signal.

The change is limited to the startup backlog behavior and does not alter the message-bus at-most-once contract or any public API.

## Validation

Targeted regression and existing dispatcher tests:

```text
10 passed in 4.61s  # Python 3.11
```

Changed-file pre-commit checks:

```text
AST, encoding, whitespace, trailing commas, mypy, Black, flake8,
pylint, and Pyroma: all passed
```

Real in-memory message-bus smoke test using `InMemoryMessageBus` and the production `WakeupDispatcher`:

```text
queued: 65
 dispatched: 65
 remaining: 0
```

The full test suite was also run under Python 3.11:

```text
2178 passed, 125 skipped, 11 failed, 388 subtests passed
```

The 11 failures were outside the changed files: five S3 blob-store tests failed while the local Moto server returned HTTP 502 during bucket creation, and six MCP SSE/streamable-HTTP tests failed in their test-service paths. The wakeup dispatcher tests and all changed-file checks passed.

## Checklist

- [x] An issue has been created for this PR: #2514
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation is not required for this internal bug fix
- [x] Code is ready for review

Thank you for reviewing this focused fix.