### PR TITLE
fix(channel): restore Discord tool approval buttons after direct reply delivery

### DIFF
--- a/src/agentscope/app/channel/_discord/_approval.py
+++ b/src/agentscope/app/channel/_discord/_approval.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""Discord tool-approval button ``custom_id`` helpers.
+
+Approval cards are sent by REST-only channel instances while component
+interactions arrive on the gateway-connected client. Explicit
+``custom_id`` values on the buttons plus parsing here let the listener
+resume the correct run without sharing a :class:`discord.Client` view
+store with the sender.
+"""
+import base64
+import json
+
+_PREFIX = "asco:"
+# Discord caps ``custom_id`` at 100 characters.
+_MAX_CUSTOM_ID_LEN = 100
+
+
+def _approval_custom_id(
+    approved: bool,
+    tool_call_id: str,
+    agent_id: str = "",
+    session_id: str = "",
+) -> str:
+    """Build a ``custom_id`` for an approval or deny button.
+
+    Args:
+        approved (`bool`): ``True`` for approve, ``False`` for deny.
+        tool_call_id (`str`): The awaiting tool call the button answers.
+        agent_id (`str`): Target agent pinned at send time.
+        session_id (`str`): Target session pinned at send time.
+
+    Returns:
+        `str`: A ``custom_id`` within Discord's length limit.
+
+    Raises:
+        ValueError: When the payload cannot be encoded within the limit.
+    """
+    payload = {
+        "a": approved,
+        "t": tool_call_id,
+        "g": agent_id,
+        "s": session_id,
+    }
+    for keys in (("t", "g", "s"), ("t", "s"), ("t",)):
+        body = {key: payload[key] for key in keys}
+        body["a"] = approved
+        encoded = base64.urlsafe_b64encode(
+            json.dumps(body, separators=(",", ":")).encode(),
+        ).decode().rstrip("=")
+        custom_id = f"{_PREFIX}{encoded}"
+        if len(custom_id) <= _MAX_CUSTOM_ID_LEN:
+            return custom_id
+    raise ValueError(
+        "Discord approval custom_id exceeds the platform limit",
+    )
+
+
+def _parse_approval_custom_id(
+    custom_id: str | None,
+) -> tuple[str, bool, str, str] | None:
+    """Parse a button ``custom_id`` into approval metadata.
+
+    Args:
+        custom_id (`str | None`): The clicked button's ``custom_id``.
+
+    Returns:
+        `tuple[str, bool, str, str] | None`:
+        ``(tool_call_id, approved, agent_id, session_id)`` for our
+        buttons, or ``None`` when the id is missing or not ours.
+    """
+    if not custom_id or not custom_id.startswith(_PREFIX):
+        return None
+    encoded = custom_id[len(_PREFIX) :]
+    pad = (-len(encoded)) % 4
+    try:
+        body = json.loads(
+            base64.urlsafe_b64decode(encoded + ("=" * pad)).decode(),
+        )
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+        return None
+    if not isinstance(body, dict):
+        return None
+    tool_call_id = str(body.get("t") or "").strip()
+    if not tool_call_id:
+        return None
+    approved = bool(body.get("a"))
+    agent_id = str(body.get("g") or "").strip()
+    session_id = str(body.get("s") or "").strip()
+    return tool_call_id, approved, agent_id, session_id

--- a/src/agentscope/app/channel/_discord/_channel.py
+++ b/src/agentscope/app/channel/_discord/_channel.py
@@ -2,10 +2,12 @@
 """Discord channel (discord.py, gateway WebSocket).
 
 discord.py is async-native and runs on the app event loop, so — unlike
-Feishu — there is no thread bridging: ``on_message`` and button callbacks
-``await self._emit(...)`` directly. On a button click the channel freezes
-its own card and emits a ``ChannelConfirmationResultEvent`` carrying the
-tool call's id.
+Feishu — there is no thread bridging: ``on_message`` and
+``on_interaction`` ``await self._emit(...)`` directly. Approval cards
+carry explicit button ``custom_id`` values because replies are sent by
+REST-only instances while component interactions arrive on the
+gateway-connected client; on a click the channel freezes its card and
+emits a ``ChannelConfirmationResultEvent`` carrying the tool call's id.
 
 Note: this channel opens one gateway connection per node. Discord's own
 model expects one connection per shard; running many nodes for one bot
@@ -30,6 +32,7 @@ from .._base import (
     ChatKind,
     _EVENT_ADAPTER,
 )
+from ._approval import _approval_custom_id, _parse_approval_custom_id
 
 if TYPE_CHECKING:
     import discord
@@ -186,6 +189,23 @@ class DiscordChannel(ChannelBase):
                 message (`discord.Message`): The inbound message.
             """
             await self._on_message(message)
+
+        @self._client.event
+        async def on_interaction(interaction: "discord.Interaction") -> None:
+            """Route approval-button clicks through the listener client.
+
+            Cards are posted by REST-only instances, so their view
+            callbacks live on a different :class:`discord.Client` than the
+            one that receives the click. Explicit ``custom_id`` values
+            plus this hook restore the approval flow.
+
+            Args:
+                interaction (`discord.Interaction`): The inbound click.
+            """
+            if interaction.type != discord.InteractionType.component:
+                return
+            custom_id = (interaction.data or {}).get("custom_id")
+            await self._on_approval_interaction(interaction, custom_id)
 
         @self._client.event
         async def on_ready() -> None:
@@ -453,14 +473,37 @@ class DiscordChannel(ChannelBase):
         client = await self._ensure_client()
         return client.get_channel(cid) or await client.fetch_channel(cid)
 
+    async def _on_approval_interaction(
+        self,
+        interaction: "discord.Interaction",
+        custom_id: str | None,
+    ) -> None:
+        """Handle an approval-card button click on the listening client.
+
+        Args:
+            interaction (`discord.Interaction`): The inbound click.
+            custom_id (`str | None`): The clicked button's ``custom_id``.
+        """
+        parsed = _parse_approval_custom_id(custom_id)
+        if parsed is None:
+            return
+        tool_call_id, approved, agent_id, session_id = parsed
+        await self._decide(
+            interaction,
+            tool_call_id,
+            approved,
+            agent_id,
+            session_id,
+        )
+
     def _build_view(
         self,
         tool_call_id: str,
         agent_id: str = "",
         session_id: str = "",
     ) -> "discord.ui.View":
-        """Build a two-button approval view whose callbacks freeze the card
-        and emit the decision for ``tool_call_id``.
+        """Build a two-button approval view with explicit ``custom_id``
+        values decoded by :meth:`_on_approval_interaction`.
 
         Args:
             tool_call_id (`str`): The tool call the buttons answer.
@@ -472,62 +515,34 @@ class DiscordChannel(ChannelBase):
         Returns:
             `discord.ui.View`: The allow/deny view for the card message.
         """
-        # pylint: disable=protected-access
         import discord
 
-        channel = self
-
-        class _ApprovalView(discord.ui.View):
-            """A persistent (never-timing-out) allow/deny button view."""
-
-            def __init__(self) -> None:
-                """Build the view with no timeout."""
-                super().__init__(timeout=None)
-
-            @discord.ui.button(
+        view = discord.ui.View(timeout=None)
+        view.add_item(
+            discord.ui.Button(
                 label="✅ Approve",
                 style=discord.ButtonStyle.green,
-            )
-            async def approve(
-                self,
-                interaction: "discord.Interaction",
-                _button: "discord.ui.Button",
-            ) -> None:
-                """Emit an approve decision.
-
-                Args:
-                    interaction (`discord.Interaction`): The click.
-                    _button (`discord.ui.Button`): The clicked button.
-                """
-                await channel._decide(
-                    interaction,
-                    tool_call_id,
+                custom_id=_approval_custom_id(
                     True,
-                    agent_id,
-                    session_id,
-                )
-
-            @discord.ui.button(label="❌ Deny", style=discord.ButtonStyle.red)
-            async def deny(
-                self,
-                interaction: "discord.Interaction",
-                _button: "discord.ui.Button",
-            ) -> None:
-                """Emit a deny decision.
-
-                Args:
-                    interaction (`discord.Interaction`): The click.
-                    _button (`discord.ui.Button`): The clicked button.
-                """
-                await channel._decide(
-                    interaction,
                     tool_call_id,
-                    False,
                     agent_id,
                     session_id,
-                )
-
-        return _ApprovalView()
+                ),
+            ),
+        )
+        view.add_item(
+            discord.ui.Button(
+                label="❌ Deny",
+                style=discord.ButtonStyle.red,
+                custom_id=_approval_custom_id(
+                    False,
+                    tool_call_id,
+                    agent_id,
+                    session_id,
+                ),
+            ),
+        )
+        return view
 
     async def _decide(
         self,

--- a/tests/channel_discord_approval_test.py
+++ b/tests/channel_discord_approval_test.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for Discord tool-approval interaction handling."""
+
+# pylint: disable=protected-access,missing-function-docstring
+from types import SimpleNamespace
+from typing import Any
+from unittest import IsolatedAsyncioTestCase
+from uuid import uuid4
+
+from agentscope.app.channel._base import ChannelConfirmationResultEvent
+from agentscope.app.channel._discord._approval import (
+    _approval_custom_id,
+    _parse_approval_custom_id,
+)
+from agentscope.app.channel._discord._channel import DiscordChannel
+
+
+def _credentials() -> DiscordChannel.Credentials:
+    return DiscordChannel.Credentials(
+        bot_token="token",
+        application_id="app-1",
+    )
+
+
+def _channel() -> DiscordChannel:
+    return DiscordChannel("discord-1", _credentials(), DiscordChannel.Config())
+
+
+class _FakeInteraction:
+    """Minimal interaction stand-in for approval tests."""
+
+    def __init__(
+        self,
+        *,
+        custom_id: str,
+        channel_id: int = 42,
+        user_id: int = 7,
+    ) -> None:
+        self.channel_id = channel_id
+        self.user = SimpleNamespace(id=user_id)
+        self.message = SimpleNamespace()
+        self.message.edit_calls: list[Any] = []
+        self.response = SimpleNamespace()
+        self.response.defer_calls: list[Any] = []
+
+        async def defer() -> None:
+            self.response.defer_calls.append(True)
+
+        self.response.defer = defer
+
+        async def edit(**kwargs: Any) -> None:
+            self.message.edit_calls.append(kwargs)
+
+        self.message.edit = edit
+
+
+class DiscordApprovalCustomIdTest(IsolatedAsyncioTestCase):
+    """Encode/decode tests for approval button custom ids."""
+
+    def test_round_trip_includes_agent_and_session(self) -> None:
+        custom_id = _approval_custom_id(
+            True,
+            "tool-1",
+            "agent-1",
+            "session-1",
+        )
+        parsed = _parse_approval_custom_id(custom_id)
+        self.assertEqual(
+            parsed,
+            ("tool-1", True, "agent-1", "session-1"),
+        )
+
+    def test_round_trip_for_deny(self) -> None:
+        custom_id = _approval_custom_id(
+            False,
+            "call_deny",
+            "agent-9",
+            "session-9",
+        )
+        parsed = _parse_approval_custom_id(custom_id)
+        self.assertEqual(
+            parsed,
+            ("call_deny", False, "agent-9", "session-9"),
+        )
+
+    def test_rejects_unknown_custom_id(self) -> None:
+        self.assertIsNone(_parse_approval_custom_id("other:button"))
+        self.assertIsNone(_parse_approval_custom_id(None))
+
+    def test_custom_id_stays_within_discord_limit_for_uuid_ids(self) -> None:
+        agent_id = uuid4().hex
+        session_id = uuid4().hex
+        tool_call_id = uuid4().hex
+        approve_id = _approval_custom_id(
+            True,
+            tool_call_id,
+            agent_id,
+            session_id,
+        )
+        deny_id = _approval_custom_id(
+            False,
+            tool_call_id,
+            agent_id,
+            session_id,
+        )
+        self.assertLessEqual(len(approve_id), 100)
+        self.assertLessEqual(len(deny_id), 100)
+
+
+class DiscordApprovalInteractionTest(IsolatedAsyncioTestCase):
+    """Approval interaction routing on the listening client."""
+
+    async def test_on_approval_interaction_emits_resume_event(self) -> None:
+        channel = _channel()
+        received: list[ChannelConfirmationResultEvent] = []
+
+        async def emit(event: ChannelConfirmationResultEvent) -> None:
+            received.append(event)
+
+        channel._emit = emit
+        custom_id = _approval_custom_id(
+            True,
+            "tool-1",
+            "agent-1",
+            "session-1",
+        )
+        interaction = _FakeInteraction(custom_id=custom_id)
+
+        await channel._on_approval_interaction(interaction, custom_id)
+
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0].tool_call_id, "tool-1")
+        self.assertEqual(received[0].agent_id, "agent-1")
+        self.assertEqual(received[0].session_id, "session-1")
+        self.assertTrue(received[0].approved)
+        self.assertEqual(received[0].chat_id, "42")
+        self.assertEqual(received[0].channel_user_id, "7")
+        self.assertEqual(interaction.response.defer_calls, [True])
+        self.assertEqual(
+            interaction.message.edit_calls,
+            [{"content": "✅ Approved", "view": None}],
+        )
+
+    async def test_on_approval_interaction_ignores_foreign_buttons(
+        self,
+    ) -> None:
+        channel = _channel()
+        received: list[ChannelConfirmationResultEvent] = []
+
+        async def emit(event: ChannelConfirmationResultEvent) -> None:
+            received.append(event)
+
+        channel._emit = emit
+        interaction = _FakeInteraction(custom_id="not-ours")
+
+        await channel._on_approval_interaction(interaction, "not-ours")
+
+        self.assertEqual(received, [])
+        self.assertEqual(interaction.response.defer_calls, [])
+
+    def test_build_view_sets_custom_ids_for_listener_dispatch(self) -> None:
+        channel = _channel()
+        view = channel._build_view("tool-1", "agent-1", "session-1")
+        custom_ids = [item.custom_id for item in view.children]
+        self.assertEqual(len(custom_ids), 2)
+        approve = _parse_approval_custom_id(custom_ids[0])
+        deny = _parse_approval_custom_id(custom_ids[1])
+        self.assertEqual(approve, ("tool-1", True, "agent-1", "session-1"))
+        self.assertEqual(deny, ("tool-1", False, "agent-1", "session-1"))


### PR DESCRIPTION
Restore Discord tool Approve/Deny after direct reply delivery by handling interactions on the listening client via custom_id. Fixes #2522
