### PR TITLE
fix(realtime): request a response after a caller-committed turn

### DIFF
--- a/src/agentscope/agent/_realtime/_agent.py
+++ b/src/agentscope/agent/_realtime/_agent.py
@@ -519,6 +519,9 @@ class RealtimeAgent:
             self._metrics.user_speech_end_at = now
             await self.model.commit_turn()
             self._metrics.turn_committed_at = time.monotonic()
+            # With turn detection off nothing answers a committed turn
+            # by itself; providers that reply on commit make this a no-op.
+            await self.model.request_response()
 
         if not pushed:
             await self.model.push_audio(pcm)

--- a/tests/realtime_agent_test.py
+++ b/tests/realtime_agent_test.py
@@ -407,6 +407,7 @@ class RealtimeAgentTest(IsolatedAsyncioTestCase):
                 "connect(session=1,td_off=True)",
                 "push_audio",
                 "commit_turn",
+                "request_response",
                 "push_audio",
                 "push_audio",
                 "close",


### PR DESCRIPTION
## Description

When a local VAD owns turn detection, `RealtimeAgent` committed the audio buffer on speech end but never asked for a response. OpenAI-shaped realtime APIs (DashScope, OpenAI, xAI) only answer after `response.create` in that mode, so the user was never answered. The agent now calls `request_response()` right after `commit_turn()`. Providers that reply on commit (Gemini's `activityEnd`) implement `request_response()` as a no-op.

## Checklist

- [x] `tests/realtime_agent_test.py` updated (local VAD call sequence)
- [x] `pre-commit run --all-files` passes