### PR TITLE
fix(channel): recover reply delivery after Redis Pub/Sub disconnect

### DIFF
--- a/src/agentscope/app/channel/_stream.py
+++ b/src/agentscope/app/channel/_stream.py
@@ -9,6 +9,7 @@ run does, or attach to one already in flight.
 import asyncio
 from typing import AsyncGenerator
 
+from ..._logging import logger
 from ...event import EventType
 from ..message_bus import MessageBus, MessageBusKeys
 
@@ -19,6 +20,11 @@ from ..message_bus import MessageBus, MessageBusKeys
 
 # How long to wait for the bus subscription to come up.
 _SUBSCRIBE_TIMEOUT_SECS = 5.0
+# Retry delay bounds for a transient subscription failure. The replay log
+# makes retrying safe: events published while the subscription is down are
+# recovered after the next subscription is ready.
+_RECONNECT_INITIAL_DELAY_SECS = 0.1
+_RECONNECT_MAX_DELAY_SECS = 5.0
 _TERMINAL_EVENTS = frozenset(
     {
         EventType.REPLY_END,
@@ -52,12 +58,97 @@ async def open_reply_stream(
     queue: asyncio.Queue[dict] = asyncio.Queue()
 
     async def feeder() -> None:
-        """Buffer live subscription events into the local queue."""
-        try:
-            async for evt in bus.subscribe(event_key, on_ready=ready.set):
-                await queue.put(evt)
-        except asyncio.CancelledError:
-            pass
+        """Buffer live events and recover a subscription that disconnects."""
+        cursor: str | None = None
+        first_subscription = True
+        reconnect_delay = _RECONNECT_INITIAL_DELAY_SECS
+
+        async def _cancel_subscription(task: asyncio.Task) -> None:
+            """Stop one subscription attempt without leaking its task."""
+            if not task.done():
+                task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+        async def _replay_from_cursor() -> None:
+            """Queue every log entry newer than the live-feed cursor."""
+            nonlocal cursor
+            while True:
+                entries = await bus.log_read(
+                    event_key,
+                    since=cursor,
+                    max_count=MessageBusKeys.SESSION_REPLAY_MAX_LEN,
+                )
+                for entry_id, evt in entries:
+                    await queue.put({**evt, "_entry_id": entry_id})
+                    cursor = str(entry_id)
+                if len(entries) < MessageBusKeys.SESSION_REPLAY_MAX_LEN:
+                    return
+
+        while True:
+            subscription_ready = asyncio.Event()
+
+            def _on_ready() -> None:
+                """Signal both initial readiness and this retry attempt."""
+                ready.set()
+                subscription_ready.set()
+
+            async def _consume_subscription() -> None:
+                """Forward one subscription attempt into the local queue."""
+                nonlocal cursor
+                async for evt in bus.subscribe(
+                    event_key,
+                    on_ready=_on_ready,
+                ):
+                    await queue.put(evt)
+                    entry_id = evt.get("_entry_id")
+                    if entry_id is not None:
+                        cursor = str(entry_id)
+
+            subscription_task = asyncio.create_task(_consume_subscription())
+            ready_wait_task = asyncio.create_task(subscription_ready.wait())
+            try:
+                done, _ = await asyncio.wait(
+                    {ready_wait_task, subscription_task},
+                    timeout=_SUBSCRIBE_TIMEOUT_SECS,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if not done:
+                    raise asyncio.TimeoutError(
+                        "message bus subscription did not become ready",
+                    )
+                if not subscription_ready.is_set():
+                    await subscription_task
+                    raise RuntimeError("message bus subscription ended early")
+
+                if not first_subscription:
+                    await _replay_from_cursor()
+                first_subscription = False
+                reconnect_delay = _RECONNECT_INITIAL_DELAY_SECS
+                await subscription_task
+                raise RuntimeError("message bus subscription ended")
+            except asyncio.CancelledError:
+                await _cancel_subscription(subscription_task)
+                raise
+            except Exception as exc:  # pylint: disable=broad-except
+                await _cancel_subscription(subscription_task)
+                logger.warning(
+                    "channel reply subscription lost for %s; retrying: %s",
+                    event_key,
+                    exc,
+                )
+            finally:
+                if not ready_wait_task.done():
+                    ready_wait_task.cancel()
+                await asyncio.gather(
+                    ready_wait_task,
+                    return_exceptions=True,
+                )
+
+            await asyncio.sleep(reconnect_delay)
+            reconnect_delay = min(
+                reconnect_delay * 2,
+                _RECONNECT_MAX_DELAY_SECS,
+            )
 
     feeder_task = asyncio.create_task(feeder())
     try:

--- a/tests/channel_stream_test.py
+++ b/tests/channel_stream_test.py
@@ -12,9 +12,12 @@ import asyncio
 from contextlib import aclosing
 from unittest import IsolatedAsyncioTestCase
 
+import fakeredis.aioredis
+from redis import exceptions as redis_exceptions
+
 from agentscope.app._bus_ops import publish_session_event
 from agentscope.app.channel._stream import open_reply_stream
-from agentscope.app.message_bus import InMemoryMessageBus
+from agentscope.app.message_bus import InMemoryMessageBus, RedisMessageBus
 from agentscope.event import (
     ReplyEndEvent,
     ReplyStartEvent,
@@ -80,6 +83,83 @@ def _external() -> RequireExternalExecutionEvent:
         name="a",
         tool_calls=[],
     )
+
+
+class _ResettingPubSub:
+    """Raise one connection error from an otherwise real fakeredis pubsub."""
+
+    def __init__(
+        self,
+        inner: object,
+        connection_reset: asyncio.Event,
+    ) -> None:
+        self._inner = inner
+        self._connection_reset = connection_reset
+        self._raised = False
+
+    async def get_message(self, *args: object, **kwargs: object) -> object:
+        """Simulate the socket error raised when Redis resets a connection."""
+        if not self._raised:
+            self._raised = True
+            self._connection_reset.set()
+            raise redis_exceptions.ConnectionError(
+                "simulated Redis connection reset",
+            )
+        return await self._inner.get_message(*args, **kwargs)  # type: ignore
+
+    def __getattr__(self, name: str) -> object:
+        """Delegate subscribe cleanup and other pubsub methods."""
+        return getattr(self._inner, name)
+
+
+class _ResettingRedisClient:
+    """Return one failing pubsub, then normal pubsubs."""
+
+    def __init__(
+        self,
+        inner: fakeredis.aioredis.FakeRedis,
+        connection_reset: asyncio.Event,
+    ) -> None:
+        self._inner = inner
+        self._connection_reset = connection_reset
+        self.pubsub_calls = 0
+
+    def pubsub(self, *args: object, **kwargs: object) -> object:
+        """Inject the reset into the first subscription only."""
+        self.pubsub_calls += 1
+        pubsub = self._inner.pubsub(*args, **kwargs)
+        if self.pubsub_calls == 1:
+            return _ResettingPubSub(pubsub, self._connection_reset)
+        return pubsub
+
+    def __getattr__(self, name: str) -> object:
+        """Delegate stream and publish operations to fakeredis."""
+        return getattr(self._inner, name)
+
+
+class _ReplayBarrierRedisBus(RedisMessageBus):
+    """Hold the initial replay open while the pubsub connection fails."""
+
+    def __init__(self, client: _ResettingRedisClient) -> None:
+        super().__init__()
+        self._client = client
+        self.replay_started = asyncio.Event()
+        self.replay_release = asyncio.Event()
+        self.replay_completed = asyncio.Event()
+
+    async def log_read(
+        self,
+        key: str,
+        since: str | None = None,
+        max_count: int = 100,
+    ) -> list[tuple[str, dict]]:
+        """Make the replay/live failure window deterministic."""
+        if not self.replay_started.is_set():
+            self.replay_started.set()
+            await self.replay_release.wait()
+        result = await super().log_read(key, since, max_count)
+        self.replay_completed.set()
+        return result
 
 
 class _SeamBus(InMemoryMessageBus):
@@ -189,3 +269,30 @@ class EventStreamTest(IsolatedAsyncioTestCase):
             await asyncio.wait_for(_drain(bus, "s-1"), timeout=2.0),
             ["REPLY_START", "REQUIRE_EXTERNAL_EXECUTION"],
         )
+
+    async def test_recovers_after_redis_pubsub_connection_reset(self) -> None:
+        """A reset subscription is recovered from the replay log."""
+        fake_redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+        connection_reset = asyncio.Event()
+        client = _ResettingRedisClient(fake_redis, connection_reset)
+        bus = _ReplayBarrierRedisBus(client)
+        session_id = "s-redis-reset"
+        stream = await open_reply_stream(bus, session_id)
+        read_task = asyncio.create_task(anext(stream))
+
+        try:
+            await asyncio.wait_for(bus.replay_started.wait(), timeout=2.0)
+            await asyncio.wait_for(connection_reset.wait(), timeout=2.0)
+            bus.replay_release.set()
+            await asyncio.wait_for(bus.replay_completed.wait(), timeout=2.0)
+            await _publish(bus, session_id, _end())
+
+            event = await asyncio.wait_for(read_task, timeout=2.0)
+            self.assertEqual(event["type"], "REPLY_END")
+            self.assertGreaterEqual(client.pubsub_calls, 2)
+        finally:
+            if not read_task.done():
+                read_task.cancel()
+            await asyncio.gather(read_task, return_exceptions=True)
+            await stream.aclose()
+            await fake_redis.aclose()


### PR DESCRIPTION
## Summary

- reconnect the channel reply subscription after a transient feeder failure
- replay every session event newer than the last live entry ID, preserving entry IDs for existing deduplication
- add a production RedisMessageBus/fakeredis regression test that injects redis.exceptions.ConnectionError and verifies the terminal reply is delivered

The fix is scoped to open_reply_stream. The generic MessageBus.subscribe contract remains transient; the channel reply stream uses its durable replay log to close the disconnect gap.

Fixes #2530

## Validation

- pre-commit run --all-files: passed
- pytest tests/channel_stream_test.py tests/service_message_bus_test.py -q: 42 passed
- repeated disconnect regression test: 5 consecutive passes
- full pytest tests: 2196 passed, 125 skipped, 11 environment failures unrelated to this change; Moto S3 and local MCP SSE/Streamable HTTP servers returned 502 before exercising the touched code
