### PR TITLE
docs: mark legacy pages and deploy from v1

### DIFF
--- a/.github/workflows/sphinx_docs.yml
+++ b/.github/workflows/sphinx_docs.yml
@@ -3,7 +3,7 @@ name: Deploy Sphinx documentation to Pages
 on:
   push:
     branches:
-      - main
+      - v1
 
 jobs:
   build_en:

--- a/docs/tutorial/_templates/page.html
+++ b/docs/tutorial/_templates/page.html
@@ -118,6 +118,21 @@
           </label>
         </div>
         <article role="main" id="furo-main-content">
+          <div class="admonition warning">
+            {% if language in ("zh_CN", "zh-CN") %}
+            <p class="admonition-title">AgentScope 1.x 文档</p>
+            <p>本页适用于 AgentScope 1.x，与 2.x API 不兼容。
+              新项目请查看<a href="https://docs.agentscope.io/stable/zh/index">当前稳定版文档</a>；
+              升级已有项目请查看<a href="https://docs.agentscope.io/stable/zh/others/change-log">迁移指南</a>。
+            </p>
+            {% else %}
+            <p class="admonition-title">AgentScope 1.x documentation</p>
+            <p>This page applies to AgentScope 1.x and is not compatible with 2.x APIs.
+              For new projects, use the <a href="https://docs.agentscope.io/stable/en/index">current stable documentation</a>.
+              To upgrade an existing project, follow the <a href="https://docs.agentscope.io/stable/en/others/change-log">migration guide</a>.
+            </p>
+            {% endif %}
+          </div>
           {% block content %}{{ body }}{% endblock %}
         </article>
       </div>


### PR DESCRIPTION
Add an English or Chinese AgentScope 1.x notice at the start of every legacy documentation page, with links to the current stable documentation and the migration guide. The notice is rendered in HTML so it is visible to readers and crawlers without JavaScript.

The Sphinx source now lives on v1, but its deployment workflow still listens to main. Update the trigger to v1 so merging documentation changes rebuilds the existing gh-pages site at doc.agentscope.io.

Validation: rendered English and Chinese pages with Sphinx/Furo using the actual shared template; verified the notice precedes page content and links to the matching-language migration guide. `git diff --check` passed. Full pre-commit passed in the Python 3.11 worktree environment installed with `uv pip install -e '.[dev]'`, using `uv run --no-sync` because re-resolving all optional extras encounters an existing py-openjudge / trinity-rft dependency conflict.
