### PR TITLE
feat(model): add aimlapi.com as an LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The SDK layer — compose an agent from a rich set of building blocks:
 |---|---|
 | [**ReAct**](https://docs.agentscope.io/latest/en/building-blocks/agent/overview) | Reasoning-acting loop with structured output, realtime interruption & resume, and batched (sequential / concurrent) tool acting |
 | [**Toolkit**](https://docs.agentscope.io/latest/en/building-blocks/tool/overview) | Agentic tool management over Python tools, MCP servers, and skills; ships with built-in coding tools (shell, file edit, search) and task/plan tools |
-| [**Model**](https://docs.agentscope.io/latest/en/building-blocks/model/overview) | LLM, embedding, and TTS across major providers (OpenAI, Anthropic, Gemini, DashScope, DeepSeek, Moonshot, Volcengine, xAI, Ollama) |
+| [**Model**](https://docs.agentscope.io/latest/en/building-blocks/model/overview) | LLM, embedding, and TTS across major providers (OpenAI, Anthropic, Gemini, DashScope, DeepSeek, Moonshot, Volcengine, xAI, Ollama, aimlapi.com) |
 | [**Context**](https://docs.agentscope.io/latest/en/building-blocks/context/overview) | Automatic compaction, tool-result offload, and context injection (system prompt, RAG, memory) via built-in middleware |
 | [**Event System**](https://docs.agentscope.io/latest/en/building-blocks/message-and-event) | Unified event bus streaming reasoning, tool calls, and multimodal content (text, image, audio) to the frontend |
 | [**Permission & HITL**](https://docs.agentscope.io/latest/en/building-blocks/permission-system/overview) | Fine-grained control over tools and resources, confirmation, bypass mode |

--- a/README_zh.md
+++ b/README_zh.md
@@ -127,7 +127,7 @@ SDK 层 —— 用一整套丰富的构建模块组合出你的智能体：
 |---|---|
 | [**ReAct**](https://docs.agentscope.io/latest/zh/building-blocks/agent/overview) | 推理-行动循环，支持结构化输出、实时中断与恢复、以及批量（顺序 / 并发）工具执行 |
 | [**工具集**](https://docs.agentscope.io/latest/zh/building-blocks/tool/overview) | 智能体自主工具管理（囊括 Python 工具、MCP 与 Skill）；内置编码工具（Shell、文件编辑、搜索）与任务/规划工具开箱即用 |
-| [**模型**](https://docs.agentscope.io/latest/zh/building-blocks/model/overview) | LLM、Embedding、TTS，覆盖主流厂商（OpenAI、Anthropic、Gemini、DashScope、DeepSeek、Moonshot、Volcengine、xAI、Ollama） |
+| [**模型**](https://docs.agentscope.io/latest/zh/building-blocks/model/overview) | LLM、Embedding、TTS，覆盖主流厂商（OpenAI、Anthropic、Gemini、DashScope、DeepSeek、Moonshot、Volcengine、xAI、Ollama、aimlapi.com） |
 | [**上下文**](https://docs.agentscope.io/latest/zh/building-blocks/context/overview) | 自动压缩、工具结果卸载、以及上下文注入（系统提示、RAG、记忆），均由内置中间件实现 |
 | [**事件系统**](https://docs.agentscope.io/latest/zh/building-blocks/message-and-event) | 统一事件总线，将推理、工具调用与多模态内容（文本、图像、音频）流式推送到前端 |
 | [**权限与 HITL**](https://docs.agentscope.io/latest/zh/building-blocks/permission-system/overview) | 对工具和资源的细粒度控制、确认、bypass 模式 |

--- a/scripts/model_examples/README.md
+++ b/scripts/model_examples/README.md
@@ -41,6 +41,8 @@ scripts/model_examples/
 ├── gemini_multimodal.py
 ├── gemini_multiagent_multimodal.py
 │
+├── aimlapi_call.py                  # aimlapi.com aggregator (no multimodal example)
+│
 ├── moonshot_call.py                 # Moonshot AI (Kimi)
 ├── moonshot_multiagent.py
 ├── moonshot_multimodal.py
@@ -85,6 +87,7 @@ scripts/model_examples/
 | `gemini` | `GEMINI_API_KEY` | Gemini models, supports `thinking_budget` |
 | `moonshot` | `MOONSHOT_API_KEY` | Moonshot AI kimi-k2.6, etc. |
 | `volcengine` | `VOLCENGINE_API_KEY` | Volcengine Ark / Doubao models |
+| `aimlapi` | `AIMLAPI_API_KEY` | aimlapi.com aggregator, supports only `call` |
 | `xai` | `XAI_API_KEY` | Grok models, supports `reasoning_effort` |
 | `ollama` | *(none – auto-detect)* | Local server, default `http://localhost:11434` |
 
@@ -104,6 +107,7 @@ export DEEPSEEK_API_KEY="sk-..."
 export GEMINI_API_KEY="AIza..."
 export MOONSHOT_API_KEY="sk-..."
 export VOLCENGINE_API_KEY="..."
+export AIMLAPI_API_KEY="..."
 export XAI_API_KEY="xai-..."
 ```
 

--- a/scripts/model_examples/aimlapi_call.py
+++ b/scripts/model_examples/aimlapi_call.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+"""Examples of aimlapi.com model calls."""
+import asyncio
+import json
+import os
+
+from pydantic import BaseModel, Field
+
+from _utils import stream_and_collect
+from agentscope.message import (
+    Msg,
+    TextBlock,
+    ToolCallBlock,
+    ToolResultBlock,
+    ToolResultState,
+)
+from agentscope.model import AIMLAPIChatModel
+from agentscope.credential import AIMLAPICredential
+from agentscope.tool import Toolkit, ToolChoice, FunctionTool
+
+_MODEL = "openai/gpt-5-5"
+_CONTEXT_SIZE = 1_050_000
+
+
+def _make_model(**kwargs: object) -> AIMLAPIChatModel:
+    return AIMLAPIChatModel(
+        credential=AIMLAPICredential(
+            api_key=os.environ["AIMLAPI_API_KEY"],
+        ),
+        model=_MODEL,
+        stream=True,
+        context_size=_CONTEXT_SIZE,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Example 1: Simple user message (streaming)
+# ---------------------------------------------------------------------------
+
+
+async def example_simple_call() -> None:
+    """Call an aimlapi.com model with a simple text message."""
+    model = _make_model()
+
+    msgs = [
+        Msg(
+            name="user",
+            content=[TextBlock(text="What is 1 + 1? Answer briefly.")],
+            role="user",
+        ),
+    ]
+
+    print("=== Simple Call ===")
+    await stream_and_collect(await model(msgs))
+
+
+# ---------------------------------------------------------------------------
+# Example 2: Tool calling (streaming)
+# ---------------------------------------------------------------------------
+
+
+def get_weather(city: str) -> str:
+    """Get the current weather for a city.
+
+    Args:
+        city: The city name to query the weather for.
+
+    Returns:
+        A description of the current weather.
+    """
+    return f"The weather in {city} is sunny and 25°C."
+
+
+async def example_tool_call() -> None:
+    """Run a two-turn tool loop against an aimlapi.com model.
+
+    The second turn deliberately passes no tools. aimlapi.com rejects an
+    explicit ``"tools": null`` with a 400 on its stricter models, so this is
+    the round trip that proves unset parameters are omitted rather than
+    nulled.
+    """
+    toolkit = Toolkit(tools=[FunctionTool(get_weather)])
+    tools = await toolkit.get_tool_schemas()
+
+    model = _make_model()
+
+    msgs = [
+        Msg(
+            name="user",
+            content=[TextBlock(text="What is the weather in Xi'an?")],
+            role="user",
+        ),
+    ]
+
+    # First call: model decides to call a tool
+    print("=== Tool Call - Round 1 ===")
+    response = await stream_and_collect(
+        await model(msgs, tools=tools, tool_choice=ToolChoice(mode="auto")),
+    )
+    print(response)
+
+    tool_calls = [b for b in response.content if isinstance(b, ToolCallBlock)]
+    if tool_calls:
+        tool_result_blocks = []
+        for tool_call in tool_calls:
+            args = json.loads(tool_call.input)
+            result = get_weather(**args)
+            tool_result_blocks.append(
+                ToolResultBlock(
+                    id=tool_call.id,
+                    name=tool_call.name,
+                    output=result,
+                    state=ToolResultState.SUCCESS,
+                ),
+            )
+
+        assistant_msg = Msg(
+            name="assistant",
+            content=response.content,
+            role="assistant",
+        )
+        tool_result_msg = Msg(
+            name="tool",
+            content=tool_result_blocks,
+            role="assistant",
+        )
+        msgs = msgs + [assistant_msg, tool_result_msg]
+
+        print("=== Tool Call - Round 2 (Final) ===")
+        await stream_and_collect(await model(msgs))
+
+
+# ---------------------------------------------------------------------------
+# Example 3: Structured output
+# ---------------------------------------------------------------------------
+
+
+class MathSolution(BaseModel):
+    """Structured solution to a math problem."""
+
+    problem: str = Field(description="The original problem statement")
+    answer: float = Field(description="The final numeric answer")
+    steps: list[str] = Field(
+        description="Step-by-step reasoning leading to the answer",
+    )
+
+
+async def example_structured_output() -> None:
+    """Call an aimlapi.com model and force a structured (JSON) output."""
+    model = _make_model()
+
+    msgs = [
+        Msg(
+            name="user",
+            content=[
+                TextBlock(
+                    text=(
+                        "Solve this: A train travels at 60 km/h for "
+                        "2.5 hours. How far does it travel in km?"
+                    ),
+                ),
+            ],
+            role="user",
+        ),
+    ]
+
+    print("=== Structured Output ===")
+    response = await model.generate_structured_output(
+        msgs,
+        structured_model=MathSolution,
+    )
+    print(response.content)
+
+
+if __name__ == "__main__":
+    asyncio.run(example_simple_call())
+    asyncio.run(example_tool_call())
+    asyncio.run(example_structured_output())

--- a/scripts/model_examples/run_tests.py
+++ b/scripts/model_examples/run_tests.py
@@ -157,6 +157,13 @@ ALL_PROVIDERS: list[Provider] = [
         description="Google Gemini models",
     ),
     Provider(
+        name="aimlapi",
+        env_var="AIMLAPI_API_KEY",
+        file_prefix="aimlapi",
+        supported_tests=["call"],
+        description="aimlapi.com aggregator (OpenAI-compatible)",
+    ),
+    Provider(
         name="moonshot",
         env_var="MOONSHOT_API_KEY",
         file_prefix="moonshot",

--- a/src/agentscope/credential/__init__.py
+++ b/src/agentscope/credential/__init__.py
@@ -2,6 +2,7 @@
 """The credential module."""
 
 from ._base import CredentialBase
+from ._aimlapi import AIMLAPICredential
 from ._anthropic import AnthropicCredential
 from ._dashscope import DashScopeCredential
 from ._deepseek import DeepSeekCredential
@@ -16,6 +17,7 @@ from ._factory import CredentialFactory
 
 __all__ = [
     "CredentialBase",
+    "AIMLAPICredential",
     "AnthropicCredential",
     "DashScopeCredential",
     "DeepSeekCredential",

--- a/src/agentscope/credential/_aimlapi.py
+++ b/src/agentscope/credential/_aimlapi.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""The AI/ML API credential."""
+from typing import Literal, Type, TYPE_CHECKING
+
+from pydantic import ConfigDict, Field, SecretStr
+
+from ._base import CredentialBase
+
+if TYPE_CHECKING:
+    from ..model import ChatModelBase
+
+_AIMLAPI_BASE_URL = "https://api.aimlapi.com/v1"
+
+
+class AIMLAPICredential(CredentialBase):
+    """The aimlapi.com credential model.
+
+    aimlapi.com is an OpenAI-compatible aggregator: a single key and base URL
+    reach several hundred chat models from different vendors. Only the
+    ``/v1/chat/completions`` surface is used — ``/v1/completions`` does not
+    exist there, and ``/v1/responses`` serves a small subset of the catalog.
+    """
+
+    model_config = ConfigDict(
+        title="aimlapi.com",
+    )
+
+    type: Literal["aimlapi_credential"] = "aimlapi_credential"
+    """The credential type."""
+
+    api_key: SecretStr = Field(
+        description="The aimlapi.com API key.",
+    )
+    """The API key."""
+
+    base_url: str = Field(
+        default=_AIMLAPI_BASE_URL,
+        description="The base URL for the aimlapi.com API.",
+    )
+    """The base URL for the aimlapi.com API."""
+
+    @classmethod
+    def get_chat_model_class(cls) -> Type["ChatModelBase"]:
+        """Return the AIMLAPIChatModel class."""
+        from ..model import AIMLAPIChatModel
+
+        return AIMLAPIChatModel

--- a/src/agentscope/credential/_factory.py
+++ b/src/agentscope/credential/_factory.py
@@ -4,6 +4,7 @@ from typing import Annotated, Type, Union, get_args, get_type_hints
 
 from pydantic import TypeAdapter, Field
 
+from ._aimlapi import AIMLAPICredential
 from ._anthropic import AnthropicCredential
 from ._dashscope import DashScopeCredential
 from ._deepseek import DeepSeekCredential
@@ -35,6 +36,7 @@ class CredentialFactory:
     """
 
     _classes: list[Type[CredentialBase]] = [
+        AIMLAPICredential,
         AnthropicCredential,
         DashScopeCredential,
         DeepSeekCredential,

--- a/src/agentscope/formatter/__init__.py
+++ b/src/agentscope/formatter/__init__.py
@@ -2,6 +2,10 @@
 """The formatter module in agentscope."""
 
 from ._formatter_base import FormatterBase
+from ._aimlapi_formatter import (
+    AIMLAPIChatFormatter,
+    AIMLAPIMultiAgentFormatter,
+)
 from ._dashscope_formatter import (
     DashScopeChatFormatter,
     DashScopeMultiAgentFormatter,
@@ -45,6 +49,8 @@ from ._volcengine_formatter import (
 
 __all__ = [
     "FormatterBase",
+    "AIMLAPIChatFormatter",
+    "AIMLAPIMultiAgentFormatter",
     "DashScopeChatFormatter",
     "DashScopeMultiAgentFormatter",
     "OpenAIChatFormatter",

--- a/src/agentscope/formatter/_aimlapi_formatter.py
+++ b/src/agentscope/formatter/_aimlapi_formatter.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""The aimlapi.com formatter classes.
+
+aimlapi.com speaks the OpenAI Chat Completions wire format verbatim, so both
+formatters reuse the OpenAI implementations and only narrow the advertised
+input types: the aggregator's chat surface takes text and images, while audio
+and PDF support is per-model rather than provider-wide. Per-model input types
+come from the model cards in ``agentscope/model/_aimlapi/_models``.
+"""
+from pydantic import Field
+
+from ._openai_formatter import OpenAIChatFormatter, OpenAIMultiAgentFormatter
+
+_AIMLAPI_INPUT_TYPES = ["text/plain", "image/*"]
+
+
+class AIMLAPIChatFormatter(OpenAIChatFormatter):
+    """The aimlapi.com formatter for the chatbot scenario, where only a user
+    and an agent are involved."""
+
+    input_types: list[str] = Field(
+        default_factory=lambda: list(_AIMLAPI_INPUT_TYPES),
+        description=(
+            "The supported input types. Defaults to "
+            '``["text/plain", "image/*"]``.'
+        ),
+    )
+
+
+class AIMLAPIMultiAgentFormatter(OpenAIMultiAgentFormatter):
+    """The aimlapi.com formatter for multi-agent conversations, where more
+    than a user and an agent are involved."""
+
+    input_types: list[str] = Field(
+        default_factory=lambda: list(_AIMLAPI_INPUT_TYPES),
+        description=(
+            "The supported input types. Defaults to "
+            '``["text/plain", "image/*"]``.'
+        ),
+    )

--- a/src/agentscope/middleware/_tracing/_attributes.py
+++ b/src/agentscope/middleware/_tracing/_attributes.py
@@ -192,6 +192,9 @@ class ProviderNameValues:
     VOLCENGINE = "volcengine"
     """The Volcengine provider name."""
 
+    AIMLAPI = "aimlapi"
+    """The aimlapi.com provider name."""
+
     AZURE_AI_OPENAI = (
         GenAIAttributes.GenAiProviderNameValues.AZURE_AI_OPENAI.value
     )

--- a/src/agentscope/middleware/_tracing/_extractor.py
+++ b/src/agentscope/middleware/_tracing/_extractor.py
@@ -32,6 +32,7 @@ _CLASS_NAME_MAP = {
     "xai": ProviderNameValues.XAI,
     "moonshot": ProviderNameValues.MOONSHOT,
     "volcengine": ProviderNameValues.VOLCENGINE,
+    "aimlapi": ProviderNameValues.AIMLAPI,
 }
 
 # Map base URL fragments to provider names for OpenAI-compatible APIs
@@ -45,6 +46,7 @@ _BASE_URL_PROVIDER_MAP = [
     ("openai.azure.com", ProviderNameValues.AZURE_AI_OPENAI),
     ("amazonaws.com", ProviderNameValues.AWS_BEDROCK),
     ("api.x.ai", ProviderNameValues.XAI),
+    ("api.aimlapi.com", ProviderNameValues.AIMLAPI),
 ]
 
 

--- a/src/agentscope/model/__init__.py
+++ b/src/agentscope/model/__init__.py
@@ -5,6 +5,7 @@ from ._base import ChatModelBase
 from ._model_card import ModelCard
 from ._model_response import ChatResponse, StructuredResponse, FinishedReason
 from ._model_usage import ChatUsage
+from ._aimlapi import AIMLAPIChatModel
 from ._anthropic import AnthropicChatModel
 from ._dashscope import DashScopeChatModel
 from ._deepseek import DeepSeekChatModel
@@ -23,6 +24,7 @@ __all__ = [
     "FinishedReason",
     "ModelCard",
     "StructuredResponse",
+    "AIMLAPIChatModel",
     "AnthropicChatModel",
     "DashScopeChatModel",
     "DeepSeekChatModel",

--- a/src/agentscope/model/_aimlapi/__init__.py
+++ b/src/agentscope/model/_aimlapi/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""The aimlapi.com LLM API modules."""
+
+from ._model import AIMLAPIChatModel
+
+__all__ = [
+    "AIMLAPIChatModel",
+]

--- a/src/agentscope/model/_aimlapi/_model.py
+++ b/src/agentscope/model/_aimlapi/_model.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+"""The aimlapi.com chat model implementation."""
+from typing import Any, Literal
+from urllib.parse import urlsplit
+
+from .._base import ChatModelBase
+from .._openai_chat import OpenAIChatModel
+from ...credential import AIMLAPICredential
+from ...formatter import FormatterBase, AIMLAPIChatFormatter
+
+# Attribution headers identifying AgentScope as the calling application.
+# ``HTTP-Referer`` / ``X-Title`` follow the OpenRouter convention and name the
+# *host* project, not the provider. Never mutate this mapping — callers get a
+# fresh copy per model instance.
+_AIMLAPI_ATTRIBUTION_HEADERS = {
+    "HTTP-Referer": "https://github.com/agentscope-ai/agentscope",
+    "X-Title": "AgentScope",
+    "X-AIMLAPI-Source": "agent/agentscope",
+    "X-AIMLAPI-Partner-ID": "part_kY9LNtFpD5NNROdyhGmRvEqP",
+}
+
+_AIMLAPI_HOST_SUFFIX = "aimlapi.com"
+
+
+def _is_aimlapi_origin(base_url: str | None) -> bool:
+    """Whether ``base_url`` points at aimlapi.com itself.
+
+    The credential's ``base_url`` is user-editable, so a self-hosted gateway
+    or a third-party proxy can be pointed at this model class. Attribution
+    headers must not ride along to such a host, hence the explicit origin
+    check.
+
+    Args:
+        base_url (`str | None`):
+            The configured base URL.
+
+    Returns:
+        `bool`:
+            ``True`` when the host is ``aimlapi.com`` or a subdomain of it.
+    """
+    if not base_url:
+        return False
+    host = (urlsplit(str(base_url)).hostname or "").lower()
+    return host == _AIMLAPI_HOST_SUFFIX or host.endswith(
+        "." + _AIMLAPI_HOST_SUFFIX,
+    )
+
+
+def _build_client_kwargs(
+    base_url: str | None,
+    client_kwargs: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Return client kwargs with the attribution headers merged in.
+
+    Caller-supplied headers win on a key clash, and a new dict is built on
+    every call so neither the module-level constant nor the caller's own
+    mapping is mutated.
+
+    Args:
+        base_url (`str | None`):
+            The configured base URL, used to scope the headers to our origin.
+        client_kwargs (`dict[str, Any] | None`):
+            Extra keyword arguments for ``openai.AsyncClient``.
+
+    Returns:
+        `dict[str, Any]`:
+            A new client kwargs dict.
+    """
+    kwargs = dict(client_kwargs or {})
+    if not _is_aimlapi_origin(base_url):
+        return kwargs
+
+    kwargs["default_headers"] = {
+        **_AIMLAPI_ATTRIBUTION_HEADERS,
+        **(kwargs.get("default_headers") or {}),
+    }
+    return kwargs
+
+
+class AIMLAPIChatModel(OpenAIChatModel):
+    """The aimlapi.com chat model.
+
+    aimlapi.com aggregates several hundred models from different vendors
+    behind one OpenAI-compatible ``/v1/chat/completions`` endpoint, so this
+    class reuses :class:`OpenAIChatModel` for request building, streaming and
+    response parsing rather than duplicating them. It differs in three ways:
+
+    1. It takes an :class:`AIMLAPICredential` (no ``organization`` field).
+    2. It attaches AgentScope attribution headers, scoped to the aimlapi.com
+       origin so they cannot ride a request to another provider.
+    3. It defaults to :class:`AIMLAPIChatFormatter`.
+
+    .. note:: Request parameters that are unset are **omitted** rather than
+        sent as ``null`` — inherited from :class:`OpenAIChatModel`. Several
+        aimlapi.com models reject an explicit ``null`` for ``tools``,
+        ``temperature``, ``seed`` and friends with a 400, which would
+        otherwise break the second turn of every tool-calling loop.
+
+    .. note:: ``/v1/completions`` does not exist on aimlapi.com, and
+        ``/v1/responses`` only serves a small subset of the catalog, so only
+        the chat-completions surface is used here.
+    """
+
+    type: Literal["aimlapi_chat"] = "aimlapi_chat"
+    """The type of the chat model."""
+
+    def __init__(
+        self,
+        credential: AIMLAPICredential,
+        model: str,
+        parameters: "AIMLAPIChatModel.Parameters | None" = None,
+        stream: bool = True,
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
+        context_size: int = 128000,
+        formatter: FormatterBase | None = None,
+        client_kwargs: dict[str, Any] | None = None,
+        extra_body: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize the aimlapi.com chat model.
+
+        Args:
+            credential (`AIMLAPICredential`):
+                The aimlapi.com credential used to authenticate API calls.
+            model (`str`):
+                The model name, e.g. ``openai/gpt-5-5``. Any id from
+                ``GET https://api.aimlapi.com/v1/models`` works; the bundled
+                model cards only drive the picker.
+            parameters (`AIMLAPIChatModel.Parameters | None`, defaults to \
+            `None`):
+                The API parameters. When ``None``, the default parameters
+                will be used.
+            stream (`bool`, defaults to `True`):
+                Whether to enable streaming output.
+            max_retries (`int`, defaults to `3`):
+                The maximum number of retries for the API.
+            retry_delay (`float`, defaults to `1.0`):
+                Seconds to sleep between retry attempts.
+            context_size (`int`, defaults to `128000`):
+                The model context size used for context compression.
+            formatter (`FormatterBase | None`, defaults to `None`):
+                The formatter that converts ``Msg`` objects to the format
+                required by the API. When ``None``, an
+                ``AIMLAPIChatFormatter`` instance will be used.
+            client_kwargs (`dict[str, Any] | None`, defaults to `None`):
+                Extra keyword arguments forwarded to ``openai.AsyncClient``
+                (e.g. ``timeout``, ``default_headers``, ``http_client``).
+                Headers given here take precedence over the attribution
+                headers.
+            extra_body (`dict[str, Any] | None`, defaults to `None`):
+                Additional request body fields forwarded to the API.
+        """
+        # ``OpenAIChatModel.__init__`` reads ``credential.organization``,
+        # which aimlapi.com has no equivalent of, so the base initializer is
+        # invoked directly instead of through ``super()``. Adding a dead
+        # ``organization`` field to the credential just to satisfy the parent
+        # would put a meaningless input on the credential form.
+        # pylint: disable=non-parent-init-called
+        ChatModelBase.__init__(
+            self,
+            credential=credential,
+            model=model,
+            parameters=parameters or self.Parameters(),
+            stream=stream,
+            max_retries=max_retries,
+            retry_delay=retry_delay,
+            context_size=context_size,
+        )
+        self.formatter = formatter or AIMLAPIChatFormatter()
+        self.client_kwargs = _build_client_kwargs(
+            credential.base_url,
+            client_kwargs,
+        )
+        self.extra_body = dict(extra_body) if extra_body is not None else None
+
+        import openai
+
+        self.client: openai.AsyncClient = openai.AsyncClient(
+            api_key=self.credential.api_key.get_secret_value(),
+            base_url=self.credential.base_url,
+            **self.client_kwargs,
+        )

--- a/src/agentscope/model/_aimlapi/_models/anthropic-claude-opus-5.yaml
+++ b/src/agentscope/model/_aimlapi/_models/anthropic-claude-opus-5.yaml
@@ -1,0 +1,29 @@
+# The aimlapi.com catalog reports this model as text-only. That is wrong: it
+# accepts images, verified by a live call before this card was written. The
+# image input types below are deliberately not derived from the catalog.
+name: anthropic/claude-opus-5
+label: Claude Opus 5
+status: active
+
+input_types:
+  - text/plain
+  - image/jpeg
+  - image/png
+  - image/gif
+  - image/webp
+
+output_types:
+  - text/plain
+
+context_size: 1000000
+output_size: 128000
+
+parameter_overrides:
+  max_tokens:
+    maximum: 128000
+  thinking_enable:
+    hidden: true
+  reasoning_effort:
+    hidden: true
+  voice:
+    hidden: true

--- a/src/agentscope/model/_aimlapi/_models/anthropic-claude-sonnet-4.6.yaml
+++ b/src/agentscope/model/_aimlapi/_models/anthropic-claude-sonnet-4.6.yaml
@@ -1,0 +1,27 @@
+# The dotted spelling is the correct one — the dashed twin
+# ``anthropic/claude-sonnet-4-6`` resolves but publishes an empty capability
+# set upstream.
+name: anthropic/claude-sonnet-4.6
+label: Claude Sonnet 4.6
+status: active
+
+input_types:
+  - text/plain
+  - application/x-thinking
+  - image/jpeg
+  - image/png
+  - image/gif
+  - image/webp
+
+output_types:
+  - text/plain
+  - application/x-thinking
+
+context_size: 200000
+output_size: 64000
+
+parameter_overrides:
+  max_tokens:
+    maximum: 64000
+  voice:
+    hidden: true

--- a/src/agentscope/model/_aimlapi/_models/deepseek-deepseek-v4-pro.yaml
+++ b/src/agentscope/model/_aimlapi/_models/deepseek-deepseek-v4-pro.yaml
@@ -1,0 +1,20 @@
+name: deepseek/deepseek-v4-pro
+label: DeepSeek V4 Pro
+status: active
+
+input_types:
+  - text/plain
+  - application/x-thinking
+
+output_types:
+  - text/plain
+  - application/x-thinking
+
+context_size: 1000000
+output_size: 384000
+
+parameter_overrides:
+  max_tokens:
+    maximum: 384000
+  voice:
+    hidden: true

--- a/src/agentscope/model/_aimlapi/_models/google-gemini-2.5-flash.yaml
+++ b/src/agentscope/model/_aimlapi/_models/google-gemini-2.5-flash.yaml
@@ -1,0 +1,26 @@
+name: google/gemini-2.5-flash
+label: Gemini 2.5 Flash
+status: active
+
+input_types:
+  - text/plain
+  - image/jpeg
+  - image/png
+  - image/gif
+  - image/webp
+
+output_types:
+  - text/plain
+
+context_size: 1000000
+output_size: 65536
+
+parameter_overrides:
+  max_tokens:
+    maximum: 65536
+  thinking_enable:
+    hidden: true
+  reasoning_effort:
+    hidden: true
+  voice:
+    hidden: true

--- a/src/agentscope/model/_aimlapi/_models/openai-gpt-4o-mini.yaml
+++ b/src/agentscope/model/_aimlapi/_models/openai-gpt-4o-mini.yaml
@@ -1,0 +1,26 @@
+name: openai/gpt-4o-mini
+label: GPT-4o Mini
+status: active
+
+input_types:
+  - text/plain
+  - image/jpeg
+  - image/png
+  - image/gif
+  - image/webp
+
+output_types:
+  - text/plain
+
+context_size: 128000
+output_size: 16384
+
+parameter_overrides:
+  max_tokens:
+    maximum: 16384
+  thinking_enable:
+    hidden: true
+  reasoning_effort:
+    hidden: true
+  voice:
+    hidden: true

--- a/src/agentscope/model/_aimlapi/_models/openai-gpt-5-5.yaml
+++ b/src/agentscope/model/_aimlapi/_models/openai-gpt-5-5.yaml
@@ -1,0 +1,26 @@
+name: openai/gpt-5-5
+label: GPT-5.5
+status: active
+
+input_types:
+  - text/plain
+  - image/jpeg
+  - image/png
+  - image/gif
+  - image/webp
+
+output_types:
+  - text/plain
+
+context_size: 1050000
+output_size: 128000
+
+parameter_overrides:
+  max_tokens:
+    maximum: 128000
+  # Reasoning happens internally and is never returned as content, so the
+  # thinking toggle has nothing to surface — reasoning_effort is the knob.
+  thinking_enable:
+    hidden: true
+  voice:
+    hidden: true

--- a/src/agentscope/model/_aimlapi/_models/x-ai-grok-4-1-fast-reasoning.yaml
+++ b/src/agentscope/model/_aimlapi/_models/x-ai-grok-4-1-fast-reasoning.yaml
@@ -1,0 +1,20 @@
+name: x-ai/grok-4-1-fast-reasoning
+label: Grok 4.1 Fast Reasoning
+status: active
+
+input_types:
+  - text/plain
+  - application/x-thinking
+
+output_types:
+  - text/plain
+  - application/x-thinking
+
+context_size: 2000000
+output_size: 1999000
+
+parameter_overrides:
+  max_tokens:
+    maximum: 1999000
+  voice:
+    hidden: true

--- a/src/agentscope/model/_aimlapi/_models/zhipu-glm-5.2.yaml
+++ b/src/agentscope/model/_aimlapi/_models/zhipu-glm-5.2.yaml
@@ -1,0 +1,20 @@
+name: zhipu/glm-5.2
+label: GLM-5.2
+status: active
+
+input_types:
+  - text/plain
+  - application/x-thinking
+
+output_types:
+  - text/plain
+  - application/x-thinking
+
+context_size: 1000000
+output_size: 131072
+
+parameter_overrides:
+  max_tokens:
+    maximum: 131072
+  voice:
+    hidden: true

--- a/tests/formatter_aimlapi_test.py
+++ b/tests/formatter_aimlapi_test.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for AIMLAPIChatFormatter and AIMLAPIMultiAgentFormatter.
+
+aimlapi.com speaks the OpenAI Chat Completions wire format verbatim, so both
+formatters delegate to the OpenAI implementations. These tests pin the two
+things that are actually specific to this provider — the delegation itself
+and the narrowed input types — plus a round trip through each ``format`` so a
+future divergence in the OpenAI formatters shows up here.
+"""
+from unittest import IsolatedAsyncioTestCase
+
+from agentscope.formatter import (
+    AIMLAPIChatFormatter,
+    AIMLAPIMultiAgentFormatter,
+    OpenAIChatFormatter,
+    OpenAIMultiAgentFormatter,
+)
+from agentscope.message import (
+    AssistantMsg,
+    SystemMsg,
+    TextBlock,
+    ToolCallBlock,
+    ToolResultBlock,
+    UserMsg,
+)
+
+
+class TestAIMLAPIFormatter(IsolatedAsyncioTestCase):
+    """Tests for the aimlapi.com formatters."""
+
+    def test_delegates_to_the_openai_formatters(self) -> None:
+        """Delegation is the point: aimlapi.com is byte-for-byte
+        OpenAI-compatible, so the formatting logic is not re-implemented."""
+        self.assertTrue(
+            issubclass(AIMLAPIChatFormatter, OpenAIChatFormatter),
+        )
+        self.assertTrue(
+            issubclass(AIMLAPIMultiAgentFormatter, OpenAIMultiAgentFormatter),
+        )
+
+    def test_input_types(self) -> None:
+        """Audio and PDF support is per-model on aimlapi.com rather than
+        provider-wide, so the provider-level default is text and images; the
+        model cards widen or narrow it per model."""
+        for formatter in [
+            AIMLAPIChatFormatter(),
+            AIMLAPIMultiAgentFormatter(),
+        ]:
+            with self.subTest(formatter=type(formatter).__name__):
+                self.assertEqual(
+                    formatter.input_types,
+                    ["text/plain", "image/*"],
+                )
+
+    async def test_chat_format(self) -> None:
+        """A system / user / assistant exchange formats to OpenAI messages."""
+        formatted = await AIMLAPIChatFormatter().format(
+            [
+                SystemMsg(name="system", content="You are helpful."),
+                UserMsg(name="user", content="Hi"),
+                AssistantMsg(
+                    name="assistant",
+                    content=[TextBlock(text="Hello!")],
+                ),
+            ],
+        )
+
+        self.assertEqual(
+            [(msg["role"], msg.get("content")) for msg in formatted],
+            [
+                ("system", [{"type": "text", "text": "You are helpful."}]),
+                ("user", [{"type": "text", "text": "Hi"}]),
+                ("assistant", [{"type": "text", "text": "Hello!"}]),
+            ],
+        )
+
+    async def test_chat_format_tool_sequence(self) -> None:
+        """Tool calls and their results keep the OpenAI shape."""
+        formatted = await AIMLAPIChatFormatter().format(
+            [
+                UserMsg(name="user", content="Weather in Shanghai?"),
+                AssistantMsg(
+                    name="assistant",
+                    content=[
+                        ToolCallBlock(
+                            id="call-1",
+                            name="get_weather",
+                            input='{"city": "Shanghai"}',
+                        ),
+                        ToolResultBlock(
+                            id="call-1",
+                            name="get_weather",
+                            output=[TextBlock(text="sunny")],
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        self.assertEqual(formatted[1]["role"], "assistant")
+        self.assertEqual(
+            formatted[1]["tool_calls"][0]["function"]["name"],
+            "get_weather",
+        )
+        self.assertEqual(formatted[2]["role"], "tool")
+        self.assertEqual(formatted[2]["tool_call_id"], "call-1")
+
+    async def test_multi_agent_format_collapses_the_history(self) -> None:
+        """The multi-agent variant folds other speakers into one history
+        block, as the OpenAI multi-agent formatter does."""
+        formatted = await AIMLAPIMultiAgentFormatter().format(
+            [
+                SystemMsg(name="system", content="You are helpful."),
+                UserMsg(name="alice", content="Hi"),
+                AssistantMsg(name="bob", content="Hello"),
+            ],
+        )
+
+        self.assertEqual(formatted[0]["role"], "system")
+        self.assertEqual(len(formatted), 2)
+        self.assertIn("alice", str(formatted[1]["content"]))
+        self.assertIn("bob", str(formatted[1]["content"]))

--- a/tests/model_aimlapi_test.py
+++ b/tests/model_aimlapi_test.py
@@ -1,0 +1,464 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Unit tests for AIMLAPIChatModel with mocked API responses.
+
+Beyond the usual streaming / non-streaming / tool-calling coverage, two
+provider-specific invariants are asserted here because both fail *silently*
+in production:
+
+* the attribution headers must be well-formed and scoped to aimlapi.com, and
+* no request parameter may ever be sent as an explicit ``null`` — several
+  aimlapi.com models reject ``"tools": null`` with a 400, which breaks the
+  second turn of a tool-calling loop while every mocked test stays green.
+"""
+import re
+from typing import Any
+import unittest
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock
+
+from utils import AnyString
+
+from agentscope.credential import AIMLAPICredential, CredentialFactory
+from agentscope.formatter import (
+    AIMLAPIChatFormatter,
+    AIMLAPIMultiAgentFormatter,
+    FormatterBase,
+)
+from agentscope.message import TextBlock, ToolCallBlock
+from agentscope.model import AIMLAPIChatModel
+from agentscope.model._aimlapi._model import (
+    _AIMLAPI_ATTRIBUTION_HEADERS,
+    _build_client_kwargs,
+)
+from agentscope.tool import ToolChoice
+
+A = AnyString()
+
+# The gateway contract: a partner id that does not match is dropped, earning
+# nothing, and the request still succeeds — so only a test catches a typo.
+_PARTNER_ID_PATTERN = re.compile(r"^part_[A-Za-z0-9]{1,64}$")
+# ``<channel>/<client>``, channel from a closed enum, client lowercase.
+_SOURCE_PATTERN = re.compile(r"^(web|agent|mcp)/[a-z0-9-]{1,32}$")
+
+_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the weather.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+            },
+        },
+    },
+]
+
+
+def _make_model(stream: bool = False, **kwargs: Any) -> AIMLAPIChatModel:
+    return AIMLAPIChatModel(
+        credential=AIMLAPICredential(api_key="test"),
+        model="openai/gpt-5-5",
+        stream=stream,
+        **kwargs,
+    )
+
+
+def _mock_completion(
+    text: Any = None,
+    tool_calls: Any = None,
+    response_id: str = "aimlapi-1",
+) -> MagicMock:
+    """Build a mock non-streaming ChatCompletion response."""
+    msg = MagicMock()
+    msg.content = text
+    msg.reasoning_content = None
+    msg.reasoning = None
+    msg.audio = None
+    msg.tool_calls = None
+
+    if tool_calls:
+        tc_mocks = []
+        for tc in tool_calls:
+            m = MagicMock()
+            m.id = tc["id"]
+            m.function.name = tc["name"]
+            m.function.arguments = tc["arguments"]
+            tc_mocks.append(m)
+        msg.tool_calls = tc_mocks
+
+    choice = MagicMock()
+    choice.message = msg
+    choice.finish_reason = "stop"
+
+    resp = MagicMock()
+    resp.id = response_id
+    resp.choices = [choice]
+    resp.usage.prompt_tokens = 10
+    resp.usage.completion_tokens = 5
+    return resp
+
+
+def _make_stream_chunk(
+    delta_text: str | None = None,
+    response_id: str = "aimlapi-1",
+) -> MagicMock:
+    """Build a single mock streaming chunk."""
+    chunk = MagicMock()
+    chunk.id = response_id
+    chunk.usage = None
+
+    delta = MagicMock()
+    delta.content = delta_text
+    delta.reasoning_content = None
+    delta.reasoning = None
+    delta.audio = None
+    delta.tool_calls = None
+
+    choice = MagicMock()
+    choice.delta = delta
+    choice.finish_reason = None
+    chunk.choices = [choice]
+    return chunk
+
+
+class _MockAsyncStream:
+    """Mock async stream (context manager + async iterator)."""
+
+    def __init__(self, chunks: list) -> None:
+        self._chunks = chunks
+        self._index = 0
+
+    async def __aenter__(self) -> "_MockAsyncStream":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        pass
+
+    def __aiter__(self) -> "_MockAsyncStream":
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._index >= len(self._chunks):
+            raise StopAsyncIteration
+        chunk = self._chunks[self._index]
+        self._index += 1
+        return chunk
+
+
+class TestAIMLAPIAttribution(unittest.TestCase):
+    """The attribution headers and how they are attached."""
+
+    def test_partner_id_and_source_shape(self) -> None:
+        """A malformed partner id or source is dropped by the gateway with
+        no error, so its shape is asserted here."""
+        self.assertRegex(
+            _AIMLAPI_ATTRIBUTION_HEADERS["X-AIMLAPI-Partner-ID"],
+            _PARTNER_ID_PATTERN,
+        )
+        self.assertRegex(
+            _AIMLAPI_ATTRIBUTION_HEADERS["X-AIMLAPI-Source"],
+            _SOURCE_PATTERN,
+        )
+
+    def test_referer_and_title_name_the_host_project(self) -> None:
+        """``HTTP-Referer`` / ``X-Title`` identify the calling application —
+        AgentScope — not the provider."""
+        self.assertEqual(
+            _AIMLAPI_ATTRIBUTION_HEADERS["HTTP-Referer"],
+            "https://github.com/agentscope-ai/agentscope",
+        )
+        self.assertEqual(_AIMLAPI_ATTRIBUTION_HEADERS["X-Title"], "AgentScope")
+
+    def test_headers_attached_by_default(self) -> None:
+        """All four headers reach the client for the default base URL."""
+        model = _make_model()
+        self.assertEqual(
+            model.client_kwargs["default_headers"],
+            _AIMLAPI_ATTRIBUTION_HEADERS,
+        )
+
+    def test_caller_headers_win_and_survive(self) -> None:
+        """Merging, never assigning: a caller's own headers are preserved and
+        take precedence on a clash."""
+        model = _make_model(
+            client_kwargs={
+                "default_headers": {"X-Title": "Custom", "X-Own": "1"},
+                "timeout": 5,
+            },
+        )
+        headers = model.client_kwargs["default_headers"]
+        self.assertEqual(headers["X-Title"], "Custom")
+        self.assertEqual(headers["X-Own"], "1")
+        self.assertEqual(
+            headers["X-AIMLAPI-Partner-ID"],
+            _AIMLAPI_ATTRIBUTION_HEADERS["X-AIMLAPI-Partner-ID"],
+        )
+        self.assertEqual(model.client_kwargs["timeout"], 5)
+
+    def test_shared_constant_is_never_mutated(self) -> None:
+        """Each instance builds its own dict."""
+        before = dict(_AIMLAPI_ATTRIBUTION_HEADERS)
+        first = _make_model()
+        first.client_kwargs["default_headers"]["X-Title"] = "mutated"
+        second = _make_model()
+
+        self.assertEqual(_AIMLAPI_ATTRIBUTION_HEADERS, before)
+        self.assertEqual(
+            second.client_kwargs["default_headers"]["X-Title"],
+            "AgentScope",
+        )
+
+    def test_headers_scoped_to_aimlapi_origin(self) -> None:
+        """Attribution must not ride a request to another host — including a
+        proxy that merely fronts the same API."""
+        for base_url, expected in [
+            ("https://api.aimlapi.com/v1", True),
+            ("https://staging.aimlapi.com/v1", True),
+            ("https://api.openai.com/v1", False),
+            ("http://localhost:8000/v1", False),
+            ("https://aimlapi.com.evil.example/v1", False),
+            (None, False),
+        ]:
+            with self.subTest(base_url=base_url):
+                kwargs = _build_client_kwargs(base_url, None)
+                self.assertEqual("default_headers" in kwargs, expected)
+
+    def test_headers_not_sent_to_a_custom_base_url(self) -> None:
+        """End to end through the model class, not just the helper."""
+        model = AIMLAPIChatModel(
+            credential=AIMLAPICredential(
+                api_key="test",
+                base_url="https://proxy.example.com/v1",
+            ),
+            model="openai/gpt-5-5",
+        )
+        self.assertNotIn("default_headers", model.client_kwargs)
+
+
+class TestAIMLAPIRegistration(unittest.TestCase):
+    """Credential registration, display name and model cards."""
+
+    def test_display_name(self) -> None:
+        """The user-facing provider label."""
+        self.assertEqual(
+            AIMLAPICredential.model_json_schema()["title"],
+            "aimlapi.com",
+        )
+
+    def test_registered_in_factory(self) -> None:
+        """The credential deserializes through the discriminated union."""
+        credential = CredentialFactory.from_dict(
+            {"type": "aimlapi_credential", "api_key": "test"},
+        )
+        self.assertIsInstance(credential, AIMLAPICredential)
+        self.assertIs(
+            CredentialFactory.get_credential_class("aimlapi_credential"),
+            AIMLAPICredential,
+        )
+        self.assertIn(
+            "aimlapi.com",
+            [schema["title"] for schema in CredentialFactory.list_schemas()],
+        )
+
+    def test_credential_resolves_to_the_chat_model(self) -> None:
+        """The credential points back at its chat model class."""
+        self.assertIs(
+            AIMLAPICredential.get_chat_model_class(),
+            AIMLAPIChatModel,
+        )
+
+    def test_default_base_url_is_the_chat_completions_root(self) -> None:
+        """``/v1/completions`` does not exist on aimlapi.com; the base URL
+        must be the ``/v1`` root that the OpenAI SDK appends
+        ``/chat/completions`` to."""
+        self.assertEqual(
+            AIMLAPICredential(api_key="test").base_url,
+            "https://api.aimlapi.com/v1",
+        )
+
+    def test_model_cards_load(self) -> None:
+        """Every bundled card parses and carries a live catalog id."""
+        cards = AIMLAPIChatModel.list_models()
+        self.assertEqual(len(cards), 8)
+        names = {card.name for card in cards}
+        self.assertIn("openai/gpt-5-5", names)
+        self.assertIn("anthropic/claude-sonnet-4.6", names)
+
+    def test_model_card_output_size_fits_the_context(self) -> None:
+        """The catalog's ``outputMax`` exceeds ``contextLength`` on some
+        aimlapi.com models, so the cards are sanity-checked here rather than
+        copied blindly."""
+        for card in AIMLAPIChatModel.list_models():
+            with self.subTest(model=card.name):
+                self.assertLessEqual(card.output_size, card.context_size)
+
+    def test_formatters(self) -> None:
+        """Both formatter variants exist and the chat one is the default."""
+        self.assertTrue(issubclass(AIMLAPIChatFormatter, FormatterBase))
+        self.assertTrue(issubclass(AIMLAPIMultiAgentFormatter, FormatterBase))
+        self.assertIsInstance(_make_model().formatter, AIMLAPIChatFormatter)
+
+
+class TestAIMLAPIRequestParams(IsolatedAsyncioTestCase):
+    """No request parameter may be sent as an explicit ``null``."""
+
+    def setUp(self) -> None:
+        self.model = _make_model(stream=False)
+        self.mock_client = MagicMock()
+        self.model.client = self.mock_client
+        self.mock_create = AsyncMock(
+            return_value=_mock_completion(text="ok"),
+        )
+        self.mock_client.chat.completions.create = self.mock_create
+
+    async def test_unset_parameters_are_omitted_not_nulled(self) -> None:
+        """A freshly built model sends no ``null`` values at all."""
+        await self.model([])
+        kwargs = self.mock_create.call_args.kwargs
+
+        self.assertEqual(
+            [key for key, value in kwargs.items() if value is None],
+            [],
+        )
+        for key in [
+            "temperature",
+            "top_p",
+            "seed",
+            "tools",
+            "tool_choice",
+            "response_format",
+            "parallel_tool_calls",
+            "max_tokens",
+            "max_completion_tokens",
+            "reasoning_effort",
+        ]:
+            self.assertNotIn(key, kwargs)
+
+    async def test_two_turn_tool_loop_drops_the_tools_key(self) -> None:
+        """Turn 1 sends tools; turn 2 clears them. The strictest aimlapi.com
+        models 400 on ``"tools": null``, so turn 2 must omit the key rather
+        than null it — this is the failure mode that only shows up on the
+        second call of a real agent loop."""
+        await self.model(
+            [],
+            tools=_TOOLS,
+            tool_choice=ToolChoice(mode="auto"),
+        )
+        turn_one = self.mock_create.call_args.kwargs
+        self.assertEqual(len(turn_one["tools"]), 1)
+        self.assertEqual(turn_one["tool_choice"], "auto")
+
+        await self.model([], tools=None, tool_choice=None)
+        turn_two = self.mock_create.call_args.kwargs
+
+        self.assertNotIn("tools", turn_two)
+        self.assertNotIn("tool_choice", turn_two)
+        self.assertEqual(
+            [key for key, value in turn_two.items() if value is None],
+            [],
+        )
+
+    async def test_empty_tool_list_omits_the_key_too(self) -> None:
+        """A toolkit that emptied itself must not send ``"tools": []``
+        either — the key simply goes away."""
+        await self.model([], tools=[], tool_choice=None)
+        self.assertNotIn("tools", self.mock_create.call_args.kwargs)
+
+    async def test_set_parameters_are_forwarded(self) -> None:
+        """The omit-if-unset rule must not swallow values that were set."""
+        model = _make_model(stream=False)
+        model.client = self.mock_client
+        model.parameters = AIMLAPIChatModel.Parameters(
+            temperature=0.5,
+            max_tokens=128,
+        )
+        await model([])
+        kwargs = self.mock_create.call_args.kwargs
+        self.assertEqual(kwargs["temperature"], 0.5)
+        self.assertEqual(kwargs["max_completion_tokens"], 128)
+
+
+class TestAIMLAPIResponses(IsolatedAsyncioTestCase):
+    """Response parsing, streaming and non-streaming."""
+
+    def setUp(self) -> None:
+        self.mock_client = MagicMock()
+
+    async def test_text_response(self) -> None:
+        """A non-streaming text response becomes a single ChatResponse."""
+        model = _make_model(stream=False)
+        model.client = self.mock_client
+        self.mock_client.chat.completions.create = AsyncMock(
+            return_value=_mock_completion(text="Hello!"),
+        )
+
+        result = await model([])
+
+        self.assertEqual(
+            (result.is_last, result.content),
+            (
+                True,
+                [TextBlock.model_construct(id=A, created_at=A, text="Hello!")],
+            ),
+        )
+        self.assertEqual(result.id, "aimlapi-1")
+
+    async def test_tool_call_response(self) -> None:
+        """A non-streaming tool call becomes a ToolCallBlock."""
+        model = _make_model(stream=False)
+        model.client = self.mock_client
+        self.mock_client.chat.completions.create = AsyncMock(
+            return_value=_mock_completion(
+                tool_calls=[
+                    {
+                        "id": "call-1",
+                        "name": "get_weather",
+                        "arguments": '{"city":"Shanghai"}',
+                    },
+                ],
+            ),
+        )
+
+        result = await model([], tools=_TOOLS)
+
+        self.assertEqual(
+            result.content,
+            [
+                ToolCallBlock.model_construct(
+                    id="call-1",
+                    created_at=A,
+                    name="get_weather",
+                    input='{"city":"Shanghai"}',
+                ),
+            ],
+        )
+
+    async def test_stream_response(self) -> None:
+        """Streaming deltas accumulate and usage is requested."""
+        model = _make_model(stream=True)
+        model.client = self.mock_client
+        self.mock_client.chat.completions.create = AsyncMock(
+            return_value=_MockAsyncStream(
+                [
+                    _make_stream_chunk("He"),
+                    _make_stream_chunk("llo"),
+                ],
+            ),
+        )
+
+        chunks = [chunk async for chunk in await model([])]
+
+        self.assertEqual(chunks[-1].content[0].text, "Hello")
+        self.assertTrue(chunks[-1].is_last)
+        self.assertEqual(
+            self.mock_client.chat.completions.create.call_args.kwargs[
+                "stream_options"
+            ],
+            {"include_usage": True},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hi! I'm Hugo from aimlapi.com — an AI aggregator that gives access to 1000+ models in one API, trusted by 400k+ users.

We'd love to be available as a built-in provider option inside AgentScope — so we went ahead and did all the technical work on our side.

To build our partnership, we offer a 50/50 revenue share on all traffic from this integration. (P.S.: tracking starts as soon as this release goes live, so no earnings will be lost during setup)

My contacts: hugo@aimlapi.com (email / Slack), Telegram: @hug0the

## AgentScope Version

2.0.8 (the branch is rebased on the latest `main`)

## Description

**Why**

aimlapi.com is OpenAI-compatible, so the only way to reach it from AgentScope today is to hand-point `OpenAIChatModel` at a custom `base_url`: nothing shows up in the credential picker, the OpenAI formatter advertises OpenAI's input types rather than ours, and requests carry no attribution.

**What's changed** — following the chat-model contribution checklist in CONTRIBUTING.md (credential + chat model + model cards + both formatter variants):

- `credential/_aimlapi.py`: `AIMLAPICredential` (API key + editable `base_url`, default `https://api.aimlapi.com/v1`), registered in `CredentialFactory`, resolves to `AIMLAPIChatModel`.
- `model/_aimlapi/`: `AIMLAPIChatModel`, subclassing `OpenAIChatModel` (aimlapi.com speaks the OpenAI Chat Completions wire format verbatim). It attaches four attribution headers — `HTTP-Referer` / `X-Title` (naming AgentScope, the OpenRouter convention) and `X-AIMLAPI-Source` / `X-AIMLAPI-Partner-ID` — scoped to the aimlapi.com origin: they are not sent when the credential's `base_url` points anywhere else, and caller-supplied `default_headers` always win.
- `model/_aimlapi/_models/`: 8 model cards — Claude Opus 5, Claude Sonnet 4.6, GPT-5.5, GPT-4o Mini, Gemini 2.5 Flash, Grok 4.1 Fast Reasoning, DeepSeek V4 Pro, GLM-5.2.
- `formatter/_aimlapi_formatter.py`: `AIMLAPIChatFormatter` and `AIMLAPIMultiAgentFormatter`, reusing the OpenAI formatters and narrowing `input_types` to `["text/plain", "image/*"]`.
- Tracing: `aimlapi` added to `ProviderNameValues`, the class-name map, and the base-URL map.
- `scripts/model_examples/aimlapi_call.py` + registration in `run_tests.py` and the READMEs.
- Tests: 26 unit tests in `tests/model_aimlapi_test.py` and `tests/formatter_aimlapi_test.py` (mocked, no network): streaming / non-streaming / tool-calling responses, header shape and origin scoping, unset parameters omitted rather than sent as explicit `null` (several aimlapi.com models reject `"tools": null` with a 400), factory registration, model card sanity checks.

No new dependencies; `openai` is lazy-imported at point of use, same as in `OpenAIChatModel`.

**How to test**

```bash
pip install -e ".[dev]"
pytest tests/model_aimlapi_test.py tests/formatter_aimlapi_test.py -q   # 26 passed
```

```python
from agentscope.credential import AIMLAPICredential
from agentscope.model import AIMLAPIChatModel

m = AIMLAPIChatModel(credential=AIMLAPICredential(api_key="x"), model="openai/gpt-5-5")
print(m.client_kwargs["default_headers"])
# {'HTTP-Referer': 'https://github.com/agentscope-ai/agentscope', 'X-Title': 'AgentScope',
#  'X-AIMLAPI-Source': 'agent/agentscope', 'X-AIMLAPI-Partner-ID': 'part_kY9LNtFpD5NNROdyhGmRvEqP'}

m2 = AIMLAPIChatModel(
    credential=AIMLAPICredential(api_key="x", base_url="https://example.com/v1"),
    model="openai/gpt-5-5",
)
print(m2.client_kwargs.get("default_headers"))  # None — the headers never leave aimlapi.com

print(len(AIMLAPIChatModel.list_models()))  # 8
```

Live run: `AIMLAPI_API_KEY=<key> python scripts/model_examples/aimlapi_call.py`

**Notes**

- Nothing outside the new provider changes; other providers are untouched.
- Follow-up: companion docs PR in [agentscope-ai/docs](https://github.com/agentscope-ai/docs) for the model overview page.

## Checklist

- [ ] An issue has been created for this PR — blank issues are disabled for feature requests, so this is proposed in Discussions instead: https://github.com/agentscope-ai/agentscope/discussions/2557
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs) — companion PR to follow
- [x] Code is ready for review