### PR TITLE
fix(realtime): reconnect before sending text input

### DIFF
--- a/src/agentscope/agent/_realtime/_agent.py
+++ b/src/agentscope/agent/_realtime/_agent.py
@@ -424,6 +424,8 @@ class RealtimeAgent:
         Raises:
             `NotImplementedError`: For a text turn when the provider takes
                 no text input.
+            `ModelDisconnectedError`: If the provider disconnects before it
+                accepts the text turn.
         """
         match inputs:
             case UserInterruptEvent():
@@ -447,8 +449,14 @@ class RealtimeAgent:
                 )
                 text = msg.get_text_content() or ""
                 await self._barge_in()
+                if not self._connected:
+                    await self.connect()
+                try:
+                    await self.model.push_text(text)
+                except ModelDisconnectedError:
+                    self._mark_disconnected()
+                    raise
                 self.state.context.append(msg)
-                await self.model.push_text(text)
 
     async def interrupt(self) -> None:
         """Stop the active reply, as when the user presses stop."""

--- a/tests/realtime_agent_test.py
+++ b/tests/realtime_agent_test.py
@@ -17,6 +17,8 @@ from agentscope.event import (
 from agentscope.message import Msg
 from agentscope.realtime import (
     AudioFrame,
+    ControlFrame,
+    ControlFrameType,
     ModelDisconnectedError,
     PlayoutPosition,
     RealtimeModelBase,
@@ -89,6 +91,8 @@ class ScriptedModel(RealtimeModelBase):
         self.calls: list[str] = []
         self.sessions = 0
         self.instructions = ""
+        self.connect_error: Exception | None = None
+        self.push_text_error: Exception | None = None
         self._open = asyncio.Event()
         self._requested = asyncio.Event()
 
@@ -100,6 +104,8 @@ class ScriptedModel(RealtimeModelBase):
     ) -> None:
         """Record a session open, its instructions and the turn-detection
         request."""
+        if self.connect_error is not None:
+            raise self.connect_error
         self.sessions += 1
         self._open.clear()
         self.instructions = instructions
@@ -132,6 +138,8 @@ class ScriptedModel(RealtimeModelBase):
     async def push_text(self, text: str) -> None:
         """Record a text turn; the agent gates on ``supports_text_input``
         before ever calling this."""
+        if self.push_text_error is not None:
+            raise self.push_text_error
         self.calls.append(f"push_text({text!r})")
 
     async def push_tool_result(self, block: ToolResultBlock) -> None:
@@ -363,6 +371,70 @@ class RealtimeAgentTest(IsolatedAsyncioTestCase):
             [(m.role, m.get_text_content()) for m in agent.state.context],
             [("user", "讲个故事"), ("user", "你好"), ("assistant", "你好呀")],
         )
+
+    async def test_provider_timeout_reconnects_on_text(self) -> None:
+        """Text reconnects a timed-out provider without duplicating the
+        new turn in the reconnect instructions."""
+        model = ScriptedModel(
+            [
+                [me.SessionEndedEvent(reason="idle")],
+                [],
+            ],
+        )
+        model.supports_text_input = True
+        agent = RealtimeAgent("Friday", "be brief", model)
+
+        async with agent:
+            await asyncio.sleep(0.1)
+            self.assertFalse(agent._connected)  # pylint: disable=W0212
+            await agent.send("hello")
+
+        self.assertEqual(model.sessions, 2)
+        self.assertEqual(model.instructions, "be brief")
+        self.assertIn("push_text('hello')", model.calls)
+        self.assertListEqual(
+            [(m.role, m.get_text_content()) for m in agent.state.context],
+            [("user", "hello")],
+        )
+
+    async def test_failed_text_delivery_does_not_change_context(self) -> None:
+        """A disconnect while sending text leaves no undelivered turn."""
+        model = ScriptedModel([[]])
+        model.supports_text_input = True
+        agent = RealtimeAgent("Friday", "be brief", model)
+        error = ModelDisconnectedError("Not connected.")
+
+        async with agent:
+            model.push_text_error = error
+            with self.assertRaisesRegex(
+                ModelDisconnectedError,
+                "Not connected",
+            ):
+                await agent._on_control(  # pylint: disable=W0212
+                    ControlFrame(
+                        type=ControlFrameType.TEXT,
+                        data={"text": "hello"},
+                    ),
+                )
+            self.assertFalse(agent._connected)  # pylint: disable=W0212
+
+        self.assertListEqual(agent.state.context, [])
+
+    async def test_failed_text_reconnect_does_not_change_context(self) -> None:
+        """A failed reconnect leaves no undelivered text turn."""
+        model = ScriptedModel(
+            [[me.SessionEndedEvent(reason="idle")]],
+        )
+        model.supports_text_input = True
+        agent = RealtimeAgent("Friday", "be brief", model)
+
+        async with agent:
+            await asyncio.sleep(0.1)
+            model.connect_error = RuntimeError("reconnect failed")
+            with self.assertRaisesRegex(RuntimeError, "reconnect failed"):
+                await agent.send("hello")
+
+        self.assertListEqual(agent.state.context, [])
 
     async def test_local_vad_owns_turns(self) -> None:
         """Passing a VAD disables provider turn detection, reports the


### PR DESCRIPTION
Fixes #2590.

## AgentScope Version

2.0.8 (`main` at `0fe41c07`)

## Description

Reconnect the realtime provider before sending text input after a disconnect. Append the user message to agent context only after the provider accepts it, so a failed reconnect or a disconnect during delivery cannot leave an undelivered turn in the conversation history.

The audio reconnect behavior and providers without text-input support remain unchanged.

## Testing

- `pytest tests/realtime_agent_test.py tests/realtime_openai_test.py tests/realtime_gemini_test.py tests/realtime_dashscope_test.py tests/realtime_xai_test.py -q` — 78 passed
- `pre-commit run --all-files` — passed

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated (no documentation change is needed for this behavioral fix)
- [x] Code is ready for review

## 中文

关联并修复 #2590。

本 PR 让 realtime provider 在断线后先重连再发送文本，并且仅在 provider 成功接受文本后才把用户消息写入 Agent 上下文。因此，无论重连失败还是发送时连接再次断开，都不会在对话历史中留下未送达的消息。音频重连逻辑和不支持文本输入的 provider 行为保持不变。

回归测试覆盖直接 `send()`、transport 文本控制帧、重连失败和发送时断线。全部 realtime 相关测试共 78 项通过，完整 pre-commit 检查通过。
