### PR TITLE
fix(app): clear inbox consumer on session delete

### DIFF
--- a/src/agentscope/app/_service/_session.py
+++ b/src/agentscope/app/_service/_session.py
@@ -658,6 +658,9 @@ class SessionService:
             MessageBusKeys.inbox(session_id),
         )
         await self._bus.registry_drop(
+            MessageBusKeys.inbox_consumer(session_id),
+        )
+        await self._bus.registry_drop(
             MessageBusKeys.bg_tasks(session_id),
         )
 

--- a/tests/service_inbox_handoff_test.py
+++ b/tests/service_inbox_handoff_test.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access
 """Tests for the session-inbox hand-off protocol in ``_bus_ops``.
 
 The protocol exists so a payload pushed to a session inbox is always
@@ -23,6 +24,7 @@ from agentscope.app._bus_ops import (
     has_pending_inbox_or_release,
     register_inbox_consumer,
 )
+from agentscope.app._service import SessionService
 from agentscope.app.message_bus import InMemoryMessageBus, MessageBusKeys
 
 
@@ -160,3 +162,15 @@ class TestInboxHandoff(IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(await self._wakeups(), [])
+
+    async def test_session_purge_releases_consumer_for_reused_id(self) -> None:
+        """Deleting a session must not suppress delivery to a reused ID."""
+        await register_inbox_consumer(self.bus, self.sid)
+        service = SessionService(storage=None, message_bus=self.bus)
+
+        await service._purge_session_bus(self.sid)
+        await self._deliver("after delete")
+
+        self.assertEqual(len(await self._wakeups()), 1)
+        entries = await self.bus.queue_drain(MessageBusKeys.inbox(self.sid))
+        self.assertEqual([p["hint"] for _i, p in entries], ["after delete"])


### PR DESCRIPTION
Fixes #2518

## Summary

- Remove the session's `inbox_consumer` marker when purging its bus state.
- Add a regression test for deleting a session, reusing the same explicit ID, and delivering a new inbox message.

Without this cleanup, a stale marker can suppress the wakeup for the reused session even though the message is successfully written to its inbox.

## Validation

- `uv run --project . --extra dev pytest tests/service_inbox_handoff_test.py tests/service_message_bus_test.py tests/in_memory_message_bus_test.py -q` — 81 passed.
- `uv run --project . --extra dev pre-commit run --all-files` — all hooks passed.
- The new regression test failed before the production change because no wakeup was emitted, and passes after the change.
- `uv run --project . --extra dev pytest tests -q` — no failures in the touched subsystem; the full run also reported 11 unrelated S3/MCP integration failures (Moto `CreateBucket` 502 responses and external MCP HTTP integration failures).