### PR TITLE
fix(agent): include paths in tool validation errors

### DIFF
--- a/src/agentscope/agent/_agent.py
+++ b/src/agentscope/agent/_agent.py
@@ -2506,7 +2506,7 @@ class Agent:
             except jsonschema.ValidationError as e:
                 raise AgentOrientedException(
                     f"Input validation failed for tool '{tool_call.name}': "
-                    f"{e.message}",
+                    f"{e.message} (at {e.json_path})",
                 ) from e
 
         # The exceptions that

--- a/tests/agent_structured_output_test.py
+++ b/tests/agent_structured_output_test.py
@@ -216,7 +216,7 @@ class AgentStructuredOutputTest(IsolatedAsyncioTestCase):
                     "name": "GenerateStructuredOutput",
                     "output": "Input validation failed for tool "
                     "'GenerateStructuredOutput': 'hot' is not of type "
-                    "'number'",
+                    "'number' (at $.temperature)",
                     "state": "error",
                     "metadata": {},
                 },

--- a/tests/tool_argument_repair_test.py
+++ b/tests/tool_argument_repair_test.py
@@ -250,7 +250,7 @@ class ToolCallArgumentRepairTest(IsolatedAsyncioTestCase):
                     "id": "record_call_0",
                     "name": "record",
                     "output": "Input validation failed for tool 'record': "
-                    "'many' is not of type 'integer'",
+                    "'many' is not of type 'integer' (at $.value)",
                     "state": "error",
                     "metadata": {},
                     "created_at": AnyString(),
@@ -258,6 +258,105 @@ class ToolCallArgumentRepairTest(IsolatedAsyncioTestCase):
                 },
             ],
         )
+
+    async def test_nested_validation_errors_include_instance_paths(
+        self,
+    ) -> None:
+        """Test that nested validation errors identify their instance paths."""
+        cases = [
+            (
+                "nested_type",
+                {
+                    "type": "object",
+                    "properties": {"city": {"type": "integer"}},
+                    "required": ["city"],
+                },
+                '{"value": {"city": "many"}}',
+                "'many' is not of type 'integer' (at $.value.city)",
+            ),
+            (
+                "array_item",
+                {"type": "array", "items": {"type": "integer"}},
+                '{"value": ["many"]}',
+                "'many' is not of type 'integer' (at $.value[0])",
+            ),
+            (
+                "nested_array_object",
+                {
+                    "type": "object",
+                    "properties": {
+                        "locations": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "city": {"type": "integer"},
+                                },
+                                "required": ["city"],
+                            },
+                        },
+                    },
+                    "required": ["locations"],
+                },
+                '{"value": {"locations": [{"city": 1}, '
+                + '{"city": "many"}]}}',
+                "'many' is not of type 'integer' "
+                "(at $.value.locations[1].city)",
+            ),
+            (
+                "missing_nested",
+                {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+                '{"value": {}}',
+                "'city' is a required property (at $.value)",
+            ),
+        ]
+
+        for case_name, value_schema, raw_input, expected_error in cases:
+            with self.subTest(case_name):
+                tool = _RecordTool(value_schema)
+                tool_call = ToolCallBlock(
+                    id=f"record_call_{case_name}",
+                    name="record",
+                    input=raw_input,
+                )
+                model = MockModel()
+                model.set_responses(
+                    [
+                        ChatResponse(content=[tool_call], is_last=True),
+                        ChatResponse(
+                            content=[TextBlock(text="Done")],
+                            is_last=True,
+                        ),
+                    ],
+                )
+                agent = Agent(
+                    name="Friday",
+                    system_prompt="You're a helpful assistant.",
+                    model=model,
+                    toolkit=Toolkit(tools=[tool]),
+                    injection_config=InjectionConfig(
+                        inject_runtime_state=False,
+                    ),
+                )
+
+                await agent.reply(
+                    UserMsg(name="user", content="Record nested value"),
+                )
+
+                result = agent.state.context[-1].get_content_blocks(
+                    "tool_result",
+                )[0]
+                self.assertEqual(
+                    result.output,
+                    "Input validation failed for tool 'record': "
+                    + expected_error,
+                )
+                self.assertListEqual(tool.permission_inputs, [])
+                self.assertListEqual(tool.executed, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## AgentScope Version

2.0.8

## Description

Tool argument validation currently reports only the JSON Schema error message and omits the instance path of the invalid value.

For example, when a tool expects `value.city` to be an integer but receives:

```json
{
  "value": {
    "city": "many"
  }
}
```

the current error result is:

```text
Input validation failed for tool 'record': 'many' is not of type 'integer'
```

This change includes the instance path in the error:

```text
Input validation failed for tool 'record': 'many' is not of type 'integer' (at $.value.city)
```

The fix also covers array and deeply nested arguments. For example:

```json
{
  "value": {
    "locations": [
      {"city": 1},
      {"city": "many"}
    ]
  }
}
```

now identifies the invalid value at:

```text
$.value.locations[1].city
```

The same behavior is covered for nested properties, array items, and missing required properties:

```text
Input validation failed for tool 'record': 'many' is not of type 'integer' (at $.value[0])
```

```text
Input validation failed for tool 'record': 'city' is a required property (at $.value)
```

The change preserves the existing error prefix and validation behavior. It does not alter argument repair, permission checks, tool execution, or structured-output retry behavior.

Fixes #2582

## Tests

- Focused and adjacent tests: 50 passed, 8 subtests passed
- Full test suite: 2338 passed, 147 skipped, 3 failed, 403 subtests passed
- The remaining failures are in unchanged MCP SSE and SQL storage tests
- Targeted pre-commit checks: passed
- `git diff --check`: passed

## Documentation

No documentation update is needed. This is a runtime diagnostic improvement and does not add or change a public API.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the CONTRIBUTING.md
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated (not applicable; runtime diagnostic improvement only)
- [x] Code is ready for review
