### PR TITLE
fix(agent): retry compression on recoverable structured-output errors

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -64,7 +64,7 @@ from ..event import (
     UserInterruptEvent,
     HintBlockEvent,
 )
-from ..exception import AgentOrientedException
+from ..exception import AgentOrientedException, StructuredOutputError
 from ..model import (
     ChatResponse,
     ChatUsage,
@@ -107,6 +107,12 @@ from ..workspace import Offloader, WorkspaceBase
 
 # The name of the tool that the agent uses to compress its own context
 _COMPRESSION_TOOL_NAME = "CompressContext"
+
+# Extra attempts to regenerate the compression summary when the model
+# returns a structurally invalid summary (a recoverable schema-validation
+# failure) rather than aborting the agent on the first try. Each retry
+# appends concise validation feedback so the model can correct the format.
+_COMPRESSION_VALIDATION_RETRIES = 2
 
 if TYPE_CHECKING:
     from ..middleware import MiddlewareBase
@@ -630,10 +636,50 @@ class Agent:
         # Compress the messages
         res = None
         try:
-            res = await self.model.generate_structured_output(
-                messages=messages,
-                structured_model=cfg.summary_schema,
-            )
+            try:
+                res = await self.model.generate_structured_output(
+                    messages=messages,
+                    structured_model=cfg.summary_schema,
+                )
+            except StructuredOutputError as validation_error:
+                # A schema-validation failure (e.g. a misspelled field) is
+                # recoverable: retry a small number of times with concise
+                # validation feedback so a long-running agent is not aborted
+                # by a one-off format deviation. On exhausted retries, fall
+                # through to the existing truncation/raise handling below.
+                retry_messages = list(messages)
+                required_fields = ", ".join(
+                    cfg.summary_schema.get("required", []),
+                )
+                fields_hint = (
+                    f"the required fields: {required_fields}"
+                    if required_fields
+                    else "the schema"
+                )
+                last_error: Exception = validation_error
+                for _ in range(_COMPRESSION_VALIDATION_RETRIES):
+                    retry_messages.append(
+                        UserMsg(
+                            name="user",
+                            content=(
+                                "The previous compression summary failed "
+                                "schema validation:\n"
+                                f"{last_error}\nPlease regenerate the "
+                                f"summary with exactly {fields_hint}."
+                            ),
+                        ),
+                    )
+                    try:
+                        res = await self.model.generate_structured_output(
+                            messages=retry_messages,
+                            structured_model=cfg.summary_schema,
+                        )
+                        break
+                    except StructuredOutputError as retry_error:
+                        last_error = retry_error
+                        continue
+                if res is None:
+                    raise last_error
 
         except Exception as error:
             if context_overflow:

--- a/tests/compress_context_test.py
+++ b/tests/compress_context_test.py
@@ -12,6 +12,7 @@ from unittest.async_case import IsolatedAsyncioTestCase
 from utils import MockModel, AnyString
 
 from agentscope.model import ChatResponse, ChatUsage, StructuredResponse
+from agentscope.exception import StructuredOutputError
 from agentscope.agent import Agent, ContextConfig, InjectionConfig
 from agentscope.state import AgentState
 from agentscope.message import (
@@ -158,6 +159,56 @@ class RecordingStructuredMockModel(MockModel):
             messages,
             structured_model,
             **kwargs,
+        )
+
+
+class _StructuredOutputFailingMockModel(MockModel):
+    """A mock model whose ``generate_structured_output`` raises a
+    ``StructuredOutputError`` (a recoverable schema-validation failure) on
+    the first ``fail_times`` calls, then returns a valid summary.
+
+    Overrides ``generate_structured_output`` directly so the agent-layer
+    retry in ``_compress_context_impl`` is exercised without the model
+    strategy ladder.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        fail_times: int = 1,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the failing mock model.
+
+        Args:
+            fail_times: Number of leading calls that fail with
+                ``StructuredOutputError`` before a valid summary is
+                returned.
+        """
+        super().__init__(*args, **kwargs)
+        self.structured_call_count = 0
+        self._fail_times = fail_times
+
+    async def generate_structured_output(
+        self,
+        messages: list[Msg],
+        structured_model: Any,
+        **kwargs: Any,
+    ) -> StructuredResponse:
+        """Fail the leading calls with a validation error, then succeed."""
+        self.structured_call_count += 1
+        if self.structured_call_count <= self._fail_times:
+            raise StructuredOutputError(
+                "'task_overview' is a required property",
+            )
+        return StructuredResponse(
+            content={
+                "task_overview": "1",
+                "current_state": "2",
+                "important_discoveries": "3",
+                "next_steps": "4",
+                "context_to_preserve": "5",
+            },
         )
 
 
@@ -2714,6 +2765,100 @@ class ContextCompressionTest(IsolatedAsyncioTestCase):
         await agent.compress_context()
 
         self.assertEqual(agent.state, expected_state)
+
+    async def test_compression_retries_on_structured_output_error(self) -> None:
+        """A recoverable schema-validation failure retries with feedback
+        instead of aborting the agent.
+
+        The model's first ``generate_structured_output`` call raises a
+        ``StructuredOutputError`` (e.g. a misspelled field). Compression
+        should retry and succeed on the second call rather than propagating
+        the error and aborting the long-running agent.
+        """
+        model = _StructuredOutputFailingMockModel(context_size=100)
+        agent = Agent(
+            name="Friday",
+            system_prompt="".join(["0" for _ in range(20 * 4)]),
+            model=model,
+            context_config=ContextConfig(
+                trigger_ratio=0.7,
+                reserve_ratio=0.4,
+            ),
+            state=AgentState(
+                session_id="123",
+                context=[
+                    UserMsg(
+                        "User",
+                        "".join(["1" for _ in range(30 * 4)]),
+                        id="1",
+                    ),
+                    AssistantMsg(
+                        "Friday",
+                        "".join(["2" for _ in range(10 * 4)]),
+                        id="2",
+                    ),
+                    UserMsg(
+                        "User",
+                        "".join(["3" for _ in range(10 * 4)]),
+                        id="3",
+                    ),
+                ],
+            ),
+            toolkit=Toolkit(),
+        )
+
+        await agent.compress_context()
+
+        # The model was called twice: one failed validation + one success.
+        self.assertEqual(model.structured_call_count, 2)
+        # Compression succeeded — the summary was generated.
+        self.assertIn("# Task Overview\n1", agent.state.summary)
+
+    async def test_compression_exhausts_retries_then_aborts(self) -> None:
+        """When validation never succeeds, the agent still aborts with the
+        error after exhausting retries (no infinite loop)."""
+        # fail_times larger than the retry budget: every call fails.
+        model = _StructuredOutputFailingMockModel(
+            context_size=100,
+            fail_times=99,
+        )
+        agent = Agent(
+            name="Friday",
+            system_prompt="".join(["0" for _ in range(20 * 4)]),
+            model=model,
+            context_config=ContextConfig(
+                trigger_ratio=0.7,
+                reserve_ratio=0.4,
+                compression_fallback_to_truncation=False,
+            ),
+            state=AgentState(
+                session_id="123",
+                context=[
+                    UserMsg(
+                        "User",
+                        "".join(["1" for _ in range(30 * 4)]),
+                        id="1",
+                    ),
+                    AssistantMsg(
+                        "Friday",
+                        "".join(["2" for _ in range(10 * 4)]),
+                        id="2",
+                    ),
+                    UserMsg(
+                        "User",
+                        "".join(["3" for _ in range(10 * 4)]),
+                        id="3",
+                    ),
+                ],
+            ),
+            toolkit=Toolkit(),
+        )
+
+        with self.assertRaises(StructuredOutputError):
+            await agent.compress_context()
+
+        # 1 initial attempt + 2 retries = 3 calls, then abort.
+        self.assertEqual(model.structured_call_count, 3)
 
     async def asyncTearDown(self) -> None:
         """The async teardown method."""

--- a/tests/compress_context_test.py
+++ b/tests/compress_context_test.py
@@ -189,6 +189,27 @@ class _StructuredOutputFailingMockModel(MockModel):
         self.structured_call_count = 0
         self._fail_times = fail_times
 
+    async def count_tokens(
+        self,
+        messages: list[Msg],
+        tools: list[dict] | None,
+    ) -> int:
+        """Keep the compression count below the context size so the retry
+        path is isolated from the overflow/truncation path.
+
+        The initial model-input count (no compression tool) is reported at
+        the context size so compression triggers; the compression-tool count
+        is reported as 1 so ``context_overflow`` stays ``False``.
+        """
+        is_compression_count = bool(
+            tools
+            and tools[0].get("function", {}).get("name")
+            == "generate_structured_output",
+        )
+        if is_compression_count:
+            return 1
+        return self.context_size
+
     async def generate_structured_output(
         self,
         messages: list[Msg],


### PR DESCRIPTION
## Problem fixed & how

When context compression triggers, `_compress_context_impl` calls `generate_structured_output` with the summary schema. If the model returns an almost-valid tool call with a misspelled field (e.g. `task_over` instead of the required `task_overview`), the `jsonschema.ValidationError` is wrapped into a `StructuredOutputError`. `_compress_context_impl` only retried when `context_overflow=True`; a schema-validation failure with `context_overflow=False` was re-raised (or fell back to truncation), aborting the entire long-running agent on a single one-off format deviation.

**Root cause** (`agent/_agent.py`, `_compress_context_impl`): the `generate_structured_output` call is wrapped by `except Exception as error`, whose retry branch is gated on `context_overflow`. `StructuredOutputError` is a recoverable format error, not an overflow, so it skipped the retry and propagated.

**Fix**: catch `StructuredOutputError` specifically before the generic `except Exception` and retry a bounded number of times (`_COMPRESSION_VALIDATION_RETRIES = 2`) with concise validation feedback appended — the validation error text plus the required schema fields — so the model can correct the format. The retry is generic (no per-field alias). On exhausted retries the most recent error is re-raised into the existing truncation/raise handling, preserving prior behavior for unrecoverable failures.

Closes #2425.

## Behavior modified

- **Previous**: a schema-validation failure during compression with `context_overflow=False` re-raised `StructuredOutputError` (or truncated context when `compression_fallback_to_truncation` is set), aborting the agent on a one-off format deviation.
- **Now**: the compression path retries up to 2 additional times with validation feedback before giving up; only exhausted retries fall through to the existing truncation/raise behavior.
- **Impact**: long-running agents are no longer aborted by a single misspelled summary field. Overflow / provider errors and the truncation fallback are unchanged — `RuntimeError` and `context_overflow` paths still hit the existing `except Exception` branch.

## Features added

N/A

## Code refactored

The retry is contained to `_compress_context_impl`'s compression call. No changes to `generate_structured_output` or the model abstraction's retry/strategy semantics.

## Functions optimized

N/A

## Test plan

- [x] `test_compression_retries_on_structured_output_error`: a mock model whose `generate_structured_output` raises `StructuredOutputError` on the first call and returns a valid summary on the second → asserts compression retries and succeeds with 2 calls. ✅ passes locally
- [x] `test_compression_exhausts_retries_then_aborts`: an always-failing mock → asserts the agent raises `StructuredOutputError` after the retry budget (1 initial + 2 retries = 3 calls), no infinite loop. ✅ passes locally
- [x] Full `tests/compress_context_test.py` suite (24 tests) passes locally — existing success / overflow-retry / truncation-fallback cases are unchanged (backward compatible).
