### PR TITLE
docs: point eslint plugin links to the npm package pages

### DIFF
--- a/examples/web_ui/frontend/README.md
+++ b/examples/web_ui/frontend/README.md
@@ -43,7 +43,7 @@ export default defineConfig([
 ]);
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+You can also install [eslint-plugin-react-x](https://www.npmjs.com/package/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://www.npmjs.com/package/eslint-plugin-react-dom) for React-specific lint rules:
 
 ```js
 // eslint.config.js


### PR DESCRIPTION
## What

Repoint the `eslint-plugin-react-x` and `eslint-plugin-react-dom` links in `examples/web_ui/frontend/README.md` to their npm package pages.

## Why

The upstream `Rel1cx/eslint-react` monorepo no longer has a `packages/plugins/` directory, so both deep links return 404. The plugins are still published on npm under those names (`5.19.0` at the time of writing), and the npm pages are the stable entry point.

## How checked

- `https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/...` → 404 (`packages/` now only contains `ast`, `core`, `eslint`, `jsx`, `kit`, `shared`, `var`)
- `npm view eslint-plugin-react-x` / `npm view eslint-plugin-react-dom` → both exist
- Docs-only change, one line in one file.