### PR TITLE
feat(channel): implement Feishu wiki access

### DIFF
--- a/src/agentscope/app/channel/_base.py
+++ b/src/agentscope/app/channel/_base.py
@@ -42,6 +42,7 @@ from ...types import ReplyFinishedReason
 
 if TYPE_CHECKING:
     from ._credential_binding import CredentialBindingBase
+    from ..storage import StorageBase
     from ...tool import ToolBase
     from ...workspace import WorkspaceBase
 
@@ -382,6 +383,18 @@ class ChannelBase(ABC):
     not access any other gateway state."""
 
     # -- Identity & connection --
+
+    def _bind_storage(self, storage: "StorageBase") -> None:
+        """Bind the service storage to a channel that needs it.
+
+        This is an internal, optional hook. Custom channels that do not need
+        storage keep the default no-op behavior and their constructor contract
+        remains unchanged.
+
+        Args:
+            storage (`StorageBase`): The application storage backend.
+        """
+        _ = storage
 
     @property
     @abstractmethod

--- a/src/agentscope/app/channel/_clients.py
+++ b/src/agentscope/app/channel/_clients.py
@@ -142,6 +142,9 @@ class ChannelClients:
                 credentials=record.credentials,
                 config=record.platform_config,
             )
+            channel._bind_storage(  # pylint: disable=protected-access
+                self._storage,
+            )
         except Exception:  # pylint: disable=broad-except
             logger.exception(
                 "channel client '%s' could not be built",

--- a/src/agentscope/app/channel/_dispatcher.py
+++ b/src/agentscope/app/channel/_dispatcher.py
@@ -137,6 +137,9 @@ class ChannelLifecycleDispatcher:
                 credentials=record.credentials,
                 config=record.platform_config,
             )
+            channel._bind_storage(  # pylint: disable=protected-access
+                self._storage,
+            )
             task = asyncio.create_task(
                 channel.start_listening(self._gateway.process),
                 name=f"channel-listener:{record.id}",

--- a/src/agentscope/app/channel/_feishu/_card_templates.py
+++ b/src/agentscope/app/channel/_feishu/_card_templates.py
@@ -14,6 +14,42 @@ _APPROVE = "approve"
 _DENY = "deny"
 
 
+def _build_user_auth_card(
+    verification_uri: str,
+    user_code: str,
+    expires_in: int,
+) -> str:
+    """Build a card that starts Feishu's user device authorization.
+
+    Args:
+        verification_uri (`str`): Browser URL for authorization.
+        user_code (`str`): One-time code the user may need to enter.
+        expires_in (`int`): Number of seconds before the request expires.
+
+    Returns:
+        `str`: The card as a JSON string.
+    """
+    body = (
+        "AgentScope needs your authorization to read Feishu Wiki with "
+        "your own permissions.\n\n"
+        f"[Open authorization page]({verification_uri})\n\n"
+        f"**User code:** `{user_code}`\n\n"
+        f"This request expires in {expires_in} seconds."
+    )
+    card = {
+        "config": {"wide_screen_mode": True},
+        "header": {
+            "template": "blue",
+            "title": {
+                "tag": "plain_text",
+                "content": "🔐 Feishu Wiki authorization required",
+            },
+        },
+        "elements": [{"tag": "markdown", "content": body}],
+    }
+    return json.dumps(card, ensure_ascii=False)
+
+
 def _build_approval_card(
     tool_call_id: str,
     chat_id: str,

--- a/src/agentscope/app/channel/_feishu/_channel.py
+++ b/src/agentscope/app/channel/_feishu/_channel.py
@@ -17,7 +17,9 @@ import base64
 import json
 import threading
 import time
+from datetime import datetime, timezone
 from typing import Any, AsyncIterator, Awaitable, Callable, TYPE_CHECKING
+from urllib.parse import quote, urlencode
 
 from pydantic import BaseModel, Field
 
@@ -31,15 +33,21 @@ from .._base import (
     ChannelConfirmationResultEvent,
     ChannelStatus,
     ChatKind,
+    WikiDocument,
+    WikiNode,
+    WikiPage,
+    WikiSpace,
     _EVENT_ADAPTER,
 )
-from ._credential_binding import FeishuCredentialBinding
 from ._card_templates import (
     _build_action_response,
     _build_approval_card,
     _build_toast,
+    _build_user_auth_card,
     _parse_action,
 )
+from ._credential_binding import FeishuCredentialBinding
+from ._user_oauth import _FeishuDeviceFlowClient
 
 if TYPE_CHECKING:
     import httpx
@@ -50,13 +58,44 @@ if TYPE_CHECKING:
     )
     from .....tool import ToolBase
     from .....workspace import WorkspaceBase
+    from ...storage import StorageBase
 
 _API = "https://open.feishu.cn/open-apis"
-_TOKEN_EXPIRED_CODES = frozenset({99991663, 99991664})
+_TOKEN_EXPIRED_CODES = frozenset(
+    {99991663, 99991664, 99991665, 99991666, 99991668, 99991671},
+)
 _MEDIA_TYPES = frozenset({"image", "audio", "media", "file"})
 _STREAM_ELEMENT_ID = "md"
 # Minimum seconds between live streaming-card updates (throttle).
 _STREAM_MIN_INTERVAL = 0.7
+_USER_TOKEN_REFRESH_SLACK = 300
+_MAX_DOCUMENT_CHARS = 20_000
+_WIKI_SCOPES = frozenset(
+    {
+        "wiki:space:retrieve",
+        "wiki:node:retrieve",
+        "wiki:node:read",
+        "docx:document:readonly",
+    },
+)
+_BLOCK_NAMES = {
+    1: "page",
+    2: "text",
+    3: "heading1",
+    4: "heading2",
+    5: "heading3",
+    6: "heading4",
+    7: "heading5",
+    8: "heading6",
+    9: "heading7",
+    10: "heading8",
+    11: "heading9",
+    12: "bullet",
+    13: "ordered",
+    15: "quote",
+    31: "table",
+    32: "table_cell",
+}
 
 
 class _ThreadLoopProxy:
@@ -135,6 +174,7 @@ class FeishuChannel(ChannelBase):
         file=True,
         interactive=True,
         streaming=True,
+        wiki=True,
         max_message_length=4000,
     )
 
@@ -161,6 +201,9 @@ class FeishuChannel(ChannelBase):
         self.status = ChannelStatus()
         self._http: "httpx.AsyncClient | None" = None
         self._token: str | None = None
+        self._storage: "StorageBase | None" = None
+        self._device_flow: Any = None
+        self._user_auth_locks: dict[str, asyncio.Lock] = {}
         self._bot_open_id: str | None = None
         self._ws_thread: threading.Thread | None = None
         self._stop = threading.Event()
@@ -177,6 +220,14 @@ class FeishuChannel(ChannelBase):
     def channel_id(self) -> str:
         """The unique channel instance identifier."""
         return self._channel_id
+
+    def _bind_storage(self, storage: "StorageBase") -> None:
+        """Bind storage used for user-scoped OAuth credentials.
+
+        Args:
+            storage (`StorageBase`): The application storage backend.
+        """
+        self._storage = storage
 
     # -- Lifecycle --
 
@@ -272,6 +323,9 @@ class FeishuChannel(ChannelBase):
             if self._http:
                 await self._http.aclose()
                 self._http = None
+            if self._device_flow is not None:
+                await self._device_flow.close()
+                self._device_flow = None
 
     def _launch_ws_thread(self) -> threading.Thread:
         """Start the lark WS client on a daemon thread with its own loop.
@@ -972,6 +1026,395 @@ class FeishuChannel(ChannelBase):
             SendImage(self, backend),
         ] + await super().list_tools(workspace, channel_user_id)
 
+    # -- User-scoped Wiki operations --
+
+    async def list_wiki_spaces(
+        self,
+        channel_user_id: str,
+        limit: int,
+        next_token: str | None = None,
+    ) -> WikiPage[WikiSpace]:
+        """List Wiki spaces visible to one Feishu user.
+
+        Args:
+            channel_user_id (`str`): The sender's Feishu ``open_id``.
+            limit (`int`): Maximum spaces to return (capped at 50).
+            next_token (`str | None`, optional): Feishu pagination token.
+
+        Returns:
+            `WikiPage[WikiSpace]`: One page of visible spaces.
+        """
+        query: dict[str, Any] = {"page_size": min(max(limit, 1), 50)}
+        if next_token:
+            query["page_token"] = next_token
+        data = await self._user_api(
+            channel_user_id,
+            "list Wiki spaces",
+            "GET",
+            "/wiki/v2/spaces",
+            query=query,
+        )
+        payload = data.get("data") or {}
+        items = []
+        for item in payload.get("items") or []:
+            space_id = str(item.get("space_id") or "")
+            if not space_id:
+                continue
+            items.append(
+                WikiSpace(
+                    space_id=space_id,
+                    name=str(item.get("name") or ""),
+                    root_node_id=space_id,
+                    description=item.get("description"),
+                    url=None,
+                ),
+            )
+        token = payload.get("page_token") if payload.get("has_more") else None
+        return WikiPage(items=items, next_token=token or None)
+
+    async def list_wiki_nodes(
+        self,
+        channel_user_id: str,
+        parent_node_id: str,
+        limit: int,
+        next_token: str | None = None,
+    ) -> WikiPage[WikiNode]:
+        """List direct children of a Feishu Wiki space or node.
+
+        Args:
+            channel_user_id (`str`): The sender's Feishu ``open_id``.
+            parent_node_id (`str`): A space id or Wiki node token.
+            limit (`int`): Maximum nodes to return (capped at 50).
+            next_token (`str | None`, optional): Feishu pagination token.
+
+        Returns:
+            `WikiPage[WikiNode]`: One page of child nodes.
+        """
+        query: dict[str, Any] = {"page_size": min(max(limit, 1), 50)}
+        if parent_node_id.startswith("wik"):
+            node = await self._get_wiki_node(
+                channel_user_id,
+                parent_node_id,
+            )
+            space_id = str(node.get("space_id") or "")
+            if not space_id:
+                raise RuntimeError(
+                    "Feishu get Wiki node returned no space id.",
+                )
+            query["parent_node_token"] = parent_node_id
+        else:
+            space_id = parent_node_id
+        if next_token:
+            query["page_token"] = next_token
+        data = await self._user_api(
+            channel_user_id,
+            "list Wiki nodes",
+            "GET",
+            f"/wiki/v2/spaces/{quote(space_id, safe='')}/nodes",
+            query=query,
+        )
+        payload = data.get("data") or {}
+        items = []
+        for item in payload.get("items") or []:
+            node_id = str(item.get("node_token") or "")
+            if not node_id:
+                continue
+            items.append(
+                WikiNode(
+                    node_id=node_id,
+                    name=str(item.get("title") or ""),
+                    has_children=bool(item.get("has_child")),
+                    is_document=item.get("obj_type") == "docx",
+                    url=item.get("node_url") or item.get("url"),
+                    updated_at=self._parse_wiki_time(
+                        item.get("obj_edit_time"),
+                    ),
+                ),
+            )
+        token = payload.get("page_token") if payload.get("has_more") else None
+        return WikiPage(items=items, next_token=token or None)
+
+    async def read_wiki_document(
+        self,
+        channel_user_id: str,
+        node_id: str,
+        start_index: int,
+        max_blocks: int,
+    ) -> WikiDocument | None:
+        """Read a bounded range from a Feishu ``docx`` Wiki node.
+
+        Args:
+            channel_user_id (`str`): The sender's Feishu ``open_id``.
+            node_id (`str`): Feishu Wiki node token.
+            start_index (`int`): Zero-based top-level block index.
+            max_blocks (`int`): Maximum top-level blocks to render.
+
+        Returns:
+            `WikiDocument | None`: Markdown content, or ``None`` for a
+            non-``docx`` node.
+        """
+        node = await self._get_wiki_node(channel_user_id, node_id)
+        if node.get("obj_type") != "docx":
+            return None
+        document_id = str(node.get("obj_token") or "")
+        if not document_id:
+            raise RuntimeError(
+                "Feishu get Wiki node returned no document id.",
+            )
+        markdown, next_index = await self._read_docx_blocks(
+            channel_user_id,
+            document_id,
+            max(start_index, 0),
+            max(max_blocks, 1),
+        )
+        return WikiDocument(
+            node_id=node_id,
+            name=str(node.get("title") or ""),
+            content=[TextBlock(text=markdown)] if markdown else [],
+            next_start_index=next_index,
+        )
+
+    async def _get_wiki_node(
+        self,
+        channel_user_id: str,
+        node_id: str,
+    ) -> dict[str, Any]:
+        """Resolve a Wiki node token to its backing object."""
+        data = await self._user_api(
+            channel_user_id,
+            "get Wiki node",
+            "GET",
+            "/wiki/v2/spaces/get_node",
+            query={"token": node_id},
+        )
+        node = (data.get("data") or {}).get("node")
+        if not isinstance(node, dict):
+            raise RuntimeError("Feishu get Wiki node returned no node.")
+        return node
+
+    @staticmethod
+    def _parse_wiki_time(value: Any) -> datetime | None:
+        """Convert Feishu's epoch value to an aware UTC datetime."""
+        try:
+            stamp = float(value)
+        except (TypeError, ValueError):
+            return None
+        if stamp > 10_000_000_000:
+            stamp /= 1000
+        try:
+            return datetime.fromtimestamp(stamp, timezone.utc)
+        except (OverflowError, OSError, ValueError):
+            return None
+
+    async def _read_docx_blocks(
+        self,
+        channel_user_id: str,
+        document_id: str,
+        start_index: int,
+        max_blocks: int,
+    ) -> tuple[str, int | None]:
+        """Fetch enough flat blocks to render one top-level range."""
+        blocks: dict[str, dict[str, Any]] = {}
+        roots: list[str] | None = None
+        page_token: str | None = None
+        seen_tokens: set[str] = set()
+        while True:
+            query: dict[str, Any] = {"page_size": 500}
+            if page_token:
+                query["page_token"] = page_token
+            data = await self._user_api(
+                channel_user_id,
+                "read Wiki document blocks",
+                "GET",
+                "/docx/v1/documents/" f"{quote(document_id, safe='')}/blocks",
+                query=query,
+            )
+            payload = data.get("data") or {}
+            for block in payload.get("items") or []:
+                block_id = str(block.get("block_id") or "")
+                if not block_id:
+                    continue
+                blocks[block_id] = block
+                if block.get("block_type") == 1:
+                    roots = [str(item) for item in block.get("children") or []]
+
+            selected = (
+                []
+                if roots is None
+                else roots[start_index : start_index + max_blocks]
+            )
+            if roots is not None and self._subtrees_complete(selected, blocks):
+                break
+            if not payload.get("has_more"):
+                if roots is None:
+                    raise RuntimeError(
+                        "Feishu document blocks returned no page block.",
+                    )
+                raise RuntimeError(
+                    "Feishu document blocks returned an incomplete tree.",
+                )
+            page_token = str(payload.get("page_token") or "")
+            if not page_token or page_token in seen_tokens:
+                raise RuntimeError(
+                    "Feishu document block pagination did not advance.",
+                )
+            seen_tokens.add(page_token)
+
+        assert roots is not None
+        selected = roots[start_index : start_index + max_blocks]
+        rendered: list[str] = []
+        returned = 0
+        used = 0
+        for block_id in selected:
+            text = self._render_docx_block(block_id, blocks).strip()
+            separator = 2 if rendered else 0
+            if rendered and used + separator + len(text) > _MAX_DOCUMENT_CHARS:
+                break
+            rendered.append(text)
+            returned += 1
+            used += separator + len(text)
+        current = start_index + returned
+        next_index = current if current < len(roots) else None
+        return "\n\n".join(rendered), next_index
+
+    @classmethod
+    def _subtrees_complete(
+        cls,
+        root_ids: list[str],
+        blocks: dict[str, dict[str, Any]],
+    ) -> bool:
+        """Return whether every referenced descendant has been fetched."""
+        pending = list(root_ids)
+        visited: set[str] = set()
+        while pending:
+            block_id = pending.pop()
+            if block_id in visited:
+                continue
+            block = blocks.get(block_id)
+            if block is None:
+                return False
+            visited.add(block_id)
+            pending.extend(str(item) for item in block.get("children") or [])
+            if block.get("block_type") == 31:
+                pending.extend(
+                    str(item)
+                    for item in (block.get("table") or {}).get("cells") or []
+                )
+        return True
+
+    @classmethod
+    def _render_docx_block(
+        cls,
+        block_id: str,
+        blocks: dict[str, dict[str, Any]],
+        depth: int = 0,
+    ) -> str:
+        """Render one fetched block tree as Markdown."""
+        block = blocks[block_id]
+        raw_block_type = block.get("block_type")
+        block_type = raw_block_type if isinstance(raw_block_type, int) else -1
+        name = _BLOCK_NAMES.get(block_type, str(block_type))
+        if block_type == 31:
+            return cls._render_docx_table(block, blocks)
+        if block_type == 32:
+            children = block.get("children") or []
+            return "\n".join(
+                cls._render_docx_block(str(child), blocks, depth)
+                for child in children
+            )
+        if block_type == 1:
+            return "\n\n".join(
+                cls._render_docx_block(str(child), blocks, depth)
+                for child in block.get("children") or []
+            )
+        if block_type not in set(range(2, 14)) | {15}:
+            return f"[Unsupported block: {name}]"
+
+        text = cls._render_docx_text(block.get(name) or {})
+        if 3 <= block_type <= 11:
+            line = f"{'#' * (block_type - 2)} {text}"
+        elif block_type == 12:
+            line = f"{'  ' * depth}- {text}"
+        elif block_type == 13:
+            line = f"{'  ' * depth}1. {text}"
+        elif block_type == 15:
+            line = "\n".join(f"> {part}" for part in text.splitlines())
+        else:
+            line = text
+        children = [
+            cls._render_docx_block(
+                str(child),
+                blocks,
+                depth + (1 if block_type in (12, 13) else 0),
+            )
+            for child in block.get("children") or []
+        ]
+        return "\n".join([line, *children]).strip()
+
+    @staticmethod
+    def _render_docx_text(detail: dict[str, Any]) -> str:
+        """Render Feishu rich-text elements as Markdown inline text."""
+        parts: list[str] = []
+        for element in detail.get("elements") or []:
+            if "text_run" in element:
+                run = element.get("text_run") or {}
+                content = str(run.get("content") or "")
+                link = (run.get("text_element_style") or {}).get("link")
+                if isinstance(link, dict) and link.get("url"):
+                    content = f"[{content}]({link['url']})"
+                parts.append(content)
+            elif "mention_doc" in element:
+                mention = element.get("mention_doc") or {}
+                title = str(mention.get("title") or "document")
+                url = mention.get("url")
+                parts.append(f"[{title}]({url})" if url else title)
+            elif "mention_user" in element:
+                mention = element.get("mention_user") or {}
+                parts.append("@" + str(mention.get("user_id") or "user"))
+            elif "equation" in element:
+                equation = element.get("equation") or {}
+                parts.append(f"${equation.get('content') or ''}$")
+        return "".join(parts)
+
+    @classmethod
+    def _render_docx_table(
+        cls,
+        block: dict[str, Any],
+        blocks: dict[str, dict[str, Any]],
+    ) -> str:
+        """Render a Feishu table whose cells are row-major block ids."""
+        table = block.get("table") or {}
+        props = table.get("property") or {}
+        rows = int(props.get("row_size") or 0)
+        columns = int(props.get("column_size") or 0)
+        cells = [str(item) for item in table.get("cells") or []]
+        if rows <= 0 or columns <= 0:
+            return "[Unsupported block: table]"
+
+        def _cell(index: int) -> str:
+            if index >= len(cells) or cells[index] not in blocks:
+                return ""
+            value = cls._render_docx_block(cells[index], blocks).strip()
+            return (
+                value.replace("\\", "\\\\")
+                .replace("|", "\\|")
+                .replace("\r\n", "<br>")
+                .replace("\n", "<br>")
+                .replace("\r", "<br>")
+            )
+
+        matrix = [
+            [_cell(row * columns + column) for column in range(columns)]
+            for row in range(rows)
+        ]
+        header = matrix[0]
+        lines = [
+            "| " + " | ".join(header) + " |",
+            "| " + " | ".join("---" for _ in header) + " |",
+        ]
+        lines.extend("| " + " | ".join(row) + " |" for row in matrix[1:])
+        return "\n".join(lines)
+
     # -- Agent-tool operations (act on chats/users other than the current) --
 
     async def send_message_to(
@@ -1165,7 +1608,18 @@ class FeishuChannel(ChannelBase):
         if self._http is not None:
             await self._http.aclose()
             self._http = None
+        if self._device_flow is not None:
+            await self._device_flow.close()
+            self._device_flow = None
         self._token = None
+
+    async def _ensure_http_client(self) -> "httpx.AsyncClient":
+        """Create and return this channel's shared async HTTP client."""
+        if self._http is None:
+            import httpx
+
+            self._http = httpx.AsyncClient(timeout=30.0)
+        return self._http
 
     async def _ensure_ready(self) -> bool:
         """Make the instance able to call the platform, connected or not.
@@ -1195,19 +1649,308 @@ class FeishuChannel(ChannelBase):
 
     async def _refresh_token(self) -> None:
         """Fetch a fresh tenant access token and cache it."""
-        if self._http is None:
-            import httpx
-
-            self._http = httpx.AsyncClient(timeout=30.0)
-        resp = await self._http.post(
+        http = await self._ensure_http_client()
+        resp = await http.post(
             f"{_API}/auth/v3/tenant_access_token/internal",
             json={"app_id": self._app_id, "app_secret": self._app_secret},
         )
         data = resp.json()
+        if not isinstance(data, dict):
+            logger.error("Feishu tenant token refresh returned invalid JSON")
+            return
         if data.get("code") == 0:
             self._token = data.get("tenant_access_token")
         else:
-            logger.error("Feishu token refresh failed: %s", data)
+            logger.error("Feishu tenant token refresh failed")
+
+    async def _user_api(
+        self,
+        channel_user_id: str,
+        operation: str,
+        method: str,
+        path: str,
+        *,
+        query: dict[str, Any] | None = None,
+        body: dict[str, Any] | None = None,
+        _retried: bool = False,
+    ) -> dict[str, Any]:
+        """Call a Feishu endpoint with one sender's access token."""
+        token = await self._require_user_token(channel_user_id)
+        url = f"{_API}{path}"
+        if query:
+            url += "?" + urlencode(query)
+        http = await self._ensure_http_client()
+        try:
+            response = await http.request(
+                method,
+                url,
+                headers={
+                    "Authorization": f"Bearer {token['access_token']}",
+                    "Content-Type": "application/json",
+                },
+                json=body,
+            )
+            data = response.json()
+        except Exception as exc:  # pylint: disable=broad-except
+            raise RuntimeError(
+                f"Feishu {operation} request failed; please try again.",
+            ) from exc
+        if not isinstance(data, dict):
+            raise RuntimeError(
+                f"Feishu {operation} returned an invalid response.",
+            )
+        if data.get("code") == 0:
+            return data
+        code = data.get("code")
+        if code in _TOKEN_EXPIRED_CODES and not _retried:
+            refreshed = await self._refresh_user_token(token)
+            if refreshed is not None:
+                await self._save_user_token(channel_user_id, refreshed)
+            else:
+                await self._delete_user_token(channel_user_id)
+            return await self._user_api(
+                channel_user_id,
+                operation,
+                method,
+                path,
+                query=query,
+                body=body,
+                _retried=True,
+            )
+        message = self._safe_platform_message(data.get("msg"))
+        access_token = str(token.get("access_token") or "")
+        if access_token:
+            message = message.replace(access_token, "[redacted]")
+        raise RuntimeError(
+            f"Feishu {operation} failed (code {code}): {message}",
+        )
+
+    async def _require_user_token(
+        self,
+        channel_user_id: str,
+    ) -> dict[str, Any]:
+        """Load, refresh, or interactively obtain a user access token."""
+        if self._storage is None:
+            raise RuntimeError(
+                "Feishu Wiki authorization storage is unavailable.",
+            )
+        lock = self._user_auth_locks.setdefault(
+            channel_user_id,
+            asyncio.Lock(),
+        )
+        async with lock:
+            try:
+                token = await self._storage.get_channel_user_credentials(
+                    self._channel_id,
+                    channel_user_id,
+                )
+            except NotImplementedError as exc:
+                raise RuntimeError(
+                    "The configured storage backend does not support "
+                    "Feishu Wiki authorization.",
+                ) from exc
+            if (
+                token
+                and token.get("open_id") == channel_user_id
+                and self._token_scopes_valid(token)
+            ):
+                expires_at = self._number(token.get("expires_at"))
+                if (
+                    expires_at is None
+                    or expires_at - time.time() > _USER_TOKEN_REFRESH_SLACK
+                ):
+                    return token
+                refreshed = await self._refresh_user_token(token)
+                if refreshed is not None:
+                    await self._save_user_token(channel_user_id, refreshed)
+                    return refreshed
+                await self._delete_user_token(channel_user_id)
+            elif token:
+                await self._delete_user_token(channel_user_id)
+            return await self._authorize_user(channel_user_id)
+
+    def _token_scopes_valid(self, token: dict[str, Any]) -> bool:
+        """Return whether a stored token has every required Wiki scope."""
+        raw = token.get("scopes") or []
+        if isinstance(raw, str):
+            scopes = set(raw.replace(",", " ").split())
+        else:
+            scopes = {str(item) for item in raw}
+        return _WIKI_SCOPES.issubset(scopes) and bool(
+            token.get("access_token"),
+        )
+
+    async def _refresh_user_token(
+        self,
+        token: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        """Refresh a near-expiry user token, returning ``None`` on failure."""
+        refresh_token = str(token.get("refresh_token") or "")
+        refresh_expires_at = self._number(token.get("refresh_expires_at"))
+        if not refresh_token or (
+            refresh_expires_at is not None
+            and refresh_expires_at <= time.time()
+        ):
+            return None
+        try:
+            client = self._get_device_flow_client()
+            refreshed = await client.refresh(refresh_token)
+        except Exception:  # pylint: disable=broad-except
+            return None
+        value = dict(refreshed)
+        if not value.get("scopes"):
+            value["scopes"] = token.get("scopes") or []
+        if not value.get("refresh_token"):
+            value["refresh_token"] = refresh_token
+        if not value.get("refresh_expires_at"):
+            value["refresh_expires_at"] = refresh_expires_at
+        if not value.get("open_id"):
+            value["open_id"] = token.get("open_id") or ""
+        return value if self._token_scopes_valid(value) else None
+
+    async def _authorize_user(
+        self,
+        channel_user_id: str,
+    ) -> dict[str, Any]:
+        """Run Feishu's device flow and verify the authorized identity."""
+        try:
+            client = self._get_device_flow_client()
+            request = await client.start(sorted(_WIKI_SCOPES))
+            verification_uri = str(
+                request.get("verification_uri_complete")
+                or request.get("verification_uri")
+                or "",
+            )
+            user_code = str(request.get("user_code") or "")
+            device_code = str(request.get("device_code") or "")
+            expires_in = int(request.get("expires_in") or 0)
+            interval = int(request.get("interval") or 5)
+            if not verification_uri or not device_code or expires_in <= 0:
+                raise RuntimeError(
+                    "Feishu returned an invalid authorization request.",
+                )
+            sent = await self._api(
+                "POST",
+                f"{_API}/im/v1/messages?receive_id_type=open_id",
+                {
+                    "receive_id": channel_user_id,
+                    "msg_type": "interactive",
+                    "content": _build_user_auth_card(
+                        verification_uri,
+                        user_code,
+                        expires_in,
+                    ),
+                },
+            )
+            if not sent or sent.get("code") != 0:
+                raise RuntimeError(
+                    "Could not send the Feishu authorization card.",
+                )
+            result = await client.poll(
+                device_code,
+                interval=interval,
+                timeout_seconds=expires_in,
+            )
+            value = dict(result)
+            if not value.get("scopes"):
+                value["scopes"] = sorted(_WIKI_SCOPES)
+            actual_open_id = await self._get_user_open_id(value)
+            if actual_open_id != channel_user_id:
+                raise RuntimeError(
+                    "The authorized Feishu account does not match the "
+                    "message sender. Please authorize with the same account.",
+                )
+            value["open_id"] = actual_open_id
+            await self._save_user_token(channel_user_id, value)
+            return value
+        except RuntimeError:
+            raise
+        except Exception as exc:  # pylint: disable=broad-except
+            raise RuntimeError(
+                "Feishu Wiki authorization was denied, expired, or failed. "
+                "Please call the tool again to retry.",
+            ) from exc
+
+    async def _get_user_open_id(self, token: dict[str, Any]) -> str:
+        """Read the identity associated with a freshly issued token."""
+        http = await self._ensure_http_client()
+        try:
+            response = await http.get(
+                f"{_API}/authen/v1/user_info",
+                headers={
+                    "Authorization": f"Bearer {token['access_token']}",
+                },
+            )
+            data = response.json()
+        except Exception as exc:  # pylint: disable=broad-except
+            raise RuntimeError(
+                "Feishu authorization identity verification failed.",
+            ) from exc
+        if data.get("code") != 0:
+            raise RuntimeError(
+                "Feishu authorization identity verification failed.",
+            )
+        return str((data.get("data") or {}).get("open_id") or "")
+
+    def _get_device_flow_client(self) -> Any:
+        """Create the Feishu device-flow client lazily."""
+        if self._device_flow is None:
+            self._device_flow = _FeishuDeviceFlowClient(
+                self._app_id,
+                self._app_secret,
+            )
+        return self._device_flow
+
+    async def _save_user_token(
+        self,
+        channel_user_id: str,
+        token: dict[str, Any],
+    ) -> None:
+        """Persist a token without its SDK raw response."""
+        assert self._storage is not None
+        try:
+            await self._storage.upsert_channel_user_credentials(
+                self._channel_id,
+                channel_user_id,
+                token,
+            )
+        except NotImplementedError as exc:
+            raise RuntimeError(
+                "The configured storage backend does not support "
+                "Feishu Wiki authorization.",
+            ) from exc
+        except Exception:  # pylint: disable=broad-except
+            raise RuntimeError(
+                "Could not securely save Feishu Wiki authorization.",
+            ) from None
+
+    async def _delete_user_token(self, channel_user_id: str) -> None:
+        """Discard a stale user token without exposing its value."""
+        assert self._storage is not None
+        try:
+            await self._storage.delete_channel_user_credentials(
+                self._channel_id,
+                channel_user_id,
+            )
+        except NotImplementedError as exc:
+            raise RuntimeError(
+                "The configured storage backend does not support "
+                "Feishu Wiki authorization.",
+            ) from exc
+
+    @staticmethod
+    def _number(value: Any) -> float | None:
+        """Convert a timestamp-like value to a float when possible."""
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _safe_platform_message(value: Any) -> str:
+        """Bound and sanitize a platform error message for tool output."""
+        message = str(value or "unknown platform error")
+        return message.replace("\r", " ").replace("\n", " ")[:300]
 
     async def _api(
         self,

--- a/src/agentscope/app/channel/_feishu/_user_oauth.py
+++ b/src/agentscope/app/channel/_feishu/_user_oauth.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+"""Feishu user OAuth used by Wiki tools."""
+import asyncio
+import time
+from typing import Any
+
+
+_DEVICE_URL = "https://accounts.feishu.cn/oauth/v1/device_authorization"
+_TOKEN_URL = "https://open.feishu.cn/open-apis/authen/v2/oauth/token"
+
+
+class _FeishuDeviceFlowClient:
+    """Small replacement for the SDK's broken device-flow helper."""
+
+    def __init__(
+        self,
+        app_id: str,
+        app_secret: str,
+        *,
+        http_client: Any = None,
+    ) -> None:
+        """Initialize with application credentials and an optional client."""
+        self._app_id = app_id
+        self._app_secret = app_secret
+        self._http = http_client
+        self._owns_http = http_client is None
+
+    async def close(self) -> None:
+        """Close the internally created HTTP client."""
+        if self._http is not None and self._owns_http:
+            await self._http.aclose()
+            self._http = None
+
+    async def start(self, scopes: list[str]) -> dict[str, Any]:
+        """Start device authorization and return browser instructions."""
+        payload = await self._post(
+            _DEVICE_URL,
+            {
+                "client_id": self._app_id,
+                "scope": " ".join(sorted({*scopes, "offline_access"})),
+            },
+            auth=(self._app_id, self._app_secret),
+        )
+        return {
+            "verification_uri": payload.get("verification_uri", ""),
+            "verification_uri_complete": payload.get(
+                "verification_uri_complete",
+                payload.get("verification_uri", ""),
+            ),
+            "user_code": payload.get("user_code", ""),
+            "device_code": payload.get("device_code", ""),
+            "expires_in": int(payload.get("expires_in") or 0),
+            "interval": int(payload.get("interval") or 5),
+        }
+
+    async def poll(
+        self,
+        device_code: str,
+        *,
+        interval: int = 5,
+        timeout_seconds: int = 600,
+    ) -> dict[str, Any]:
+        """Poll until the user grants authorization or it expires."""
+        deadline = time.monotonic() + timeout_seconds
+        delay = max(interval, 1)
+        while time.monotonic() < deadline:
+            payload = await self._post(
+                _TOKEN_URL,
+                {
+                    "grant_type": (
+                        "urn:ietf:params:oauth:grant-type:device_code"
+                    ),
+                    "device_code": device_code,
+                    "client_id": self._app_id,
+                    "client_secret": self._app_secret,
+                },
+                pending=True,
+            )
+            error = payload.get("error")
+            if not error:
+                return self._token(payload)
+            if error == "slow_down":
+                delay += 2
+            await asyncio.sleep(delay)
+        raise RuntimeError("Feishu device authorization timed out.")
+
+    async def refresh(self, refresh_token: str) -> dict[str, Any]:
+        """Refresh a user token."""
+        return self._token(
+            await self._post(
+                _TOKEN_URL,
+                {
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                    "client_id": self._app_id,
+                    "client_secret": self._app_secret,
+                },
+            ),
+        )
+
+    async def _post(
+        self,
+        url: str,
+        data: dict[str, str],
+        *,
+        auth: tuple[str, str] | None = None,
+        pending: bool = False,
+    ) -> dict[str, Any]:
+        """Send one form-encoded OAuth request."""
+        if self._http is None:
+            import httpx
+
+            self._http = httpx.AsyncClient(timeout=30.0)
+        try:
+            response = await self._http.post(url, data=data, auth=auth)
+            payload = response.json()
+        except Exception as exc:  # pylint: disable=broad-except
+            raise RuntimeError(
+                "Feishu user authorization request failed.",
+            ) from exc
+        if not isinstance(payload, dict):
+            raise RuntimeError("Feishu authorization returned invalid data.")
+        payload = payload.get("data") or payload
+        error = str(payload.get("error") or "")
+        allowed = pending and error in {"authorization_pending", "slow_down"}
+        if error and not allowed:
+            raise RuntimeError(f"Feishu user authorization failed: {error}.")
+        if payload.get("code") not in (None, 0) and not error:
+            raise RuntimeError("Feishu user authorization failed.")
+        return payload
+
+    @staticmethod
+    def _token(payload: dict[str, Any]) -> dict[str, Any]:
+        """Convert a token response to the shape used by the channel."""
+        if not payload.get("access_token"):
+            raise RuntimeError("Feishu authorization returned no token.")
+        now = time.time()
+        expires_in = int(payload.get("expires_in") or 0)
+        refresh_expires_in = int(
+            payload.get("refresh_token_expires_in") or 0,
+        )
+        return {
+            "access_token": str(payload["access_token"]),
+            "refresh_token": str(payload.get("refresh_token") or ""),
+            "expires_at": now + expires_in if expires_in else None,
+            "refresh_expires_at": (
+                now + refresh_expires_in if refresh_expires_in else None
+            ),
+            "scopes": str(payload.get("scope") or "")
+            .replace(",", " ")
+            .split(),
+            "open_id": "",
+        }

--- a/src/agentscope/app/channel/_tools/_base.py
+++ b/src/agentscope/app/channel/_tools/_base.py
@@ -21,6 +21,7 @@ class _WikiToolBase(ToolBase):
     is_concurrency_safe: bool = False
     is_state_injected: bool = False
     is_external_tool: bool = False
+    can_offload: bool = False
     is_mcp: bool = False
     mcp_name: str | None = None
 

--- a/src/agentscope/app/middleware/_tool_offload_middleware.py
+++ b/src/agentscope/app/middleware/_tool_offload_middleware.py
@@ -125,8 +125,9 @@ class ToolOffloadMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
           the agent of the background task id is yielded instead.
 
         .. note::
-            Tools with ``is_state_injected=True`` or ``is_external_tool=True``
-            bypass this logic and are always executed synchronously.
+            Tools with ``is_state_injected=True``, ``is_external_tool=True``,
+            or ``can_offload=False`` bypass this logic and are always
+            executed synchronously.
 
         Args:
             agent (`Agent`):
@@ -144,7 +145,7 @@ class ToolOffloadMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
         tool_call = input_kwargs["tool_call"]
 
         # ----------------------------------------------------------------
-        # Guard: state-injected tools and external tools are never offloaded.
+        # Guard tools whose execution must remain attached to the current run.
         # - is_state_injected: the tool receives the live agent.state object;
         #   running it concurrently in a background task could cause race
         #   conditions on agent.state. For now, we fall back to synchronous
@@ -155,7 +156,9 @@ class ToolOffloadMiddleware(MiddlewareBase):  # pylint: disable=abstract-method
         #   agent would lose track of the pending confirmation.
         tool = await agent.toolkit.get_tool(tool_call.name)
         if tool is not None and (
-            tool.is_state_injected or tool.is_external_tool
+            tool.is_state_injected
+            or tool.is_external_tool
+            or not tool.can_offload
         ):
             async for item in next_handler(**input_kwargs):
                 yield item

--- a/src/agentscope/app/storage/_base.py
+++ b/src/agentscope/app/storage/_base.py
@@ -727,6 +727,62 @@ class StorageBase(ABC):
             "This storage backend has no channel support.",
         )
 
+    async def get_channel_user_credentials(
+        self,
+        channel_id: str,
+        channel_user_id: str,
+    ) -> dict[str, Any] | None:
+        """Fetch credentials held for one user of a channel.
+
+        This optional capability lets a channel persist user-scoped OAuth
+        tokens without exposing them through channel management records.
+
+        Args:
+            channel_id (`str`): The channel instance id.
+            channel_user_id (`str`): The platform-side user id.
+
+        Returns:
+            `dict[str, Any] | None`: Stored credentials, or ``None``.
+        """
+        raise NotImplementedError(
+            "This storage backend has no channel-user credential support.",
+        )
+
+    async def upsert_channel_user_credentials(
+        self,
+        channel_id: str,
+        channel_user_id: str,
+        credentials: dict[str, Any],
+    ) -> None:
+        """Insert or replace credentials for one channel user.
+
+        Args:
+            channel_id (`str`): The channel instance id.
+            channel_user_id (`str`): The platform-side user id.
+            credentials (`dict[str, Any]`): Secret credential payload.
+        """
+        raise NotImplementedError(
+            "This storage backend has no channel-user credential support.",
+        )
+
+    async def delete_channel_user_credentials(
+        self,
+        channel_id: str,
+        channel_user_id: str,
+    ) -> bool:
+        """Delete credentials held for one user of a channel.
+
+        Args:
+            channel_id (`str`): The channel instance id.
+            channel_user_id (`str`): The platform-side user id.
+
+        Returns:
+            `bool`: Whether a credential record was deleted.
+        """
+        raise NotImplementedError(
+            "This storage backend has no channel-user credential support.",
+        )
+
     # ------------------------------------------------------------------
     # Message persistence
     # ------------------------------------------------------------------

--- a/src/agentscope/app/storage/_redis_storage.py
+++ b/src/agentscope/app/storage/_redis_storage.py
@@ -2,6 +2,7 @@
 # pylint: disable=too-many-public-methods
 """The Redis storage implementation."""
 
+import json
 import warnings
 from datetime import datetime, timedelta
 from typing import Any, TYPE_CHECKING, Self
@@ -112,6 +113,13 @@ class RedisStorage(StorageBase):
         channel_botid_index: str = "agentscope:channel_botid:{platform_bot_id}"
         channel_session_index: str = (
             "agentscope:user:{user_id}:channel:{channel_id}:sessions"
+        )
+        channel_user_credential: str = (
+            "agentscope:channel:{channel_id}:user_credential:"
+            "{channel_user_id}"
+        )
+        channel_user_credential_index: str = (
+            "agentscope:channel:{channel_id}:user_credentials"
         )
 
         team: str = "agentscope:user:{user_id}:team:{team_id}"
@@ -1386,6 +1394,23 @@ class RedisStorage(StorageBase):
         """Delete a channel record and clean up all indexes."""
         key = self._key(self.key_config.channel, channel_id=channel_id)
         raw = await self._client.get(key)
+        credential_index = self._key(
+            self.key_config.channel_user_credential_index,
+            channel_id=channel_id,
+        )
+        channel_users = await self._client.smembers(credential_index)
+        credential_keys = [
+            self._key(
+                self.key_config.channel_user_credential,
+                channel_id=channel_id,
+                channel_user_id=channel_user_id,
+            )
+            for channel_user_id in channel_users
+        ]
+        if credential_keys:
+            await self._client.delete(*credential_keys)
+        await self._client.delete(credential_index)
+
         if not raw:
             return False
         record = ChannelRecord.model_validate_json(raw)
@@ -1406,6 +1431,63 @@ class RedisStorage(StorageBase):
             ),
         )
         return True
+
+    async def get_channel_user_credentials(
+        self,
+        channel_id: str,
+        channel_user_id: str,
+    ) -> dict[str, Any] | None:
+        """Fetch credentials for one channel user."""
+        raw = await self._client.get(
+            self._key(
+                self.key_config.channel_user_credential,
+                channel_id=channel_id,
+                channel_user_id=channel_user_id,
+            ),
+        )
+        if not raw:
+            return None
+        value = json.loads(raw)
+        return value if isinstance(value, dict) else None
+
+    async def upsert_channel_user_credentials(
+        self,
+        channel_id: str,
+        channel_user_id: str,
+        credentials: dict[str, Any],
+    ) -> None:
+        """Insert or replace credentials for one channel user."""
+        key = self._key(
+            self.key_config.channel_user_credential,
+            channel_id=channel_id,
+            channel_user_id=channel_user_id,
+        )
+        index = self._key(
+            self.key_config.channel_user_credential_index,
+            channel_id=channel_id,
+        )
+        await self._set_with_ttl(key, json.dumps(credentials))
+        await self._client.sadd(index, channel_user_id)
+        await self._refresh_key_ttl(index)
+
+    async def delete_channel_user_credentials(
+        self,
+        channel_id: str,
+        channel_user_id: str,
+    ) -> bool:
+        """Delete credentials for one channel user."""
+        key = self._key(
+            self.key_config.channel_user_credential,
+            channel_id=channel_id,
+            channel_user_id=channel_user_id,
+        )
+        index = self._key(
+            self.key_config.channel_user_credential_index,
+            channel_id=channel_id,
+        )
+        deleted = await self._client.delete(key)
+        await self._client.srem(index, channel_user_id)
+        return bool(deleted)
 
     async def get_channel_id_by_platform_bot_id(
         self,

--- a/src/agentscope/app/storage/_sql/_alembic/versions/0004_channel_user_credentials.py
+++ b/src/agentscope/app/storage/_sql/_alembic/versions/0004_channel_user_credentials.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""Channel-user OAuth credential table.
+
+Revision ID: 0004_channel_user_credentials
+Revises: 0003_channels
+Create Date: 2026-09-12 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0004_channel_user_credentials"
+down_revision: Union[str, None] = "0003_channels"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+VERSION_TIMESTAMP = sa.DateTime().with_variant(
+    mysql.DATETIME(fsp=6),
+    "mysql",
+    "mariadb",
+)
+
+
+def upgrade() -> None:
+    """Create the ``channel_user_credentials`` table."""
+    op.create_table(
+        "channel_user_credentials",
+        sa.Column("channel_id", sa.String(length=255), nullable=False),
+        sa.Column("channel_user_id", sa.String(length=255), nullable=False),
+        sa.Column("credentials", sa.JSON(), nullable=False),
+        sa.Column("updated_at", VERSION_TIMESTAMP, nullable=False),
+        sa.ForeignKeyConstraint(
+            ["channel_id"],
+            ["channels.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("channel_id", "channel_user_id"),
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``channel_user_credentials`` table."""
+    op.drop_table("channel_user_credentials")

--- a/src/agentscope/app/storage/_sql/_storage.py
+++ b/src/agentscope/app/storage/_sql/_storage.py
@@ -42,6 +42,7 @@ from ._tables import (
     _Base,
     AgentRow,
     ChannelRow,
+    ChannelUserCredentialRow,
     CredentialRow,
     KnowledgeBaseRow,
     KnowledgeDocumentRow,
@@ -1480,8 +1481,68 @@ class AsyncSQLAlchemyStorage(StorageBase):
 
         _ = platform_bot_id
         async with self._session() as sess:
+            await sess.execute(
+                delete(ChannelUserCredentialRow).where(
+                    ChannelUserCredentialRow.channel_id == channel_id,
+                ),
+            )
             result = await sess.execute(
                 delete(ChannelRow).where(ChannelRow.id == channel_id),
+            )
+            await sess.commit()
+        return result.rowcount > 0
+
+    async def get_channel_user_credentials(
+        self,
+        channel_id: str,
+        channel_user_id: str,
+    ) -> dict[str, Any] | None:
+        """Fetch credentials for one channel user."""
+        async with self._session() as sess:
+            row = await sess.get(
+                ChannelUserCredentialRow,
+                (channel_id, channel_user_id),
+            )
+        return None if row is None else dict(row.credentials)
+
+    async def upsert_channel_user_credentials(
+        self,
+        channel_id: str,
+        channel_user_id: str,
+        credentials: dict[str, Any],
+    ) -> None:
+        """Atomically insert or replace credentials for a channel user."""
+        values = {
+            "channel_id": channel_id,
+            "channel_user_id": channel_user_id,
+            "credentials": dict(credentials),
+            "updated_at": _utcnow(),
+        }
+        stmt = self._upsert_stmt(
+            ChannelUserCredentialRow,
+            values,
+            ["channel_id", "channel_user_id"],
+            ("credentials", "updated_at"),
+        )
+        async with self._session() as sess:
+            await sess.execute(stmt)
+            await sess.commit()
+
+    async def delete_channel_user_credentials(
+        self,
+        channel_id: str,
+        channel_user_id: str,
+    ) -> bool:
+        """Delete credentials for one channel user."""
+        from sqlalchemy import delete
+
+        async with self._session() as sess:
+            result = await sess.execute(
+                delete(ChannelUserCredentialRow).where(
+                    ChannelUserCredentialRow.channel_id == channel_id,
+                    ChannelUserCredentialRow.channel_user_id
+                    == channel_user_id,
+                ),
             )
             await sess.commit()
         return result.rowcount > 0

--- a/src/agentscope/app/storage/_sql/_tables.py
+++ b/src/agentscope/app/storage/_sql/_tables.py
@@ -396,6 +396,27 @@ class ChannelRow(_JsonRecordMixin):
     _indexed_fields = ("user_id",)
 
 
+class ChannelUserCredentialRow(_Base):
+    """Secret OAuth credentials for one platform user and channel."""
+
+    __tablename__ = "channel_user_credentials"
+
+    channel_id: Mapped[str] = mapped_column(
+        String(_ID_LEN),
+        ForeignKey("channels.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    channel_user_id: Mapped[str] = mapped_column(
+        String(_ID_LEN),
+        primary_key=True,
+    )
+    credentials: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime().with_variant(_MySQLDateTime(fsp=6), "mysql", "mariadb"),
+        nullable=False,
+    )
+
+
 class MessageRow(_Base):
     """One row per persisted :class:`~agentscope.message.Msg`.
 

--- a/src/agentscope/tool/_base.py
+++ b/src/agentscope/tool/_base.py
@@ -118,6 +118,8 @@ class ToolBase(ABC):
     the state will be injected by an argument named `_agent_state`. Note your
     tool should be able to accept such argument.
     """
+    can_offload: bool = True
+    """Whether a long-running call may continue as a background task."""
     metadata_schema: dict[str, Any] | None = None
     """What an external executor must put in
     :attr:`~..message.ToolResultBlock.metadata`, as a JSON schema.

--- a/tests/channel_clients_test.py
+++ b/tests/channel_clients_test.py
@@ -63,6 +63,11 @@ class _FakeChannel(ChannelBase):
         self.closed = False
         self.sent_to = ""
         self.returned = False
+        self.storage: Any = None
+
+    def _bind_storage(self, storage: Any) -> None:
+        """Record the internal storage binding."""
+        self.storage = storage
 
     @property
     def channel_id(self) -> str:
@@ -139,13 +144,15 @@ class ChannelClientsTest(IsolatedAsyncioTestCase):
     async def test_builds_without_opening_a_connection(self) -> None:
         """The instance is usable but never listened — that is what lets
         it live in a process that holds no connection."""
-        clients = self._clients(_Storage(_record()))
+        storage = _Storage(_record())
+        clients = self._clients(storage)
 
         channel = await clients.get("chan-1")
 
         self.assertIsInstance(channel, _FakeChannel)
         self.assertFalse(channel.listened)
         self.assertEqual(channel.bot_id, "bot-1")
+        self.assertIs(channel.storage, storage)
 
     async def test_cached_until_the_record_changes(self) -> None:
         """A rotated credential takes effect without a restart."""

--- a/tests/channel_feishu_wiki_test.py
+++ b/tests/channel_feishu_wiki_test.py
@@ -1,0 +1,585 @@
+# -*- coding: utf-8 -*-
+"""Tests for Feishu user OAuth and Wiki browsing."""
+
+# pylint: disable=protected-access
+import time
+from datetime import timezone
+from types import SimpleNamespace
+from typing import Any
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+from agentscope.app.channel._feishu import FeishuChannel
+from agentscope.app.channel._feishu._user_oauth import (
+    _FeishuDeviceFlowClient,
+)
+
+_SCOPES = [
+    "docx:document:readonly",
+    "wiki:node:read",
+    "wiki:node:retrieve",
+    "wiki:space:retrieve",
+]
+
+
+class _Storage:
+    """Minimal channel-user credential storage fake."""
+
+    def __init__(self) -> None:
+        self.values: dict[tuple[str, str], dict[str, Any]] = {}
+
+    async def get_channel_user_credentials(
+        self,
+        channel_id: str,
+        channel_user_id: str,
+    ) -> dict[str, Any] | None:
+        """Return stored credentials for one channel user."""
+        return self.values.get((channel_id, channel_user_id))
+
+    async def upsert_channel_user_credentials(
+        self,
+        channel_id: str,
+        channel_user_id: str,
+        credentials: dict[str, Any],
+    ) -> None:
+        """Insert or replace credentials for one channel user."""
+        self.values[(channel_id, channel_user_id)] = credentials
+
+    async def delete_channel_user_credentials(
+        self,
+        channel_id: str,
+        channel_user_id: str,
+    ) -> bool:
+        """Delete credentials for one channel user."""
+        return self.values.pop((channel_id, channel_user_id), None) is not None
+
+
+class _Response:
+    """Small httpx response stand-in."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    def json(self) -> dict[str, Any]:
+        """Return the scripted JSON body."""
+        return self._data
+
+
+def _channel() -> FeishuChannel:
+    """Build a Feishu channel without opening network resources."""
+    return FeishuChannel(
+        "channel-1",
+        FeishuChannel.Credentials(app_id="app", app_secret="secret"),
+        FeishuChannel.Config(),
+    )
+
+
+def _valid_token(value: str = "user-token") -> dict[str, Any]:
+    """Build a non-expiring-enough stored user token."""
+    return {
+        "access_token": value,
+        "refresh_token": "refresh",
+        "expires_at": time.time() + 3600,
+        "refresh_expires_at": time.time() + 7200,
+        "scopes": _SCOPES,
+        "open_id": "ou-user",
+    }
+
+
+class FeishuWikiTest(IsolatedAsyncioTestCase):
+    """Exercise Feishu's sender-scoped Wiki implementation."""
+
+    async def test_user_api_uses_stored_user_token(self) -> None:
+        """Wiki REST calls never reuse the tenant token."""
+        channel = _channel()
+        storage = _Storage()
+        storage.values[("channel-1", "ou-user")] = _valid_token()
+        channel._bind_storage(storage)  # type: ignore[arg-type]
+        channel._token = "tenant-token"
+        http = SimpleNamespace(
+            request=AsyncMock(return_value=_Response({"code": 0, "data": {}})),
+        )
+        channel._http = http
+
+        await channel._user_api(
+            "ou-user",
+            "list Wiki spaces",
+            "GET",
+            "/wiki/v2/spaces",
+        )
+
+        headers = http.request.await_args.kwargs["headers"]
+        self.assertEqual(headers["Authorization"], "Bearer user-token")
+        self.assertNotIn("tenant-token", str(http.request.await_args))
+
+    async def test_wiki_tools_require_a_trusted_sender(self) -> None:
+        """Generic Wiki tools load only when a sender id is available."""
+        channel = _channel()
+        workspace = SimpleNamespace(get_backend=lambda: None)
+
+        without_sender = await channel.list_tools(workspace)
+        with_sender = await channel.list_tools(workspace, "ou-user")
+        channel.capabilities = channel.capabilities.model_copy(
+            update={"wiki": False},
+        )
+        disabled = await channel.list_tools(workspace, "ou-user")
+
+        self.assertEqual(len(without_sender), 5)
+        self.assertEqual(len(with_sender), 8)
+        self.assertEqual(len(disabled), 5)
+
+    async def test_near_expiry_token_is_refreshed_and_saved(self) -> None:
+        """User tokens are refreshed five minutes before expiry."""
+        channel = _channel()
+        storage = _Storage()
+        token = _valid_token("old-token")
+        token["expires_at"] = time.time() + 20
+        storage.values[("channel-1", "ou-user")] = token
+        channel._bind_storage(storage)  # type: ignore[arg-type]
+        channel._device_flow = SimpleNamespace(
+            refresh=AsyncMock(
+                return_value={
+                    "access_token": "new-token",
+                    "refresh_token": "new-refresh",
+                    "expires_at": time.time() + 3600,
+                    "refresh_expires_at": time.time() + 7200,
+                    "scopes": _SCOPES,
+                    "open_id": "",
+                },
+            ),
+        )
+
+        refreshed = await channel._require_user_token("ou-user")
+
+        self.assertEqual(refreshed["access_token"], "new-token")
+        self.assertEqual(refreshed["open_id"], "ou-user")
+        self.assertEqual(
+            storage.values[("channel-1", "ou-user")]["access_token"],
+            "new-token",
+        )
+
+    async def test_invalid_token_reauthorizes_once(self) -> None:
+        """An API invalid-token response clears state and retries once."""
+        channel = _channel()
+        storage = _Storage()
+        storage.values[("channel-1", "ou-user")] = _valid_token("old-token")
+        channel._bind_storage(storage)  # type: ignore[arg-type]
+        channel._authorize_user = AsyncMock(
+            return_value={**_valid_token("new-token")},
+        )
+        channel._device_flow = SimpleNamespace(
+            refresh=AsyncMock(side_effect=RuntimeError("refresh failed")),
+        )
+        http = SimpleNamespace(
+            request=AsyncMock(
+                side_effect=[
+                    _Response({"code": 99991671, "msg": "invalid"}),
+                    _Response({"code": 0, "data": {"items": []}}),
+                ],
+            ),
+        )
+        channel._http = http
+
+        result = await channel._user_api(
+            "ou-user",
+            "list Wiki spaces",
+            "GET",
+            "/wiki/v2/spaces",
+        )
+
+        self.assertEqual(result["code"], 0)
+        self.assertEqual(channel._authorize_user.await_count, 1)
+        first = http.request.await_args_list[0].kwargs["headers"]
+        second = http.request.await_args_list[1].kwargs["headers"]
+        self.assertEqual(first["Authorization"], "Bearer old-token")
+        self.assertEqual(second["Authorization"], "Bearer new-token")
+
+    async def test_invalid_token_refreshes_before_reauthorizing(self) -> None:
+        """An expired API token is refreshed without another device flow."""
+        channel = _channel()
+        storage = _Storage()
+        storage.values[("channel-1", "ou-user")] = _valid_token("old-token")
+        channel._bind_storage(storage)  # type: ignore[arg-type]
+        refreshed = _valid_token("new-token")
+        channel._device_flow = SimpleNamespace(
+            refresh=AsyncMock(return_value=refreshed),
+        )
+        channel._authorize_user = AsyncMock()
+        channel._http = SimpleNamespace(
+            request=AsyncMock(
+                side_effect=[
+                    _Response({"code": 99991668, "msg": "expired"}),
+                    _Response({"code": 0, "data": {"items": []}}),
+                ],
+            ),
+        )
+
+        result = await channel._user_api(
+            "ou-user",
+            "list Wiki spaces",
+            "GET",
+            "/wiki/v2/spaces",
+        )
+
+        self.assertEqual(result["code"], 0)
+        channel._authorize_user.assert_not_awaited()
+        self.assertEqual(
+            storage.values[("channel-1", "ou-user")]["access_token"],
+            "new-token",
+        )
+
+    async def test_list_spaces_maps_page(self) -> None:
+        """Space ids double as browsing roots and pagination is bounded."""
+        channel = _channel()
+        channel._user_api = AsyncMock(
+            return_value={
+                "code": 0,
+                "data": {
+                    "items": [
+                        {
+                            "space_id": "spc-1",
+                            "name": "Engineering",
+                            "description": "Docs",
+                        },
+                    ],
+                    "has_more": True,
+                    "page_token": "next",
+                },
+            },
+        )
+
+        page = await channel.list_wiki_spaces("ou-user", 100)
+
+        self.assertEqual(page.items[0].root_node_id, "spc-1")
+        self.assertIsNone(page.items[0].url)
+        self.assertEqual(page.next_token, "next")
+        self.assertEqual(
+            channel._user_api.await_args.kwargs["query"]["page_size"],
+            50,
+        )
+
+    async def test_nested_node_resolves_space_and_maps_fields(self) -> None:
+        """A Wiki node token is resolved before listing its children."""
+        channel = _channel()
+        channel._get_wiki_node = AsyncMock(
+            return_value={"space_id": "spc-1"},
+        )
+        channel._user_api = AsyncMock(
+            return_value={
+                "code": 0,
+                "data": {
+                    "items": [
+                        {
+                            "node_token": "wik-child",
+                            "title": "Roadmap",
+                            "has_child": True,
+                            "obj_type": "docx",
+                            "node_url": "https://example.test/wiki",
+                            "obj_edit_time": "1700000000",
+                        },
+                    ],
+                    "has_more": False,
+                },
+            },
+        )
+
+        page = await channel.list_wiki_nodes("ou-user", "wik-parent", 20)
+
+        node = page.items[0]
+        self.assertTrue(node.has_children)
+        self.assertTrue(node.is_document)
+        self.assertEqual(node.updated_at.tzinfo, timezone.utc)
+        call = channel._user_api.await_args
+        self.assertIn("/spaces/spc-1/nodes", call.args[3])
+        self.assertEqual(
+            call.kwargs["query"]["parent_node_token"],
+            "wik-parent",
+        )
+
+    async def test_read_document_paginates_and_renders_markdown(self) -> None:
+        """Flat block pages become ordered Markdown block trees."""
+        channel = _channel()
+        channel._get_wiki_node = AsyncMock(
+            return_value={
+                "obj_type": "docx",
+                "obj_token": "doc/1",
+                "title": "Guide",
+            },
+        )
+        pages = [
+            {
+                "code": 0,
+                "data": {
+                    "items": [
+                        {
+                            "block_id": "page",
+                            "block_type": 1,
+                            "children": ["heading", "list", "table"],
+                        },
+                        {
+                            "block_id": "heading",
+                            "block_type": 3,
+                            "heading1": {
+                                "elements": [
+                                    {"text_run": {"content": "Title"}},
+                                ],
+                            },
+                        },
+                    ],
+                    "has_more": True,
+                    "page_token": "p2",
+                },
+            },
+            {
+                "code": 0,
+                "data": {
+                    "items": [
+                        {
+                            "block_id": "list",
+                            "block_type": 12,
+                            "bullet": {
+                                "elements": [
+                                    {
+                                        "text_run": {
+                                            "content": "linked",
+                                            "text_element_style": {
+                                                "link": {
+                                                    "url": (
+                                                        "https://example.test"
+                                                    ),
+                                                },
+                                            },
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                        {
+                            "block_id": "table",
+                            "block_type": 31,
+                            "table": {
+                                "property": {
+                                    "row_size": 2,
+                                    "column_size": 1,
+                                },
+                                "cells": ["c1", "c2"],
+                            },
+                        },
+                        {
+                            "block_id": "c1",
+                            "block_type": 32,
+                            "children": ["t1"],
+                        },
+                        {
+                            "block_id": "c2",
+                            "block_type": 32,
+                            "children": ["t2"],
+                        },
+                        {
+                            "block_id": "t1",
+                            "block_type": 2,
+                            "text": {
+                                "elements": [
+                                    {"text_run": {"content": "Header"}},
+                                ],
+                            },
+                        },
+                        {
+                            "block_id": "t2",
+                            "block_type": 2,
+                            "text": {
+                                "elements": [
+                                    {"equation": {"content": "x|y"}},
+                                ],
+                            },
+                        },
+                    ],
+                    "has_more": False,
+                },
+            },
+        ]
+        channel._user_api = AsyncMock(side_effect=pages)
+
+        document = await channel.read_wiki_document(
+            "ou-user",
+            "wik-node",
+            0,
+            3,
+        )
+
+        self.assertEqual(document.name, "Guide")
+        text = document.content[0].text
+        self.assertIn("# Title", text)
+        self.assertIn("- [linked](https://example.test)", text)
+        self.assertIn("| Header |", text)
+        self.assertIn("$x\\|y$", text)
+        self.assertIsNone(document.next_start_index)
+        self.assertIn("doc%2F1", channel._user_api.await_args.args[3])
+
+    async def test_non_docx_node_is_not_readable(self) -> None:
+        """Legacy documents and other Wiki objects stay unsupported."""
+        channel = _channel()
+        channel._get_wiki_node = AsyncMock(
+            return_value={"obj_type": "sheet", "title": "Sheet"},
+        )
+        self.assertIsNone(
+            await channel.read_wiki_document("ou-user", "wik-node", 0, 20),
+        )
+
+    async def test_character_budget_never_splits_a_top_level_block(
+        self,
+    ) -> None:
+        """An oversized first block is returned whole with a resume index."""
+        channel = _channel()
+        large = "x" * 20_001
+        channel._user_api = AsyncMock(
+            return_value={
+                "code": 0,
+                "data": {
+                    "items": [
+                        {
+                            "block_id": "page",
+                            "block_type": 1,
+                            "children": ["first", "second"],
+                        },
+                        {
+                            "block_id": "first",
+                            "block_type": 2,
+                            "text": {
+                                "elements": [
+                                    {"text_run": {"content": large}},
+                                ],
+                            },
+                        },
+                        {
+                            "block_id": "second",
+                            "block_type": 2,
+                            "text": {
+                                "elements": [
+                                    {"text_run": {"content": "next"}},
+                                ],
+                            },
+                        },
+                    ],
+                    "has_more": False,
+                },
+            },
+        )
+
+        content, next_index = await channel._read_docx_blocks(
+            "ou-user",
+            "document",
+            0,
+            2,
+        )
+
+        self.assertEqual(content, large)
+        self.assertEqual(next_index, 1)
+
+    async def test_device_flow_verifies_sender_before_save(self) -> None:
+        """An authorization from a different account is discarded."""
+        channel = _channel()
+        storage = _Storage()
+        channel._bind_storage(storage)  # type: ignore[arg-type]
+        channel._api = AsyncMock(return_value={"code": 0})
+        flow = SimpleNamespace(
+            start=AsyncMock(
+                return_value={
+                    "verification_uri_complete": "https://example.test/auth",
+                    "user_code": "ABCD",
+                    "device_code": "device",
+                    "expires_in": 60,
+                    "interval": 1,
+                },
+            ),
+            poll=AsyncMock(
+                return_value={
+                    "access_token": "access",
+                    "refresh_token": "refresh",
+                    "expires_at": time.time() + 3600,
+                    "refresh_expires_at": time.time() + 7200,
+                    "scopes": _SCOPES,
+                    "open_id": "",
+                },
+            ),
+        )
+        channel._device_flow = flow
+        channel._get_user_open_id = AsyncMock(return_value="ou-other")
+
+        with self.assertRaisesRegex(RuntimeError, "does not match"):
+            await channel._require_user_token("ou-user")
+        self.assertEqual(storage.values, {})
+        self.assertEqual(channel._api.await_args.args[0], "POST")
+
+
+class FeishuDeviceFlowTest(IsolatedAsyncioTestCase):
+    """Exercise the minimal Feishu device-flow protocol adapter."""
+
+    async def test_device_flow_protocol(self) -> None:
+        """Start, poll, and refresh follow Feishu's live API contract."""
+        http = SimpleNamespace(
+            post=AsyncMock(
+                side_effect=[
+                    _Response(
+                        {
+                            "verification_uri": "https://example.test/auth",
+                            "user_code": "ABCD",
+                            "device_code": "device",
+                            "expires_in": 600,
+                            "interval": 5,
+                        },
+                    ),
+                    _Response({"error": "authorization_pending"}),
+                    _Response(
+                        {
+                            "access_token": "access",
+                            "refresh_token": "refresh",
+                            "expires_in": 3600,
+                            "scope": "wiki:node:read offline_access",
+                        },
+                    ),
+                    _Response(
+                        {
+                            "access_token": "new-access",
+                            "refresh_token": "new-refresh",
+                            "expires_in": 3600,
+                            "scope": "wiki:node:read offline_access",
+                        },
+                    ),
+                ],
+            ),
+        )
+        client = _FeishuDeviceFlowClient(
+            "app",
+            "secret",
+            http_client=http,
+        )
+
+        request = await client.start(["wiki:node:read"])
+
+        call = http.post.await_args_list[0]
+        self.assertEqual(
+            call.args[0],
+            "https://accounts.feishu.cn/oauth/v1/device_authorization",
+        )
+        self.assertEqual(call.kwargs["auth"], ("app", "secret"))
+        self.assertIn("offline_access", call.kwargs["data"]["scope"])
+        self.assertEqual(request["device_code"], "device")
+
+        with patch(
+            "agentscope.app.channel._feishu._user_oauth.asyncio.sleep",
+            new=AsyncMock(),
+        ):
+            token = await client.poll("device", interval=1)
+
+        self.assertEqual(token["access_token"], "access")
+        self.assertGreater(token["expires_at"] or 0, time.time())
+        refreshed = await client.refresh("refresh")
+
+        call = http.post.await_args_list[3]
+        self.assertEqual(
+            call.args[0],
+            "https://open.feishu.cn/open-apis/authen/v2/oauth/token",
+        )
+        self.assertEqual(call.kwargs["data"]["grant_type"], "refresh_token")
+        self.assertEqual(refreshed["access_token"], "new-access")

--- a/tests/storage_redis_test.py
+++ b/tests/storage_redis_test.py
@@ -12,6 +12,9 @@ from agentscope.app.storage import (
     SessionConfig,
     SessionRecord,
     ChatModelConfig,
+    ChannelBinding,
+    ChannelRecord,
+    RoutingConfig,
     ScheduleRecord,
     ScheduleData,
     ChannelOrigin,
@@ -19,6 +22,7 @@ from agentscope.app.storage import (
     TeamData,
     TeamMember,
     TeamRecord,
+    SessionSettings,
 )
 from agentscope.app.storage import MCPRecord, SkillRecord
 from agentscope.credential import OllamaCredential
@@ -64,6 +68,84 @@ def make_session_config(workspace_id: str = "ws-1") -> SessionConfig:
             parameters={},
         ),
     )
+
+
+def make_channel_record(channel_id: str) -> ChannelRecord:
+    """Create a minimal channel record for Redis tests."""
+    return ChannelRecord(
+        id=channel_id,
+        channel_type="feishu",
+        user_id="user-1",
+        credentials={"app_id": channel_id},
+        routing=RoutingConfig(
+            bindings=[ChannelBinding(match_value="*", agent_id="agent-x")],
+        ),
+        session=SessionSettings(
+            chat_model_config={
+                "type": "openai",
+                "credential_id": "cred-1",
+                "model": "gpt-4o",
+                "parameters": {},
+            },
+        ),
+    )
+
+
+class TestChannelUserCredentials(IsolatedAsyncioTestCase):
+    """Tests for Redis-backed channel-user OAuth credentials."""
+
+    async def asyncSetUp(self) -> None:
+        """Create an isolated fake Redis backend."""
+        self.storage = make_storage()
+        await self.storage.upsert_channel(
+            make_channel_record("chan-1"),
+            "cli-1",
+        )
+
+    async def test_crud_overwrite_and_channel_cleanup(self) -> None:
+        """Credentials overwrite, isolate users, and cascade on delete."""
+        await self.storage.upsert_channel_user_credentials(
+            "chan-1",
+            "ou-1",
+            {"access_token": "old"},
+        )
+        await self.storage.upsert_channel_user_credentials(
+            "chan-1",
+            "ou-1",
+            {"access_token": "new"},
+        )
+        await self.storage.upsert_channel_user_credentials(
+            "chan-1",
+            "ou-2",
+            {"access_token": "second"},
+        )
+        self.assertEqual(
+            await self.storage.get_channel_user_credentials(
+                "chan-1",
+                "ou-1",
+            ),
+            {"access_token": "new"},
+        )
+        self.assertTrue(
+            await self.storage.delete_channel_user_credentials(
+                "chan-1",
+                "ou-2",
+            ),
+        )
+        self.assertFalse(
+            await self.storage.delete_channel_user_credentials(
+                "chan-1",
+                "missing",
+            ),
+        )
+
+        await self.storage.delete_channel("chan-1", "cli-1")
+        self.assertIsNone(
+            await self.storage.get_channel_user_credentials(
+                "chan-1",
+                "ou-1",
+            ),
+        )
 
 
 class TestCredential(IsolatedAsyncioTestCase):

--- a/tests/storage_sql_test.py
+++ b/tests/storage_sql_test.py
@@ -1051,6 +1051,80 @@ class AsyncSQLAlchemyStorageTest(IsolatedAsyncioTestCase):
             "chan-1",
         )
 
+    async def test_channel_user_credentials_are_isolated_and_cascade(
+        self,
+    ) -> None:
+        """User OAuth secrets upsert independently and follow the channel."""
+        await self.storage.upsert_channel(
+            _channel_record("chan-1"),
+            "cli-1",
+        )
+        await self.storage.upsert_channel(
+            _channel_record("chan-2"),
+            "cli-2",
+        )
+        await self.storage.upsert_channel_user_credentials(
+            "chan-1",
+            "ou-1",
+            {"access_token": "old"},
+        )
+        await self.storage.upsert_channel_user_credentials(
+            "chan-1",
+            "ou-1",
+            {"access_token": "new"},
+        )
+        await self.storage.upsert_channel_user_credentials(
+            "chan-2",
+            "ou-1",
+            {"access_token": "other"},
+        )
+
+        self.assertEqual(
+            await self.storage.get_channel_user_credentials(
+                "chan-1",
+                "ou-1",
+            ),
+            {"access_token": "new"},
+        )
+        self.assertIsNone(
+            await self.storage.get_channel_user_credentials(
+                "chan-1",
+                "ou-2",
+            ),
+        )
+        self.assertTrue(
+            await self.storage.delete_channel_user_credentials(
+                "chan-1",
+                "ou-1",
+            ),
+        )
+        self.assertFalse(
+            await self.storage.delete_channel_user_credentials(
+                "chan-1",
+                "ou-1",
+            ),
+        )
+
+        await self.storage.upsert_channel_user_credentials(
+            "chan-1",
+            "ou-1",
+            {"access_token": "again"},
+        )
+        await self.storage.delete_channel("chan-1", "cli-1")
+        self.assertIsNone(
+            await self.storage.get_channel_user_credentials(
+                "chan-1",
+                "ou-1",
+            ),
+        )
+        self.assertEqual(
+            await self.storage.get_channel_user_credentials(
+                "chan-2",
+                "ou-1",
+            ),
+            {"access_token": "other"},
+        )
+
 
 class AsyncSQLAlchemyStorageAutoMigrateTest(IsolatedAsyncioTestCase):
     """Boot via ``auto_migrate=True`` and confirm the schema is live.
@@ -1103,6 +1177,18 @@ class AsyncSQLAlchemyStorageAutoMigrateTest(IsolatedAsyncioTestCase):
                 self.assertEqual(
                     await storage.get_channel_id_by_platform_bot_id("cli-1"),
                     "chan-1",
+                )
+                await storage.upsert_channel_user_credentials(
+                    "chan-1",
+                    "ou-1",
+                    {"access_token": "token"},
+                )
+                self.assertEqual(
+                    await storage.get_channel_user_credentials(
+                        "chan-1",
+                        "ou-1",
+                    ),
+                    {"access_token": "token"},
                 )
 
 

--- a/tests/tool_offload_middleware_test.py
+++ b/tests/tool_offload_middleware_test.py
@@ -86,6 +86,13 @@ class SlowTool(ToolBase):
         )
 
 
+class ForegroundSlowTool(SlowTool):
+    """A slow tool whose result must stay attached to the current run."""
+
+    name: str = "foreground_slow_tool"
+    can_offload: bool = False
+
+
 class _FastToolParams(BaseModel):
     """Parameters for the fast test tool."""
 
@@ -272,6 +279,26 @@ class ToolOffloadMiddlewareTest(IsolatedAsyncioTestCase):
 
         # Background task should be registered
         self.assertEqual(len(self.bg_manager.tasks), 1)
+
+    async def test_tool_can_opt_out_of_background_offload(self) -> None:
+        """A non-offloadable tool waits for and returns its real result."""
+        toolkit = Toolkit(tools=[ForegroundSlowTool()])
+        agent, _ = self._make_agent(toolkit, timeout_secs=0.01)
+        tool_call = ToolCallBlock(
+            id="call_foreground",
+            name="foreground_slow_tool",
+            input=json.dumps({"delay": 0.02}),
+        )
+
+        results = [item async for item in agent._acting(tool_call)]
+
+        responses = [r for r in results if isinstance(r, ToolResponse)]
+        self.assertEqual(len(responses), 1)
+        self.assertIn(
+            "SlowTool finished",
+            responses[0].content[0].text,  # type: ignore[union-attr]
+        )
+        self.assertEqual(len(self.bg_manager.tasks), 0)
 
     async def test_background_task_result_injected_into_context(
         self,


### PR DESCRIPTION
## AgentScope Version

2.0.8

## Description

Closes [#2580](https://github.com/agentscope-ai/agentscope/issues/2580).

This PR implements user-scoped Wiki access for `FeishuChannel` using the shared channel Wiki contract. It enables agents in Feishu private chats to browse the current sender's accessible Wiki spaces, navigate the node tree, read Docx documents, and use the retrieved content when answering users.

### Changes

- Enables `ChannelCapability.wiki` for `FeishuChannel` and implements `list_wiki_spaces`, `list_wiki_nodes`, and `read_wiki_document`.
- Resolves Feishu Wiki nodes to their underlying Docx objects and renders headings, paragraphs, lists, quotes, links, mentions, equations, and tables as Markdown.
- Adds Feishu Device Flow authorization so Wiki requests run with the message sender's own permissions instead of the application's tenant permissions.
- Persists per-channel-user OAuth credentials in Redis and SQL storage, including an Alembic migration for SQL deployments.
- Reuses and refreshes stored tokens, including recovery from Feishu access-token expiration and invalidation responses.
- Keeps Wiki authorization attached to the active agent run instead of offloading the long-running authorization wait to a background task.

Wiki tools are equipped for an identified private-chat user. The first Wiki call starts OAuth authorization when required; subsequent calls reuse the stored user credential. Existing generic channel behavior keeps user-scoped Wiki tools unavailable in shared group-chat sessions.

### Testing

The following focused test suite passed under a UTF-8 locale:

```bash
LC_ALL=en_US.UTF-8 .venv/bin/python -m pytest \
  tests/channel_feishu_wiki_test.py \
  tests/tool_offload_middleware_test.py \
  tests/channel_clients_test.py \
  tests/storage_sql_test.py \
  tests/storage_redis_test.py -q
```

Result: **151 passed**.

The affected files also passed `add-trailing-comma`, `flake8`, `mypy`, `pylint`, and `git diff --check`.

#### E2E: first-time user authorization

A private-chat Wiki request successfully delivered the Feishu Device Flow authorization card to the current sender.

<img width="970" height="462" alt="8dec38b7878b8554a899b1662c7e1e58" src="https://github.com/user-attachments/assets/80fce810-2248-4c0d-9464-0ea63bc48ece" />

#### E2E: Wiki lookup and document-backed answer

After authorization, the agent listed the available Wiki spaces and nodes, found the ReMe document, read its Docx blocks, and summarized the requested Auto Dream content. A later request reused the persisted credential without requiring authorization again.

<img width="962" height="1614" alt="9cf4b49c1f322405e65104346a3f3cef" src="https://github.com/user-attachments/assets/c0426b60-161c-4ce0-9787-b3d0bca06fcd" />

## Checklist

- [x] An issue has been created for this PR
- [x] I have read the [CONTRIBUTING.md](https://github.com/agentscope-ai/agentscope/blob/main/CONTRIBUTING.md)
- [x] Docstrings are in Google style
- [ ] Related documentation has been updated (e.g. links, examples, etc.) in [documentation repository](https://github.com/agentscope-ai/docs)
- [x] Code is ready for review