### PR TITLE
fix(rag): preserve blank lines between paragraphs in WordParser

### DIFF
--- a/src/agentscope/rag/_parser/_word.py
+++ b/src/agentscope/rag/_parser/_word.py
@@ -71,16 +71,6 @@ def _extract_text_from_paragraph(para: DocxParagraph) -> str:
     return text.strip()
 
 
-def _is_truly_blank_paragraph(para: DocxParagraph) -> bool:
-    """Return whether a paragraph has no content beyond properties."""
-    from docx.oxml.ns import qn
-
-    paragraph_properties_tag = qn("w:pPr")
-    return all(
-        child.tag == paragraph_properties_tag for child in para._element
-    )
-
-
 def _extract_table_data(table: DocxTable) -> list[list[str]]:
     """Extract table data from a python-docx Table, preserving line breaks
     within cells.
@@ -290,6 +280,8 @@ class WordParser(ParserBase):
         text_buffer: list[str] = []
 
         def flush_text() -> None:
+            while text_buffer and text_buffer[-1] == "":
+                text_buffer.pop()
             if not text_buffer:
                 return
             sections.append(
@@ -308,7 +300,9 @@ class WordParser(ParserBase):
                 text = _extract_text_from_paragraph(para)
                 if text:
                     text_buffer.append(text)
-                elif text_buffer and _is_truly_blank_paragraph(para):
+                elif text_buffer and all(
+                    child.tag == qn("w:pPr") for child in para._element
+                ):
                     text_buffer.append("")
 
                 if self.include_image:

--- a/src/agentscope/rag/_parser/_word.py
+++ b/src/agentscope/rag/_parser/_word.py
@@ -300,9 +300,10 @@ class WordParser(ParserBase):
                 text = _extract_text_from_paragraph(para)
                 if text:
                     text_buffer.append(text)
-                elif text_buffer and all(
-                    child.tag == qn("w:pPr") for child in para._element
+                elif text_buffer and not para._element.findall(
+                    ".//" + qn("w:r"),
                 ):
+                    # No runs at all, i.e. a blank line in Word
                     text_buffer.append("")
 
                 if self.include_image:

--- a/src/agentscope/rag/_parser/_word.py
+++ b/src/agentscope/rag/_parser/_word.py
@@ -71,6 +71,16 @@ def _extract_text_from_paragraph(para: DocxParagraph) -> str:
     return text.strip()
 
 
+def _is_truly_blank_paragraph(para: DocxParagraph) -> bool:
+    """Return whether a paragraph has no content beyond properties."""
+    from docx.oxml.ns import qn
+
+    paragraph_properties_tag = qn("w:pPr")
+    return all(
+        child.tag == paragraph_properties_tag for child in para._element
+    )
+
+
 def _extract_table_data(table: DocxTable) -> list[list[str]]:
     """Extract table data from a python-docx Table, preserving line breaks
     within cells.
@@ -298,6 +308,8 @@ class WordParser(ParserBase):
                 text = _extract_text_from_paragraph(para)
                 if text:
                     text_buffer.append(text)
+                elif text_buffer and _is_truly_blank_paragraph(para):
+                    text_buffer.append("")
 
                 if self.include_image:
                     has_drawing = bool(

--- a/tests/rag_parser_test.py
+++ b/tests/rag_parser_test.py
@@ -1210,6 +1210,36 @@ class WordParserTest(IsolatedAsyncioTestCase):
             ],
         )
 
+    async def test_empty_paragraph_is_preserved_between_text(self) -> None:
+        """A blank paragraph between text paragraphs remains a blank line."""
+        docx_bytes = _make_docx_simple(
+            ["Paragraph one.", "", "Paragraph two."],
+        )
+        sections = await WordParser(include_image=False).parse(
+            docx_bytes,
+            "demo.docx",
+        )
+
+        self.assertEqual(
+            sections[0].content.text,
+            "Paragraph one.\n\nParagraph two.",
+        )
+
+    async def test_consecutive_empty_paragraphs_are_preserved(self) -> None:
+        """Consecutive blank paragraphs preserve each intervening line."""
+        docx_bytes = _make_docx_simple(
+            ["Paragraph one.", "", "", "Paragraph two."],
+        )
+        sections = await WordParser(include_image=False).parse(
+            docx_bytes,
+            "demo.docx",
+        )
+
+        self.assertEqual(
+            sections[0].content.text,
+            "Paragraph one.\n\n\nParagraph two.",
+        )
+
     async def test_table_merges_by_default(self) -> None:
         """``separate_table=False`` merges the table into surrounding
         text."""

--- a/tests/rag_parser_test.py
+++ b/tests/rag_parser_test.py
@@ -1240,6 +1240,17 @@ class WordParserTest(IsolatedAsyncioTestCase):
             "Paragraph one.\n\n\nParagraph two.",
         )
 
+    async def test_trailing_empty_paragraphs_do_not_add_newlines(self) -> None:
+        """Trailing blank paragraphs do not leave a trailing newline."""
+        docx_bytes = _make_docx_simple(["Paragraph one.", "", ""])
+        sections = await WordParser(include_image=False).parse(
+            docx_bytes,
+            "demo.docx",
+        )
+
+        self.assertEqual(len(sections), 1)
+        self.assertEqual(sections[0].content.text, "Paragraph one.")
+
     async def test_table_merges_by_default(self) -> None:
         """``separate_table=False`` merges the table into surrounding
         text."""

--- a/tests/rag_parser_test.py
+++ b/tests/rag_parser_test.py
@@ -1240,6 +1240,37 @@ class WordParserTest(IsolatedAsyncioTestCase):
             "Paragraph one.\n\n\nParagraph two.",
         )
 
+    async def test_empty_paragraph_with_bookmark_is_preserved(self) -> None:
+        """Word often leaves bookmarks (e.g. ``_GoBack``) on blank
+        paragraphs, which are still blank lines."""
+        from docx import Document as DocxDocument
+        from docx.oxml import OxmlElement
+        from docx.oxml.ns import qn
+
+        doc = DocxDocument()
+        doc.add_paragraph("Paragraph one.")
+        blank = doc.add_paragraph("")
+        start = OxmlElement("w:bookmarkStart")
+        start.set(qn("w:id"), "0")
+        start.set(qn("w:name"), "_GoBack")
+        end = OxmlElement("w:bookmarkEnd")
+        end.set(qn("w:id"), "0")
+        blank._element.append(start)  # pylint: disable=protected-access
+        blank._element.append(end)  # pylint: disable=protected-access
+        doc.add_paragraph("Paragraph two.")
+        buffer = io.BytesIO()
+        doc.save(buffer)
+
+        sections = await WordParser(include_image=False).parse(
+            buffer.getvalue(),
+            "demo.docx",
+        )
+
+        self.assertEqual(
+            sections[0].content.text,
+            "Paragraph one.\n\nParagraph two.",
+        )
+
     async def test_trailing_empty_paragraphs_do_not_add_newlines(self) -> None:
         """Trailing blank paragraphs do not leave a trailing newline."""
         docx_bytes = _make_docx_simple(["Paragraph one.", "", ""])


### PR DESCRIPTION
## AgentScope Version

2.0.8

## Description

Closes #2535.

Word represents a blank line as a structurally empty `w:p` paragraph. `WordParser` previously discarded it, so text on both sides was joined with one newline and the blank line was lost.

This change preserves a structurally empty paragraph after existing text by appending an empty text-buffer entry. It accepts only paragraphs with no direct children other than `w:pPr`; image-only paragraphs (`w:drawing` / `w:pict`), break-only runs, and other structurally non-empty paragraphs are not treated as blank lines. Leading or all-empty paragraphs still do not create an empty `Section`.

## Testing

- `pytest tests/rag_parser_test.py` — 46 passed
- Changed-file `pre-commit` hooks — passed: mypy, black, flake8, pylint, pyroma, and repository checks
- Added in-memory DOCX regression coverage for one blank paragraph and consecutive blank paragraphs
- `pytest tests` locally: 2183 passed, 147 skipped, 3 failed. The same three failures reproduce unchanged on `main` with Python 3.13: one MCP schema docstring-format assertion and two Alembic locale-encoding failures.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Related documentation has been updated — n/a; this corrects existing parser behavior and adds no public API, configuration, or newly documented feature
- [x] Code is ready for review