### PR TITLE
fix(channel): preserve wakeups for messages arriving during run finalization

### DIFF
--- a/src/agentscope/app/channel/_gateway.py
+++ b/src/agentscope/app/channel/_gateway.py
@@ -22,7 +22,7 @@ from ..._logging import logger
 from ...message import DataBlock, HintBlock, TextBlock, UserMsg
 from ...permission import PermissionContext, PermissionMode
 from ...state import AgentState
-from .._bus_ops import enqueue_run_trigger
+from .._bus_ops import deliver_to_inbox, enqueue_run_trigger
 from ..message_bus import MessageBus, MessageBusKeys
 from ..storage import (
     ChannelRecord,
@@ -205,9 +205,12 @@ class ChannelGateway:
         # A reply already in flight → inject the input as a hint so the
         # live run folds it in. Otherwise start a fresh user turn.
         if await self._bus.is_locked(MessageBusKeys.session_lock(session_id)):
-            await self._bus.queue_push(
-                MessageBusKeys.inbox(session_id),
-                HintBlock(
+            await deliver_to_inbox(
+                self._bus,
+                user_id=record.user_id,
+                session_id=session_id,
+                agent_id=agent_id,
+                payload=HintBlock(
                     hint=content,
                     source=json.dumps(
                         {

--- a/tests/channel_gateway_test.py
+++ b/tests/channel_gateway_test.py
@@ -8,10 +8,15 @@ needs a running agent and is exercised end-to-end against a real bot.
 """
 # pylint: disable=protected-access,missing-function-docstring,unused-argument
 # pylint: disable=attribute-defined-outside-init
+import asyncio
 from types import SimpleNamespace
 from typing import Any, AsyncIterator
 from unittest import IsolatedAsyncioTestCase
 
+from agentscope.app._bus_ops import (
+    has_pending_inbox_or_release,
+    register_inbox_consumer,
+)
 from agentscope.app.channel._base import (
     ChannelBase,
     ChannelConfirmationResultEvent,
@@ -19,6 +24,7 @@ from agentscope.app.channel._base import (
     _EVENT_ADAPTER,
 )
 from agentscope.app.channel._gateway import ChannelGateway
+from agentscope.app.channel._routing import resolve
 from agentscope.message import Msg, ToolCallBlock, ToolCallState
 from agentscope.state import AgentState
 from agentscope.app.message_bus import InMemoryMessageBus
@@ -336,6 +342,74 @@ def _channel_record(user_id: str) -> ChannelRecord:
             },
         ),
     )
+
+
+class _ChannelStorage:
+    """Return one channel record for the gateway hand-off test."""
+
+    def __init__(self, record: ChannelRecord) -> None:
+        self._record = record
+
+    async def get_channel(self, channel_id: str) -> ChannelRecord:
+        del channel_id
+        return self._record
+
+
+class _PausedSessionCheckBus(InMemoryMessageBus):
+    """Pause the gateway after it observes the active session lock."""
+
+    def __init__(self, lock_key: str) -> None:
+        super().__init__()
+        self._lock_key = lock_key
+        self.checked = asyncio.Event()
+        self.resume = asyncio.Event()
+
+    async def is_locked(self, key: str) -> bool:
+        locked = await super().is_locked(key)
+        if key == self._lock_key:
+            self.checked.set()
+            await self.resume.wait()
+        return locked
+
+
+class ChannelInboxHandoffTest(IsolatedAsyncioTestCase):
+    """Channel hints must use the session inbox hand-off protocol."""
+
+    async def test_late_channel_message_enqueues_wakeup(self) -> None:
+        """A message after the final consumer check cannot be stranded."""
+        record = _channel_record("user-1")
+        event = ChannelEvent(
+            channel_id="chan-1",
+            channel_user_id="member-1",
+            chat_id="chat-1",
+            content=[TextBlock(text="late message")],
+        )
+        _agent_id, session_id, _scope = resolve(event, record)
+        bus = _PausedSessionCheckBus(
+            MessageBusKeys.session_lock(session_id),
+        )
+        gateway = ChannelGateway(
+            storage=_ChannelStorage(record),
+            message_bus=bus,
+            workspace_manager=_WM(isolation=IsolationPolicy.PER_AGENT),
+        )
+
+        await register_inbox_consumer(bus, session_id)
+        async with bus.acquire_lock(
+            MessageBusKeys.session_lock(session_id),
+        ):
+            message_task = asyncio.create_task(gateway.process(event))
+            await asyncio.wait_for(bus.checked.wait(), timeout=2)
+
+            self.assertFalse(
+                await has_pending_inbox_or_release(bus, session_id),
+            )
+            bus.resume.set()
+            await asyncio.wait_for(message_task, timeout=2)
+
+        wakeups = await bus.queue_drain(MessageBusKeys.wakeup_queue())
+        self.assertEqual(len(wakeups), 1)
+        self.assertEqual(wakeups[0][1]["session_id"], session_id)
 
 
 class WorkspaceIsolationTest(IsolatedAsyncioTestCase):

--- a/tests/channel_gateway_test.py
+++ b/tests/channel_gateway_test.py
@@ -409,7 +409,21 @@ class ChannelInboxHandoffTest(IsolatedAsyncioTestCase):
 
         wakeups = await bus.queue_drain(MessageBusKeys.wakeup_queue())
         self.assertEqual(len(wakeups), 1)
-        self.assertEqual(wakeups[0][1]["session_id"], session_id)
+        self.assertDictEqual(
+            wakeups[0][1],
+            {
+                "user_id": "user-1",
+                "session_id": session_id,
+                "agent_id": "agent-x",
+                "kind": MessageBusKeys.WAKEUP_KIND_WAKE,
+                "input": None,
+            },
+        )
+
+        inbox = await bus.queue_drain(MessageBusKeys.inbox(session_id))
+        self.assertEqual(len(inbox), 1)
+        self.assertEqual(inbox[0][1]["type"], "hint")
+        self.assertEqual(inbox[0][1]["hint"][0]["text"], "late message")
 
 
 class WorkspaceIsolationTest(IsolatedAsyncioTestCase):

--- a/tests/channel_gateway_test.py
+++ b/tests/channel_gateway_test.py
@@ -13,6 +13,8 @@ from types import SimpleNamespace
 from typing import Any, AsyncIterator
 from unittest import IsolatedAsyncioTestCase
 
+from utils import AnyString
+
 from agentscope.app._bus_ops import (
     has_pending_inbox_or_release,
     register_inbox_consumer,
@@ -421,9 +423,27 @@ class ChannelInboxHandoffTest(IsolatedAsyncioTestCase):
         )
 
         inbox = await bus.queue_drain(MessageBusKeys.inbox(session_id))
-        self.assertEqual(len(inbox), 1)
-        self.assertEqual(inbox[0][1]["type"], "hint")
-        self.assertEqual(inbox[0][1]["hint"][0]["text"], "late message")
+        self.assertListEqual(
+            [payload for _entry_id, payload in inbox],
+            [
+                {
+                    "type": "hint",
+                    "hint": [
+                        {
+                            "type": "text",
+                            "text": "late message",
+                            "id": AnyString(),
+                            "created_at": AnyString(),
+                            "finished_at": None,
+                        },
+                    ],
+                    "id": AnyString(),
+                    "source": '{"label": "channel", "sublabel": "member-1"}',
+                    "created_at": AnyString(),
+                    "finished_at": AnyString(),
+                },
+            ],
+        )
 
 
 class WorkspaceIsolationTest(IsolatedAsyncioTestCase):


### PR DESCRIPTION
Fixes #2520

## Summary

`ChannelGateway` used to push hints directly to a running session's inbox after checking `session_lock`. That bypassed the inbox hand-off protocol used by `ChatService` and could leave a channel message queued without a wakeup when it arrived after the run's final inbox check.

## Changes

- Route active-run Channel hints through `deliver_to_inbox()`.
- Add a deterministic regression test through the public `ChannelGateway.process()` path.
- Assert the wakeup payload and serialized inbox hint remain compatible with the existing protocol.

The change does not alter public APIs or the Channel message format.

## Validation

- Focused Channel/inbox tests: `47 passed`.
- Final regression and hand-off tests after review: `8 passed`.
- Full pre-commit suite: passed, including AST, mypy, Black, Flake8, Pylint, and Pyroma.
- Full test suite: `2178 passed, 125 skipped, 11 failed`.
  The 11 failures are existing environment-dependent failures: five S3 Moto tests received HTTP 502 during bucket creation, and six MCP SSE/streamable-HTTP tests could not complete their test-service paths.
- Production `RedisMessageBus` backed by fakeredis smoke test:

```text
PUBLIC_PROCESS_PENDING_AT_FINAL_CHECK=False
INBOX_ENTRIES=1
DURABLE_WAKEUP_ENTRIES=1
WAKEUP_SESSION_ID_MATCH=True
```

This is intentionally limited to the missing producer hand-off; no unrelated refactor is included.
