### PR TITLE
fix(realtime): isolate event queues across connections

### DIFF
--- a/src/agentscope/realtime/_dashscope/_model.py
+++ b/src/agentscope/realtime/_dashscope/_model.py
@@ -92,6 +92,7 @@ class DashScopeRealtimeModel(RealtimeModelBase):
         """Open the WebSocket and send the session config."""
         import websockets
 
+        self._queue = asyncio.Queue()
         if kwargs.get("turn_detection_disabled"):
             self.parameters = self.parameters.model_copy(
                 update={"turn_detection": "none"},

--- a/src/agentscope/realtime/_gemini/_model.py
+++ b/src/agentscope/realtime/_gemini/_model.py
@@ -120,6 +120,7 @@ class GeminiRealtimeModel(RealtimeModelBase):
         """Open the WebSocket and send the setup message."""
         import websockets
 
+        self._queue = asyncio.Queue()
         if kwargs.get("turn_detection_disabled"):
             self.parameters = self.parameters.model_copy(
                 update={"turn_detection": "none"},

--- a/src/agentscope/realtime/_openai/_model.py
+++ b/src/agentscope/realtime/_openai/_model.py
@@ -108,6 +108,7 @@ class OpenAIRealtimeModel(RealtimeModelBase):
         """Open the WebSocket and send the session config."""
         import websockets
 
+        self._queue = asyncio.Queue()
         if kwargs.get("turn_detection_disabled"):
             self.parameters = self.parameters.model_copy(
                 update={"turn_detection": "none"},

--- a/src/agentscope/realtime/_xai/_model.py
+++ b/src/agentscope/realtime/_xai/_model.py
@@ -100,6 +100,7 @@ class XAIRealtimeModel(RealtimeModelBase):
         """Open the WebSocket and send the session config."""
         import websockets
 
+        self._queue = asyncio.Queue()
         if kwargs.get("turn_detection_disabled"):
             self.parameters = self.parameters.model_copy(
                 update={"turn_detection": "none"},

--- a/tests/realtime_reconnect_test.py
+++ b/tests/realtime_reconnect_test.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for realtime model reconnection lifecycle."""
+# pylint: disable=protected-access
+import asyncio
+import json
+from unittest.async_case import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+from agentscope.credential import (
+    DashScopeCredential,
+    GeminiCredential,
+    OpenAICredential,
+    XAICredential,
+)
+from agentscope.realtime import (
+    DashScopeRealtimeModel,
+    GeminiRealtimeModel,
+    OpenAIRealtimeModel,
+    XAIRealtimeModel,
+)
+from agentscope.realtime import _events as me
+
+
+class _BlockingWebSocket:
+    """A socket that stays open after an optional first server frame."""
+
+    def __init__(self, first_frame: dict | None = None) -> None:
+        self._first_frame = first_frame
+        self._closed = asyncio.Event()
+        self.send = AsyncMock()
+
+    def __aiter__(self) -> "_BlockingWebSocket":
+        return self
+
+    async def __anext__(self) -> str:
+        if self._first_frame is not None:
+            frame, self._first_frame = self._first_frame, None
+            return json.dumps(frame)
+        await self._closed.wait()
+        raise StopAsyncIteration
+
+    async def close(self) -> None:
+        """Release the blocked asynchronous iterator."""
+        self._closed.set()
+
+
+class RealtimeReconnectTest(IsolatedAsyncioTestCase):
+    """Every provider isolates event queues between connections."""
+
+    async def test_connect_replaces_previous_session_queue(self) -> None:
+        """A stale end sentinel cannot terminate the next event stream."""
+        cases = [
+            (
+                OpenAIRealtimeModel(
+                    "gpt-realtime-2.1",
+                    OpenAICredential(api_key="unused"),
+                ),
+                None,
+            ),
+            (
+                GeminiRealtimeModel(
+                    "gemini-3.1-flash-live-preview",
+                    GeminiCredential(api_key="unused"),
+                ),
+                {"setupComplete": {}},
+            ),
+            (
+                DashScopeRealtimeModel(
+                    DashScopeRealtimeModel.list_models()[0].name,
+                    DashScopeCredential(api_key="unused"),
+                ),
+                None,
+            ),
+            (
+                XAIRealtimeModel(
+                    XAIRealtimeModel.list_models()[0].name,
+                    XAICredential(api_key="unused"),
+                ),
+                None,
+            ),
+        ]
+
+        for model, first_frame in cases:
+            with self.subTest(provider=model.type):
+                previous_queue = model._queue
+                previous_queue.put_nowait(
+                    me.SessionEndedEvent(reason="previous close"),
+                )
+                previous_queue.put_nowait(None)
+                socket = _BlockingWebSocket(first_frame)
+
+                with patch(
+                    "websockets.connect",
+                    new=AsyncMock(return_value=socket),
+                ):
+                    await model.connect(instructions="test")
+
+                self.assertIsNot(model._queue, previous_queue)
+                self.assertTrue(model._queue.empty())
+                await model.close()


### PR DESCRIPTION
Fixes #2587.

## AgentScope Version

2.0.8 (main at `0fe41c07`)

## Description

Create a fresh event queue whenever the OpenAI, Gemini, DashScope, or xAI realtime adapter starts a connection. This prevents a terminal event and end-of-stream sentinel left by the previous session from ending the newly connected event stream.

The regression test seeds a previous session's terminal entries, reconnects each provider adapter with a mocked WebSocket, and verifies that the new connection uses an empty, distinct queue.

## Testing

- `pytest tests/realtime_openai_test.py tests/realtime_gemini_test.py tests/realtime_dashscope_test.py tests/realtime_xai_test.py tests/realtime_agent_test.py tests/realtime_reconnect_test.py -q` — 76 passed, 4 subtests passed
- `pre-commit run --all-files` — passed

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated
- [ ] Code is ready for review

## 中文

Realtime 模型关闭并重新连接后，新事件流可能被旧连接遗留的结束标记立即终止。
具体过程：
OpenAI、Gemini、DashScope 和 xAI adapter 初始化时只创建一次事件队列。
旧连接关闭时，会向队列写入 SessionEndedEvent 和 None 结束哨兵。
再次调用 connect() 时，代码此前继续复用这个旧队列。
新的 events() 读取到旧连接遗留的 None 后立即退出。
新连接虽然已经成功建立，但新产生的音频、转写和工具调用事件会留在队列里，无人消费。
总而言之表现上就是：同一个 RealtimeAgent 实例断开并重连后，看起来已经连接成功，却可能不再输出任何响应，而且通常没有异常信息。
本PR是让四个 realtime adapter 在每次建立新连接时创建独立的新事件队列，确保旧 session 的结束哨兵不会影响新 session。