### PR TITLE
fix(pipeline): honor verifier context reset

### DIFF
--- a/src/agentscope/pipeline/_goal_pipeline.py
+++ b/src/agentscope/pipeline/_goal_pipeline.py
@@ -90,6 +90,20 @@ class GoalPipeline:
         self._iters = 0
         self._goal: None | list[TextBlock | DataBlock] = None
 
+    def _reset_verifier_context(self) -> None:
+        """Clear conversation state before the next verification round.
+
+        A failed verdict starts a new executor-verifier iteration. Keeping the
+        verifier's prior conversation in that next iteration contradicts
+        ``verifier_reset_context`` and can make a new report look like a
+        continuation of the rejected one. Deliberately leave the rest of the
+        verifier state intact: tool configuration, tasks, middleware state,
+        and an in-progress HITL reply all belong to the verifier itself rather
+        than to its conversation history.
+        """
+        self.verifier.state.context.clear()
+        self.verifier.state.summary = ""
+
     async def reply_stream(
         self,
         inputs: Msg
@@ -303,6 +317,8 @@ class GoalPipeline:
                     break_loop = True
                 else:
                     self._iters += 1
+                    if self.verifier_reset_context:
+                        self._reset_verifier_context()
                     if self._iters >= self.max_iters:
                         # Out of attempts; the work never passed
                         break_loop = True

--- a/src/agentscope/pipeline/_goal_pipeline.py
+++ b/src/agentscope/pipeline/_goal_pipeline.py
@@ -90,20 +90,6 @@ class GoalPipeline:
         self._iters = 0
         self._goal: None | list[TextBlock | DataBlock] = None
 
-    def _reset_verifier_context(self) -> None:
-        """Clear conversation state before the next verification round.
-
-        A failed verdict starts a new executor-verifier iteration. Keeping the
-        verifier's prior conversation in that next iteration contradicts
-        ``verifier_reset_context`` and can make a new report look like a
-        continuation of the rejected one. Deliberately leave the rest of the
-        verifier state intact: tool configuration, tasks, middleware state,
-        and an in-progress HITL reply all belong to the verifier itself rather
-        than to its conversation history.
-        """
-        self.verifier.state.context.clear()
-        self.verifier.state.summary = ""
-
     async def reply_stream(
         self,
         inputs: Msg
@@ -318,7 +304,9 @@ class GoalPipeline:
                 else:
                     self._iters += 1
                     if self.verifier_reset_context:
-                        self._reset_verifier_context()
+                        # Only the conversation, tool/task state stays
+                        self.verifier.state.context.clear()
+                        self.verifier.state.summary = ""
                     if self._iters >= self.max_iters:
                         # Out of attempts; the work never passed
                         break_loop = True

--- a/tests/pipeline_goal_test.py
+++ b/tests/pipeline_goal_test.py
@@ -67,8 +67,13 @@ class StubAgent:
         """Initialize the stub with one script entry per call."""
         self.name = name
         self.script = script
-        self.state = SimpleNamespace(reply_id=f"{name}-reply")
+        self.state = SimpleNamespace(
+            reply_id=f"{name}-reply",
+            context=[],
+            summary="",
+        )
         self.received: list[Any] = []
+        self.conversation_before_calls: list[tuple[list[Any], Any]] = []
 
     # pylint: disable=unused-argument
     async def reply_stream(
@@ -80,6 +85,9 @@ class StubAgent:
         """Yield the next batch, holding the final message back unless it
         was asked for, the way ``Agent.reply_stream`` does."""
         self.received.append(inputs)
+        self.conversation_before_calls.append(
+            (list(self.state.context), self.state.summary),
+        )
         batch = self.script[min(len(self.received) - 1, len(self.script) - 1)]
         for chunk in batch:
             if isinstance(chunk, Msg) and not yield_final_msg:
@@ -130,6 +138,57 @@ class GoalPipelineTest(IsolatedAsyncioTestCase):
         self.assertIn(
             "缺 requirements.txt",
             executor.received[1].get_text_content(),
+        )
+
+    async def test_resets_verifier_conversation_between_refused_rounds(
+        self,
+    ) -> None:
+        """The default keeps a refused verdict out of the next check."""
+        executor = StubAgent("executor", [[_report()], [_report()]])
+        verifier = StubAgent(
+            "verifier",
+            [[_verdict("fail", "try again")], [_verdict("pass")]],
+        )
+        verifier.state.context.append(UserMsg("user", "prior verdict"))
+        verifier.state.summary = "prior summary"
+        pipe = GoalPipeline(executor, verifier)
+
+        await self._run(pipe, self.query)
+
+        self.assertEqual(len(verifier.conversation_before_calls), 2)
+        self.assertEqual(
+            verifier.conversation_before_calls[0][0][0].get_text_content(),
+            "prior verdict",
+        )
+        self.assertEqual(
+            verifier.conversation_before_calls[0][1],
+            "prior summary",
+        )
+        self.assertEqual(verifier.conversation_before_calls[1], ([], ""))
+
+    async def test_can_keep_verifier_conversation_between_refused_rounds(
+        self,
+    ) -> None:
+        """Opting out preserves the verifier's existing conversation."""
+        executor = StubAgent("executor", [[_report()], [_report()]])
+        verifier = StubAgent(
+            "verifier",
+            [[_verdict("fail", "try again")], [_verdict("pass")]],
+        )
+        verifier.state.context.append(UserMsg("user", "prior verdict"))
+        verifier.state.summary = "prior summary"
+        pipe = GoalPipeline(executor, verifier, verifier_reset_context=False)
+
+        await self._run(pipe, self.query)
+
+        self.assertEqual(len(verifier.conversation_before_calls), 2)
+        self.assertEqual(
+            verifier.conversation_before_calls[1][0][0].get_text_content(),
+            "prior verdict",
+        )
+        self.assertEqual(
+            verifier.conversation_before_calls[1][1],
+            "prior summary",
         )
 
     async def test_stops_at_max_iters(self) -> None:

--- a/tests/pipeline_goal_test.py
+++ b/tests/pipeline_goal_test.py
@@ -149,22 +149,17 @@ class GoalPipelineTest(IsolatedAsyncioTestCase):
             "verifier",
             [[_verdict("fail", "try again")], [_verdict("pass")]],
         )
-        verifier.state.context.append(UserMsg("user", "prior verdict"))
+        prior = UserMsg("user", "prior verdict")
+        verifier.state.context.append(prior)
         verifier.state.summary = "prior summary"
         pipe = GoalPipeline(executor, verifier)
 
         await self._run(pipe, self.query)
 
-        self.assertEqual(len(verifier.conversation_before_calls), 2)
-        self.assertEqual(
-            verifier.conversation_before_calls[0][0][0].get_text_content(),
-            "prior verdict",
+        self.assertListEqual(
+            verifier.conversation_before_calls,
+            [([prior], "prior summary"), ([], "")],
         )
-        self.assertEqual(
-            verifier.conversation_before_calls[0][1],
-            "prior summary",
-        )
-        self.assertEqual(verifier.conversation_before_calls[1], ([], ""))
 
     async def test_can_keep_verifier_conversation_between_refused_rounds(
         self,
@@ -175,20 +170,16 @@ class GoalPipelineTest(IsolatedAsyncioTestCase):
             "verifier",
             [[_verdict("fail", "try again")], [_verdict("pass")]],
         )
-        verifier.state.context.append(UserMsg("user", "prior verdict"))
+        prior = UserMsg("user", "prior verdict")
+        verifier.state.context.append(prior)
         verifier.state.summary = "prior summary"
         pipe = GoalPipeline(executor, verifier, verifier_reset_context=False)
 
         await self._run(pipe, self.query)
 
-        self.assertEqual(len(verifier.conversation_before_calls), 2)
-        self.assertEqual(
-            verifier.conversation_before_calls[1][0][0].get_text_content(),
-            "prior verdict",
-        )
-        self.assertEqual(
-            verifier.conversation_before_calls[1][1],
-            "prior summary",
+        self.assertListEqual(
+            verifier.conversation_before_calls,
+            [([prior], "prior summary"), ([prior], "prior summary")],
         )
 
     async def test_stops_at_max_iters(self) -> None:


### PR DESCRIPTION
Fixes #2543

## AgentScope Version

2.0.8

## Description

`GoalPipeline` documented and stored `verifier_reset_context`, but never read it. A verifier that rejected one execution report therefore carried its prior conversation and summary into the next verification attempt.

This PR clears only the verifier conversation state after a completed `fail` verdict when the option is enabled (the default). It leaves executor state, tool/task configuration, middleware state, structured-output retries, and HITL resumes unchanged. Setting `verifier_reset_context=False` preserves the prior accumulating behavior.

The regression coverage verifies both the default reset path and the opt-out path.

## Validation

- `PYTHONPYCACHEPREFIX=/private/tmp/agentscope_pycache .venv/bin/pytest tests/pipeline_goal_test.py -q` — 12 passed
- `PYTHONPYCACHEPREFIX=/private/tmp/agentscope_pycache .venv/bin/pre-commit run --all-files` — passed

## Checklist

- [x] An issue has been created for this PR
- [x] I have read CONTRIBUTING.md
- [x] Docstrings are in Google style
- [x] No documentation update is needed: the public option already documents the intended behavior
- [x] Code is ready for review