### PR TITLE
fix(deps): pin ripgrep below 15.x to restore Windows dev installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,10 +99,12 @@ workspace = [
 # ------------ Tools ------------
 # Ships the ``rg`` binary for the builtin Grep tool on LocalWorkspace
 # (remote sandboxes install ripgrep inside the sandbox instead).
-# Capped below 15.x: those releases ship no Windows wheels, which breaks
-# `pip install -e ".[dev]"` on Windows (issue #2504).
+# 15.x ships wheels only for macOS-arm64 and manylinux_2_39 x86_64, so
+# everything else (Windows, glibc<2.39, musl, aarch64) falls back to the
+# Rust sdist and fails without a toolchain (#2504). 14.0 lacks those
+# wheels too, hence the lower bound. Lift once upstream restores them.
 tools = [
-    "ripgrep<15",
+    "ripgrep>=14.1,<15",
 ]
 # ------------ A2A ------------
 a2a = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,8 +99,10 @@ workspace = [
 # ------------ Tools ------------
 # Ships the ``rg`` binary for the builtin Grep tool on LocalWorkspace
 # (remote sandboxes install ripgrep inside the sandbox instead).
+# Capped below 15.x: those releases ship no Windows wheels, which breaks
+# `pip install -e ".[dev]"` on Windows (issue #2504).
 tools = [
-    "ripgrep",
+    "ripgrep<15",
 ]
 # ------------ A2A ------------
 a2a = [


### PR DESCRIPTION
## AgentScope Version

2.0.8 (main @ 41ba021)

## Description

**Background**: `pip install -e ".[dev]"` fails on Windows without a Rust toolchain. The `dev` extra pulls `full → agentscope[tools]`, and `tools` depends on unpinned `ripgrep`. ripgrep 15.0.0/15.1.0 ship no Windows wheels (only macOS arm64 + manylinux x86_64 wheels plus an sdist), so the resolver falls back to the sdist and the Rust build aborts the whole dev install (#2504). 14.1.0 ships `win_amd64`/`win32` wheels.

**Changes**: cap the `tools` extra at `ripgrep<15` with a comment recording why, so the cap can be lifted if upstream restores Windows wheels. The PyPI package only delivers the `rg` binary spawned by the builtin Grep tool (`src/agentscope/tool/_builtin/_grep.py`); every flag used there (`-l/-c/-n/-C/-B/-A/-e/--type/--glob/--hidden/--max-columns/-U/--multiline-dotall`) is long-standing and was verified working against the 14.1.0 binary.

**Testing**:
- PyPI JSON: 14.1.0 → 14 wheels incl. win_amd64/win32; 15.0.0/15.1.0 → 2 non-Windows wheels + sdist each
- Windows 11, Python 3.12: `uv pip install "ripgrep<15"` installs 14.1.0, `rg --version` works; representative `_grep.py` command shapes (`--hidden --max-columns -n -C -e --type --glob`, `-U --multiline-dotall`) run correctly with the 14.1.0 binary
- `pyproject.toml` parses with `tomllib`

Fixes #2504

## Checklist

- [x] An issue has been created for this PR (#2504)
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style (no docstrings changed in this PR)
- [x] Related documentation has been updated — not needed (dependency constraint only)
- [x] Code is ready for review
