### PR TITLE
ci(github): track pr state with awaiting review / awaiting changes labels

### DIFF
--- a/.github/workflows/pr-review-relay.yml
+++ b/.github/workflows/pr-review-relay.yml
@@ -1,0 +1,21 @@
+name: PR Review Relay
+
+# pull_request_review runs with a read-only GITHUB_TOKEN on fork PRs, so it
+# can't edit labels. Hand the review to pr-state-labels.yml via workflow_run.
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  relay:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          EVENT: ${{ toJson(github.event) }}
+        run: |
+          jq '{number: .pull_request.number, author: .pull_request.user.login,
+               reviewer: .review.user.login, state: .review.state}' <<< "$EVENT" > review.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: review
+          path: review.json

--- a/.github/workflows/pr-state-labels.yml
+++ b/.github/workflows/pr-state-labels.yml
@@ -1,0 +1,54 @@
+name: PR State Labels
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize, edited]
+  workflow_run:
+    workflows: [PR Review Relay]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+
+env:
+  MAINTAINERS: DavdGao qbc2016
+  GH_TOKEN: ${{ github.token }}
+  GH_REPO: ${{ github.repository }}
+
+jobs:
+  # New commits (or a fresh PR) hand the ball back to the maintainers.
+  on-push:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    env:
+      PR: ${{ github.event.pull_request.number }}
+    steps:
+      - if: github.event.action != 'edited' && !github.event.pull_request.draft
+        run: |
+          gh pr edit "$PR" --add-label "state: awaiting review" --remove-label "state: awaiting changes"
+
+      - if: github.event.action == 'opened' || github.event.action == 'edited'
+        run: |
+          linked=$(gh pr view "$PR" --json closingIssuesReferences --jq '.closingIssuesReferences | length')
+          if [ "$linked" = 0 ]; then
+            gh pr edit "$PR" --add-label "no linked issue"
+          else
+            gh pr edit "$PR" --remove-label "no linked issue"
+          fi
+
+  # A maintainer review hands the ball to the author.
+  on-review:
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh run download ${{ github.event.workflow_run.id }} -n review
+      - run: |
+          read -r number author reviewer state < <(jq -r '"\(.number) \(.author) \(.reviewer) \(.state)"' review.json)
+          case " $MAINTAINERS " in *" $reviewer "*) ;; *) exit 0 ;; esac
+          if [ "$reviewer" = "$author" ]; then exit 0; fi
+          if [ "$state" = approved ]; then
+            gh pr edit "$number" --remove-label "state: awaiting review" --remove-label "state: awaiting changes"
+          else
+            gh pr edit "$number" --add-label "state: awaiting changes" --remove-label "state: awaiting review"
+          fi


### PR DESCRIPTION
## Description

Keep a single state label on every PR so the list page shows whose turn it is:

| Label | Set when | Cleared when |
|---|---|---|
| `state: awaiting review` | PR opened / reopened / marked ready for review / new commits pushed | a maintainer review lands |
| `state: awaiting changes` | DavdGao or qbc2016 submits a review that is not an approval (comment or request changes) | new commits are pushed |
| `no linked issue` | PR is opened or edited and closes no issue | PR body gains a `Fixes #N` style link |

A maintainer approval clears both state labels. Reviews by the PR author or by non-maintainers are ignored. Draft PRs get no state label until they are marked ready for review.

## Implementation notes

`pull_request_review` runs with a read-only `GITHUB_TOKEN` on fork PRs, so it cannot edit labels. `pr-review-relay.yml` only uploads the review info as an artifact, and `pr-state-labels.yml` picks it up through `workflow_run`, which runs with write permissions. This is the pattern recommended in the GitHub Actions docs.

Because the relay workflow is read from the PR's merge ref, it only fires for PRs whose branch contains the file, i.e. PRs opened or rebased after this is merged.

The labels `state: awaiting review` and `no linked issue` have been created in the repo; `state: awaiting changes` already existed.

## Checklist

- [x] Pre-commit passes
- [ ] Verified after merge on a real PR
