### PR TITLE
fix(realtime): drop the previous session's terminal events on reconnect

### DIFF
--- a/src/agentscope/realtime/_dashscope/_model.py
+++ b/src/agentscope/realtime/_dashscope/_model.py
@@ -108,8 +108,13 @@ class DashScopeRealtimeModel(RealtimeModelBase):
         )
 
         # A previous session leaves its terminal SessionEndedEvent and the
-        # None sentinel in the queue; a new events() iterator would stop
-        # on them before seeing anything from this session.
+        # None sentinel in the queue, and a reader that is still running
+        # would add them after the drain. Stop that reader first (its
+        # finally block enqueues the terminal events), then empty the queue
+        # so a new events() iterator only sees this session.
+        if self._reader is not None:
+            self._reader.cancel()
+            await asyncio.gather(self._reader, return_exceptions=True)
         while not self._queue.empty():
             self._queue.get_nowait()
         self._reader = asyncio.create_task(self._read(), name="dashscope-rt")

--- a/src/agentscope/realtime/_dashscope/_model.py
+++ b/src/agentscope/realtime/_dashscope/_model.py
@@ -106,6 +106,12 @@ class DashScopeRealtimeModel(RealtimeModelBase):
                 "X-DashScope-DataInspection": "disable",
             },
         )
+
+        # A previous session leaves its terminal SessionEndedEvent and the
+        # None sentinel in the queue; a new events() iterator would stop
+        # on them before seeing anything from this session.
+        while not self._queue.empty():
+            self._queue.get_nowait()
         self._reader = asyncio.create_task(self._read(), name="dashscope-rt")
         await self._send(self._session_update(instructions, tools))
 

--- a/src/agentscope/realtime/_gemini/_model.py
+++ b/src/agentscope/realtime/_gemini/_model.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """The Gemini Live API realtime model."""
-
 import asyncio
 import base64
 import json
@@ -134,8 +133,13 @@ class GeminiRealtimeModel(RealtimeModelBase):
         )
         self._ready.clear()
         # A previous session leaves its terminal SessionEndedEvent and the
-        # None sentinel in the queue; a new events() iterator would stop
-        # on them before seeing anything from this session.
+        # None sentinel in the queue, and a reader that is still running
+        # would add them after the drain. Stop that reader first (its
+        # finally block enqueues the terminal events), then empty the queue
+        # so a new events() iterator only sees this session.
+        if self._reader is not None:
+            self._reader.cancel()
+            await asyncio.gather(self._reader, return_exceptions=True)
         while not self._queue.empty():
             self._queue.get_nowait()
         self._reader = asyncio.create_task(self._read(), name="gemini-rt")

--- a/src/agentscope/realtime/_gemini/_model.py
+++ b/src/agentscope/realtime/_gemini/_model.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """The Gemini Live API realtime model."""
+
 import asyncio
 import base64
 import json
@@ -132,6 +133,11 @@ class GeminiRealtimeModel(RealtimeModelBase):
             f"{_LIVE_URL}?key={credential.api_key.get_secret_value()}",
         )
         self._ready.clear()
+        # A previous session leaves its terminal SessionEndedEvent and the
+        # None sentinel in the queue; a new events() iterator would stop
+        # on them before seeing anything from this session.
+        while not self._queue.empty():
+            self._queue.get_nowait()
         self._reader = asyncio.create_task(self._read(), name="gemini-rt")
         await self._send(
             self._setup(

--- a/src/agentscope/realtime/_openai/_model.py
+++ b/src/agentscope/realtime/_openai/_model.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """The OpenAI realtime model."""
-
 import asyncio
 import base64
 import json
@@ -130,8 +129,13 @@ class OpenAIRealtimeModel(RealtimeModelBase):
             additional_headers=headers,
         )
         # A previous session leaves its terminal SessionEndedEvent and the
-        # None sentinel in the queue; a new events() iterator would stop
-        # on them before seeing anything from this session.
+        # None sentinel in the queue, and a reader that is still running
+        # would add them after the drain. Stop that reader first (its
+        # finally block enqueues the terminal events), then empty the queue
+        # so a new events() iterator only sees this session.
+        if self._reader is not None:
+            self._reader.cancel()
+            await asyncio.gather(self._reader, return_exceptions=True)
         while not self._queue.empty():
             self._queue.get_nowait()
         self._reader = asyncio.create_task(self._read(), name="openai-rt")

--- a/src/agentscope/realtime/_openai/_model.py
+++ b/src/agentscope/realtime/_openai/_model.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """The OpenAI realtime model."""
+
 import asyncio
 import base64
 import json
@@ -128,6 +129,11 @@ class OpenAIRealtimeModel(RealtimeModelBase):
             f"{url}/realtime?model={self.model}",
             additional_headers=headers,
         )
+        # A previous session leaves its terminal SessionEndedEvent and the
+        # None sentinel in the queue; a new events() iterator would stop
+        # on them before seeing anything from this session.
+        while not self._queue.empty():
+            self._queue.get_nowait()
         self._reader = asyncio.create_task(self._read(), name="openai-rt")
         await self._send(self._session_update(instructions, tools))
 

--- a/src/agentscope/realtime/_xai/_model.py
+++ b/src/agentscope/realtime/_xai/_model.py
@@ -113,6 +113,12 @@ class XAIRealtimeModel(RealtimeModelBase):
                 f"{credential.api_key.get_secret_value()}",
             },
         )
+
+        # A previous session leaves its terminal SessionEndedEvent and the
+        # None sentinel in the queue; a new events() iterator would stop
+        # on them before seeing anything from this session.
+        while not self._queue.empty():
+            self._queue.get_nowait()
         self._reader = asyncio.create_task(self._read(), name="xai-rt")
         await self._send(self._session_update(instructions, tools))
 

--- a/src/agentscope/realtime/_xai/_model.py
+++ b/src/agentscope/realtime/_xai/_model.py
@@ -115,8 +115,13 @@ class XAIRealtimeModel(RealtimeModelBase):
         )
 
         # A previous session leaves its terminal SessionEndedEvent and the
-        # None sentinel in the queue; a new events() iterator would stop
-        # on them before seeing anything from this session.
+        # None sentinel in the queue, and a reader that is still running
+        # would add them after the drain. Stop that reader first (its
+        # finally block enqueues the terminal events), then empty the queue
+        # so a new events() iterator only sees this session.
+        if self._reader is not None:
+            self._reader.cancel()
+            await asyncio.gather(self._reader, return_exceptions=True)
         while not self._queue.empty():
             self._queue.get_nowait()
         self._reader = asyncio.create_task(self._read(), name="xai-rt")

--- a/tests/realtime_reconnect_test.py
+++ b/tests/realtime_reconnect_test.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+"""Explicitly closing a realtime model and connecting again must give the new
+session a clean event stream (issue #2587)."""
+
+import asyncio
+import json
+from typing import Any
+from unittest.async_case import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+from agentscope.credential import (
+    DashScopeCredential,
+    GeminiCredential,
+    OpenAICredential,
+    XAICredential,
+)
+from agentscope.realtime import (
+    DashScopeRealtimeModel,
+    GeminiRealtimeModel,
+    OpenAIRealtimeModel,
+    XAIRealtimeModel,
+)
+from agentscope.realtime import _events as me
+
+
+class IdleSocket:
+    """A WebSocket that replays a few frames, then stays open until closed."""
+
+    def __init__(self, frames: list[dict] | None = None) -> None:
+        self._frames = [json.dumps(_) for _ in (frames or [])]
+        self._closed = asyncio.Event()
+        self.sent: list[Any] = []
+
+    async def send(self, payload: str) -> None:
+        """Record what the model sends."""
+        self.sent.append(json.loads(payload))
+
+    async def close(self) -> None:
+        """Release the reader."""
+        self._closed.set()
+
+    def __aiter__(self) -> "IdleSocket":
+        return self
+
+    async def __anext__(self) -> str:
+        if self._frames:
+            return self._frames.pop(0)
+        await self._closed.wait()
+        raise StopAsyncIteration
+
+
+class ReconnectTest(IsolatedAsyncioTestCase):
+    """The previous session's terminal events must not end the new stream."""
+
+    async def _reconnect_and_collect(
+        self,
+        model: Any,
+        frames: list[dict] | None = None,
+    ) -> list[me.ModelEvent]:
+        # What close() leaves behind: the reader's finally block enqueues the
+        # terminal event and the end-of-stream sentinel.
+        model._queue.put_nowait(me.SessionEndedEvent(reason="closed"))
+        model._queue.put_nowait(None)
+
+        socket = IdleSocket(frames)
+        with patch("websockets.connect", new=AsyncMock(return_value=socket)):
+            await model.connect("Be brief.")
+        self.assertIsNotNone(model._reader)
+
+        fresh = me.ResponseCreatedEvent(item_id="item_new")
+        model._queue.put_nowait(fresh)
+        model._queue.put_nowait(None)
+        got = [event async for event in model.events()]
+        await model.close()
+        return got
+
+    async def test_openai_reconnect_starts_with_the_new_sessions_events(
+        self,
+    ) -> None:
+        model = OpenAIRealtimeModel(
+            "gpt-realtime-1.5",
+            OpenAICredential(api_key="sk-x"),
+        )
+        got = await self._reconnect_and_collect(model)
+        self.assertEqual(got, [me.ResponseCreatedEvent(item_id="item_new")])
+
+    async def test_dashscope_reconnect_starts_with_the_new_sessions_events(
+        self,
+    ) -> None:
+        model = DashScopeRealtimeModel(
+            "qwen-omni-turbo-realtime",
+            DashScopeCredential(api_key="sk-x"),
+        )
+        got = await self._reconnect_and_collect(model)
+        self.assertEqual(got, [me.ResponseCreatedEvent(item_id="item_new")])
+
+    async def test_xai_reconnect_starts_with_the_new_sessions_events(
+        self,
+    ) -> None:
+        model = XAIRealtimeModel(
+            "grok-voice-latest",
+            XAICredential(api_key="sk-x"),
+        )
+        got = await self._reconnect_and_collect(model)
+        self.assertEqual(got, [me.ResponseCreatedEvent(item_id="item_new")])
+
+    async def test_gemini_reconnect_starts_with_the_new_sessions_events(
+        self,
+    ) -> None:
+        model = GeminiRealtimeModel(
+            "gemini-2.5-flash-native-audio-preview-12-2025",
+            GeminiCredential(api_key="key-x"),
+        )
+        # connect() waits for the server's setupComplete before returning.
+        got = await self._reconnect_and_collect(
+            model,
+            frames=[{"setupComplete": {}}],
+        )
+        self.assertEqual(got, [me.ResponseCreatedEvent(item_id="item_new")])
+
+    async def test_events_after_close_without_reconnect_still_end(
+        self,
+    ) -> None:
+        """Draining happens only on connect(); a closed session still
+        terminates its consumer."""
+        model = OpenAIRealtimeModel(
+            "gpt-realtime-1.5",
+            OpenAICredential(api_key="sk-x"),
+        )
+        model._queue.put_nowait(me.SessionEndedEvent(reason="closed"))
+        model._queue.put_nowait(None)
+        got = [event async for event in model.events()]
+        self.assertEqual(got, [me.SessionEndedEvent(reason="closed")])

--- a/tests/realtime_reconnect_test.py
+++ b/tests/realtime_reconnect_test.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Explicitly closing a realtime model and connecting again must give the new
 session a clean event stream (issue #2587)."""
-
+# pylint: disable=protected-access
 import asyncio
 import json
 from typing import Any
@@ -32,8 +32,10 @@ class IdleSocket:
         self.sent: list[Any] = []
 
     async def send(self, payload: str) -> None:
-        """Record what the model sends."""
+        """Record what the model sends. Like a real socket write this
+        yields to the event loop, which lets the reader task start."""
         self.sent.append(json.loads(payload))
+        await asyncio.sleep(0)
 
     async def close(self) -> None:
         """Release the reader."""
@@ -52,82 +54,112 @@ class IdleSocket:
 class ReconnectTest(IsolatedAsyncioTestCase):
     """The previous session's terminal events must not end the new stream."""
 
-    async def _reconnect_and_collect(
+    async def _connect(
         self,
         model: Any,
         frames: list[dict] | None = None,
-    ) -> list[me.ModelEvent]:
-        # What close() leaves behind: the reader's finally block enqueues the
-        # terminal event and the end-of-stream sentinel.
-        model._queue.put_nowait(me.SessionEndedEvent(reason="closed"))
-        model._queue.put_nowait(None)
-
+    ) -> IdleSocket:
+        """Connect the model to a fresh idle socket."""
         socket = IdleSocket(frames)
         with patch("websockets.connect", new=AsyncMock(return_value=socket)):
             await model.connect("Be brief.")
         self.assertIsNotNone(model._reader)
+        return socket
 
-        fresh = me.ResponseCreatedEvent(item_id="item_new")
-        model._queue.put_nowait(fresh)
+    async def _collect_new_session(self, model: Any) -> list[me.ModelEvent]:
+        """Feed one event of the new session, end it, and read the stream."""
+        model._queue.put_nowait(me.ResponseCreatedEvent(item_id="item_new"))
         model._queue.put_nowait(None)
         got = [event async for event in model.events()]
         await model.close()
         return got
 
+    async def _close_and_reconnect(
+        self,
+        model: Any,
+        frames: list[dict] | None = None,
+    ) -> list[me.ModelEvent]:
+        """Run the real lifecycle: connect, close, connect again, then read
+        what the second session's consumer sees."""
+        await self._connect(model, frames)
+        await model.close()
+        await self._connect(model, frames)
+        return await self._collect_new_session(model)
+
     async def test_openai_reconnect_starts_with_the_new_sessions_events(
         self,
     ) -> None:
+        """OpenAI: the closed session's terminal events are not replayed."""
         model = OpenAIRealtimeModel(
             "gpt-realtime-1.5",
             OpenAICredential(api_key="sk-x"),
         )
-        got = await self._reconnect_and_collect(model)
+        got = await self._close_and_reconnect(model)
         self.assertEqual(got, [me.ResponseCreatedEvent(item_id="item_new")])
 
     async def test_dashscope_reconnect_starts_with_the_new_sessions_events(
         self,
     ) -> None:
+        """DashScope: the closed session's terminal events are not replayed."""
         model = DashScopeRealtimeModel(
             "qwen-omni-turbo-realtime",
             DashScopeCredential(api_key="sk-x"),
         )
-        got = await self._reconnect_and_collect(model)
+        got = await self._close_and_reconnect(model)
         self.assertEqual(got, [me.ResponseCreatedEvent(item_id="item_new")])
 
     async def test_xai_reconnect_starts_with_the_new_sessions_events(
         self,
     ) -> None:
+        """xAI: the closed session's terminal events are not replayed."""
         model = XAIRealtimeModel(
             "grok-voice-latest",
             XAICredential(api_key="sk-x"),
         )
-        got = await self._reconnect_and_collect(model)
+        got = await self._close_and_reconnect(model)
         self.assertEqual(got, [me.ResponseCreatedEvent(item_id="item_new")])
 
     async def test_gemini_reconnect_starts_with_the_new_sessions_events(
         self,
     ) -> None:
+        """Gemini: the closed session's terminal events are not replayed."""
         model = GeminiRealtimeModel(
             "gemini-2.5-flash-native-audio-preview-12-2025",
             GeminiCredential(api_key="key-x"),
         )
         # connect() waits for the server's setupComplete before returning.
-        got = await self._reconnect_and_collect(
+        got = await self._close_and_reconnect(
             model,
             frames=[{"setupComplete": {}}],
         )
+        self.assertEqual(got, [me.ResponseCreatedEvent(item_id="item_new")])
+
+    async def test_reconnect_without_close_stops_the_old_reader(self) -> None:
+        """connect() on a session whose reader is still running (half-open
+        socket) cancels that reader first, so its terminal events cannot end
+        the new stream and the task is not leaked."""
+        model = OpenAIRealtimeModel(
+            "gpt-realtime-1.5",
+            OpenAICredential(api_key="sk-x"),
+        )
+        await self._connect(model)
+        old_reader = model._reader
+        await self._connect(model)
+        self.assertTrue(old_reader.done())
+        self.assertIsNot(model._reader, old_reader)
+        got = await self._collect_new_session(model)
         self.assertEqual(got, [me.ResponseCreatedEvent(item_id="item_new")])
 
     async def test_events_after_close_without_reconnect_still_end(
         self,
     ) -> None:
         """Draining happens only on connect(); a closed session still
-        terminates its consumer."""
+        terminates its consumer with the terminal event."""
         model = OpenAIRealtimeModel(
             "gpt-realtime-1.5",
             OpenAICredential(api_key="sk-x"),
         )
-        model._queue.put_nowait(me.SessionEndedEvent(reason="closed"))
-        model._queue.put_nowait(None)
+        await self._connect(model)
+        await model.close()
         got = [event async for event in model.events()]
         self.assertEqual(got, [me.SessionEndedEvent(reason="closed")])


### PR DESCRIPTION
## AgentScope Version

`2.0.8` (current `main`, 0fe41c0)

## Description

Fixes #2587.

**Background.** The OpenAI, Gemini, DashScope and xAI realtime adapters allocate their event queue once in `__init__`. `close()` cancels the reader task, whose `finally` block enqueues a `SessionEndedEvent` followed by the `None` end-of-stream sentinel. A later `connect()` started a new reader on the same queue without clearing it.

**Effect.** After an explicit close and reconnect on the same instance, the next `events()` iterator consumed the previous session's terminal event and sentinel and stopped, while the provider WebSocket was connected and receiving input; the new session's audio, transcript and tool-call events stayed unread.

**Change.** `connect()` drains the queue (`get_nowait` until empty) right before starting the reader, in all four adapters. The queue object itself is kept, so an `events()` iterator created before `connect()` keeps working, and a closed session that is *not* reconnected still terminates its consumer exactly as before (covered by a test).

**How to test.** `tests/realtime_reconnect_test.py` drives each adapter with a fake WebSocket (`websockets.connect` patched; for Gemini the fake replays `setupComplete` so `connect()` returns): the queue is pre-loaded with `SessionEndedEvent` + `None` as `close()` leaves it, `connect()` is called, a fresh `ResponseCreatedEvent` is enqueued, and `events()` must yield only that fresh event. Plus the no-reconnect case.

```
cd tests && python -m pytest realtime_reconnect_test.py realtime_openai_test.py realtime_dashscope_test.py realtime_gemini_test.py realtime_xai_test.py -q
# 68 passed
black --line-length=79 / flake8 on the touched files: clean
```

## Checklist

- [x] An issue has been created for this PR (#2587)
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated — no documentation describes this behaviour
- [x] Code is ready for review
