### PR TITLE
fix(app): reconnect index task consumer after Redis Pub/Sub disconnect

### DIFF
--- a/src/agentscope/app/_service/_index_task_consumer.py
+++ b/src/agentscope/app/_service/_index_task_consumer.py
@@ -30,6 +30,11 @@ from typing import TYPE_CHECKING, Any, Self
 from ..message_bus import MessageBusKeys
 from ..._logging import logger
 
+# Keep reconnect attempts responsive during a short Redis interruption while
+# avoiding a hot loop when the broker is unavailable for longer.
+_RECONNECT_INITIAL_BACKOFF_SECS = 1.0
+_RECONNECT_MAX_BACKOFF_SECS = 30.0
+
 if TYPE_CHECKING:
     from ..message_bus import MessageBus
     from ._index_worker import IndexWorker
@@ -70,6 +75,9 @@ class IndexTaskConsumer:
         # can cancel + drain them; otherwise the event-loop teardown
         # would swallow exceptions raised inside the worker.
         self._inflight: set[asyncio.Task[Any]] = set()
+        # Drains scheduled by a successful re-subscription. They are
+        # tracked separately because they are not worker.process calls.
+        self._reconnect_drains: set[asyncio.Task[Any]] = set()
 
     async def __aenter__(self) -> Self:
         """Start the consumer loop and wait until its subscription
@@ -116,6 +124,15 @@ class IndexTaskConsumer:
             await asyncio.gather(*self._inflight, return_exceptions=True)
         self._inflight.clear()
 
+        for task in list(self._reconnect_drains):
+            task.cancel()
+        if self._reconnect_drains:
+            await asyncio.gather(
+                *self._reconnect_drains,
+                return_exceptions=True,
+            )
+        self._reconnect_drains.clear()
+
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
@@ -131,22 +148,66 @@ class IndexTaskConsumer:
                 can publish a signal immediately after start-up
                 without racing.
         """
-        try:
-            async for _signal in self._bus.subscribe(
-                MessageBusKeys.index_tasks_signal(),
-                on_ready=ready.set,
-            ):
-                await self._drain_and_dispatch()
-        except Exception:  # pylint: disable=broad-except
-            logger.exception(
-                "IndexTaskConsumer loop crashed; subscription ended.",
-            )
-        finally:
-            # If ``subscribe`` raises before ``on_ready`` fires, the
-            # ``__aenter__`` coroutine would deadlock on ``ready.wait()``.
-            # Set the event unconditionally on the way out so startup
-            # cannot stall on a transient bus failure.
+        backoff = _RECONNECT_INITIAL_BACKOFF_SECS
+
+        def on_ready() -> None:
+            """Mark readiness and catch up after a re-subscription."""
+            nonlocal backoff
+            if ready.is_set():
+                self._schedule_reconnect_drain()
             ready.set()
+            backoff = _RECONNECT_INITIAL_BACKOFF_SECS
+
+        while True:
+            try:
+                async for _signal in self._bus.subscribe(
+                    MessageBusKeys.index_tasks_signal(),
+                    on_ready=on_ready,
+                ):
+                    backoff = _RECONNECT_INITIAL_BACKOFF_SECS
+                    await self._drain_and_dispatch()
+            except asyncio.CancelledError:  # pylint: disable=try-except-raise
+                raise
+            except Exception:  # pylint: disable=broad-except
+                logger.exception(
+                    "IndexTaskConsumer subscription lost; retrying in %.1fs",
+                    backoff,
+                )
+            else:
+                logger.warning(
+                    "IndexTaskConsumer subscription ended; retrying in %.1fs",
+                    backoff,
+                )
+            finally:
+                # If ``subscribe`` raises before ``on_ready`` fires, the
+                # ``__aenter__`` coroutine would deadlock on ``ready.wait()``.
+                # Set the event unconditionally so startup can proceed while
+                # this loop retries the transient bus failure.
+                ready.set()
+
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, _RECONNECT_MAX_BACKOFF_SECS)
+
+    def _schedule_reconnect_drain(self) -> None:
+        """Catch up durable work after a subscription is re-established."""
+        task = asyncio.create_task(
+            self._drain_and_dispatch(),
+            name="index-task-reconnect-drain",
+        )
+        self._reconnect_drains.add(task)
+        task.add_done_callback(self._on_reconnect_drain_done)
+
+    def _on_reconnect_drain_done(self, task: asyncio.Task[Any]) -> None:
+        """Forget a reconnect drain and surface unexpected failures."""
+        self._reconnect_drains.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.exception(
+                "IndexTaskConsumer: reconnect drain raised",
+                exc_info=exc,
+            )
 
     async def _drain_and_dispatch(self) -> None:
         """Read up to a batch of task entries and dispatch each one."""

--- a/tests/service_index_task_consumer_test.py
+++ b/tests/service_index_task_consumer_test.py
@@ -12,6 +12,8 @@ Verifies the four behaviours callers rely on:
   ``worker.process`` call.
 - Entries left on the queue from before ``__aenter__`` are picked up
   on the initial drain without waiting for a fresh signal.
+- A transient subscription failure is recovered by reconnecting and
+  draining entries queued while the signal channel was unavailable.
 - Malformed entries are logged and skipped, not raised; later valid
   entries still dispatch.
 - An exception inside ``worker.process`` is logged but does not crash
@@ -188,6 +190,31 @@ class _FakeBus(MessageBus):
 
     async def registry_drop(self, namespace: str) -> None:
         raise NotImplementedError
+
+
+class _ReconnectOnceBus(_FakeBus):
+    """Fail the first subscription, then provide a live subscription."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.subscribe_calls = 0
+        self.first_subscription_failed = asyncio.Event()
+
+    async def subscribe(
+        self,
+        key: str,
+        *,
+        on_ready: Callable[[], None] | None = None,
+    ) -> AsyncGenerator[dict, None]:
+        self.subscribe_calls += 1
+        if self.subscribe_calls == 1:
+            if on_ready is not None:
+                on_ready()
+            self.first_subscription_failed.set()
+            raise ConnectionError("simulated Pub/Sub disconnect")
+
+        async for signal in super().subscribe(key, on_ready=on_ready):
+            yield signal
 
 
 class _RecordingWorker:
@@ -374,6 +401,41 @@ class TestIndexTaskConsumerDispatch(IsolatedAsyncioTestCase):
 
         doc_ids = [c["document_id"] for c in worker.calls]
         self.assertEqual(doc_ids, ["boom", "ok"])
+
+    async def test_reconnect_drains_queue_without_a_new_signal(self) -> None:
+        """A task queued during a disconnect is handled after reconnect."""
+        bus = _ReconnectOnceBus()
+        worker = _RecordingWorker()
+        consumer = IndexTaskConsumer(message_bus=bus, worker=worker)
+
+        # pylint: disable=unnecessary-dunder-call
+        await consumer.__aenter__()
+        await bus.first_subscription_failed.wait()
+        await bus.queue_push(
+            MessageBusKeys.index_tasks_queue(),
+            {
+                "user_id": "u",
+                "knowledge_base_id": "kb",
+                "document_id": "queued-during-disconnect",
+            },
+        )
+
+        try:
+            await asyncio.wait_for(worker.notify.wait(), timeout=3.0)
+        finally:
+            await consumer.__aexit__(None, None, None)
+
+        self.assertGreaterEqual(bus.subscribe_calls, 2)
+        self.assertEqual(
+            worker.calls,
+            [
+                {
+                    "user_id": "u",
+                    "knowledge_base_id": "kb",
+                    "document_id": "queued-during-disconnect",
+                },
+            ],
+        )
 
 
 class TestIndexTaskConsumerLifecycle(IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary

- reconnect `IndexTaskConsumer` after a transient Pub/Sub failure or normal subscription termination;
- use bounded exponential backoff from 1 second to 30 seconds;
- drain the durable index-task queue after re-subscription so tasks do not depend on a new signal;
- cancel and await reconnect catch-up tasks during shutdown.

The generic `MessageBus.subscribe` transient broadcast contract and public APIs are unchanged.

## Reproduction addressed

A Redis Pub/Sub connection reset previously terminated the only index-task consumer task while queued indexing work remained in the durable Redis stream. The API-side sweeper could re-enqueue work but could not revive the consumer.

The regression test simulates the first subscription raising `ConnectionError`, queues a task without publishing another signal, and verifies that the worker receives it after the consumer reconnects.

## Validation

- `.venv/bin/pre-commit run --all-files` — passed;
- targeted consumer/message-bus tests — `44 passed`;
- production `RedisMessageBus` + fakeredis fault-injection check — passed: a real `get_message()` connection error caused a second subscription, the queued task was dispatched without a new signal, and the queue was empty afterward;
- full test suite — `2196 passed, 125 skipped, 11 failed`: the failures were unrelated local Moto S3 and MCP HTTP test services returning `502 Bad Gateway`.

Fixes #2537
