### PR TITLE
fix(rag): escape Excel Markdown table cells

### DIFF
--- a/src/agentscope/rag/_parser/_excel.py
+++ b/src/agentscope/rag/_parser/_excel.py
@@ -192,11 +192,7 @@ class ExcelParser(ParserBase):
                 sheets are never combined into the same section.
             table_format (`Literal["markdown", "json"]``, defaults to
                 ``"markdown"``):
-                How to render tables.  ``"markdown"`` uses pipe-table
-                syntax, escaping pipes and rendering cell line breaks
-                as ``<br>``; ``"json"`` emits a JSON array prefixed with
-                a ``<system-info>`` marker and preserves extracted cell
-                strings without Markdown rendering.
+                How to render tables.
 
         Raises:
             `ValueError`: If ``table_format`` is not ``"markdown"``
@@ -408,13 +404,7 @@ class ExcelParser(ParserBase):
         sheet_name: str,
     ) -> str:
         """Render table data as Markdown with optional sheet header and
-        cell coordinates.
-
-        Pipe characters and backslashes are escaped so they remain part
-        of the cell, and line breaks within a cell are rendered as
-        ``<br>`` tags so each table row stays on one physical Markdown
-        line.
-        """
+        cell coordinates."""
         if not table_data or not table_data[0]:
             return ""
 

--- a/src/agentscope/rag/_parser/_excel.py
+++ b/src/agentscope/rag/_parser/_excel.py
@@ -21,7 +21,7 @@ from ..._logging import logger
 from ...message import Base64Source, DataBlock, TextBlock
 from .._document import Section
 from ._base import ParserBase
-from ._utils import _guess_image_media_type
+from ._utils import _format_markdown_table_cell, _guess_image_media_type
 
 
 def _get_excel_column_name(col_index: int) -> str:
@@ -192,7 +192,11 @@ class ExcelParser(ParserBase):
                 sheets are never combined into the same section.
             table_format (`Literal["markdown", "json"]``, defaults to
                 ``"markdown"``):
-                How to render tables.
+                How to render tables.  ``"markdown"`` uses pipe-table
+                syntax, escaping pipes and rendering cell line breaks
+                as ``<br>``; ``"json"`` emits a JSON array prefixed with
+                a ``<system-info>`` marker and preserves extracted cell
+                strings without Markdown rendering.
 
         Raises:
             `ValueError`: If ``table_format`` is not ``"markdown"``
@@ -404,7 +408,13 @@ class ExcelParser(ParserBase):
         sheet_name: str,
     ) -> str:
         """Render table data as Markdown with optional sheet header and
-        cell coordinates."""
+        cell coordinates.
+
+        Pipe characters and backslashes are escaped so they remain part
+        of the cell, and line breaks within a cell are rendered as
+        ``<br>`` tags so each table row stays on one physical Markdown
+        line.
+        """
         if not table_data or not table_data[0]:
             return ""
 
@@ -416,7 +426,7 @@ class ExcelParser(ParserBase):
         num_cols = len(table_data[0])
 
         def _fmt(cell: str, row_idx: int, col_idx: int) -> str:
-            escaped = cell.replace("|", "\\|")
+            escaped = _format_markdown_table_cell(cell)
             if self.include_cell_coordinates:
                 coord = f"{_get_excel_column_name(col_idx)}{row_idx + 1}"
                 return f"[{coord}] {escaped}"

--- a/tests/rag_parser_test.py
+++ b/tests/rag_parser_test.py
@@ -221,18 +221,6 @@ def _make_xlsx_simple(
     return buffer.getvalue()
 
 
-def _make_xlsx_with_special_table_cells() -> bytes:
-    """Build an XLSX whose cells carry pipes and a line break."""
-    return _make_xlsx_simple(
-        {
-            "S1": [
-                ["A|B", r"Path \| label"],
-                ["1|2", "Line 1\nLine 2"],
-            ],
-        },
-    )
-
-
 class TextParserTest(IsolatedAsyncioTestCase):
     """Behavioural coverage for :class:`TextParser`."""
 
@@ -926,7 +914,14 @@ class ExcelParserTest(IsolatedAsyncioTestCase):
 
     async def test_markdown_table_escapes_special_cells(self) -> None:
         """Pipes and line breaks do not corrupt Markdown table rows."""
-        xlsx_bytes = _make_xlsx_with_special_table_cells()
+        xlsx_bytes = _make_xlsx_simple(
+            {
+                "S1": [
+                    ["A|B", r"Path \| label"],
+                    ["1|2", "Line 1\nLine 2"],
+                ],
+            },
+        )
         parser = ExcelParser(include_sheet_names=False)
         sections = await parser.parse(xlsx_bytes, "special.xlsx")
 

--- a/tests/rag_parser_test.py
+++ b/tests/rag_parser_test.py
@@ -221,6 +221,18 @@ def _make_xlsx_simple(
     return buffer.getvalue()
 
 
+def _make_xlsx_with_special_table_cells() -> bytes:
+    """Build an XLSX whose cells carry pipes and a line break."""
+    return _make_xlsx_simple(
+        {
+            "S1": [
+                ["A|B", r"Path \| label"],
+                ["1|2", "Line 1\nLine 2"],
+            ],
+        },
+    )
+
+
 class TextParserTest(IsolatedAsyncioTestCase):
     """Behavioural coverage for :class:`TextParser`."""
 
@@ -907,6 +919,39 @@ class ExcelParserTest(IsolatedAsyncioTestCase):
                         "finished_at": None,
                     },
                     "source": "demo.xlsx",
+                    "metadata": {},
+                },
+            ],
+        )
+
+    async def test_markdown_table_escapes_special_cells(self) -> None:
+        """Pipes and line breaks do not corrupt Markdown table rows."""
+        xlsx_bytes = _make_xlsx_with_special_table_cells()
+        parser = ExcelParser(include_sheet_names=False)
+        sections = await parser.parse(xlsx_bytes, "special.xlsx")
+
+        expected_text = (
+            "\n".join(
+                [
+                    r"| A\|B | Path \\\| label |",
+                    "| --- | --- |",
+                    r"| 1\|2 | Line 1<br>Line 2 |",
+                ],
+            )
+            + "\n"
+        )
+        self.assertEqual(
+            [section.model_dump() for section in sections],
+            [
+                {
+                    "content": {
+                        "type": "text",
+                        "text": expected_text,
+                        "id": AnyString(),
+                        "created_at": AnyString(),
+                        "finished_at": None,
+                    },
+                    "source": "special.xlsx",
                     "metadata": {},
                 },
             ],


### PR DESCRIPTION
## AgentScope Version

2.0.8 (`main`, base commit `41ba021`)

## Description

`ExcelParser` renders a sheet through its own cell formatter, `_fmt` at `src/agentscope/rag/_parser/_excel.py:419`, which escapes the pipe character and nothing else. Two ordinary kinds of spreadsheet cell corrupt the table it produces.

A cell containing a line break (alt+enter in Excel) ends the Markdown row early. `_extract_table_data` normalises CRLF to LF at `_excel.py:74` and keeps the break, so the text after it lands on its own physical line and the row is cut short there.

A cell containing a backslash in front of a pipe loses a column. `Path \| label` is escaped to `Path \\| label`, and Markdown reads `\\` as a literal backslash and the `|` after it as an unescaped column separator, so one cell renders as two.

`WordParser` and `PPTParser` are not affected: both render through the shared `_format_markdown_table_cell` in `src/agentscope/rag/_parser/_utils.py:50`, which escapes backslashes and pipes and turns line breaks into `<br>`. The Excel path predates that helper and was never switched over to it.

Repro on `main`, with a sheet whose cells are `A|B`, `Path \| label`, `1|2` and `Line 1\nLine 2`:

```
| A\|B | Path \\| label |
| --- | --- |
| 1\|2 | Line 1
Line 2 |
```

After this change:

```
| A\|B | Path \\\| label |
| --- | --- |
| 1\|2 | Line 1<br>Line 2 |
```

## Change

`_fmt` calls `_format_markdown_table_cell` instead of its own single `replace`. The `[A1]` cell-coordinate prefix and the `table_format="json"` path are untouched, and cells with no pipe, backslash or line break render exactly as before.

## Tests

Added `ExcelParserTest.test_markdown_table_escapes_special_cells`, which mirrors the Word and PPT tests of the same name and asserts the whole parsed `Section` dump. It fails on `main` (`Path \\| label` and the split row) and passes with the change.

```bash
python -m pytest tests/rag_parser_test.py -q
# 44 passed

python -m pytest tests/ -k rag -q
# 228 passed, 1 skipped

pre-commit run --files src/agentscope/rag/_parser/_excel.py tests/rag_parser_test.py
# all hooks passed
```

Run on macOS with Python 3.11, pandas 3.0.5 and openpyxl 3.1.5. The new test uses only `_make_xlsx_simple`, the helper the existing Excel tests already build workbooks with, so it needs nothing that CI does not already install.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  An issue has been created for this PR
- [x]  I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [x]  Code is ready for review
