### PR TITLE
test(mcp): follow SDK transport defaults

### DIFF
--- a/tests/mcp_runtime_headers_test.py
+++ b/tests/mcp_runtime_headers_test.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, patch
 
 import httpx
 from fastapi.testclient import TestClient
+from mcp.client.streamable_http import create_mcp_http_client
 
 from agentscope.mcp import HttpMCPConfig, MCPClient
 from agentscope.workspace._gateway_client import GatewayClient
@@ -154,6 +155,12 @@ class MCPRuntimeHeadersTest(IsolatedAsyncioTestCase):
 
     async def test_owning_the_client_keeps_transport_defaults(self) -> None:
         """Taking ownership must not change how the client is configured."""
+        async with create_mcp_http_client() as transport_default_client:
+            transport_defaults = {
+                "follow_redirects": transport_default_client.follow_redirects,
+                "read_timeout": transport_default_client.timeout.read,
+            }
+
         defaults: dict[str, Any] = {}
         for label, config in (
             (
@@ -187,10 +194,7 @@ class MCPRuntimeHeadersTest(IsolatedAsyncioTestCase):
                     "follow_redirects": False,
                     "read_timeout": 30.0,
                 },
-                "untimed": {
-                    "follow_redirects": True,
-                    "read_timeout": 300.0,
-                },
+                "untimed": transport_defaults,
             },
         )
 


### PR DESCRIPTION
## Description

`MCPRuntimeHeadersTest.test_owning_the_client_keeps_transport_defaults` hard-coded `follow_redirects=True`, matching MCP 1.28.x. MCP 1.30.0 intentionally changed the HTTP client default to `False` because redirects are now handled safely inside the transport. Since AgentScope accepts any `mcp<2.0.0` release and CI installs without a lock file, the assertion started failing after 1.30.0 was published.

This change derives the expected untimed-client settings from MCP's `create_mcp_http_client()` factory. The test continues to verify that AgentScope preserves the SDK transport defaults without coupling itself to one MCP 1.x release.

## Tests

- `tests/mcp_runtime_headers_test.py` with MCP 1.28.1: 16 passed, 11 subtests passed
- `tests/mcp_runtime_headers_test.py` with MCP 1.30.0: 16 passed, 11 subtests passed
- Black, Flake8, and Pylint passed
