### PR TITLE
docs: fix broken apple container install link

### DIFF
--- a/examples/workspace/apple-container-workspace.md
+++ b/examples/workspace/apple-container-workspace.md
@@ -5,7 +5,7 @@ AgentScope workspace backed by Apple's `container` CLI. Runs agent tool calls (B
 ## Prerequisites
 
 - **macOS 26+** on Apple silicon (Intel Macs are not supported by Apple Container).
-- **Apple Container 1.0.0 or later** (tested on 1.0.0 and 1.1.0). Install from the [Apple Container developer site](https://developer.apple.com/container/).
+- **Apple Container 1.0.0 or later** (tested on 1.0.0 and 1.1.0). Install from the [Apple Container project page](https://opensource.apple.com/projects/container).
 - **`container system start`** must be running before creating any workspace.
 - **Outbound network access from the container VM** is required during the first `initialize()` — the bootstrap installs system packages via `apt-get` and downloads `uv` via the installer script. If the container VM cannot reach the internet, initialize will fail at the bootstrap step with an apt-get or curl error.
 


### PR DESCRIPTION
## What

Point the Apple Container install link in `examples/workspace/apple-container-workspace.md` to Apple's official project page, `https://opensource.apple.com/projects/container`.

## Why

The previous `https://developer.apple.com/container/` URL returns 404; Apple does not host a developer page for Container at that path. The official project page (and the linked `apple/container` repo it references) is where the installer is published.

## How checked

- `https://developer.apple.com/container/` → 404
- `https://opensource.apple.com/projects/container` → 200
- Docs-only change, one link in one file.