### PR TITLE
refactor(app): group the agent's text-mode settings under chat_config

### DIFF
--- a/examples/web_ui/frontend/src/api/types.ts
+++ b/examples/web_ui/frontend/src/api/types.ts
@@ -40,13 +40,18 @@ export interface InviteConfig {
 
 // ─── Agent ────────────────────────────────────────────────────────────────────
 
+/** Settings that apply when the agent talks in text. */
+export interface ChatConfig {
+	context_config: ContextConfig;
+	react_config: ReActConfig;
+	invite_config: InviteConfig;
+}
+
 export interface AgentData {
 	id: string;
 	name: string;
 	system_prompt: string;
-	context_config: ContextConfig;
-	react_config: ReActConfig;
-	invite_config: InviteConfig;
+	chat_config: ChatConfig;
 }
 
 export interface AgentView extends RecordBase {
@@ -62,9 +67,7 @@ export interface AgentView extends RecordBase {
 export interface CreateAgentRequest {
 	name: string;
 	system_prompt?: string;
-	context_config?: ContextConfig;
-	react_config?: ReActConfig;
-	invite_config?: InviteConfig;
+	chat_config?: ChatConfig;
 }
 
 export interface CreateAgentResponse {
@@ -74,9 +77,7 @@ export interface CreateAgentResponse {
 export interface UpdateAgentRequest {
 	name?: string;
 	system_prompt?: string;
-	context_config?: ContextConfig;
-	react_config?: ReActConfig;
-	invite_config?: InviteConfig;
+	chat_config?: ChatConfig;
 }
 
 export interface AgentListResponse {
@@ -99,11 +100,10 @@ export interface AgentSchemaResponse {
 /**
  * Response of `GET /agent/schema/v2`. `schema` is the full `AgentData`
  * JSON Schema (with `$ref`s inlined, `id` filtered out, and
- * `context_config.summary_schema` filtered out). The frontend derives
- * its section grouping directly from `schema.properties`:
+ * `chat_config.context_config.summary_schema` filtered out). The
+ * frontend derives its section grouping directly from `schema`:
  *   - top-level scalar/textarea/boolean properties → "identity" section
- *   - top-level `object`-typed properties (currently `context_config`,
- *     `react_config`, and `invite_config`) → one section each
+ *   - each object under a mode block (`chat_config`) → one section
  */
 export interface AgentSchemaV2Response {
 	schema: JSONSchema;

--- a/examples/web_ui/frontend/src/components/dialog/AgentDialog.tsx
+++ b/examples/web_ui/frontend/src/components/dialog/AgentDialog.tsx
@@ -67,9 +67,11 @@ export function AgentDialog({ onCreated, children }: Props) {
 				{
 					name,
 					system_prompt: values.identity.system_prompt as string | undefined,
-					context_config: values.context_config as unknown as ContextConfig,
-					react_config: values.react_config as unknown as ReActConfig,
-					invite_config: values.invite_config as unknown as InviteConfig,
+					chat_config: {
+						context_config: values.context_config as unknown as ContextConfig,
+						react_config: values.react_config as unknown as ReActConfig,
+						invite_config: values.invite_config as unknown as InviteConfig,
+					},
 				},
 				{ silent: true },
 			);

--- a/examples/web_ui/frontend/src/components/dialog/EditAgentDialog.tsx
+++ b/examples/web_ui/frontend/src/components/dialog/EditAgentDialog.tsx
@@ -57,9 +57,9 @@ export function EditAgentDialog({ open, onOpenChange, agent, onUpdated }: Props)
 				name: d.name,
 				system_prompt: d.system_prompt,
 			},
-			context_config: { ...base.context_config, ...(d.context_config ?? {}) },
-			react_config: { ...base.react_config, ...(d.react_config ?? {}) },
-			invite_config: { ...base.invite_config, ...(d.invite_config ?? {}) },
+			context_config: { ...base.context_config, ...d.chat_config.context_config },
+			react_config: { ...base.react_config, ...d.chat_config.react_config },
+			invite_config: { ...base.invite_config, ...d.chat_config.invite_config },
 		});
 		setErrorMsg('');
 	}, [open, schema, agent]);
@@ -83,9 +83,11 @@ export function EditAgentDialog({ open, onOpenChange, agent, onUpdated }: Props)
 				{
 					name,
 					system_prompt: values.identity.system_prompt as string | undefined,
-					context_config: values.context_config as unknown as ContextConfig,
-					react_config: values.react_config as unknown as ReActConfig,
-					invite_config: values.invite_config as unknown as InviteConfig,
+					chat_config: {
+						context_config: values.context_config as unknown as ContextConfig,
+						react_config: values.react_config as unknown as ReActConfig,
+						invite_config: values.invite_config as unknown as InviteConfig,
+					},
 				},
 				{ silent: true },
 			);

--- a/examples/web_ui/frontend/src/components/form/AgentFormFields.tsx
+++ b/examples/web_ui/frontend/src/components/form/AgentFormFields.tsx
@@ -23,11 +23,12 @@ interface Props {
 }
 
 /**
- * Section derivation from the flat `AgentData` schema. Ordered — controls
- * the visual order of the fieldsets. "identity" carries every top-level
- * property that is NOT one of the nested-object sections below, so any
- * newly added scalar / boolean / textarea field on `AgentData` shows up
- * in the identity fieldset automatically.
+ * Section derivation from the `AgentData` schema. Ordered — controls the
+ * visual order of the fieldsets. "identity" carries every top-level
+ * property that is not a mode block, so any newly added scalar / boolean
+ * / textarea field on `AgentData` shows up in the identity fieldset
+ * automatically; the sections below live one level down, inside the
+ * `chat_config` mode block.
  */
 const NESTED_SECTIONS: Array<{ key: Exclude<AgentSection, 'identity'>; i18n: string }> = [
 	{ key: 'context_config', i18n: 'context-config' },
@@ -35,19 +36,25 @@ const NESTED_SECTIONS: Array<{ key: Exclude<AgentSection, 'identity'>; i18n: str
 	{ key: 'invite_config', i18n: 'invite-config' },
 ];
 
+/** Top-level `AgentData` properties that group one mode's settings. */
+const MODE_BLOCKS = ['chat_config'];
+
 const IDENTITY_I18N = 'identity';
 
 const toKebab = (s: string) => s.replace(/_/g, '-');
 
-/** Split the flat `AgentData` schema into the sections the form renders
+/** Split the `AgentData` schema into the sections the form renders
  * (currently four: `identity` + one per `NESTED_SECTIONS` entry). */
 function sliceSchema(root: JSONSchema): Record<AgentSection, JSONSchema> {
 	const props = root.properties ?? {};
-	const nestedKeys = new Set(NESTED_SECTIONS.map((s) => s.key));
+	const chatProps = ((props.chat_config as JSONSchema)?.properties ?? {}) as Record<
+		string,
+		JSONSchemaProperty
+	>;
 
 	const identityProps: Record<string, JSONSchemaProperty> = {};
 	for (const [k, prop] of Object.entries(props)) {
-		if (nestedKeys.has(k as Exclude<AgentSection, 'identity'>)) continue;
+		if (MODE_BLOCKS.includes(k)) continue;
 		identityProps[k] = prop;
 	}
 
@@ -55,22 +62,20 @@ function sliceSchema(root: JSONSchema): Record<AgentSection, JSONSchema> {
 		type: 'object',
 		title: 'Identity',
 		properties: identityProps,
-		required: (root.required ?? []).filter(
-			(r) => !nestedKeys.has(r as Exclude<AgentSection, 'identity'>),
-		),
+		required: (root.required ?? []).filter((r) => !MODE_BLOCKS.includes(r)),
 	};
 
 	return {
 		identity,
-		context_config: (props.context_config as JSONSchema) ?? {
+		context_config: (chatProps.context_config as JSONSchema) ?? {
 			type: 'object',
 			properties: {},
 		},
-		react_config: (props.react_config as JSONSchema) ?? {
+		react_config: (chatProps.react_config as JSONSchema) ?? {
 			type: 'object',
 			properties: {},
 		},
-		invite_config: (props.invite_config as JSONSchema) ?? {
+		invite_config: (chatProps.invite_config as JSONSchema) ?? {
 			type: 'object',
 			properties: {},
 		},

--- a/src/agentscope/app/_router/_agent.py
+++ b/src/agentscope/app/_router/_agent.py
@@ -103,21 +103,21 @@ async def get_agent_schema_v2() -> AgentSchemaV2Response:
 
     - ``id``: server-assigned, marked :class:`SkipJsonSchema` on
       :attr:`AgentData.id`.
-    - ``context_config.summary_schema``: internal structured-output
-      spec for the compression model, dropped below since it is not
-      user-editable and there is no equivalent hook on the Pydantic
-      side.
+    - ``chat_config.context_config.summary_schema``: internal
+      structured-output spec for the compression model, dropped below
+      since it is not user-editable and there is no equivalent hook on
+      the Pydantic side.
 
     ``$ref`` inlining is delegated to
     :func:`~agentscope._utils._common._flatten_json_schema` so the
     frontend can render every property from the response body alone.
 
-    The frontend derives its section grouping (identity / context /
-    react / invite) directly from this schema — top-level scalar
-    properties are the "identity" section, and top-level nested-object
-    properties each become their own section. Adding a new
-    user-editable field to :class:`AgentData` is thus enough to have it
-    appear in the create / edit form without a router change.
+    The frontend derives its section grouping directly from this
+    schema — top-level scalar properties are the "identity" section,
+    and every nested object below a mode block (``chat_config``)
+    becomes its own section. Adding a new user-editable field to
+    :class:`AgentData` is thus enough to have it appear in the create /
+    edit form without a router change.
 
     Returns:
         `AgentSchemaV2Response`:
@@ -127,7 +127,11 @@ async def get_agent_schema_v2() -> AgentSchemaV2Response:
     # ``summary_schema`` is Pydantic's structured-output spec fed to the
     # compression model — internal, not user-editable. No pydantic-side
     # hook covers this deep nested field, so drop it after inlining.
-    context_config = schema.get("properties", {}).get("context_config", {})
+    chat_config = schema.get("properties", {}).get("chat_config", {})
+    context_config = chat_config.get("properties", {}).get(
+        "context_config",
+        {},
+    )
     context_config.get("properties", {}).pop("summary_schema", None)
     return AgentSchemaV2Response(schema=schema)
 
@@ -191,18 +195,12 @@ async def create_agent(
         `HTTPException`: 422 if the request body passes
             :class:`CreateAgentRequest` validation but the resulting
             :class:`AgentData` fails its cross-field invariants (e.g.
-            ``invite_config.invitable=True`` without a non-empty
-            ``invite_description``). Symmetrical with
+            ``chat_config.invite_config.invitable=True`` without a
+            non-empty ``invite_description``). Symmetrical with
             :func:`update_agent`.
     """
     try:
-        data = AgentData(
-            name=body.name,
-            system_prompt=body.system_prompt,
-            context_config=body.context_config,
-            react_config=body.react_config,
-            invite_config=body.invite_config,
-        )
+        data = AgentData.model_validate(body.model_dump(exclude_none=True))
     except ValidationError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -255,7 +253,9 @@ async def update_agent(
     # ``AgentData.model_validate`` on the merged shape so the
     # ``invite_config`` sub-model's ``invitable ⇒ non-empty description``
     # invariant enforced by ``@model_validator(mode="after")`` produces
-    # an HTTP 422 instead of a stored-but-invalid record.
+    # an HTTP 422 instead of a stored-but-invalid record. A body still
+    # using the pre-``chat_config`` field names is folded in there too,
+    # on top of the stored block rather than over it.
     try:
         updated_data = AgentData.model_validate(
             {**existing.data.model_dump(), **updates},

--- a/src/agentscope/app/_router/_schema/_agent.py
+++ b/src/agentscope/app/_router/_schema/_agent.py
@@ -5,33 +5,39 @@ import warnings
 from pydantic import BaseModel, Field
 
 from ....agent import ContextConfig, ReActConfig
-from ...storage import InviteConfig
+from ...storage import ChatConfig, InviteConfig
 from ..._service import AgentView
 
 
 class CreateAgentRequest(BaseModel):
-    """Request body for creating a new agent."""
+    """Request body for creating a new agent.
+
+    Mirrors :class:`AgentData`, so the shape a client reads back is the
+    shape it writes. The three pre-``chat_config`` fields below are
+    still accepted and are folded into it by
+    :class:`AgentData`; sending both puts the flat one on top.
+    """
 
     name: str = Field(description="Display name of the agent.")
     system_prompt: str = Field(
         default="You're a helpful assistant.",
         description="Base system prompt fed to the agent.",
     )
-    context_config: ContextConfig = Field(
-        default_factory=ContextConfig,
-        description="Context-window management configuration.",
+    chat_config: ChatConfig = Field(
+        default_factory=ChatConfig,
+        description="Settings for the agent's text conversations.",
     )
-    react_config: ReActConfig = Field(
-        default_factory=ReActConfig,
-        description="ReAct loop configuration.",
+    context_config: ContextConfig | None = Field(
+        default=None,
+        description="**Deprecated.** Use ``chat_config.context_config``.",
     )
-    invite_config: InviteConfig = Field(
-        default_factory=InviteConfig,
-        description=(
-            "Invite-pool settings for this agent. See "
-            ":class:`InviteConfig` — enforces the "
-            "``invitable ⇒ non-empty description`` invariant."
-        ),
+    react_config: ReActConfig | None = Field(
+        default=None,
+        description="**Deprecated.** Use ``chat_config.react_config``.",
+    )
+    invite_config: InviteConfig | None = Field(
+        default=None,
+        description="**Deprecated.** Use ``chat_config.invite_config``.",
     )
 
 
@@ -52,21 +58,27 @@ class UpdateAgentRequest(BaseModel):
         default=None,
         description="New system prompt.",
     )
+    chat_config: ChatConfig | None = Field(
+        default=None,
+        description=(
+            "New text-conversation settings. Replaces the block as a "
+            "whole, so pass every sub-config that should survive."
+        ),
+    )
     context_config: ContextConfig | None = Field(
         default=None,
-        description="New context configuration.",
+        description=(
+            "**Deprecated.** Use ``chat_config``. Still honoured, and "
+            "narrower: it replaces only this sub-config."
+        ),
     )
     react_config: ReActConfig | None = Field(
         default=None,
-        description="New ReAct loop configuration.",
+        description="**Deprecated.** Use ``chat_config``.",
     )
     invite_config: InviteConfig | None = Field(
         default=None,
-        description=(
-            "New invite-pool settings. Pass the full :class:`InviteConfig` "
-            "object to update; omit to leave both invitable-related "
-            "fields unchanged."
-        ),
+        description="**Deprecated.** Use ``chat_config``.",
     )
 
 

--- a/src/agentscope/app/_service/_chat.py
+++ b/src/agentscope/app/_service/_chat.py
@@ -1107,14 +1107,15 @@ class ChatService:
 
                 agent_state = session_record.state
                 agent_state.session_id = session_id
+                chat_config = agent_record.data.chat_config
                 agent = self._agent_cls(
                     name=agent_record.data.name,
                     system_prompt=system_prompt,
                     model=model,
                     toolkit=toolkit,
                     model_config=ModelConfig(fallback_model=fallback_model),
-                    context_config=agent_record.data.context_config,
-                    react_config=agent_record.data.react_config,
+                    context_config=chat_config.context_config,
+                    react_config=chat_config.react_config,
                     state=agent_state,
                     middlewares=middlewares,
                     offloader=workspace,

--- a/src/agentscope/app/_service/_toolkit.py
+++ b/src/agentscope/app/_service/_toolkit.py
@@ -208,8 +208,10 @@ time or interval"
         invitable_pool = [
             view
             for view in visible_agents
-            if view.data.invite_config.invitable
-            and (view.data.invite_config.invite_description or "").strip()
+            if view.data.chat_config.invite_config.invitable
+            and (
+                view.data.chat_config.invite_config.invite_description or ""
+            ).strip()
         ]
         if invitable_pool:
             tools.append(

--- a/src/agentscope/app/_tool/_agent_create.py
+++ b/src/agentscope/app/_tool/_agent_create.py
@@ -14,6 +14,7 @@ from .._bus_ops import deliver_to_inbox
 from ..storage import (
     AgentData,
     AgentRecord,
+    ChatConfig,
     SessionConfig,
     TeamMember,
     TeamOrigin,
@@ -409,12 +410,10 @@ optional):
                 data=AgentData(
                     name=name,
                     system_prompt=system_prompt,
-                    context_config=template.context_config.model_copy(
-                        deep=True,
-                    ),
-                    react_config=template.react_config.model_copy(
-                        deep=True,
-                    ),
+                    chat_config=ChatConfig(
+                        context_config=template.context_config,
+                        react_config=template.react_config,
+                    ).model_copy(deep=True),
                 ),
             )
             await self._storage.upsert_agent(self._user_id, worker_agent)

--- a/src/agentscope/app/_tool/_agent_invite.py
+++ b/src/agentscope/app/_tool/_agent_invite.py
@@ -217,7 +217,7 @@ class AgentInvite(_TeamToolBase):
         ]
         target_lines = [
             f"- ``{_display_name(a.data.name, a.id)!r}`` — "
-            f"{a.data.invite_config.invite_description}"
+            f"{a.data.chat_config.invite_config.invite_description}"
             for a in invitable_pool
         ]
         self.description = (
@@ -295,9 +295,10 @@ class AgentInvite(_TeamToolBase):
                     fresh = None
             if (
                 fresh is None
-                or not fresh.data.invite_config.invitable
+                or not fresh.data.chat_config.invite_config.invitable
                 or not (
-                    fresh.data.invite_config.invite_description or ""
+                    fresh.data.chat_config.invite_config.invite_description
+                    or ""
                 ).strip()
             ):
                 return _error(

--- a/src/agentscope/app/storage/__init__.py
+++ b/src/agentscope/app/storage/__init__.py
@@ -41,6 +41,7 @@ from ._model import (
     TeamRecord,
     UserRecord,
     TeamMember,
+    ChatConfig,
     InviteConfig,
 )
 
@@ -76,6 +77,7 @@ __all__ = [
     "RedisStorage",
     "AsyncSQLAlchemyStorage",
     # The ORM models
+    "ChatConfig",
     "InviteConfig",
     "AgentData",
     "AgentRecord",

--- a/src/agentscope/app/storage/_model/__init__.py
+++ b/src/agentscope/app/storage/_model/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Storage models for persisted resources."""
 
-from ._agent import AgentRecord, AgentData, InviteConfig
+from ._agent import AgentRecord, AgentData, ChatConfig, InviteConfig
 from ._channel import (
     ChannelBinding,
     ChannelRecord,
@@ -78,5 +78,6 @@ __all__ = [
     "TeamRecord",
     "TeamMember",
     "UserRecord",
+    "ChatConfig",
     "InviteConfig",
 ]

--- a/src/agentscope/app/storage/_model/_agent.py
+++ b/src/agentscope/app/storage/_model/_agent.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """The agent storage class."""
-from typing import Literal, Self
+from typing import Any, Literal, Self
 
 from pydantic import Field, BaseModel, model_validator
 from pydantic.json_schema import SkipJsonSchema
@@ -62,6 +62,34 @@ class InviteConfig(BaseModel):
         return self
 
 
+class ChatConfig(BaseModel):
+    """The settings that apply when the agent talks in text.
+
+    Grouped in their own sub-model so a second interaction mode — a
+    realtime voice one, whose context management and parameters differ
+    from the text loop's — adds a block beside this one instead of
+    widening :class:`AgentData` with fields that only apply to one mode.
+    """
+
+    context_config: ContextConfig = Field(
+        default_factory=ContextConfig,
+        description="The context config for the agent.",
+        title="Context Config",
+    )
+
+    react_config: ReActConfig = Field(
+        default_factory=ReActConfig,
+        description="The react config for the agent.",
+        title="React Config",
+    )
+
+    invite_config: InviteConfig = Field(
+        default_factory=InviteConfig,
+        description="The invite config for the agent.",
+        title="Invite Config",
+    )
+
+
 class AgentData(BaseModel):
     """The agent data model."""
 
@@ -92,21 +120,42 @@ class AgentData(BaseModel):
         json_schema_extra={"format": "textarea"},
     )
 
-    context_config: ContextConfig = Field(
-        description="The context config for the agent.",
-        title="Context Config",
+    chat_config: ChatConfig = Field(
+        default_factory=ChatConfig,
+        description="The settings for the agent's text conversations.",
+        title="Chat Config",
     )
 
-    react_config: ReActConfig = Field(
-        description="The react config for the agent.",
-        title="React Config",
-    )
+    @model_validator(mode="before")
+    @classmethod
+    def _fold_legacy_configs(cls, data: Any) -> Any:
+        """Read agents written before the text-mode settings moved under
+        :attr:`chat_config`.
 
-    invite_config: InviteConfig = Field(
-        default_factory=InviteConfig,
-        description="The invite config for the agent.",
-        title="Invite Config",
-    )
+        Those carry ``context_config`` / ``react_config`` /
+        ``invite_config`` at the top level. Nothing migrates the stored
+        rows; they are folded here and written back in the new shape on
+        the next save. A ``PATCH`` body still using the old names lands
+        here too, which is why the legacy values are merged *into* an
+        existing ``chat_config`` rather than replacing it — the merged
+        record carries both, and only the named sub-configs change.
+        """
+        if not isinstance(data, dict):
+            return data
+        legacy = {
+            key: data[key]
+            for key in ("context_config", "react_config", "invite_config")
+            if key in data
+        }
+        if not legacy:
+            return data
+
+        chat_config = data.get("chat_config") or {}
+        if not isinstance(chat_config, dict):
+            chat_config = chat_config.model_dump()
+        data = {k: v for k, v in data.items() if k not in legacy}
+        data["chat_config"] = {**chat_config, **legacy}
+        return data
 
 
 class AgentRecord(_RecordBase):

--- a/tests/agent_config_grouping_test.py
+++ b/tests/agent_config_grouping_test.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+"""``AgentData.chat_config`` grouping test case.
+
+The text-mode settings moved from the top level of ``AgentData`` into a
+``chat_config`` block, so a realtime voice mode can add its own block
+beside them. Nothing migrates the stored rows and nothing rewrites the
+request bodies clients already send, so both the old and the new shape
+have to land in the same place — that is what these cases pin down.
+"""
+from typing import Any
+from unittest import IsolatedAsyncioTestCase
+
+import fakeredis.aioredis
+from fastapi.testclient import TestClient
+
+from agentscope.app import create_app
+from agentscope.app.message_bus import RedisMessageBus
+from agentscope.app.storage import AgentData, AgentRecord, RedisStorage
+from agentscope.app.workspace_manager import LocalWorkspaceManager
+
+HEADERS = {"X-User-ID": "alice"}
+
+
+class AgentConfigGroupingTest(IsolatedAsyncioTestCase):
+    """Reading, creating and updating agents across both shapes."""
+
+    async def asyncSetUp(self) -> None:
+        """Start an app backed by fakeredis."""
+        redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+
+        class _Storage(RedisStorage):
+            async def __aenter__(self) -> Any:
+                self._client = redis
+                return self
+
+            async def aclose(self) -> None:
+                self._client = None
+
+        class _Bus(RedisMessageBus):
+            async def __aenter__(self) -> Any:
+                self._client = redis
+                return self
+
+            async def aclose(self) -> None:
+                self._client = None
+
+        app = create_app(
+            storage=_Storage(),
+            message_bus=_Bus(),
+            workspace_manager=LocalWorkspaceManager("/tmp"),
+            enable_index_worker=False,
+        )
+        # pylint: disable=consider-using-with
+        self.client = self.enterContext(TestClient(app))
+        self.storage = app.state.storage
+
+    def test_legacy_record_folds_into_chat_config(self) -> None:
+        """An agent written before the grouping reads back grouped."""
+        data = AgentData.model_validate(
+            {
+                "id": "a1",
+                "name": "ann",
+                "system_prompt": "You are ann.",
+                "context_config": {"max_image_num": 3},
+                "react_config": {"max_iters": 7},
+                "invite_config": {
+                    "invitable": True,
+                    "invite_description": "an old agent",
+                },
+            },
+        )
+
+        self.assertListEqual(
+            sorted(data.model_dump()),
+            ["chat_config", "id", "name", "system_prompt"],
+        )
+        self.assertListEqual(
+            sorted(data.model_dump()["chat_config"]),
+            ["context_config", "invite_config", "react_config"],
+        )
+        self.assertEqual(data.chat_config.context_config.max_image_num, 3)
+        self.assertEqual(data.chat_config.react_config.max_iters, 7)
+        self.assertEqual(
+            data.chat_config.invite_config.invite_description,
+            "an old agent",
+        )
+
+    def test_create_accepts_both_shapes(self) -> None:
+        """POST bodies in either shape store the same grouped record."""
+        nested = self.client.post(
+            "/agent/",
+            headers=HEADERS,
+            json={
+                "name": "nested",
+                "chat_config": {"react_config": {"max_iters": 5}},
+            },
+        )
+        legacy = self.client.post(
+            "/agent/",
+            headers=HEADERS,
+            json={"name": "legacy", "react_config": {"max_iters": 5}},
+        )
+        self.assertEqual(nested.status_code, 201)
+        self.assertEqual(legacy.status_code, 201)
+
+        agents = self.client.get("/agent/", headers=HEADERS).json()["agents"]
+        by_name = {a["data"]["name"]: a["data"] for a in agents}
+        self.assertListEqual(
+            sorted(by_name["nested"]["chat_config"]),
+            ["context_config", "invite_config", "react_config"],
+        )
+        self.assertEqual(
+            by_name["nested"]["chat_config"]["react_config"]["max_iters"],
+            5,
+        )
+        self.assertEqual(
+            by_name["legacy"]["chat_config"]["react_config"]["max_iters"],
+            5,
+        )
+
+    def test_update_keeps_untouched_sub_configs(self) -> None:
+        """A legacy PATCH replaces its own sub-config and nothing else."""
+        agent_id = self.client.post(
+            "/agent/",
+            headers=HEADERS,
+            json={
+                "name": "ann",
+                "chat_config": {
+                    "react_config": {"max_iters": 5},
+                    "invite_config": {
+                        "invitable": True,
+                        "invite_description": "keep me",
+                    },
+                },
+            },
+        ).json()["agent_id"]
+
+        updated = self.client.patch(
+            f"/agent/{agent_id}",
+            headers=HEADERS,
+            json={"context_config": {"max_image_num": 9}},
+        )
+
+        self.assertEqual(updated.status_code, 200)
+        chat_config = updated.json()["data"]["chat_config"]
+        self.assertEqual(chat_config["context_config"]["max_image_num"], 9)
+        self.assertEqual(chat_config["react_config"]["max_iters"], 5)
+        self.assertEqual(
+            chat_config["invite_config"]["invite_description"],
+            "keep me",
+        )
+
+    def test_schema_exposes_the_grouped_sections(self) -> None:
+        """The form schema carries the sections inside ``chat_config``."""
+        schema = self.client.get("/agent/schema/v2").json()["schema"]
+
+        self.assertListEqual(
+            sorted(schema["properties"]),
+            ["chat_config", "name", "system_prompt"],
+        )
+        chat_config = schema["properties"]["chat_config"]
+        self.assertListEqual(
+            sorted(chat_config["properties"]),
+            ["context_config", "invite_config", "react_config"],
+        )
+        self.assertNotIn(
+            "summary_schema",
+            chat_config["properties"]["context_config"]["properties"],
+        )
+
+    async def test_stored_agent_survives_a_round_trip(self) -> None:
+        """A legacy row in storage is readable and rewritten grouped."""
+        record = AgentRecord(
+            user_id="alice",
+            data=AgentData.model_validate(
+                {
+                    "name": "ann",
+                    "react_config": {"max_iters": 7},
+                },
+            ),
+        )
+        agent_id = await self.storage.upsert_agent("alice", record)
+
+        stored = await self.storage.get_agent("alice", agent_id)
+
+        self.assertEqual(stored.data.chat_config.react_config.max_iters, 7)
+        self.assertListEqual(
+            sorted(stored.data.model_dump()),
+            ["chat_config", "id", "name", "system_prompt"],
+        )

--- a/tests/service_team_tools_test.py
+++ b/tests/service_team_tools_test.py
@@ -906,12 +906,12 @@ class TestAgentCreateTemplates(_TeamToolsTestBase):
             team.data.member_ids[1],
         )
         self.assertIsNot(
-            a1.data.context_config,
-            a2.data.context_config,
+            a1.data.chat_config.context_config,
+            a2.data.chat_config.context_config,
         )
         self.assertIsNot(
-            a1.data.react_config,
-            a2.data.react_config,
+            a1.data.chat_config.react_config,
+            a2.data.chat_config.react_config,
         )
 
 
@@ -1374,8 +1374,11 @@ class TestAgentDataInvitableValidator(IsolatedAsyncioTestCase):
                 invite_description="draft",
             ),
         )
-        self.assertEqual(data.invite_config.invite_description, "draft")
-        self.assertFalse(data.invite_config.invitable)
+        self.assertEqual(
+            data.chat_config.invite_config.invite_description,
+            "draft",
+        )
+        self.assertFalse(data.chat_config.invite_config.invitable)
 
 
 class _AgentInviteTestBase(_TeamToolsTestBase):
@@ -1731,8 +1734,8 @@ class TestAgentInviteRejections(_AgentInviteTestBase):
         """Snapshot said invitable but fresh read shows the toggle off."""
         # Flip the toggle off in storage while pool snapshot still has it.
         stale = self.monday_agent
-        stale.data.invite_config.invitable = False
-        stale.data.invite_config.invite_description = None
+        stale.data.chat_config.invite_config.invitable = False
+        stale.data.chat_config.invite_config.invite_description = None
         await self.storage.upsert_agent(self.user_id, stale)
 
         chunk = await self._tool(pool=[stale])(


### PR DESCRIPTION
## Why

`context_config`, `react_config` and `invite_config` all configure the text ReAct loop. The realtime voice mode needs its own, different set — a `ContextConfig` whose fields do not match the text one, plus a workspace to offload compressed segments (#2566). Keeping both at the top level of `AgentData` would mix two modes' settings in one flat record.

So the text-mode settings move into a `chat_config` block, and the voice mode gets to add a block beside it instead of widening `AgentData`. Identity stays where it is: `name` and `system_prompt` describe the agent itself and are shared by both modes.

```
AgentData
├── name
├── system_prompt
└── chat_config
    ├── context_config
    ├── react_config
    └── invite_config
```

## Compatibility

**Stored records.** Nothing migrates them. An agent written before this change keeps the flat shape in its `payload` JSON and is folded into `chat_config` when read, then written back grouped on the next save — the same approach `SessionRecord` uses for its pre-`origin` rows.

**Tables.** No change and no alembic revision. `AgentRow` promotes only `user_id` and `source` to columns, both read from the record's top level, and everything else lives in the `payload` JSON column.

**API.** `POST /agent/` and `PATCH /agent/{id}` accept the new nested `chat_config` and still accept the old flat field names, which are folded into it. A PATCH carrying `context_config` keeps replacing just that sub-config; a PATCH carrying `chat_config` replaces the block as a whole.

**Form schema.** `GET /agent/schema/v2` now nests the three sections inside `chat_config`; the frontend reads them from there and renders the same four fieldsets as before.

## Tests

`tests/agent_config_grouping_test.py` covers the fold of a legacy record, creation through both request shapes, a legacy PATCH leaving its neighbours alone, the form schema, and a storage round trip.
