### PR TITLE
feat(tool): add AskUser, an external tool for asking the user

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -2009,6 +2009,13 @@ class Agent:
         elif isinstance(event, ExternalExecutionResultEvent):
             # Directly append the execution results into context
             for tool_result in event.execution_results:
+                # Whoever executed this promised a shape; a result that
+                # breaks it is their bug to fix, and the reply stays
+                # parked so they can send it again.
+                tool = await self.toolkit.get_tool(tool_result.name)
+                if tool is not None:
+                    await tool.check_external_result(tool_result)
+
                 async for evt in self._convert_tool_chunk_to_event(
                     tool_result.id,
                     tool_result.output,

--- a/src/agentscope/tool/__init__.py
+++ b/src/agentscope/tool/__init__.py
@@ -8,8 +8,7 @@ from ._base import ToolBase, ParamsBase, ToolMiddlewareBase
 from ._adapters import MCPTool, FunctionTool
 from ._builtin import (
     AskUser,
-    AskUserAnswer,
-    AskUserAnswers,
+    AskUserMetadata,
     AskUserParams,
     ResetTools,
     Bash,
@@ -34,8 +33,7 @@ from ._tool_group import ToolGroup
 
 __all__ = [
     "AskUser",
-    "AskUserAnswer",
-    "AskUserAnswers",
+    "AskUserMetadata",
     "AskUserParams",
     # Basic tool related types and functions
     "ToolChoice",

--- a/src/agentscope/tool/__init__.py
+++ b/src/agentscope/tool/__init__.py
@@ -7,6 +7,7 @@ from ._toolkit import Toolkit
 from ._base import ToolBase, ParamsBase, ToolMiddlewareBase
 from ._adapters import MCPTool, FunctionTool
 from ._builtin import (
+    AskUser,
     ResetTools,
     Bash,
     PowerShell,
@@ -29,6 +30,7 @@ from ._task import (
 from ._tool_group import ToolGroup
 
 __all__ = [
+    "AskUser",
     # Basic tool related types and functions
     "ToolChoice",
     "Function",

--- a/src/agentscope/tool/__init__.py
+++ b/src/agentscope/tool/__init__.py
@@ -8,6 +8,9 @@ from ._base import ToolBase, ParamsBase, ToolMiddlewareBase
 from ._adapters import MCPTool, FunctionTool
 from ._builtin import (
     AskUser,
+    AskUserAnswer,
+    AskUserAnswers,
+    AskUserParams,
     ResetTools,
     Bash,
     PowerShell,
@@ -31,6 +34,9 @@ from ._tool_group import ToolGroup
 
 __all__ = [
     "AskUser",
+    "AskUserAnswer",
+    "AskUserAnswers",
+    "AskUserParams",
     # Basic tool related types and functions
     "ToolChoice",
     "Function",

--- a/src/agentscope/tool/__init__.py
+++ b/src/agentscope/tool/__init__.py
@@ -8,6 +8,7 @@ from ._base import ToolBase, ParamsBase, ToolMiddlewareBase
 from ._adapters import MCPTool, FunctionTool
 from ._builtin import (
     AskUser,
+    AskUserAnswer,
     AskUserMetadata,
     AskUserParams,
     ResetTools,
@@ -33,6 +34,7 @@ from ._tool_group import ToolGroup
 
 __all__ = [
     "AskUser",
+    "AskUserAnswer",
     "AskUserMetadata",
     "AskUserParams",
     # Basic tool related types and functions

--- a/src/agentscope/tool/_base.py
+++ b/src/agentscope/tool/_base.py
@@ -5,7 +5,9 @@ import inspect
 import os
 from abc import abstractmethod, ABC
 from pathlib import Path
-from typing import AsyncGenerator, Any, Callable, List
+from typing import AsyncGenerator, Any, Callable, List, TYPE_CHECKING
+
+import jsonschema
 
 from pydantic import BaseModel
 
@@ -18,6 +20,9 @@ from ..permission import (
 )
 from ._response import ToolChunk
 from ._utils import _remove_title_field
+
+if TYPE_CHECKING:
+    from ..message import ToolResultBlock
 
 
 class ParamsBase(BaseModel):
@@ -113,6 +118,15 @@ class ToolBase(ABC):
     the state will be injected by an argument named `_agent_state`. Note your
     tool should be able to accept such argument.
     """
+    metadata_schema: dict[str, Any] | None = None
+    """What an external executor must put in
+    :attr:`~..message.ToolResultBlock.metadata`, as a JSON schema.
+
+    The counterpart of :attr:`input_schema`: that one tells the model how
+    to call the tool, this one tells whoever executes it how to answer.
+    ``output`` stays whatever reads well to the model — this is the half
+    a caller may depend on. ``None`` means nothing is promised."""
+
     is_mcp: bool = False
     """If this tool is an MCP tool, which will be used in the permission"""
     mcp_name: str | None = None
@@ -254,6 +268,27 @@ class ToolBase(ABC):
         context: PermissionContext,
     ) -> PermissionDecision:
         """Check permissions for the tool usage."""
+
+    async def check_external_result(
+        self,
+        result: "ToolResultBlock",
+    ) -> None:
+        """Reject a result an external executor sent back.
+
+        Called only for externally executed calls — a tool that produced
+        its own result has nothing to check. Shape only, against
+        :attr:`metadata_schema`; whether the content is any good is the
+        caller's judgement, not this tool's, since a user who answers
+        "no idea" has produced a perfectly valid result.
+
+        Raises:
+            `jsonschema.ValidationError`:
+                If the metadata does not match what the tool promised its
+                caller. The reply stays parked, so the executor can fix
+                what it sent and try again.
+        """
+        if self.metadata_schema is not None:
+            jsonschema.validate(result.metadata, self.metadata_schema)
 
     async def check_read_only(
         self,

--- a/src/agentscope/tool/_builtin/__init__.py
+++ b/src/agentscope/tool/_builtin/__init__.py
@@ -3,6 +3,7 @@
 
 from ._ask_user import (
     AskUser,
+    AskUserAnswer,
     AskUserMetadata,
     AskUserParams,
 )
@@ -19,6 +20,7 @@ from ._write import Write
 
 __all__ = [
     "AskUser",
+    "AskUserAnswer",
     "AskUserMetadata",
     "AskUserParams",
     "ResetTools",

--- a/src/agentscope/tool/_builtin/__init__.py
+++ b/src/agentscope/tool/_builtin/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """The builtin tools in agentscope."""
 
+from ._ask_user import AskUser
 from ._backend import BackendBase, DirEntry, ExecResult, LocalBackend
 from ._bash import Bash
 from ._edit import Edit
@@ -13,6 +14,7 @@ from ._skill import SkillViewer
 from ._write import Write
 
 __all__ = [
+    "AskUser",
     "ResetTools",
     "SkillViewer",
     "Bash",

--- a/src/agentscope/tool/_builtin/__init__.py
+++ b/src/agentscope/tool/_builtin/__init__.py
@@ -3,8 +3,7 @@
 
 from ._ask_user import (
     AskUser,
-    AskUserAnswer,
-    AskUserAnswers,
+    AskUserMetadata,
     AskUserParams,
 )
 from ._backend import BackendBase, DirEntry, ExecResult, LocalBackend
@@ -20,8 +19,7 @@ from ._write import Write
 
 __all__ = [
     "AskUser",
-    "AskUserAnswer",
-    "AskUserAnswers",
+    "AskUserMetadata",
     "AskUserParams",
     "ResetTools",
     "SkillViewer",

--- a/src/agentscope/tool/_builtin/__init__.py
+++ b/src/agentscope/tool/_builtin/__init__.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 """The builtin tools in agentscope."""
 
-from ._ask_user import AskUser
+from ._ask_user import (
+    AskUser,
+    AskUserAnswer,
+    AskUserAnswers,
+    AskUserParams,
+)
 from ._backend import BackendBase, DirEntry, ExecResult, LocalBackend
 from ._bash import Bash
 from ._edit import Edit
@@ -15,6 +20,9 @@ from ._write import Write
 
 __all__ = [
     "AskUser",
+    "AskUserAnswer",
+    "AskUserAnswers",
+    "AskUserParams",
     "ResetTools",
     "SkillViewer",
     "Bash",

--- a/src/agentscope/tool/_builtin/_ask_user.py
+++ b/src/agentscope/tool/_builtin/_ask_user.py
@@ -95,7 +95,7 @@ class _Question(BaseModel):
     )
 
 
-class AskUserAnswer(BaseModel):
+class _Answer(BaseModel):
     """One question's answer, as the caller must return it."""
 
     question: str = Field(
@@ -116,15 +116,15 @@ class AskUserAnswer(BaseModel):
     )
 
 
-class AskUserAnswers(BaseModel):
+class AskUserMetadata(BaseModel):
     """What the caller must put in ``ToolResultBlock.metadata``.
 
     ``output`` is for the model to read; this is the half a program may
-    branch on — a SOP step deciding whether its work was approved cannot
-    do that on prose.
+    branch on — a step deciding whether its work was approved cannot do
+    that on prose.
     """
 
-    answers: list[AskUserAnswer]
+    answers: list[_Answer]
 
 
 class AskUserParams(BaseModel):
@@ -175,12 +175,15 @@ Use this tool when you need to ask the user questions during execution:
 - Put whatever the user must look at to answer — a draft, a diff, an error — in `context` rather than in the question text.
 
 ## What comes back
-`output` is written for you to read. The caller also returns the same answers in `ToolResultBlock.metadata`, shaped by `AskUserAnswers`, for programs that must branch on the choice rather than read prose."""  # noqa: E501
+`output` is written for you to read. The caller also returns the same answers in `ToolResultBlock.metadata`, shaped by `AskUserMetadata`, for programs that must branch on the choice rather than read prose."""  # noqa: E501
     """The description presented to the agent."""
 
     input_schema: dict[str, Any] = AskUserParams.model_json_schema()
 
-    metadata_schema: dict[str, Any] | None = AskUserAnswers.model_json_schema()
+    metadata_schema: dict[
+        str,
+        Any,
+    ] | None = AskUserMetadata.model_json_schema()
 
     is_read_only: bool = True
     is_state_injected: bool = False

--- a/src/agentscope/tool/_builtin/_ask_user.py
+++ b/src/agentscope/tool/_builtin/_ask_user.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+"""The asking user tool class."""
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .._base import ToolBase
+from ...permission import (
+    PermissionContext,
+    PermissionDecision,
+    PermissionBehavior,
+)
+
+_HEADER_MAX_CHARS = 12
+
+
+class _Option(BaseModel):
+    """A single selectable option within a question."""
+
+    label: str = Field(
+        description=(
+            "The display text for this option that the user will see and "
+            "select. Should be concise (1-5 words) and clearly describe the "
+            "choice."
+        ),
+    )
+
+    description: str = Field(
+        description=(
+            "Explanation of what this option means or what will happen if "
+            "chosen. Useful for providing context about trade-offs or "
+            "implications."
+        ),
+    )
+
+    preview: str | None = Field(
+        default=None,
+        description=(
+            "Optional preview content rendered when this option is focused. "
+            "Use for mockups, code snippets, or visual comparisons that help "
+            "users compare options. Only supported in single-select questions."
+        ),
+    )
+
+
+class _Question(BaseModel):
+    """A single question presented to the user."""
+
+    question: str = Field(
+        description=(
+            "The complete question to ask the user. Should be clear, "
+            "specific, and end with a question mark. "
+            'Example: "Which library should we use for date formatting?" '
+            "If multi_select is true, phrase it accordingly, "
+            'e.g. "Which features do you want to enable?"'
+        ),
+    )
+
+    header: str = Field(
+        max_length=_HEADER_MAX_CHARS,
+        description=(
+            f"Very short label displayed as a chip/tag "
+            f"(max {_HEADER_MAX_CHARS} chars). "
+            'Examples: "Auth method", "Library", "Approach".'
+        ),
+    )
+
+    options: list[_Option] = Field(
+        min_length=2,
+        max_length=4,
+        description=(
+            "The available choices for this question. Must have 2-4 options. "
+            "Each option should be a distinct, mutually exclusive choice "
+            "(unless multi_select is enabled). There should be no 'Other' "
+            "option — that will be provided automatically."
+        ),
+    )
+
+    multi_select: bool = Field(
+        default=False,
+        description=(
+            "Set to true to allow the user to select multiple options instead "
+            "of just one. Use when choices are not mutually exclusive. "
+            "Note: preview is only supported when multi_select is false."
+        ),
+    )
+
+
+class _AskUserParams(BaseModel):
+    """The full input parameters for the AskUser tool."""
+
+    questions: list[_Question] = Field(
+        min_length=1,
+        max_length=4,
+        description=(
+            "Questions to ask the user (1-4 questions). Question texts must "
+            "be unique; option labels must be unique within each question."
+        ),
+    )
+
+
+class AskUser(ToolBase):
+    """The tool to collect information from the user via multiple-choice
+    questions.
+
+    External by nature: only whatever is driving the agent can put a
+    question in front of a person, so the agent yields the call and waits
+    for the answer to come back rather than executing anything itself.
+    """
+
+    name: str = "AskUser"
+    """The tool name."""
+
+    # pylint: disable=line-too-long
+    description: str = """Asks the user multiple-choice questions to gather information, clarify ambiguity, understand preferences, make decisions, or offer choices.
+
+Use this tool when you need to ask the user questions during execution:
+1. Gather user preferences or requirements.
+2. Clarify ambiguous instructions before proceeding.
+3. Get decisions on implementation choices as you work.
+4. Offer the user a set of directions to take.
+
+## Usage rules
+- You may batch 1–4 questions in a single call; batch related questions together.
+- Each question must have 2–4 options. Option labels must be unique within a question.
+- Question texts must be unique across the batch.
+- Users will always be able to select "Other" to provide free-text input — do not add an "Other" option yourself.
+- Use `multi_select: true` only when the choices are genuinely not mutually exclusive.
+- If you recommend a specific option, place it first and append "(Recommended)" to its label.
+- The `preview` field on an option renders a side-by-side visual comparison; only use it for concrete artifacts (code snippets, ASCII mockups, config examples) where seeing the content helps the user choose. Preview is only supported for single-select questions."""  # noqa: E501
+    """The description presented to the agent."""
+
+    input_schema: dict[str, Any] = _AskUserParams.model_json_schema()
+
+    is_read_only: bool = True
+    is_state_injected: bool = False
+    is_concurrency_safe: bool = True
+    is_external_tool: bool = True
+
+    async def check_permissions(
+        self,
+        tool_input: dict[str, Any],
+        context: PermissionContext,
+    ) -> PermissionDecision:
+        """Never asks to ask.
+
+        The call is answered by the user in the first place, so a
+        confirmation in front of it would only be a prompt about a
+        prompt.
+        """
+        return PermissionDecision(
+            behavior=PermissionBehavior.ALLOW,
+            message="The AskUser tool is always permitted.",
+        )

--- a/src/agentscope/tool/_builtin/_ask_user.py
+++ b/src/agentscope/tool/_builtin/_ask_user.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """The asking user tool class."""
-from typing import Any
+from typing import Any, ClassVar
 
 from pydantic import BaseModel, Field
 
@@ -65,6 +65,15 @@ class _Question(BaseModel):
         ),
     )
 
+    context: str | None = Field(
+        default=None,
+        description=(
+            "What the user should look at while answering — the draft "
+            "being reviewed, the two designs being compared, the error "
+            "that prompted the question. Shown above the options."
+        ),
+    )
+
     options: list[_Option] = Field(
         min_length=2,
         max_length=4,
@@ -84,6 +93,38 @@ class _Question(BaseModel):
             "Note: preview is only supported when multi_select is false."
         ),
     )
+
+
+class _Answer(BaseModel):
+    """One question's answer, as the caller must return it."""
+
+    question: str = Field(
+        description="The question this answers, verbatim.",
+    )
+
+    selected: list[str] = Field(
+        default_factory=list,
+        description="Labels of the options the user chose.",
+    )
+
+    other: str | None = Field(
+        default=None,
+        description=(
+            "What the user typed instead of choosing, when they answered "
+            "in their own words."
+        ),
+    )
+
+
+class AskUserAnswers(BaseModel):
+    """What the caller must put in ``ToolResultBlock.metadata``.
+
+    ``output`` is for the model to read; this is the half a program may
+    branch on — a SOP step deciding whether its work was approved cannot
+    do that on prose.
+    """
+
+    answers: list[_Answer]
 
 
 class _AskUserParams(BaseModel):
@@ -127,10 +168,20 @@ Use this tool when you need to ask the user questions during execution:
 - Users will always be able to select "Other" to provide free-text input — do not add an "Other" option yourself.
 - Use `multi_select: true` only when the choices are genuinely not mutually exclusive.
 - If you recommend a specific option, place it first and append "(Recommended)" to its label.
-- The `preview` field on an option renders a side-by-side visual comparison; only use it for concrete artifacts (code snippets, ASCII mockups, config examples) where seeing the content helps the user choose. Preview is only supported for single-select questions."""  # noqa: E501
+- The `preview` field on an option renders a side-by-side visual comparison; only use it for concrete artifacts (code snippets, ASCII mockups, config examples) where seeing the content helps the user choose. Preview is only supported for single-select questions.
+- Put whatever the user must look at to answer — a draft, a diff, an error — in `context` rather than in the question text.
+
+## What comes back
+`output` is written for you to read. The caller also returns the same answers in `ToolResultBlock.metadata`, shaped by `AskUser.Answers`, for programs that must branch on the choice rather than read prose."""  # noqa: E501
     """The description presented to the agent."""
 
     input_schema: dict[str, Any] = _AskUserParams.model_json_schema()
+
+    metadata_schema: dict[str, Any] | None = AskUserAnswers.model_json_schema()
+
+    Answers: ClassVar[type[BaseModel]] = AskUserAnswers
+    """The shape a caller must return, beside the tool that asks for
+    it — so the two cannot drift apart."""
 
     is_read_only: bool = True
     is_state_injected: bool = False

--- a/src/agentscope/tool/_builtin/_ask_user.py
+++ b/src/agentscope/tool/_builtin/_ask_user.py
@@ -95,8 +95,12 @@ class _Question(BaseModel):
     )
 
 
-class _Answer(BaseModel):
-    """One question's answer, as the caller must return it."""
+class AskUserAnswer(BaseModel):
+    """One question's answer, as the caller must return it.
+
+    An entry of :attr:`AskUserMetadata.answers`; a frontend building
+    them one at a time has this to build them with.
+    """
 
     question: str = Field(
         description="The question this answers, verbatim.",
@@ -124,7 +128,7 @@ class AskUserMetadata(BaseModel):
     that on prose.
     """
 
-    answers: list[_Answer]
+    answers: list[AskUserAnswer]
 
 
 class AskUserParams(BaseModel):

--- a/src/agentscope/tool/_builtin/_ask_user.py
+++ b/src/agentscope/tool/_builtin/_ask_user.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """The asking user tool class."""
-from typing import Any, ClassVar
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -95,7 +95,7 @@ class _Question(BaseModel):
     )
 
 
-class _Answer(BaseModel):
+class AskUserAnswer(BaseModel):
     """One question's answer, as the caller must return it."""
 
     question: str = Field(
@@ -124,11 +124,14 @@ class AskUserAnswers(BaseModel):
     do that on prose.
     """
 
-    answers: list[_Answer]
+    answers: list[AskUserAnswer]
 
 
-class _AskUserParams(BaseModel):
-    """The full input parameters for the AskUser tool."""
+class AskUserParams(BaseModel):
+    """What a caller asks for — the questions, and their options.
+
+    A model fills this in from :attr:`AskUser.input_schema`; a program
+    building the call itself has this to build it with."""
 
     questions: list[_Question] = Field(
         min_length=1,
@@ -172,16 +175,12 @@ Use this tool when you need to ask the user questions during execution:
 - Put whatever the user must look at to answer — a draft, a diff, an error — in `context` rather than in the question text.
 
 ## What comes back
-`output` is written for you to read. The caller also returns the same answers in `ToolResultBlock.metadata`, shaped by `AskUser.Answers`, for programs that must branch on the choice rather than read prose."""  # noqa: E501
+`output` is written for you to read. The caller also returns the same answers in `ToolResultBlock.metadata`, shaped by `AskUserAnswers`, for programs that must branch on the choice rather than read prose."""  # noqa: E501
     """The description presented to the agent."""
 
-    input_schema: dict[str, Any] = _AskUserParams.model_json_schema()
+    input_schema: dict[str, Any] = AskUserParams.model_json_schema()
 
     metadata_schema: dict[str, Any] | None = AskUserAnswers.model_json_schema()
-
-    Answers: ClassVar[type[BaseModel]] = AskUserAnswers
-    """The shape a caller must return, beside the tool that asks for
-    it — so the two cannot drift apart."""
 
     is_read_only: bool = True
     is_state_injected: bool = False

--- a/tests/ask_user_tool_test.py
+++ b/tests/ask_user_tool_test.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""Unittests for the AskUser tool."""
+from unittest import IsolatedAsyncioTestCase
+
+from pydantic import ValidationError
+
+from agentscope.permission import PermissionBehavior, PermissionContext
+from agentscope.tool import AskUser
+from agentscope.tool._builtin._ask_user import _AskUserParams
+
+
+class AskUserTest(IsolatedAsyncioTestCase):
+    """Test the AskUser tool."""
+
+    def setUp(self) -> None:
+        """Build the tool."""
+        self.tool = AskUser()
+
+    async def test_the_call_is_left_to_whoever_can_ask(self) -> None:
+        """Nothing executes it here — the agent yields it instead."""
+        self.assertTrue(self.tool.is_external_tool)
+        with self.assertRaises(RuntimeError):
+            await self.tool()
+
+    async def test_it_never_asks_to_ask(self) -> None:
+        """A confirmation in front of a question is a prompt about a
+        prompt."""
+        decision = await self.tool.check_permissions(
+            {"questions": []},
+            PermissionContext(),
+        )
+        self.assertEqual(decision.behavior, PermissionBehavior.ALLOW)
+
+    async def test_a_question_needs_between_two_and_four_options(
+        self,
+    ) -> None:
+        """One option is not a choice, and five is a menu."""
+        option = {"label": "a", "description": "d"}
+        for count in (1, 5):
+            with self.assertRaises(ValidationError):
+                _AskUserParams.model_validate(
+                    {
+                        "questions": [
+                            {
+                                "question": "Which?",
+                                "header": "Pick",
+                                "options": [option] * count,
+                            },
+                        ],
+                    },
+                )
+
+    async def test_a_header_stays_short_enough_to_be_a_chip(self) -> None:
+        """It is rendered as a tag, so it cannot run on."""
+        with self.assertRaises(ValidationError):
+            _AskUserParams.model_validate(
+                {
+                    "questions": [
+                        {
+                            "question": "Which?",
+                            "header": "a header far too long to be a chip",
+                            "options": [
+                                {"label": "a", "description": "d"},
+                                {"label": "b", "description": "d"},
+                            ],
+                        },
+                    ],
+                },
+            )
+
+    async def test_the_schema_reaches_the_model_whole(self) -> None:
+        """Nested models mean $defs, which the model layers inline."""
+        schema = self.tool.input_schema
+        self.assertListEqual(
+            sorted(schema["$defs"]),
+            ["_Option", "_Question"],
+        )
+        self.assertEqual(
+            schema["properties"]["questions"]["items"]["$ref"],
+            "#/$defs/_Question",
+        )

--- a/tests/ask_user_tool_test.py
+++ b/tests/ask_user_tool_test.py
@@ -2,8 +2,10 @@
 """Unittests for the AskUser tool."""
 from unittest import IsolatedAsyncioTestCase
 
+import jsonschema
 from pydantic import ValidationError
 
+from agentscope.message import ToolResultBlock, ToolResultState
 from agentscope.permission import PermissionBehavior, PermissionContext
 from agentscope.tool import AskUser
 from agentscope.tool._builtin._ask_user import _AskUserParams
@@ -67,6 +69,24 @@ class AskUserTest(IsolatedAsyncioTestCase):
                     ],
                 },
             )
+
+    async def test_a_result_that_breaks_its_promise_is_refused(self) -> None:
+        """The shape is the caller's to keep; prose alone is not enough."""
+        result = ToolResultBlock(
+            id="call-1",
+            name="AskUser",
+            output="通过",
+            state=ToolResultState.SUCCESS,
+        )
+        with self.assertRaises(jsonschema.ValidationError):
+            await self.tool.check_external_result(result)
+
+        result.metadata = AskUser.Answers(
+            answers=[
+                {"question": "批准吗？", "selected": ["通过"], "other": None},
+            ],
+        ).model_dump()
+        await self.tool.check_external_result(result)
 
     async def test_the_schema_reaches_the_model_whole(self) -> None:
         """Nested models mean $defs, which the model layers inline."""

--- a/tests/ask_user_tool_test.py
+++ b/tests/ask_user_tool_test.py
@@ -7,7 +7,7 @@ from pydantic import ValidationError
 
 from agentscope.message import ToolResultBlock, ToolResultState
 from agentscope.permission import PermissionBehavior, PermissionContext
-from agentscope.tool import AskUser, AskUserAnswers, AskUserParams
+from agentscope.tool import AskUser, AskUserMetadata, AskUserParams
 
 
 class AskUserTest(IsolatedAsyncioTestCase):
@@ -80,7 +80,7 @@ class AskUserTest(IsolatedAsyncioTestCase):
         with self.assertRaises(jsonschema.ValidationError):
             await self.tool.check_external_result(result)
 
-        result.metadata = AskUserAnswers(
+        result.metadata = AskUserMetadata(
             answers=[
                 {"question": "批准吗？", "selected": ["通过"], "other": None},
             ],

--- a/tests/ask_user_tool_test.py
+++ b/tests/ask_user_tool_test.py
@@ -7,8 +7,7 @@ from pydantic import ValidationError
 
 from agentscope.message import ToolResultBlock, ToolResultState
 from agentscope.permission import PermissionBehavior, PermissionContext
-from agentscope.tool import AskUser
-from agentscope.tool._builtin._ask_user import _AskUserParams
+from agentscope.tool import AskUser, AskUserAnswers, AskUserParams
 
 
 class AskUserTest(IsolatedAsyncioTestCase):
@@ -40,7 +39,7 @@ class AskUserTest(IsolatedAsyncioTestCase):
         option = {"label": "a", "description": "d"}
         for count in (1, 5):
             with self.assertRaises(ValidationError):
-                _AskUserParams.model_validate(
+                AskUserParams.model_validate(
                     {
                         "questions": [
                             {
@@ -55,7 +54,7 @@ class AskUserTest(IsolatedAsyncioTestCase):
     async def test_a_header_stays_short_enough_to_be_a_chip(self) -> None:
         """It is rendered as a tag, so it cannot run on."""
         with self.assertRaises(ValidationError):
-            _AskUserParams.model_validate(
+            AskUserParams.model_validate(
                 {
                     "questions": [
                         {
@@ -81,7 +80,7 @@ class AskUserTest(IsolatedAsyncioTestCase):
         with self.assertRaises(jsonschema.ValidationError):
             await self.tool.check_external_result(result)
 
-        result.metadata = AskUser.Answers(
+        result.metadata = AskUserAnswers(
             answers=[
                 {"question": "批准吗？", "selected": ["通过"], "other": None},
             ],


### PR DESCRIPTION
## What

An agent that needs a decision from the person it is working for has had no way to ask for one — it could only guess, or stop and hope the guess was mentioned. `AskUser` gives it a call to make:

```python
from agentscope.tool import AskUser

toolkit = Toolkit(tools=[AskUser()])
```

One to four questions per call, each with two to four options, each option carrying a description and an optional preview so a renderer can put the trade-offs — or a code snippet — beside the choice.

## It is external, and that is the point

`is_external_tool = True`, no `__call__`. Only whatever is driving the agent can put a question in front of a person, so the agent yields `RequireExternalExecutionEvent` and waits for an `ExternalExecutionResultEvent` to come back. That is the same event a UI already handles for any externally-executed tool, so a renderer that supports one supports this.

Permission checking passes it straight through: the call is answered by the user in the first place, so a confirmation in front of it would only be a prompt about a prompt.

## Notes

- The `header` length is enforced rather than merely asked for — it is rendered as a chip, so it cannot run on.
- The nested option/question models mean the schema carries `$defs` / `$ref`. The OpenAI and Gemini model layers already inline those before the schema reaches the provider.
- "Other" is promised to the user in the description, so a renderer is expected to offer free-text input alongside the options.

## Testing

`tests/ask_user_tool_test.py` — five cases: the call is left to the driver (calling it raises), permissions allow without asking, a question needs two to four options, a header stays chip-sized, and the schema keeps its `$defs`. `pre-commit run` clean.
