### PR TITLE
fix(realtime): report tool call arguments in the event stream

### DIFF
--- a/src/agentscope/agent/_realtime/_agent.py
+++ b/src/agentscope/agent/_realtime/_agent.py
@@ -34,6 +34,7 @@ from ...event import (
     TextBlockDeltaEvent,
     TextBlockEndEvent,
     TextBlockStartEvent,
+    ToolCallDeltaEvent,
     ToolCallEndEvent,
     ToolCallStartEvent,
     ToolResultEndEvent,
@@ -979,6 +980,15 @@ class RealtimeAgent:
                 reply_id=reply_id,
                 tool_call_id=call.id,
                 tool_call_name=call.name,
+            ),
+        )
+        # The provider delivers the arguments in one piece, so a single
+        # delta carries them; without it consumers rebuild an empty input.
+        self._emit(
+            ToolCallDeltaEvent(
+                reply_id=reply_id,
+                tool_call_id=call.id,
+                delta=call.input,
             ),
         )
         self._emit(ToolCallEndEvent(reply_id=reply_id, tool_call_id=call.id))

--- a/tests/realtime_agent_test.py
+++ b/tests/realtime_agent_test.py
@@ -661,6 +661,58 @@ class RealtimeAgentToolTest(IsolatedAsyncioTestCase):
         )
         self.assertIn("tool_result(c1,'boom')", model.calls)
 
+    async def test_tool_call_arguments_reach_the_event_stream(self) -> None:
+        """A client rebuilding the reply from the event stream sees the
+        tool call's arguments, not an empty input."""
+        model = ScriptedModel([_tool_script("stream_tool")])
+        agent = RealtimeAgent(
+            "Friday",
+            "be brief",
+            model,
+            toolkit=Toolkit(tools=[StreamTool()]),
+        )
+        rebuilt = Msg(id="r1", role="assistant", name="Friday", content=[])
+        async with agent:
+            transport = FakeTransport(frames=4)
+            async with transport:
+                async for event in agent.reply_stream(transport):
+                    if getattr(event, "reply_id", None) == "r1":
+                        rebuilt.append_event(event)
+
+        self.assertListEqual(
+            [b.model_dump() for b in rebuilt.content],
+            [
+                {
+                    "type": "tool_call",
+                    "id": "c1",
+                    "name": "stream_tool",
+                    "input": '{"q": "x"}',
+                    "state": "finished",
+                    "suggested_rules": [],
+                    "created_at": AnyString(),
+                    "finished_at": AnyString(),
+                },
+                {
+                    "type": "tool_result",
+                    "id": "c1",
+                    "name": "stream_tool",
+                    "output": [
+                        {
+                            "type": "text",
+                            "text": "x-ax-b",
+                            "id": AnyString(),
+                            "created_at": AnyString(),
+                            "finished_at": None,
+                        },
+                    ],
+                    "state": "success",
+                    "metadata": {},
+                    "created_at": AnyString(),
+                    "finished_at": AnyString(),
+                },
+            ],
+        )
+
 
 class RealtimeAgentFullStreamTest(IsolatedAsyncioTestCase):
     """The complete event stream of a turn that calls a tool and then
@@ -865,6 +917,15 @@ class RealtimeAgentFullStreamTest(IsolatedAsyncioTestCase):
                     "reply_id": "r1",
                     "tool_call_id": "c1",
                     "tool_call_name": "stream_tool",
+                },
+                {
+                    "id": AnyString(),
+                    "created_at": AnyString(),
+                    "metadata": {},
+                    "type": "TOOL_CALL_DELTA",
+                    "reply_id": "r1",
+                    "tool_call_id": "c1",
+                    "delta": '{"q": "x"}',
                 },
                 {
                     "id": AnyString(),


### PR DESCRIPTION
## Problem

`RealtimeAgent` emits `ToolCallStartEvent` and `ToolCallEndEvent` for each tool call, but never a `ToolCallDeltaEvent`. Since `Msg.append_event` creates the `ToolCallBlock` with `input=""` on `TOOL_CALL_START` and only fills it from `TOOL_CALL_DELTA`, any consumer that rebuilds the reply from the event stream (TUI, SSE clients) ends up with an empty `input`. The HITL confirmation panel therefore asks the user to approve a call without showing its arguments.

The arguments themselves are not missing: the realtime models assemble them from the provider's `function_call_arguments` deltas and hand the agent a complete `ToolCallBlock`, which is what execution and `state.context` use. Only the outgoing event stream drops them.

## Fix

Emit a `ToolCallDeltaEvent` carrying `call.input` between the start and end events in `_run_tool`, the same way `ReActAgent` reports tool call arguments. No protocol change.

Tests: the full event-stream test now covers the delta, plus a new test asserting that a `Msg` rebuilt with `append_event` gets the complete tool call input.