### PR TITLE
fix: block sending by Enter while a reply is in progress

### DIFF
--- a/examples/web_ui/frontend/src/components/chat/TextInput.tsx
+++ b/examples/web_ui/frontend/src/components/chat/TextInput.tsx
@@ -218,7 +218,9 @@ export const TextInput = forwardRef<TextInputRef, TextInputProps>(
 		};
 
 		const handleSend = () => {
-			if (!value.trim() || disabled || hasProcessing) return;
+			// ``phase`` is guarded here rather than only on the button, since Enter
+			// calls this directly and would otherwise send during a running reply.
+			if (phase !== 'idle' || !value.trim() || disabled || hasProcessing) return;
 
 			const blocks: ContentBlock[] = [];
 


### PR DESCRIPTION
## Description

In the web UI chat input, the send/stop button picks its icon, tooltip, disabled state and click handler from the reply `phase`, but the Enter key path bypasses that entirely — `handleKeyDown` calls `handleSend()` directly, and `handleSend` only checked `value`/`disabled`/`hasProcessing`.

So while the agent is replying (button showing Stop), typing and pressing Enter still appended a user message and fired `POST /chat/`. Same during `interrupting`, where the button is already disabled, and during HITL, where the user could send a message instead of answering the confirmation card.

Nothing upstream guards it either: `ChatViewport` passes `disabled={selectedModel === null}`, and `useMessages.send` only checks for an agent/session.

Fix is one line — guard `phase` in `handleSend` so the keyboard and the button agree.

## Checklist

- [x] `pre-commit run --all-files`
- [x] `pnpm lint` / `tsc -b` in `examples/web_ui/frontend`
- [x] `pnpm format` in `examples/web_ui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015R6wJkdyA8jMppg3A6DtQt