### PR TITLE
fix(rag): prevent deleted documents from being reinserted during indexing

### DIFF
--- a/examples/web_ui/frontend/src/api/types.ts
+++ b/examples/web_ui/frontend/src/api/types.ts
@@ -949,6 +949,8 @@ export interface UpdateKnowledgeBaseRequest {
  *
  * - `pending` — accepted, blob stored, indexing not yet started.
  * - `parsing` / `chunking` / `indexing` — worker phases.
+ * - `deleting` — deletion is in progress; the record is fenced from
+ *   further indexing writes.
  * - `ready` — chunks committed to the vector store.
  * - `error` — terminal failure; `error` field carries the reason.
  */
@@ -957,6 +959,7 @@ export type KnowledgeDocumentStatus =
 	| 'parsing'
 	| 'chunking'
 	| 'indexing'
+	| 'deleting'
 	| 'ready'
 	| 'error';
 

--- a/examples/web_ui/frontend/src/i18n/locales/en.json
+++ b/examples/web_ui/frontend/src/i18n/locales/en.json
@@ -378,6 +378,7 @@
 				"parsing": "Parsing",
 				"chunking": "Chunking",
 				"indexing": "Indexing",
+				"deleting": "Deleting",
 				"ready": "Ready",
 				"error": "Error",
 				"cancelled": "Cancelled"

--- a/examples/web_ui/frontend/src/i18n/locales/zh.json
+++ b/examples/web_ui/frontend/src/i18n/locales/zh.json
@@ -378,6 +378,7 @@
 				"parsing": "解析中",
 				"chunking": "分块中",
 				"indexing": "建立索引",
+				"deleting": "删除中",
 				"ready": "已就绪",
 				"error": "失败",
 				"cancelled": "已取消"

--- a/src/agentscope/app/_router/_knowledge_base.py
+++ b/src/agentscope/app/_router/_knowledge_base.py
@@ -478,7 +478,7 @@ async def list_knowledge_documents(
     | None = Query(
         default=None,
         alias="status",
-        pattern="^(pending|parsing|chunking|indexing|ready|error)$",
+        pattern="^(pending|parsing|chunking|indexing|deleting|ready|error)$",
         description="Filter by indexing status.",
     ),
     page: int = Query(default=1, ge=1, description="1-based page number."),
@@ -495,7 +495,8 @@ async def list_knowledge_documents(
 
     Reads from the storage backend (service-mode source of truth), so
     documents in any lifecycle state — including ``pending`` /
-    ``parsing`` / ``error`` — are returned alongside ``ready`` ones.
+    ``parsing`` / ``deleting`` / ``error`` — are returned alongside
+    ``ready`` ones.
 
     Args:
         knowledge_base_id (`str`):

--- a/src/agentscope/app/_service/_index_worker.py
+++ b/src/agentscope/app/_service/_index_worker.py
@@ -361,6 +361,12 @@ class IndexWorker:
                 document_id,
             )
             return
+        if record.status == "deleting":
+            logger.debug(
+                "Skipping %s — deletion is already in progress.",
+                document_id,
+            )
+            return
 
         kb_record = await self._manager.get_knowledge_base(
             user_id,
@@ -399,6 +405,17 @@ class IndexWorker:
         file_bytes = await self._read_blob(data.blob_uri)
         sections = await self._parse(parser, file_bytes, data.filename)
 
+        # A delete can arrive while parsing is in progress. Re-read the
+        # record before doing more work so a stale parser result never
+        # reaches the vector store.
+        record = await self._storage.get_knowledge_document(
+            user_id,
+            knowledge_base_id,
+            document_id,
+        )
+        if record is None or record.status == "deleting":
+            return
+
         # ---- chunking ----
         await self._storage.update_knowledge_document_status(
             user_id,
@@ -415,6 +432,13 @@ class IndexWorker:
             document_id,
             "indexing",
         )
+        record = await self._storage.get_knowledge_document(
+            user_id,
+            knowledge_base_id,
+            document_id,
+        )
+        if record is None or record.status == "deleting":
+            return
         knowledge = await self._manager.get_knowledge(
             user_id,
             knowledge_base_id,
@@ -441,6 +465,18 @@ class IndexWorker:
                 "size_bytes": data.size,
             },
         )
+
+        # The delete path removes vectors before deleting the storage
+        # record. If it crossed the insert above, clean up the stale
+        # write before allowing the worker to finish.
+        record = await self._storage.get_knowledge_document(
+            user_id,
+            knowledge_base_id,
+            document_id,
+        )
+        if record is None or record.status == "deleting":
+            await knowledge.delete_document(document_id)
+            return
 
         # ---- ready ----
         await self._storage.update_knowledge_document_status(

--- a/src/agentscope/app/_service/_knowledge_base.py
+++ b/src/agentscope/app/_service/_knowledge_base.py
@@ -460,8 +460,8 @@ class KnowledgeBaseService:
 
         Service-mode source of truth: reads from storage, NOT the
         vector store.  Documents in ``pending`` / ``parsing`` /
-        ``chunking`` / ``indexing`` / ``error`` show up here even
-        though they have no chunks in the vector store yet.
+        ``chunking`` / ``indexing`` / ``deleting`` / ``error`` show up
+        here even though they have no chunks in the vector store yet.
 
         Args:
             user_id (`str`):
@@ -475,7 +475,8 @@ class KnowledgeBaseService:
                 Case-insensitive substring filter on the filename.
             doc_status (`str | None`, optional):
                 Filter by indexing status (``pending`` / ``parsing`` /
-                ``chunking`` / ``indexing`` / ``ready`` / ``error``).
+                ``chunking`` / ``indexing`` / ``deleting`` / ``ready`` /
+                ``error``).
             page (`int`, defaults to ``1``):
                 1-based page number.
             page_size (`int`, defaults to ``30``):
@@ -756,16 +757,18 @@ class KnowledgeBaseService:
         Order is chosen so that a crash mid-way always leaves a
         recoverable state:
 
-        1. Vector store delete (idempotent — re-deleting an already
+        1. Mark the storage record ``deleting``.  This fences any
+           already-running indexing worker from publishing new vectors.
+        2. Vector store delete (idempotent — re-deleting an already
            empty document_id is harmless).
-        2. Storage record delete.
-        3. Blob delete (idempotent).
+        3. Storage record delete.
+        4. Blob delete (idempotent).
 
-        A failure at step 1 surfaces as an exception to the caller and
-        the record + blob are left untouched, so a retry sees the same
-        state.  Failures at steps 2/3 leave a small amount of orphan
-        data but the user-visible deletion has already succeeded from
-        the vector store's point of view.
+        A failure at step 2 surfaces as an exception to the caller and
+        the ``deleting`` record + blob are left untouched, so a retry
+        can finish the cleanup.  Failures at steps 3/4 leave a small
+        amount of orphan data but the user-visible deletion has already
+        succeeded from the vector store's point of view.
 
         Args:
             user_id (`str`):
@@ -791,6 +794,12 @@ class KnowledgeBaseService:
             # document is already gone.
             return
 
+        await self._storage.update_knowledge_document_status(
+            owner_id,
+            knowledge_base_id,
+            document_id,
+            "deleting",
+        )
         knowledge = await self._resolve_knowledge(user_id, knowledge_base_id)
         await knowledge.delete_document(document_id)
         await self._storage.delete_knowledge_document(

--- a/src/agentscope/app/storage/_base.py
+++ b/src/agentscope/app/storage/_base.py
@@ -1086,9 +1086,12 @@ class StorageBase(ABC):
 
         Used by the indexing worker as it walks the lifecycle
         transitions (``parsing`` → ``chunking`` → ``indexing`` →
-        ``ready`` / ``error``).  Cheaper than a full upsert and avoids
-        races with concurrent lease writes by touching only the status
-        / error / chunk_count fields.
+        ``ready`` / ``error``).  ``deleting`` is a terminal marker used
+        by the delete path to fence an already-running worker.  Once a
+        record is marked ``deleting``, later worker-owned transitions
+        must be ignored.  Cheaper than a full upsert and avoids races
+        with concurrent lease writes by touching only the status / error
+        / chunk_count fields.
 
         Args:
             user_id (`str`):
@@ -1228,7 +1231,8 @@ class StorageBase(ABC):
 
         Scans every user / knowledge base — used by the sweeper, not
         by user-facing endpoints.  A document is "expired" when
-        ``data.status`` is not terminal (``ready`` / ``error``),
+        ``data.status`` is not terminal (``deleting`` / ``ready`` /
+        ``error``),
         ``processing_node`` is set, and ``data.lease_expires_at`` is
         in the past.  Implementations are free to skip records that
         match no work and return an unspecified order.

--- a/src/agentscope/app/storage/_model/_knowledge_document.py
+++ b/src/agentscope/app/storage/_model/_knowledge_document.py
@@ -29,14 +29,18 @@ KnowledgeDocumentStatus = Literal[
     "parsing",
     "chunking",
     "indexing",
+    "deleting",
     "ready",
     "error",
 ]
-# The six lifecycle states of a knowledge document.
+# The seven lifecycle states of a knowledge document.
 #
 # ``pending`` — bytes are in the blob store, waiting for a worker to
 # pick the document up. ``parsing`` / ``chunking`` / ``indexing`` are
-# worker-owned transitions; ``ready`` and ``error`` are terminal.
+# worker-owned transitions. ``deleting`` is a terminal marker written
+# before cleanup so a worker that already read the record cannot publish
+# vectors after the user has requested deletion. ``ready`` and ``error``
+# are also terminal.
 
 
 class KnowledgeDocumentData(BaseModel):

--- a/src/agentscope/app/storage/_redis_storage.py
+++ b/src/agentscope/app/storage/_redis_storage.py
@@ -2094,23 +2094,38 @@ class RedisStorage(StorageBase):
     ) -> None:
         """Update only the status-related fields of a document record.
 
-        Reads the record, mutates the status fields in memory, and
-        writes it back.  Not atomic across multiple writers — relies
-        on the indexing worker holding the lease, which serialises
-        status transitions for a single document.
+        Reads and writes the record under a Redis WATCH.  The delete
+        path uses the terminal ``deleting`` state as a fence: a worker
+        that already loaded the record must not overwrite that marker
+        with a later lifecycle transition.
         """
         key = self._document_key(user_id, knowledge_base_id, document_id)
-        raw = await self._client.get(key)
-        if not raw:
-            return
-        record = KnowledgeDocumentRecord.model_validate_json(raw)
-        record.status = status
-        if error is not None:
-            record.data.error = error
-        if chunk_count is not None:
-            record.data.chunk_count = chunk_count
-        record.updated_at = datetime.now()
-        await self._set_with_ttl(key, record.model_dump_json())
+        async with self._client.pipeline(transaction=True) as pipe:
+            for _ in range(3):
+                try:
+                    await pipe.watch(key)
+                    raw = await pipe.get(key)
+                    if not raw:
+                        await pipe.unwatch()
+                        return
+                    record = KnowledgeDocumentRecord.model_validate_json(raw)
+                    if record.status == "deleting" and status != "deleting":
+                        await pipe.unwatch()
+                        return
+                    record.status = status
+                    if error is not None:
+                        record.data.error = error
+                    if chunk_count is not None:
+                        record.data.chunk_count = chunk_count
+                    record.updated_at = datetime.now()
+                    pipe.multi()
+                    pipe.set(key, record.model_dump_json())
+                    if self.key_ttl is not None:
+                        pipe.expire(key, self.key_ttl)
+                    await pipe.execute()
+                    return
+                except _watch_error():
+                    continue
 
     async def acquire_knowledge_document_lease(
         self,
@@ -2147,6 +2162,9 @@ class RedisStorage(StorageBase):
                         await pipe.unwatch()
                         return False
                     record = KnowledgeDocumentRecord.model_validate_json(raw)
+                    if record.status == "deleting":
+                        await pipe.unwatch()
+                        return False
                     holder = record.processing_node
                     deadline = record.lease_expires_at
                     if (
@@ -2265,7 +2283,7 @@ class RedisStorage(StorageBase):
         cares about the small subset of non-terminal documents.
         """
         now = now or datetime.now()
-        terminal = {"ready", "error"}
+        terminal = {"deleting", "ready", "error"}
         tokens = await self._client.smembers(
             self.key_config.knowledge_document_global_index,
         )

--- a/src/agentscope/app/storage/_sql/_storage.py
+++ b/src/agentscope/app/storage/_sql/_storage.py
@@ -1865,10 +1865,14 @@ class AsyncSQLAlchemyStorage(StorageBase):
         """Fast-path column UPDATE + optional payload rewrite.
 
         ``status`` is a column so it can always be updated with a
-        single ``UPDATE``; ``error`` / ``chunk_count`` live inside
-        :attr:`~KnowledgeDocumentRecord.data` (payload) and therefore
-        require the classic read-modify-write when they change.
+        single conditional ``UPDATE``; ``error`` / ``chunk_count`` live
+        inside :attr:`~KnowledgeDocumentRecord.data` (payload) and
+        therefore require the classic read-modify-write when they
+        change.  The condition prevents a worker transition from
+        overwriting the terminal ``deleting`` fence.
         """
+        from sqlalchemy import update
+
         async with self._session() as sess:
             row = await sess.get(KnowledgeDocumentRow, document_id)
             if (
@@ -1885,9 +1889,22 @@ class AsyncSQLAlchemyStorage(StorageBase):
                 record.data.chunk_count = chunk_count
             record.updated_at = _utcnow()
             new_row = _from_record(KnowledgeDocumentRow, record)
-            row.status = new_row.status
-            row.payload = new_row.payload
-            row.updated_at = new_row.updated_at
+            conditions = [
+                KnowledgeDocumentRow.id == document_id,
+                KnowledgeDocumentRow.user_id == user_id,
+                KnowledgeDocumentRow.knowledge_base_id == knowledge_base_id,
+            ]
+            if status != "deleting":
+                conditions.append(KnowledgeDocumentRow.status != "deleting")
+            await sess.execute(
+                update(KnowledgeDocumentRow)
+                .where(*conditions)
+                .values(
+                    status=new_row.status,
+                    payload=new_row.payload,
+                    updated_at=new_row.updated_at,
+                ),
+            )
             await sess.commit()
 
     async def acquire_knowledge_document_lease(
@@ -1913,6 +1930,7 @@ class AsyncSQLAlchemyStorage(StorageBase):
                     KnowledgeDocumentRow.user_id == user_id,
                     KnowledgeDocumentRow.knowledge_base_id
                     == knowledge_base_id,
+                    KnowledgeDocumentRow.status != "deleting",
                     or_(
                         KnowledgeDocumentRow.processing_node.is_(None),
                         KnowledgeDocumentRow.lease_expires_at.is_(None),
@@ -1995,7 +2013,7 @@ class AsyncSQLAlchemyStorage(StorageBase):
         from sqlalchemy import select
 
         now = _to_naive_utc(now) if now is not None else _utcnow()
-        terminal = ("ready", "error")
+        terminal = ("deleting", "ready", "error")
         async with self._session() as sess:
             rows = (
                 (

--- a/tests/service_knowledge_base_upload_test.py
+++ b/tests/service_knowledge_base_upload_test.py
@@ -16,6 +16,7 @@ delete flow through ``TestClient``.  Verifies that:
 * delete tears down the vector-store and storage records together.
 """
 import asyncio
+import io
 import tempfile
 from typing import Any
 from unittest.async_case import IsolatedAsyncioTestCase
@@ -24,6 +25,7 @@ import fakeredis.aioredis
 from fastapi.testclient import TestClient
 
 from agentscope.app import create_app
+from agentscope.app._service import IndexWorker
 from agentscope.app.rag.blob_store import LocalBlobStore
 from agentscope.app.rag.knowledge_base_manager import (
     KnowledgeBaseManagerBase,
@@ -42,7 +44,8 @@ from agentscope.app.storage import (
     RedisStorage,
 )
 from agentscope.app.workspace_manager._base import WorkspaceManagerBase
-from agentscope.rag import VectorStoreBase
+from agentscope.message import TextBlock
+from agentscope.rag import ParserBase, Section, VectorStoreBase
 from agentscope.rag._vdb._vector_store import (
     DocumentSummary,
     VectorRecord,
@@ -53,6 +56,31 @@ from agentscope.rag._vdb._vector_store import (
 # ----------------------------------------------------------------------
 # Test doubles
 # ----------------------------------------------------------------------
+
+
+class _BlockingTextParser(ParserBase):
+    """Pause parsing so a test can delete the document mid-pipeline."""
+
+    supported_media_types = ["text/plain"]
+
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def parse(
+        self,
+        file: bytes | str,
+        filename: str,
+    ) -> list[Section]:
+        self.started.set()
+        await self.release.wait()
+        text = file.decode() if isinstance(file, bytes) else file
+        return [
+            Section(
+                content=TextBlock(text=text),
+                source=filename,
+            ),
+        ]
 
 
 class _FakeVectorStore(VectorStoreBase):
@@ -499,3 +527,58 @@ class KnowledgeBaseUploadFlowTest(IsolatedAsyncioTestCase):
             )
             self.assertEqual(resp.status_code, 200, resp.text)
             self.assertEqual(resp.json()["items"], [])
+
+    async def test_delete_during_indexing_does_not_reinsert_vectors(
+        self,
+    ) -> None:
+        """A deleted document must not be written by a stale worker."""
+        parser = _BlockingTextParser()
+        app = create_app(
+            storage=self._app.state.storage,
+            message_bus=self._app.state.message_bus,
+            workspace_manager=self._app.state.workspace_manager,
+            knowledge_base_manager=self._app.state.knowledge_base_manager,
+            blob_store=self._app.state.blob_store,
+            knowledge_parsers=[parser],
+            enable_index_worker=False,
+        )
+
+        async with app.router.lifespan_context(app):
+            service = app.state.knowledge_base_service
+            record = await service.register_document(
+                user_id="user-1",
+                knowledge_base_id=self._kb_id,
+                filename="deleted-during-indexing.txt",
+                stream=io.BytesIO(b"document contents"),
+                size=len(b"document contents"),
+                content_type="text/plain",
+            )
+            worker = IndexWorker(
+                storage=app.state.storage,
+                blob_store=app.state.blob_store,
+                knowledge_base_manager=app.state.knowledge_base_manager,
+                parsers=app.state.knowledge_parsers,
+                node_id="test-worker",
+            )
+            worker_task = asyncio.create_task(
+                worker.process("user-1", self._kb_id, record.id),
+            )
+
+            await asyncio.wait_for(parser.started.wait(), timeout=2)
+            await service.delete_document(
+                user_id="user-1",
+                knowledge_base_id=self._kb_id,
+                document_id=record.id,
+            )
+            parser.release.set()
+            await worker_task
+
+            collection = f"kb_{self._kb_id}"
+            remaining = [
+                vector_record
+                for vector_record in self._vector_store._collections[
+                    collection
+                ]
+                if vector_record.document_id == record.id
+            ]
+            self.assertEqual(remaining, [])

--- a/tests/storage_redis_knowledge_base_test.py
+++ b/tests/storage_redis_knowledge_base_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=protected-access
 """Unit tests for the knowledge base persistence layer of RedisStorage."""
+from datetime import timedelta
 from unittest.async_case import IsolatedAsyncioTestCase
 
 import fakeredis.aioredis
@@ -9,6 +10,8 @@ from agentscope.app.storage import (
     EmbeddingModelConfig,
     KnowledgeBaseData,
     KnowledgeBaseRecord,
+    KnowledgeDocumentData,
+    KnowledgeDocumentRecord,
     RedisStorage,
 )
 
@@ -98,6 +101,52 @@ class KnowledgeBaseStorageTest(IsolatedAsyncioTestCase):
         rec = make_record("user-1")
         with self.assertRaises(ValueError):
             await storage.upsert_knowledge_base("user-2", rec)
+
+    async def test_deleting_status_fences_stale_worker_updates(self) -> None:
+        """Deletion markers survive worker updates and lease retries."""
+        storage = make_storage()
+        kb = make_record("user-1")
+        await storage.upsert_knowledge_base("user-1", kb)
+        document = KnowledgeDocumentRecord(
+            user_id="user-1",
+            knowledge_base_id=kb.id,
+            data=KnowledgeDocumentData(
+                filename="document.txt",
+                size=1,
+                blob_uri="local://document",
+            ),
+        )
+        await storage.upsert_knowledge_document("user-1", document)
+
+        await storage.update_knowledge_document_status(
+            "user-1",
+            kb.id,
+            document.id,
+            "deleting",
+        )
+        await storage.update_knowledge_document_status(
+            "user-1",
+            kb.id,
+            document.id,
+            "ready",
+            chunk_count=3,
+        )
+        fetched = await storage.get_knowledge_document(
+            "user-1",
+            kb.id,
+            document.id,
+        )
+        self.assertEqual(fetched.status, "deleting")
+        self.assertEqual(fetched.data.chunk_count, 0)
+        self.assertFalse(
+            await storage.acquire_knowledge_document_lease(
+                "user-1",
+                kb.id,
+                document.id,
+                "worker-A",
+                timedelta(minutes=5),
+            ),
+        )
 
     async def test_upsert_overwrites_and_preserves_created_at(self) -> None:
         """Re-upsert with same id keeps created_at, refreshes updated_at."""

--- a/tests/storage_sql_test.py
+++ b/tests/storage_sql_test.py
@@ -743,6 +743,38 @@ class AsyncSQLAlchemyStorageTest(IsolatedAsyncioTestCase):
         self.assertIsNone(fetched.processing_node)
         self.assertIsNone(fetched.lease_expires_at)
 
+        # Deletion is a terminal fence: stale worker transitions must not
+        # resurrect the record, and no new worker may acquire its lease.
+        await self.storage.update_knowledge_document_status(
+            "user-1",
+            kb.id,
+            doc.id,
+            "deleting",
+        )
+        await self.storage.update_knowledge_document_status(
+            "user-1",
+            kb.id,
+            doc.id,
+            "ready",
+            chunk_count=3,
+        )
+        fetched = await self.storage.get_knowledge_document(
+            "user-1",
+            kb.id,
+            doc.id,
+        )
+        self.assertEqual(fetched.status, "deleting")
+        self.assertEqual(fetched.data.chunk_count, 0)
+        self.assertFalse(
+            await self.storage.acquire_knowledge_document_lease(
+                "user-1",
+                kb.id,
+                doc.id,
+                "worker-C",
+                timedelta(minutes=5),
+            ),
+        )
+
     async def test_expired_lease_and_pending_sweep(self) -> None:
         """``list_..._with_expired_lease`` + ``..._pending_since`` filters."""
         kb = _kb_record("user-1")


### PR DESCRIPTION
## Summary

Fixes a race where deleting a document while its asynchronous indexing worker is parsing or chunking could leave the deleted document reinserted into the vector store.

`KnowledgeBaseService.delete_document` now marks the storage record as `deleting` before vector cleanup. Redis and SQL status/lease paths treat that marker as terminal and prevent stale worker transitions from overwriting it. `IndexWorker` rechecks the record before indexing and removes any vector write that crosses deletion. The public status filter and frontend types/locales also recognize the transient state.

## Reproduction

A production-shaped test pauses a parser, deletes the document, releases the parser, and waits for the worker. Before this change, the worker inserted a vector for the deleted document; after this change, the vector store and storage record are both empty.

## Validation

- `pre-commit run --all-files`
- `pytest tests/service_knowledge_base_upload_test.py tests/storage_redis_knowledge_base_test.py tests/storage_sql_test.py tests/index_worker_lease_test.py -q` — 40 passed
- `pytest tests` — 2179 passed, 125 skipped; the 11 failures are the existing Moto S3 502 and external MCP service connectivity failures
- Real `QdrantStore(location=":memory:")` with the production service and worker — `QDRANT_REMAINING []`, `STORAGE_RECORD None`

Fixes #2523
