### PR TITLE
fix(utils): preserve instance values during schema flattening

### DIFF
--- a/src/agentscope/_utils/_common.py
+++ b/src/agentscope/_utils/_common.py
@@ -16,6 +16,15 @@ from .._logging import logger
 from ..exception import ToolJSONDecodeError
 
 
+# These mappings use property names as keys and schemas as values.
+_SCHEMA_MAP_KEYWORDS = frozenset(
+    {"properties", "patternProperties", "dependentSchemas", "dependencies"},
+)
+# These keywords hold instance data, which must be kept verbatim.
+_INSTANCE_VALUE_KEYWORDS = frozenset(
+    {"default", "const", "enum", "examples"},
+)
+
 _id_factory: Callable[[], str] = lambda: uuid.uuid4().hex
 _timestamp_factory: Callable[[], str] = lambda: datetime.now().isoformat()
 
@@ -345,67 +354,49 @@ def _flatten_json_schema(schema: dict) -> dict:
     if not defs:
         return schema
 
-    schema_map_keywords = {
-        "properties",
-        "patternProperties",
-        "dependentSchemas",
-        "dependencies",
-    }
-
-    def _resolve_ref(
-        obj: Any,
-        visited: frozenset = frozenset(),
-        is_schema_map: bool = False,
-    ) -> Any:
+    def _resolve_ref(obj: Any, visited: frozenset = frozenset()) -> Any:
         if isinstance(obj, list):
             return [_resolve_ref(item, visited) for item in obj]
         if not isinstance(obj, dict):
             return obj
-        if is_schema_map:
-            return {
-                key: _resolve_ref(value, visited) for key, value in obj.items()
-            }
+
+        resolved: dict[str, Any] = {}
         if "$ref" in obj:
             ref_path = obj["$ref"]
-            if isinstance(ref_path, str) and (
-                ref_path.startswith("#/$defs/")
-                or ref_path.startswith("#/definitions/")
+            if not isinstance(ref_path, str) or not ref_path.startswith(
+                ("#/$defs/", "#/definitions/"),
             ):
-                def_name = ref_path.split("/")[-1]
-                if def_name in visited:
-                    logger.warning(
-                        "Circular reference detected for '%s' in tool "
-                        "schema",
-                        def_name,
-                    )
-                    return {
-                        "type": "object",
-                        "description": f"(circular: {def_name})",
-                    }
-                if def_name in defs:
-                    resolved = _resolve_ref(
-                        defs[def_name],
-                        visited | {def_name},
-                    )
-                    for key, value in obj.items():
-                        if key != "$ref":
-                            resolved[key] = _resolve_ref(
-                                value,
-                                visited | {def_name},
-                                key in schema_map_keywords,
-                            )
-                    return resolved
-            return obj
-        result: dict[str, Any] = {}
+                return obj
+
+            def_name = ref_path.split("/")[-1]
+            if def_name in visited:
+                logger.warning(
+                    "Circular reference detected for '%s' in tool schema",
+                    def_name,
+                )
+                return {
+                    "type": "object",
+                    "description": f"(circular: {def_name})",
+                }
+            if def_name not in defs:
+                return obj
+
+            visited = visited | {def_name}
+            resolved = _resolve_ref(defs[def_name], visited)
+
         for key, value in obj.items():
-            if key in ("$defs", "definitions"):
+            if key in ("$ref", "$defs", "definitions"):
                 continue
-            result[key] = _resolve_ref(
-                value,
-                visited,
-                key in schema_map_keywords,
-            )
-        return result
+            if key in _INSTANCE_VALUE_KEYWORDS:
+                resolved[key] = value
+            elif key in _SCHEMA_MAP_KEYWORDS and isinstance(value, dict):
+                resolved[key] = {
+                    name: _resolve_ref(sub, visited)
+                    for name, sub in value.items()
+                }
+            else:
+                resolved[key] = _resolve_ref(value, visited)
+        return resolved
 
     return _resolve_ref(schema)
 

--- a/tests/model_gemini_test.py
+++ b/tests/model_gemini_test.py
@@ -964,6 +964,68 @@ class TestGeminiSchemaUtils(unittest.TestCase):
             },
         )
 
+    def test_flatten_keeps_property_names(self) -> None:
+        """Schema keywords used as property names are preserved."""
+        for keyword in (
+            "properties",
+            "patternProperties",
+            "dependentSchemas",
+            "dependencies",
+        ):
+            with self.subTest(keyword=keyword):
+                self.assertEqual(
+                    _flatten_json_schema(
+                        {
+                            "$defs": {"Name": {"type": "string"}},
+                            keyword: {
+                                "definitions": {"$ref": "#/$defs/Name"},
+                                "$defs": {"$ref": "#/$defs/Name"},
+                                "$ref": {"$ref": "#/$defs/Name"},
+                            },
+                        },
+                    ),
+                    {
+                        keyword: {
+                            "definitions": {"type": "string"},
+                            "$defs": {"type": "string"},
+                            "$ref": {"type": "string"},
+                        },
+                    },
+                )
+
+    def test_flatten_keeps_instance_values(self) -> None:
+        """Instance data stays intact, including next to a schema $ref."""
+        data = {
+            "definitions": {"x": 1},
+            "$defs": {"x": 2},
+        }
+        for keyword, value in (
+            ("default", data),
+            ("const", data),
+            ("enum", [{"$ref": "#/$defs/Value"}]),
+            ("examples", [{"nested": data}]),
+        ):
+            for with_ref in (False, True):
+                with self.subTest(keyword=keyword, with_ref=with_ref):
+                    prop = {keyword: value}
+                    if with_ref:
+                        prop["$ref"] = "#/$defs/Value"
+                    else:
+                        prop["type"] = "object"
+                    self.assertEqual(
+                        _flatten_json_schema(
+                            {
+                                "$defs": {"Value": {"type": "object"}},
+                                "properties": {"value": prop},
+                            },
+                        ),
+                        {
+                            "properties": {
+                                "value": {"type": "object", keyword: value},
+                            },
+                        },
+                    )
+
     def test_flatten_legacy_definitions_ref(self) -> None:
         """Legacy 'definitions' keyword is resolved like '$defs'."""
         self.assertEqual(


### PR DESCRIPTION
## AgentScope Version

2.0.8

## Description

Follow-up to #2575, addressing [the review feedback](https://github.com/agentscope-ai/agentscope/pull/2575#pullrequestreview-5174928051). Refs #2574.

`_flatten_json_schema` still treated instance data under `default`, `const`, `enum`, and `examples` as schemas. This could remove ordinary `definitions` / `$defs` keys from defaults or expand literal `$ref` values inside enums.

- Preserve instance values verbatim.
- Use one field-processing loop for ordinary schemas and `$ref` siblings, and move the keyword sets to module-level constants.
- Add regression tests for schema-like property names and instance values, including values next to a schema `$ref`.

## Validation

- Before the fix, the instance-value regression failed in all 8 subcases.
- `python -m pytest tests/model_gemini_test.py -q -p no:cacheprovider`: 32 tests and 12 subtests passed.

## Checklist

- [x] An issue has been created for this PR (#2574; follow-up to #2575).
- [x] I have read the CONTRIBUTING.md.
- [x] Docstrings are in Google style.
- [ ] Related documentation has been updated (not applicable: internal schema-flattening bug fix).
- [x] Code is ready for review.