### PR TITLE
chore(model): use polymorphic block methods in count_tokens

### DIFF
--- a/src/agentscope/message/__init__.py
+++ b/src/agentscope/message/__init__.py
@@ -2,6 +2,7 @@
 """The message module in agentscope."""
 
 from ._block import (
+    BlockBase,
     ContentBlock,
     ContentBlockTypes,
     TextBlock,
@@ -19,6 +20,7 @@ from ._base import Msg, UserMsg, AssistantMsg, SystemMsg, Usage
 
 
 __all__ = [
+    "BlockBase",
     "TextBlock",
     "ThinkingBlock",
     "HintBlock",

--- a/src/agentscope/message/_block.py
+++ b/src/agentscope/message/_block.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """The content blocks of messages."""
+from abc import abstractmethod
 from enum import StrEnum
 from typing import Literal, List, TypeAlias, Any
 from pydantic import BaseModel, Field, AnyUrl, field_serializer, ConfigDict
@@ -8,7 +9,24 @@ from .._utils._common import _generate_id, _generate_timestamp
 from ..permission import PermissionRule
 
 
-class TextBlock(BaseModel):
+class BlockBase(BaseModel):
+    """Base class for all content blocks.
+
+    Defines the polymorphic contract used by ``ChatModelBase.count_tokens``
+    to flatten a block into its text segments and count its nested data
+    blocks.
+    """
+
+    @abstractmethod
+    def extract_text(self) -> list[str]:
+        """Return the text segments contributed by this block."""
+
+    @abstractmethod
+    def count_data_blocks(self) -> int:
+        """Return the number of data blocks nested in this block."""
+
+
+class TextBlock(BlockBase):
     """The text block."""
 
     type: Literal["text"] = "text"
@@ -22,8 +40,16 @@ class TextBlock(BaseModel):
     finished_at: str | None = None
     """The finished time of the block"""
 
+    def extract_text(self) -> list[str]:
+        """Return the text segments contributed by this block."""
+        return [self.text]
 
-class ThinkingBlock(BaseModel):
+    def count_data_blocks(self) -> int:
+        """Return the number of data blocks nested in this block."""
+        return 0
+
+
+class ThinkingBlock(BlockBase):
     """The thinking block.
 
     Allows extra provider-specific fields (e.g. Anthropic's ``signature``,
@@ -51,6 +77,14 @@ class ThinkingBlock(BaseModel):
     """The creation time of the block"""
     finished_at: str | None = None
     """The finished time of the block"""
+
+    def extract_text(self) -> list[str]:
+        """Return the text segments contributed by this block."""
+        return [self.thinking]
+
+    def count_data_blocks(self) -> int:
+        """Return the number of data blocks nested in this block."""
+        return 0
 
 
 class Base64Source(BaseModel):
@@ -80,7 +114,7 @@ class URLSource(BaseModel):
         return str(url)
 
 
-class DataBlock(BaseModel):
+class DataBlock(BlockBase):
     """The data block for binary content (images, audio, video, etc.)."""
 
     type: Literal["data"] = "data"
@@ -97,8 +131,16 @@ class DataBlock(BaseModel):
     finished_at: str | None = None
     """The finished time of the block"""
 
+    def extract_text(self) -> list[str]:
+        """Return the text segments contributed by this block."""
+        return []
 
-class HintBlock(BaseModel):
+    def count_data_blocks(self) -> int:
+        """Return the number of data blocks nested in this block."""
+        return 1
+
+
+class HintBlock(BlockBase):
     """A block used to provide instructions or hints to the LLM during the
     reasoning-acting loop. When passed to the LLM API, the hint block is
     converted into a user message.
@@ -124,6 +166,21 @@ class HintBlock(BaseModel):
     finished_at: str | None = Field(default_factory=_generate_timestamp)
     """The finished time of the block"""
 
+    def extract_text(self) -> list[str]:
+        """Return the text segments contributed by this block."""
+        if isinstance(self.hint, str):
+            return [self.hint]
+        texts: list[str] = []
+        for block in self.hint:
+            texts.extend(block.extract_text())
+        return texts
+
+    def count_data_blocks(self) -> int:
+        """Return the number of data blocks nested in this block."""
+        if isinstance(self.hint, str):
+            return 0
+        return sum(block.count_data_blocks() for block in self.hint)
+
 
 class ToolCallState(StrEnum):
     """The state of the tool call."""
@@ -135,7 +192,7 @@ class ToolCallState(StrEnum):
     FINISHED = "finished"
 
 
-class ToolCallBlock(BaseModel):
+class ToolCallBlock(BlockBase):
     """The tool call block."""
 
     model_config = ConfigDict(use_enum_values=True)
@@ -181,6 +238,14 @@ class ToolCallBlock(BaseModel):
     finished_at: str | None = None
     """The finished time of the block"""
 
+    def extract_text(self) -> list[str]:
+        """Return the text segments contributed by this block."""
+        return [self.input]
+
+    def count_data_blocks(self) -> int:
+        """Return the number of data blocks nested in this block."""
+        return 0
+
 
 class ToolResultState(StrEnum):
     """The tool result state."""
@@ -192,7 +257,7 @@ class ToolResultState(StrEnum):
     RUNNING = "running"
 
 
-class ToolResultBlock(BaseModel):
+class ToolResultBlock(BlockBase):
     """The tool result block."""
 
     model_config = ConfigDict(use_enum_values=True)
@@ -214,6 +279,21 @@ class ToolResultBlock(BaseModel):
     """The creation time of the block"""
     finished_at: str | None = None
     """The finished time of the block"""
+
+    def extract_text(self) -> list[str]:
+        """Return the text segments contributed by this block."""
+        if isinstance(self.output, str):
+            return [self.output]
+        texts: list[str] = []
+        for block in self.output:
+            texts.extend(block.extract_text())
+        return texts
+
+    def count_data_blocks(self) -> int:
+        """Return the number of data blocks nested in this block."""
+        if isinstance(self.output, str):
+            return 0
+        return sum(block.count_data_blocks() for block in self.output)
 
 
 ContentBlock: TypeAlias = (

--- a/src/agentscope/model/_base.py
+++ b/src/agentscope/model/_base.py
@@ -23,10 +23,6 @@ from ..message import (
     TextBlock,
     UserMsg,
     ToolCallBlock,
-    ThinkingBlock,
-    ToolResultBlock,
-    DataBlock,
-    HintBlock,
 )
 from ..tool import ToolChoice
 
@@ -394,50 +390,11 @@ class ChatModelBase:
         cnt = 0
 
         acc_texts = []
-        data_blocks = []
+        n_data_blocks = 0
         for msg in messages:
             for block in msg.get_content_blocks():
-                if isinstance(block, TextBlock):
-                    acc_texts.append(block.text)
-
-                elif isinstance(block, ThinkingBlock):
-                    acc_texts.append(block.thinking)
-
-                elif isinstance(block, HintBlock):
-                    # ``hint`` may be a plain string or a list of
-                    # ``TextBlock`` / ``DataBlock`` for multimodal
-                    # content; mirror the ``ToolResultBlock.output``
-                    # branching above.
-                    if isinstance(block.hint, str):
-                        acc_texts.append(block.hint)
-                    else:
-                        for item in block.hint:
-                            if isinstance(item, TextBlock):
-                                acc_texts.append(item.text)
-                            elif isinstance(item, DataBlock):
-                                data_blocks.append(item)
-
-                elif isinstance(block, ToolCallBlock):
-                    acc_texts.append(block.input)
-
-                elif isinstance(block, ToolResultBlock):
-                    if isinstance(block.output, str):
-                        acc_texts.append(block.output)
-                    elif isinstance(block.output, list):
-                        for item in block.output:
-                            if isinstance(item, TextBlock):
-                                acc_texts.append(item.text)
-                            elif isinstance(item, DataBlock):
-                                data_blocks.append(item)
-
-                elif isinstance(block, DataBlock):
-                    data_blocks.append(block)
-
-                else:
-                    logger.warning(
-                        "Unknown block type %s in token counting, skipping.",
-                        type(block),
-                    )
+                acc_texts.extend(block.extract_text())
+                n_data_blocks += block.count_data_blocks()
 
         # Count the tokens of the tool JSON schemas
         if tools:
@@ -446,7 +403,7 @@ class ChatModelBase:
         # Add the multimodal tokens. Binary payloads are not consumed by
         # multimodal models as base64 text, and file URLs should not count as
         # only a path string. Use a stable flat estimate for all DataBlocks.
-        cnt += len(data_blocks) * _MULTIMODAL_DATA_BLOCK_TOKEN_ESTIMATE
+        cnt += n_data_blocks * _MULTIMODAL_DATA_BLOCK_TOKEN_ESTIMATE
 
         # Count the text tokens
         acc_text = "".join(acc_texts)


### PR DESCRIPTION
## AgentScope Version

`2.0.8`

## Description

### Background

`ChatModelBase.count_tokens` used a long `isinstance` chain to walk every
content block, extract its text, and collect `DataBlock`s. The `str | list`
branching for `HintBlock.hint` and `ToolResultBlock.output` was duplicated,
and any future block type would force another edit to `count_tokens`.

### Changes

- Add two polymorphic methods to each content block (`TextBlock`,
  `ThinkingBlock`, `HintBlock`, `ToolCallBlock`, `ToolResultBlock`,
  `DataBlock`):
  - `extract_text() -> list[str]` — returns the text segments this block
    contributes.
  - `count_data_blocks() -> int` — returns the number of data blocks nested
    in this block.
- `HintBlock` and `ToolResultBlock` handle their own `str | list` field
  inline in these two methods.
- Rewrite `count_tokens` to call these methods instead of the `isinstance`
  chain. Since only the *count* of data blocks was used, it now accumulates
  an integer instead of materializing the full `data_blocks` list.

### How to test

```bash
pytest tests/model_count_tokens_test.py tests/message_test.py tests/model_base_test.py
Checklist
Please check the following items before code is ready to be reviewed.
- An issue has been created for this PR
- I have read the CONTRIBUTING.md (https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- Docstrings are in Google style
- Related documentation has been updated (e.g. links, examples, etc.) in documentation repository (https://github.com/agentscope-ai/docs)
- Code is ready for review