### PR TITLE
fix(app): pass model card's context_size to chat model

### DIFF
--- a/src/agentscope/app/_service/_model.py
+++ b/src/agentscope/app/_service/_model.py
@@ -51,23 +51,33 @@ async def get_model(
         if config.parameters
         else None
     )
+    # Look up the built-in model card so both the context size and the
+    # formatter's input types can be taken from it. Custom models have no
+    # card, so keep the constructor and formatter defaults.
+    card = None
+    try:
+        for candidate in model_cls.list_models():
+            if candidate.name == config.model:
+                card = candidate
+                break
+    except Exception:  # pylint: disable=broad-except
+        logger.debug(
+            "Failed to look up model card for %s, using defaults.",
+            config.model,
+        )
+
+    model_kwargs: dict = {}
+    if card is not None:
+        model_kwargs["context_size"] = card.context_size
+
     model = model_cls(
         credential=credential,
         model=config.model,
         parameters=parameters,
+        **model_kwargs,
     )
 
-    # Override the formatter's input types with the built-in model card's
-    # when one matches; custom models have no card, so keep the default.
-    try:
-        for card in model_cls.list_models():
-            if card.name == config.model:
-                model.formatter.input_types = card.input_types
-                break
-    except Exception:  # pylint: disable=broad-except
-        logger.debug(
-            "Failed to look up model card for %s, using formatter defaults.",
-            config.model,
-        )
+    if card is not None:
+        model.formatter.input_types = card.input_types
 
     return model

--- a/tests/service_model_test.py
+++ b/tests/service_model_test.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for :func:`get_model` — the chat model factory.
+
+The factory used to build the model with only ``credential``, ``model``
+and ``parameters``, so the matching model card's ``context_size`` never
+reached the constructor and every model silently kept its provider class
+default — 65536 for DeepSeek while the card declares 1000000. ``Agent``
+derives every context-compression threshold from
+``model.context_size``, so an under-reported value makes compression
+fire far too early.
+"""
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase
+
+from agentscope.app._service._model import get_model
+from agentscope.app.storage import ChatModelConfig
+
+
+class _StubAccess:
+    """Stand-in for ``ResourceAccessService``.
+
+    ``get_model`` only reads the resolved record's ``data``.
+    """
+
+    def __init__(self, data: dict) -> None:
+        self._data = data
+
+    async def resolve_credential(
+        self,
+        user_id: str,
+        credential_id: str,
+    ) -> SimpleNamespace:
+        """Return the canned credential record.
+
+        Args:
+            user_id (`str`):
+                The viewer's user id, unused.
+            credential_id (`str`):
+                The credential id, unused.
+
+        Returns:
+            `SimpleNamespace`:
+                The canned record.
+        """
+        del user_id, credential_id
+        return SimpleNamespace(data=self._data)
+
+
+def _config(model: str) -> ChatModelConfig:
+    """Build a DeepSeek chat model config for ``model``.
+
+    Args:
+        model (`str`):
+            The model name.
+
+    Returns:
+        `ChatModelConfig`:
+            The configuration.
+    """
+    return ChatModelConfig(
+        type="deepseek",
+        credential_id="cred-1",
+        model=model,
+        parameters={},
+    )
+
+
+_CREDENTIAL = {"type": "deepseek_credential", "api_key": "test"}
+
+
+class GetModelContextSizeTest(IsolatedAsyncioTestCase):
+    """The factory must forward the model card's ``context_size``."""
+
+    async def test_uses_card_context_size(self) -> None:
+        """A matching card's value wins over the class default."""
+        model = await get_model(
+            "user-1",
+            _config("deepseek-v4-flash"),
+            _StubAccess(_CREDENTIAL),
+        )
+
+        self.assertEqual(1000000, model.context_size)
+
+    async def test_keeps_default_for_unknown_model(self) -> None:
+        """A model without a card keeps the constructor default."""
+        model = await get_model(
+            "user-1",
+            _config("my-custom-model"),
+            _StubAccess(_CREDENTIAL),
+        )
+
+        self.assertEqual(65536, model.context_size)


### PR DESCRIPTION
Fixes #2596

## AgentScope Version

2.0.8 (`import agentscope; print(agentscope.__version__)`)

## Description

`get_model()` built the chat model without forwarding the matching model
card's `context_size`, so every model silently kept its provider class
default — 65536 for DeepSeek while the card declares 1000000. `Agent`
derives every context-compression threshold from `model.context_size`,
so an under-reported value made compression fire far too early. The
fallback chat model goes through the same factory.

The card lookup that already patched `formatter.input_types` now also
sets `context_size` from the matching card. Both are assigned after
construction, since `ChatModelBase.__init__` only stores `context_size`
as an attribute. Models without a card keep the constructor default, and
the existing graceful degradation when the lookup fails is preserved.

I opened this PR while the issue is still open — happy to adjust the
approach or close it if you would rather fix this differently.

## How to test

```
pytest tests/service_model_test.py
```

The first case fails on main with `AssertionError: 1000000 != 65536`
and passes with this change; the second locks in the fallback for
card-less custom models.

Full suite: `2233 passed, 299 skipped` with no new failures — the 7
failures in `storage_sql_test.py` / `test_e2e_api.py` are pre-existing
on main and reproduce without this change.

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the CONTRIBUTING.md
- [x] Docstrings are in Google style
- [x] Related documentation has been updated — not applicable, no
      user-visible API change
- [x] Code is ready for review
