### PR TITLE
fix(app): assign unique AG-UI message IDs to tool results

### DIFF
--- a/src/agentscope/app/middleware/_protocol/_agui.py
+++ b/src/agentscope/app/middleware/_protocol/_agui.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """The AGUI middleware class."""
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
 from starlette.types import ASGIApp
 
@@ -41,6 +42,9 @@ else:
     AGUIBaseEvent = Any
 
 
+_TOOL_RESULT_MESSAGE_ID_SEPARATOR = ":"
+
+
 class AGUIProtocolMiddleware(ProtocolMiddlewareBase):
     """The middleware that converts the AgentScope events into AGUI
     protocol."""
@@ -56,7 +60,7 @@ class AGUIProtocolMiddleware(ProtocolMiddlewareBase):
         # but not across concurrent requests.  Use contextvars if
         # concurrency is needed.
         self._last_model_name: str = "model_call"
-        self._tool_result_buffers: dict[str, list[str]] = {}
+        self._tool_result_buffers: dict[tuple[str, str], list[str]] = {}
 
     def _convert_to_protocol(self, event: AgentEvent) -> dict:
         """Convert the AgentScope events into AGUI protocol."""
@@ -194,7 +198,7 @@ class AGUIProtocolMiddleware(ProtocolMiddlewareBase):
 
         if isinstance(event, ToolResultTextDeltaEvent):
             self._tool_result_buffers.setdefault(
-                event.tool_call_id,
+                (event.reply_id, event.tool_call_id),
                 [],
             ).append(event.delta)
             return AGUICustomEvent(
@@ -210,11 +214,22 @@ class AGUIProtocolMiddleware(ProtocolMiddlewareBase):
 
         if isinstance(event, ToolResultEndEvent):
             content = "".join(
-                self._tool_result_buffers.pop(event.tool_call_id, []),
+                self._tool_result_buffers.pop(
+                    (event.reply_id, event.tool_call_id),
+                    [],
+                ),
             )
+            # ``reply_id`` is shared by all tool results of one reply, so
+            # combine encoded IDs with the per-tool ``tool_call_id`` for the
+            # result message ID. The separator stays unambiguous because it is
+            # not emitted by ``quote(..., safe="")``.
             return AGUIToolCallResultEvent(
                 tool_call_id=event.tool_call_id,
-                message_id=event.reply_id,
+                message_id=(
+                    f"{quote(event.reply_id, safe='')}"
+                    f"{_TOOL_RESULT_MESSAGE_ID_SEPARATOR}"
+                    f"{quote(event.tool_call_id, safe='')}"
+                ),
                 content=content or str(event.state),
             )
 

--- a/src/agentscope/app/middleware/_protocol/_agui.py
+++ b/src/agentscope/app/middleware/_protocol/_agui.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """The AGUI middleware class."""
 from typing import TYPE_CHECKING, Any
-from urllib.parse import quote
 
 from starlette.types import ASGIApp
 
@@ -40,9 +39,6 @@ if TYPE_CHECKING:
     from ag_ui.core.events import BaseEvent as AGUIBaseEvent
 else:
     AGUIBaseEvent = Any
-
-
-_TOOL_RESULT_MESSAGE_ID_SEPARATOR = ":"
 
 
 class AGUIProtocolMiddleware(ProtocolMiddlewareBase):
@@ -219,17 +215,12 @@ class AGUIProtocolMiddleware(ProtocolMiddlewareBase):
                     [],
                 ),
             )
-            # ``reply_id`` is shared by all tool results of one reply, so
-            # combine encoded IDs with the per-tool ``tool_call_id`` for the
-            # result message ID. The separator stays unambiguous because it is
-            # not emitted by ``quote(..., safe="")``.
+            # ``reply_id`` is shared by every tool result of one reply, so
+            # qualify it with ``tool_call_id`` to keep each result its own
+            # message.
             return AGUIToolCallResultEvent(
                 tool_call_id=event.tool_call_id,
-                message_id=(
-                    f"{quote(event.reply_id, safe='')}"
-                    f"{_TOOL_RESULT_MESSAGE_ID_SEPARATOR}"
-                    f"{quote(event.tool_call_id, safe='')}"
-                ),
+                message_id=f"{event.reply_id}:{event.tool_call_id}",
                 content=content or str(event.state),
             )
 

--- a/tests/agui_protocol_test.py
+++ b/tests/agui_protocol_test.py
@@ -105,6 +105,21 @@ class AGUIProtocolStreamTest(IsolatedAsyncioTestCase):
         self.assertEqual(data["runId"], "reply_1")
         self.assertNotIn("session_id", data)
 
+    async def test_sse_tool_result_with_separator_is_converted(self) -> None:
+        """Test tool-result IDs with separators survive stream conversion."""
+        event = ToolResultEndEvent(
+            reply_id="reply:1",
+            tool_call_id="tc:1",
+            state=ToolResultState.SUCCESS,
+        )
+
+        body = await _collect_stream(self.mw, [event.model_dump_json()])
+        data = json.loads(body)
+
+        self.assertEqual(data["type"], "TOOL_CALL_RESULT")
+        self.assertEqual(data["toolCallId"], "tc:1")
+        self.assertEqual(data["messageId"], "reply%3A1:tc%3A1")
+
     async def test_sse_heartbeat_is_passed_through(self) -> None:
         """Test SSE heartbeat frames are not modified."""
         self.assertEqual(
@@ -466,7 +481,7 @@ class AGUIProtocolToolResultTest(IsolatedAsyncioTestCase):
 
         self.assertEqual(result["type"], "TOOL_CALL_RESULT")
         self.assertEqual(result["toolCallId"], "tc_1")
-        self.assertEqual(result["messageId"], "reply_1")
+        self.assertEqual(result["messageId"], "reply_1:tc_1")
         self.assertEqual(result["content"], "partial result")
 
     async def test_tool_result_end_fallback_to_state(self) -> None:
@@ -480,7 +495,109 @@ class AGUIProtocolToolResultTest(IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(result["type"], "TOOL_CALL_RESULT")
+        self.assertEqual(result["messageId"], "reply_1:tc_1")
         self.assertEqual(result["content"], "error")
+
+    async def test_tool_result_message_id_escapes_separator(self) -> None:
+        """Test that composite tool result IDs escape the separator."""
+        self.mw._convert_to_protocol(
+            ToolResultTextDeltaEvent(
+                reply_id="reply:1",
+                tool_call_id="tc:1",
+                delta="preserved",
+            ),
+        )
+
+        result = self.mw._convert_to_protocol(
+            ToolResultEndEvent(
+                reply_id="reply:1",
+                tool_call_id="tc:1",
+                state=ToolResultState.SUCCESS,
+            ),
+        )
+
+        self.assertEqual(result["messageId"], "reply%3A1:tc%3A1")
+        self.assertEqual(result["content"], "preserved")
+        self.assertEqual(self.mw._tool_result_buffers, {})
+
+        left = self.mw._convert_to_protocol(
+            ToolResultEndEvent(
+                reply_id="reply:1",
+                tool_call_id="tc_1",
+                state=ToolResultState.SUCCESS,
+            ),
+        )
+        right = self.mw._convert_to_protocol(
+            ToolResultEndEvent(
+                reply_id="reply",
+                tool_call_id="1:tc_1",
+                state=ToolResultState.SUCCESS,
+            ),
+        )
+        self.assertNotEqual(left["messageId"], right["messageId"])
+
+    async def test_multiple_tool_results_use_unique_message_ids(self) -> None:
+        """Test that multiple tool results in one reply get unique ids."""
+        self.mw._convert_to_protocol(
+            ToolResultTextDeltaEvent(
+                reply_id="reply_1",
+                tool_call_id="tc_1",
+                delta="result A",
+            ),
+        )
+        self.mw._convert_to_protocol(
+            ToolResultTextDeltaEvent(
+                reply_id="reply_1",
+                tool_call_id="tc_2",
+                delta="result B",
+            ),
+        )
+        self.mw._convert_to_protocol(
+            ToolResultTextDeltaEvent(
+                reply_id="reply_2",
+                tool_call_id="tc_1",
+                delta="result C",
+            ),
+        )
+
+        # Complete a result from the second reply first to verify that
+        # interleaved replies keep their per-tool buffers independent.
+        result_3 = self.mw._convert_to_protocol(
+            ToolResultEndEvent(
+                reply_id="reply_2",
+                tool_call_id="tc_1",
+                state=ToolResultState.SUCCESS,
+            ),
+        )
+        result_2 = self.mw._convert_to_protocol(
+            ToolResultEndEvent(
+                reply_id="reply_1",
+                tool_call_id="tc_2",
+                state=ToolResultState.SUCCESS,
+            ),
+        )
+        result_1 = self.mw._convert_to_protocol(
+            ToolResultEndEvent(
+                reply_id="reply_1",
+                tool_call_id="tc_1",
+                state=ToolResultState.SUCCESS,
+            ),
+        )
+
+        self.assertEqual(result_1["type"], "TOOL_CALL_RESULT")
+        self.assertEqual(result_2["type"], "TOOL_CALL_RESULT")
+        self.assertEqual(result_3["type"], "TOOL_CALL_RESULT")
+        self.assertEqual(result_1["toolCallId"], "tc_1")
+        self.assertEqual(result_2["toolCallId"], "tc_2")
+        self.assertEqual(result_3["toolCallId"], "tc_1")
+        self.assertEqual(result_1["content"], "result A")
+        self.assertEqual(result_2["content"], "result B")
+        self.assertEqual(result_3["content"], "result C")
+        self.assertNotEqual(result_1["messageId"], result_2["messageId"])
+        self.assertNotEqual(result_1["messageId"], result_3["messageId"])
+        self.assertEqual(result_1["messageId"], "reply_1:tc_1")
+        self.assertEqual(result_2["messageId"], "reply_1:tc_2")
+        self.assertEqual(result_3["messageId"], "reply_2:tc_1")
 
     async def test_tool_result_start_to_custom(self) -> None:
         """Test ToolResultStartEvent -> CUSTOM."""

--- a/tests/agui_protocol_test.py
+++ b/tests/agui_protocol_test.py
@@ -105,21 +105,6 @@ class AGUIProtocolStreamTest(IsolatedAsyncioTestCase):
         self.assertEqual(data["runId"], "reply_1")
         self.assertNotIn("session_id", data)
 
-    async def test_sse_tool_result_with_separator_is_converted(self) -> None:
-        """Test tool-result IDs with separators survive stream conversion."""
-        event = ToolResultEndEvent(
-            reply_id="reply:1",
-            tool_call_id="tc:1",
-            state=ToolResultState.SUCCESS,
-        )
-
-        body = await _collect_stream(self.mw, [event.model_dump_json()])
-        data = json.loads(body)
-
-        self.assertEqual(data["type"], "TOOL_CALL_RESULT")
-        self.assertEqual(data["toolCallId"], "tc:1")
-        self.assertEqual(data["messageId"], "reply%3A1:tc%3A1")
-
     async def test_sse_heartbeat_is_passed_through(self) -> None:
         """Test SSE heartbeat frames are not modified."""
         self.assertEqual(
@@ -498,106 +483,49 @@ class AGUIProtocolToolResultTest(IsolatedAsyncioTestCase):
         self.assertEqual(result["messageId"], "reply_1:tc_1")
         self.assertEqual(result["content"], "error")
 
-    async def test_tool_result_message_id_escapes_separator(self) -> None:
-        """Test that composite tool result IDs escape the separator."""
-        self.mw._convert_to_protocol(
-            ToolResultTextDeltaEvent(
-                reply_id="reply:1",
-                tool_call_id="tc:1",
-                delta="preserved",
-            ),
-        )
-
-        result = self.mw._convert_to_protocol(
-            ToolResultEndEvent(
-                reply_id="reply:1",
-                tool_call_id="tc:1",
-                state=ToolResultState.SUCCESS,
-            ),
-        )
-
-        self.assertEqual(result["messageId"], "reply%3A1:tc%3A1")
-        self.assertEqual(result["content"], "preserved")
-        self.assertEqual(self.mw._tool_result_buffers, {})
-
-        left = self.mw._convert_to_protocol(
-            ToolResultEndEvent(
-                reply_id="reply:1",
-                tool_call_id="tc_1",
-                state=ToolResultState.SUCCESS,
-            ),
-        )
-        right = self.mw._convert_to_protocol(
-            ToolResultEndEvent(
-                reply_id="reply",
-                tool_call_id="1:tc_1",
-                state=ToolResultState.SUCCESS,
-            ),
-        )
-        self.assertNotEqual(left["messageId"], right["messageId"])
-
     async def test_multiple_tool_results_use_unique_message_ids(self) -> None:
-        """Test that multiple tool results in one reply get unique ids."""
-        self.mw._convert_to_protocol(
-            ToolResultTextDeltaEvent(
-                reply_id="reply_1",
-                tool_call_id="tc_1",
-                delta="result A",
-            ),
-        )
-        self.mw._convert_to_protocol(
-            ToolResultTextDeltaEvent(
-                reply_id="reply_1",
-                tool_call_id="tc_2",
-                delta="result B",
-            ),
-        )
-        self.mw._convert_to_protocol(
-            ToolResultTextDeltaEvent(
-                reply_id="reply_2",
-                tool_call_id="tc_1",
-                delta="result C",
-            ),
-        )
+        """Test that two tool results of one reply get distinct ids."""
+        for tool_call_id, delta in (
+            ("tc_1", "result A"),
+            ("tc_2", "result B"),
+        ):
+            self.mw._convert_to_protocol(
+                ToolResultTextDeltaEvent(
+                    reply_id="reply_1",
+                    tool_call_id=tool_call_id,
+                    delta=delta,
+                ),
+            )
 
-        # Complete a result from the second reply first to verify that
-        # interleaved replies keep their per-tool buffers independent.
-        result_3 = self.mw._convert_to_protocol(
-            ToolResultEndEvent(
-                reply_id="reply_2",
-                tool_call_id="tc_1",
-                state=ToolResultState.SUCCESS,
-            ),
-        )
-        result_2 = self.mw._convert_to_protocol(
-            ToolResultEndEvent(
-                reply_id="reply_1",
-                tool_call_id="tc_2",
-                state=ToolResultState.SUCCESS,
-            ),
-        )
-        result_1 = self.mw._convert_to_protocol(
-            ToolResultEndEvent(
-                reply_id="reply_1",
-                tool_call_id="tc_1",
-                state=ToolResultState.SUCCESS,
-            ),
-        )
+        results = [
+            self.mw._convert_to_protocol(
+                ToolResultEndEvent(
+                    reply_id="reply_1",
+                    tool_call_id=tool_call_id,
+                    state=ToolResultState.SUCCESS,
+                ),
+            )
+            for tool_call_id in ("tc_2", "tc_1")
+        ]
 
-        self.assertEqual(result_1["type"], "TOOL_CALL_RESULT")
-        self.assertEqual(result_2["type"], "TOOL_CALL_RESULT")
-        self.assertEqual(result_3["type"], "TOOL_CALL_RESULT")
-        self.assertEqual(result_1["toolCallId"], "tc_1")
-        self.assertEqual(result_2["toolCallId"], "tc_2")
-        self.assertEqual(result_3["toolCallId"], "tc_1")
-        self.assertEqual(result_1["content"], "result A")
-        self.assertEqual(result_2["content"], "result B")
-        self.assertEqual(result_3["content"], "result C")
-        self.assertNotEqual(result_1["messageId"], result_2["messageId"])
-        self.assertNotEqual(result_1["messageId"], result_3["messageId"])
-        self.assertEqual(result_1["messageId"], "reply_1:tc_1")
-        self.assertEqual(result_2["messageId"], "reply_1:tc_2")
-        self.assertEqual(result_3["messageId"], "reply_2:tc_1")
+        self.assertListEqual(
+            results,
+            [
+                {
+                    "type": "TOOL_CALL_RESULT",
+                    "messageId": "reply_1:tc_2",
+                    "toolCallId": "tc_2",
+                    "content": "result B",
+                },
+                {
+                    "type": "TOOL_CALL_RESULT",
+                    "messageId": "reply_1:tc_1",
+                    "toolCallId": "tc_1",
+                    "content": "result A",
+                },
+            ],
+        )
+        self.assertDictEqual(self.mw._tool_result_buffers, {})
 
     async def test_tool_result_start_to_custom(self) -> None:
         """Test ToolResultStartEvent -> CUSTOM."""


### PR DESCRIPTION
## AgentScope Version

2.0.8

## Description

### Problem in One Sentence

Two different tool results are currently sent with the same message ID.

One assistant reply can call multiple tools:

```text
reply_id = reply_1
|
+-- Tool 1: tc_1 -> Result A
|
+-- Tool 2: tc_2 -> Result B
```

The middleware currently gives both results the shared reply-level ID:

```text
Tool 1 -> messageId = reply_1
Tool 2 -> messageId = reply_1
```

An AG-UI consumer that identifies messages by `messageId` may therefore treat
the two results as one message and overwrite the first result with the second.

This is an AG-UI adapter identity bug: the original logic maps one reply-level
ID to multiple independent tool-result message IDs.

Each tool result needs its own stable message ID while preserving the parent
reply association:

```text
Tool 1 -> messageId = reply_1:tc_1
Tool 2 -> messageId = reply_1:tc_2
```

### Changes

- Percent-encode each source ID and compose the tool-result message ID as
  `encoded_reply_id:encoded_tool_call_id`.
- Keep `:` as the composite-ID separator. Encoding prevents collisions even
  when an upstream reply ID or tool call ID contains `:`.
- Key buffered tool-result deltas by `(reply_id, tool_call_id)` so interleaved
  replies cannot merge content when they reuse a tool call ID.
- Preserve the existing reply association, tool call ID, buffered result
  content, and state fallback behavior.
- Add regression coverage for multiple results, out-of-order completion,
  reuse of a tool call ID across interleaved replies, separator encoding on the
  real stream path, and state fallback.

### Compatibility and scope

This is an AG-UI adapter fix only. It does not change the core event model,
`reply_id` semantics, tracing fields, or the legacy adapter. Existing IDs that
contain only URI-unreserved characters keep the same `reply_id:tool_call_id`
format; reserved characters such as `:` are percent-encoded before composition
rather than rejected or allowed to create ambiguous IDs.

### Verification

- `pytest tests/agui_protocol_test.py -q` — 37 passed.
- `pre-commit run --files src/agentscope/app/middleware/_protocol/_agui.py tests/agui_protocol_test.py` — all applicable hooks passed.
- `git diff --check` — passed.
- Local full-suite baseline run before the final rebase — 2,171 passed, 147
  skipped, 29 failed. The failures were unrelated environment/optional-service
  tests covering local socket/port binding, S3/Moto, MCP transports, Milvus
  Lite, SQL migrations, and bubblewrap workspace behavior. The GitHub Actions
  checks for this PR provide the final-head verification.

### Checklist

- [x] An issue has been created for this PR: #2554
- [x] I have read [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [x] Code is ready for review (targeted verification and pre-commit checks passed)

Fixes #2554
